### PR TITLE
Fix number pattern of `stringify` to support exponential log value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.2.0",
+  "version": "4.2.1-dev.20230808",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.2.0",
+  "version": "4.2.1-dev.20230808",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.2.0"
+    "typia": "4.2.1-dev.20230808"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/programmers/RandomProgrammer.ts
+++ b/src/programmers/RandomProgrammer.ts
@@ -219,9 +219,7 @@ export namespace RandomProgrammer {
             const expressions: ts.Expression[] = [];
             if (meta.any)
                 expressions.push(
-                    ts.factory.createStringLiteral(
-                        "any type used...",
-                    ),
+                    ts.factory.createStringLiteral("any type used..."),
                 );
 
             // NULL COALESCING

--- a/src/programmers/internal/stringify_dynamic_properties.ts
+++ b/src/programmers/internal/stringify_dynamic_properties.ts
@@ -145,6 +145,10 @@ export const stringify_dynamic_properties = (
         );
         statements.push(condition);
     }
+    statements.push(
+        ts.factory.createReturnStatement(ts.factory.createStringLiteral("")),
+    );
+
     return output();
 };
 

--- a/src/utils/PatternUtil.ts
+++ b/src/utils/PatternUtil.ts
@@ -17,7 +17,10 @@ export namespace PatternUtil {
             .replace(/-/g, "\\x2d");
     };
 
-    export const NUMBER = "-?\\d+\\.?\\d*";
+    export const NUMBER =
+        "[+-]?" + // optional sign
+        "\\d+(?:\\.\\d+)?" + // integer or decimal
+        "(?:[eE][+-]?\\d+)?"; // optional exponent
     export const BOOLEAN = "true|false";
     export const STRING = "(.*)";
 }

--- a/test/features/issues/test_issue_exponential_key_stringify.ts
+++ b/test/features/issues/test_issue_exponential_key_stringify.ts
@@ -1,0 +1,24 @@
+import typia from "typia";
+
+import { DynamicComposite } from "../../structures/DynamicComposite";
+
+export const test_issue_exponential_key_stringify = () => {
+    const data: DynamicComposite = {
+        id: "id",
+        name: "name",
+        "5.175933557310941e-7": -0.170261004873707,
+        prefix_upzzoug: "udwpvy",
+        sqqfzv_postfix: "xpwmpwr",
+        "value_0.18500123790254852": true,
+        "value_-0.4744943749449395": -0.12959620300810482,
+        "value_-0.41442283348249553": "wchfdtils",
+        "between_tmzivbd_and_-0.45295511336433414": false,
+    };
+    const json: string = typia.stringify(data);
+    const expected: string = JSON.stringify(data);
+
+    if (json !== expected)
+        throw new Error(
+            "Bug on typia.stringify: failed to understand exponential numbered key.",
+        );
+};

--- a/test/generated/output/assert/test_assert_DynamicComposite.ts
+++ b/test/generated/output/assert/test_assert_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_assert_DynamicComposite = _test_assert(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_assert_DynamicComposite = _test_assert(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_assert_DynamicComposite = _test_assert(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +80,11 @@ export const test_assert_DynamicComposite = _test_assert(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -98,7 +112,11 @@ export const test_assert_DynamicComposite = _test_assert(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         ("number" === typeof value &&
@@ -113,7 +131,7 @@ export const test_assert_DynamicComposite = _test_assert(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (

--- a/test/generated/output/assert/test_assert_DynamicTemplate.ts
+++ b/test/generated/output/assert/test_assert_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_assert_DynamicTemplate = _test_assert(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +76,11 @@ export const test_assert_DynamicTemplate = _test_assert(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -81,9 +91,9 @@ export const test_assert_DynamicTemplate = _test_assert(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/assert/test_assert_DynamicUnion.ts
+++ b/test/generated/output/assert/test_assert_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_assert_DynamicUnion = _test_assert(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_assert_DynamicUnion = _test_assert(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -54,7 +58,11 @@ export const test_assert_DynamicUnion = _test_assert(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -83,7 +91,7 @@ export const test_assert_DynamicUnion = _test_assert(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (

--- a/test/generated/output/assert/test_assert_TemplateAtomic.ts
+++ b/test/generated/output/assert/test_assert_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_assert_TemplateAtomic = _test_assert(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -80,9 +80,9 @@ export const test_assert_TemplateAtomic = _test_assert(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -98,7 +98,7 @@ export const test_assert_TemplateAtomic = _test_assert(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/assertClone/test_assertClone_DynamicComposite.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -33,9 +41,9 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -75,7 +83,11 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                                 Object.keys(input).every((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -104,9 +116,9 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -122,7 +134,7 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (
@@ -162,7 +174,11 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                         name: input.name as any,
                     } as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -174,12 +190,18 @@ export const test_assertClone_DynamicComposite = _test_assertClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/assertClone/test_assertClone_DynamicTemplate.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicTemplate.ts
@@ -18,15 +18,19 @@ export const test_assertClone_DynamicTemplate = _test_assertClone(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -73,7 +77,11 @@ export const test_assertClone_DynamicTemplate = _test_assertClone(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -85,7 +93,7 @@ export const test_assertClone_DynamicTemplate = _test_assertClone(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -132,12 +140,18 @@ export const test_assertClone_DynamicTemplate = _test_assertClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/assertClone/test_assertClone_DynamicUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -55,7 +59,11 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         $guard(_exceptionable, {
@@ -84,7 +92,7 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                                     );
                                 if (
                                     RegExp(
-                                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -124,7 +132,11 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                 const $co0 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -138,7 +150,7 @@ export const test_assertClone_DynamicUnion = _test_assertClone(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                             output[key] = value as any;

--- a/test/generated/output/assertClone/test_assertClone_TemplateAtomic.ts
+++ b/test/generated/output/assertClone/test_assertClone_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_assertClone_TemplateAtomic = _test_assertClone(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -83,9 +83,9 @@ export const test_assertClone_TemplateAtomic = _test_assertClone(
                                     value: input.middle_string_empty,
                                 })) &&
                             (("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -101,7 +101,7 @@ export const test_assertClone_TemplateAtomic = _test_assertClone(
                                 })) &&
                             (("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicComposite.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicComposite.ts
@@ -23,7 +23,11 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                             return true;
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -32,7 +36,11 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -40,7 +48,9 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return false;
@@ -86,7 +96,11 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                                     return true;
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -114,7 +128,11 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         ("number" === typeof value &&
@@ -129,7 +147,7 @@ export const test_assertEquals_DynamicComposite = _test_assertEquals(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicTemplate.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicTemplate.ts
@@ -23,13 +23,19 @@ export const test_assertEquals_DynamicTemplate = _test_assertEquals(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return false;
@@ -76,7 +82,11 @@ export const test_assertEquals_DynamicTemplate = _test_assertEquals(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -87,9 +97,9 @@ export const test_assertEquals_DynamicTemplate = _test_assertEquals(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/assertEquals/test_assertEquals_DynamicUnion.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_DynamicUnion.ts
@@ -19,7 +19,11 @@ export const test_assertEquals_DynamicUnion = _test_assertEquals(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -27,7 +31,7 @@ export const test_assertEquals_DynamicUnion = _test_assertEquals(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -60,7 +64,11 @@ export const test_assertEquals_DynamicUnion = _test_assertEquals(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -89,7 +97,7 @@ export const test_assertEquals_DynamicUnion = _test_assertEquals(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (

--- a/test/generated/output/assertEquals/test_assertEquals_TemplateAtomic.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TemplateAtomic.ts
@@ -26,14 +26,14 @@ export const test_assertEquals_TemplateAtomic = _test_assertEquals(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&
@@ -108,9 +108,9 @@ export const test_assertEquals_TemplateAtomic = _test_assertEquals(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -126,7 +126,7 @@ export const test_assertEquals_TemplateAtomic = _test_assertEquals(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/assertParse/test_assertParse_DynamicComposite.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -33,9 +41,9 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -75,7 +83,11 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                                 Object.keys(input).every((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -104,9 +116,9 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -122,7 +134,7 @@ export const test_assertParse_DynamicComposite = _test_assertParse(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/assertParse/test_assertParse_DynamicTemplate.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicTemplate.ts
@@ -18,15 +18,19 @@ export const test_assertParse_DynamicTemplate = _test_assertParse(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -73,7 +77,11 @@ export const test_assertParse_DynamicTemplate = _test_assertParse(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -85,7 +93,7 @@ export const test_assertParse_DynamicTemplate = _test_assertParse(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (

--- a/test/generated/output/assertParse/test_assertParse_DynamicUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_assertParse_DynamicUnion = _test_assertParse(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_assertParse_DynamicUnion = _test_assertParse(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -55,7 +59,11 @@ export const test_assertParse_DynamicUnion = _test_assertParse(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         $guard(_exceptionable, {
@@ -84,7 +92,7 @@ export const test_assertParse_DynamicUnion = _test_assertParse(
                                     );
                                 if (
                                     RegExp(
-                                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (

--- a/test/generated/output/assertParse/test_assertParse_TemplateAtomic.ts
+++ b/test/generated/output/assertParse/test_assertParse_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_assertParse_TemplateAtomic = _test_assertParse(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -83,9 +83,9 @@ export const test_assertParse_TemplateAtomic = _test_assertParse(
                                     value: input.middle_string_empty,
                                 })) &&
                             (("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -101,7 +101,7 @@ export const test_assertParse_TemplateAtomic = _test_assertParse(
                                 })) &&
                             (("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicComposite.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -33,9 +41,9 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -75,7 +83,11 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                                 Object.keys(input).every((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -104,9 +116,9 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -122,7 +134,7 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (
@@ -159,16 +171,26 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                         if (undefined === value) return;
                         if ("id" === key) return;
                         if ("name" === key) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -176,11 +198,17 @@ export const test_assertPrune_DynamicComposite = _test_assertPrune(
                         if (
                             "id" === key ||
                             "name" === key ||
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicTemplate.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicTemplate.ts
@@ -18,15 +18,19 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -73,7 +77,11 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -85,7 +93,7 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -126,10 +134,16 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -137,8 +151,12 @@ export const test_assertPrune_DynamicTemplate = _test_assertPrune(
                         if (
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_DynamicUnion.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -55,7 +59,11 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         $guard(_exceptionable, {
@@ -84,7 +92,7 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                                     );
                                 if (
                                     RegExp(
-                                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -122,7 +130,11 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                 const $po0 = (input: any): any => {
                     Object.entries(input).forEach(([key, value]: any) => {
                         if (undefined === value) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
@@ -130,18 +142,20 @@ export const test_assertPrune_DynamicUnion = _test_assertPrune(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                         }
                     });
                     for (const key of Object.keys(input)) {
                         if (
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             continue;

--- a/test/generated/output/assertPrune/test_assertPrune_TemplateAtomic.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_assertPrune_TemplateAtomic = _test_assertPrune(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -83,9 +83,9 @@ export const test_assertPrune_TemplateAtomic = _test_assertPrune(
                                     value: input.middle_string_empty,
                                 })) &&
                             (("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -101,7 +101,7 @@ export const test_assertPrune_TemplateAtomic = _test_assertPrune(
                                 })) &&
                             (("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicComposite.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -33,9 +41,9 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -75,7 +83,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                 Object.keys(input).every((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -104,9 +116,9 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -122,7 +134,7 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (
@@ -171,7 +183,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                     )
                                 )
                                     return "";
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${$number(
                                         value,
                                     )}`;
@@ -183,7 +199,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                     return `${JSON.stringify(key)}:${$string(
                                         value,
                                     )}`;
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${(() => {
                                         if ("string" === typeof value)
                                             return $string(value);
@@ -199,10 +219,11 @@ export const test_assertStringify_DynamicComposite = _test_assertStringify(
                                     })()}`;
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return `${JSON.stringify(key)}:${value}`;
+                                return "";
                             })
                             .filter((str: any) => "" !== str)
                             .join(",")}`,

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicTemplate.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicTemplate.ts
@@ -18,15 +18,19 @@ export const test_assertStringify_DynamicTemplate = _test_assertStringify(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -73,7 +77,11 @@ export const test_assertStringify_DynamicTemplate = _test_assertStringify(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -85,7 +93,7 @@ export const test_assertStringify_DynamicTemplate = _test_assertStringify(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -133,16 +141,21 @@ export const test_assertStringify_DynamicTemplate = _test_assertStringify(
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/assertStringify/test_assertStringify_DynamicUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -55,7 +59,11 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         $guard(_exceptionable, {
@@ -84,7 +92,7 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                                     );
                                 if (
                                     RegExp(
-                                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -125,7 +133,11 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
@@ -139,12 +151,13 @@ export const test_assertStringify_DynamicUnion = _test_assertStringify(
                                 )}`;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/assertStringify/test_assertStringify_TemplateAtomic.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_assertStringify_TemplateAtomic = _test_assertStringify(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -83,9 +83,9 @@ export const test_assertStringify_TemplateAtomic = _test_assertStringify(
                                     value: input.middle_string_empty,
                                 })) &&
                             (("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -101,7 +101,7 @@ export const test_assertStringify_TemplateAtomic = _test_assertStringify(
                                 })) &&
                             (("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/clone/test_clone_DynamicComposite.ts
+++ b/test/generated/output/clone/test_clone_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_clone_DynamicComposite = _test_clone(
                     name: input.name as any,
                 } as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -26,11 +30,19 @@ export const test_clone_DynamicComposite = _test_clone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/clone/test_clone_DynamicTemplate.ts
+++ b/test/generated/output/clone/test_clone_DynamicTemplate.ts
@@ -19,11 +19,19 @@ export const test_clone_DynamicTemplate = _test_clone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/clone/test_clone_DynamicUnion.ts
+++ b/test/generated/output/clone/test_clone_DynamicUnion.ts
@@ -11,7 +11,11 @@ export const test_clone_DynamicUnion = _test_clone(
             const $co0 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -25,7 +29,7 @@ export const test_clone_DynamicUnion = _test_clone(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                         output[key] = value as any;

--- a/test/generated/output/createAssert/test_createAssert_DynamicComposite.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_createAssert_DynamicComposite = _test_assert(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_createAssert_DynamicComposite = _test_assert(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -64,7 +76,11 @@ export const test_createAssert_DynamicComposite = _test_assert(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -92,7 +108,11 @@ export const test_createAssert_DynamicComposite = _test_assert(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -105,9 +125,9 @@ export const test_createAssert_DynamicComposite = _test_assert(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/createAssert/test_createAssert_DynamicTemplate.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_createAssert_DynamicTemplate = _test_assert(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -66,7 +74,11 @@ export const test_createAssert_DynamicTemplate = _test_assert(
                                     value: value,
                                 })
                             );
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 ("number" === typeof value &&
                                     Number.isFinite(value)) ||
@@ -77,7 +89,9 @@ export const test_createAssert_DynamicTemplate = _test_assert(
                                 })
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return (
                                 "boolean" === typeof value ||

--- a/test/generated/output/createAssert/test_createAssert_DynamicUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_createAssert_DynamicUnion = _test_assert(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_createAssert_DynamicUnion = _test_assert(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -52,7 +56,11 @@ export const test_createAssert_DynamicUnion = _test_assert(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 $guard(_exceptionable, {
@@ -81,7 +89,7 @@ export const test_createAssert_DynamicUnion = _test_assert(
                             );
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (

--- a/test/generated/output/createAssert/test_createAssert_TemplateAtomic.ts
+++ b/test/generated/output/createAssert/test_createAssert_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_createAssert_TemplateAtomic = _test_assert(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -71,9 +73,9 @@ export const test_createAssert_TemplateAtomic = _test_assert(
                             value: input.middle_string_empty,
                         })) &&
                     (("string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        )) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle_numeric",
                             expected: "`the_${number}_value`",
@@ -88,7 +90,7 @@ export const test_createAssert_TemplateAtomic = _test_assert(
                         })) &&
                     (("string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4)) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",

--- a/test/generated/output/createAssert/test_createAssert_TemplateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_createAssert_TemplateUnion = _test_assert(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_createAssert_TemplateUnion = _test_assert(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));
@@ -56,9 +62,9 @@ export const test_createAssert_TemplateUnion = _test_assert(
                 ): boolean =>
                     (("string" === typeof input.prefix &&
                         (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                            RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                input.prefix,
-                            ))) ||
+                            RegExp(
+                                /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(input.prefix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected:
@@ -67,9 +73,9 @@ export const test_createAssert_TemplateUnion = _test_assert(
                         })) &&
                     (("string" === typeof input.postfix &&
                         (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                            RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                input.postfix,
-                            ))) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                            ).test(input.postfix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected:
@@ -79,9 +85,9 @@ export const test_createAssert_TemplateUnion = _test_assert(
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle",
                             expected:
@@ -108,9 +114,9 @@ export const test_createAssert_TemplateUnion = _test_assert(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ((("object" === typeof input.mixed &&
                             null !== input.mixed) ||
                             $guard(_exceptionable, {

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicComposite.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +80,11 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -98,7 +112,11 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         ("number" === typeof value &&
@@ -113,7 +131,7 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -153,7 +171,11 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                     name: input.name as any,
                 } as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -165,11 +187,19 @@ export const test_createAssertClone_DynamicComposite = _test_assertClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicTemplate.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_createAssertClone_DynamicTemplate = _test_assertClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +76,11 @@ export const test_createAssertClone_DynamicTemplate = _test_assertClone(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -81,9 +91,9 @@ export const test_createAssertClone_DynamicTemplate = _test_assertClone(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||
@@ -129,11 +139,19 @@ export const test_createAssertClone_DynamicTemplate = _test_assertClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createAssertClone/test_createAssertClone_DynamicUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -54,7 +58,11 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -83,7 +91,7 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -121,7 +129,11 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
             const $co0 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -135,7 +147,7 @@ export const test_createAssertClone_DynamicUnion = _test_assertClone(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                         output[key] = value as any;

--- a/test/generated/output/createAssertClone/test_createAssertClone_TemplateAtomic.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_createAssertClone_TemplateAtomic = _test_assertClone(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -80,9 +80,9 @@ export const test_createAssertClone_TemplateAtomic = _test_assertClone(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -98,7 +98,7 @@ export const test_createAssertClone_TemplateAtomic = _test_assertClone(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TemplateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -61,9 +65,9 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                     ): boolean =>
                         (("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -72,9 +76,9 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                             })) &&
                         (("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -84,9 +88,9 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                         ("the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -113,9 +117,9 @@ export const test_createAssertClone_TemplateUnion = _test_assertClone(
                                 Number.isFinite(input.mixed)) ||
                             "boolean" === typeof input.mixed ||
                             ("string" === typeof input.mixed &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.mixed,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.mixed)) ||
                             ((("object" === typeof input.mixed &&
                                 null !== input.mixed) ||
                                 $guard(_exceptionable, {

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicComposite.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicComposite.ts
@@ -22,7 +22,11 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
                         return true;
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -30,14 +34,22 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });
@@ -78,7 +90,11 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
                                 return true;
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -106,7 +122,11 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -119,9 +139,9 @@ export const test_createAssertEquals_DynamicComposite = _test_assertEquals(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicTemplate.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicTemplate.ts
@@ -22,11 +22,19 @@ export const test_createAssertEquals_DynamicTemplate = _test_assertEquals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });
@@ -72,7 +80,11 @@ export const test_createAssertEquals_DynamicTemplate = _test_assertEquals(
                                     value: value,
                                 })
                             );
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 ("number" === typeof value &&
                                     Number.isFinite(value)) ||
@@ -83,7 +95,9 @@ export const test_createAssertEquals_DynamicTemplate = _test_assertEquals(
                                 })
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return (
                                 "boolean" === typeof value ||

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicUnion.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_DynamicUnion.ts
@@ -18,7 +18,11 @@ export const test_createAssertEquals_DynamicUnion = _test_assertEquals(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -26,7 +30,7 @@ export const test_createAssertEquals_DynamicUnion = _test_assertEquals(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -58,7 +62,11 @@ export const test_createAssertEquals_DynamicUnion = _test_assertEquals(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 $guard(_exceptionable, {
@@ -87,7 +95,7 @@ export const test_createAssertEquals_DynamicUnion = _test_assertEquals(
                             );
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TemplateAtomic.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TemplateAtomic.ts
@@ -23,12 +23,14 @@ export const test_createAssertEquals_TemplateAtomic = _test_assertEquals(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&
@@ -99,9 +101,9 @@ export const test_createAssertEquals_TemplateAtomic = _test_assertEquals(
                             value: input.middle_string_empty,
                         })) &&
                     (("string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        )) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle_numeric",
                             expected: "`the_${number}_value`",
@@ -116,7 +118,7 @@ export const test_createAssertEquals_TemplateAtomic = _test_assertEquals(
                         })) &&
                     (("string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4)) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TemplateUnion.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TemplateUnion.ts
@@ -16,16 +16,20 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
             ): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -34,7 +38,9 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed, true && _exceptionable))) &&
@@ -88,9 +94,9 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
                 ): boolean =>
                     (("string" === typeof input.prefix &&
                         (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                            RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                input.prefix,
-                            ))) ||
+                            RegExp(
+                                /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(input.prefix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected:
@@ -99,9 +105,9 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
                         })) &&
                     (("string" === typeof input.postfix &&
                         (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                            RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                input.postfix,
-                            ))) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                            ).test(input.postfix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected:
@@ -111,9 +117,9 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle",
                             expected:
@@ -140,9 +146,9 @@ export const test_createAssertEquals_TemplateUnion = _test_assertEquals(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ((("object" === typeof input.mixed &&
                             null !== input.mixed) ||
                             $guard(_exceptionable, {

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicComposite.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +80,11 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -98,7 +112,11 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         ("number" === typeof value &&
@@ -113,7 +131,7 @@ export const test_createAssertParse_DynamicComposite = _test_assertParse(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicTemplate.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_createAssertParse_DynamicTemplate = _test_assertParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +76,11 @@ export const test_createAssertParse_DynamicTemplate = _test_assertParse(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -81,9 +91,9 @@ export const test_createAssertParse_DynamicTemplate = _test_assertParse(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/createAssertParse/test_createAssertParse_DynamicUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createAssertParse_DynamicUnion = _test_assertParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_createAssertParse_DynamicUnion = _test_assertParse(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -54,7 +58,11 @@ export const test_createAssertParse_DynamicUnion = _test_assertParse(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -83,7 +91,7 @@ export const test_createAssertParse_DynamicUnion = _test_assertParse(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (

--- a/test/generated/output/createAssertParse/test_createAssertParse_TemplateAtomic.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_createAssertParse_TemplateAtomic = _test_assertParse(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -80,9 +80,9 @@ export const test_createAssertParse_TemplateAtomic = _test_assertParse(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -98,7 +98,7 @@ export const test_createAssertParse_TemplateAtomic = _test_assertParse(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TemplateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -61,9 +65,9 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                     ): boolean =>
                         (("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -72,9 +76,9 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                             })) &&
                         (("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -84,9 +88,9 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                         ("the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -113,9 +117,9 @@ export const test_createAssertParse_TemplateUnion = _test_assertParse(
                                 Number.isFinite(input.mixed)) ||
                             "boolean" === typeof input.mixed ||
                             ("string" === typeof input.mixed &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.mixed,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.mixed)) ||
                             ((("object" === typeof input.mixed &&
                                 null !== input.mixed) ||
                                 $guard(_exceptionable, {

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicComposite.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +80,11 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                             Object.keys(input).every((key: any) => {
                                 const value = input[key];
                                 if (undefined === value) return true;
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return (
                                         ("number" === typeof value &&
                                             Number.isFinite(value)) ||
@@ -98,7 +112,11 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                                             value: value,
                                         })
                                     );
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return (
                                         "string" === typeof value ||
                                         ("number" === typeof value &&
@@ -113,7 +131,7 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                                     );
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return (
@@ -150,26 +168,44 @@ export const test_createAssertPrune_DynamicComposite = _test_assertPrune(
                     if (undefined === value) return;
                     if ("id" === key) return;
                     if ("name" === key) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
                         "name" === key ||
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicTemplate.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_createAssertPrune_DynamicTemplate = _test_assertPrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +76,11 @@ export const test_createAssertPrune_DynamicTemplate = _test_assertPrune(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -81,9 +91,9 @@ export const test_createAssertPrune_DynamicTemplate = _test_assertPrune(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||
@@ -123,17 +133,29 @@ export const test_createAssertPrune_DynamicTemplate = _test_assertPrune(
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicUnion.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -54,7 +58,11 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -83,7 +91,7 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -121,7 +129,11 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
             const $po0 = (input: any): any => {
                 Object.entries(input).forEach(([key, value]: any) => {
                     if (undefined === value) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
@@ -129,18 +141,20 @@ export const test_createAssertPrune_DynamicUnion = _test_assertPrune(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         continue;

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TemplateAtomic.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_createAssertPrune_TemplateAtomic = _test_assertPrune(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -80,9 +80,9 @@ export const test_createAssertPrune_TemplateAtomic = _test_assertPrune(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -98,7 +98,7 @@ export const test_createAssertPrune_TemplateAtomic = _test_assertPrune(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TemplateUnion.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -61,9 +65,9 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                     ): boolean =>
                         (("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -72,9 +76,9 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                             })) &&
                         (("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -84,9 +88,9 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                         ("the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -113,9 +117,9 @@ export const test_createAssertPrune_TemplateUnion = _test_assertPrune(
                                 Number.isFinite(input.mixed)) ||
                             "boolean" === typeof input.mixed ||
                             ("string" === typeof input.mixed &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.mixed,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.mixed)) ||
                             ((("object" === typeof input.mixed &&
                                 null !== input.mixed) ||
                                 $guard(_exceptionable, {

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicComposite.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_createAssertStringify_DynamicComposite =
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_createAssertStringify_DynamicComposite =
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -33,9 +41,9 @@ export const test_createAssertStringify_DynamicComposite =
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -76,7 +84,11 @@ export const test_createAssertStringify_DynamicComposite =
                                 Object.keys(input).every((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -105,9 +117,9 @@ export const test_createAssertStringify_DynamicComposite =
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -123,7 +135,7 @@ export const test_createAssertStringify_DynamicComposite =
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (
@@ -172,7 +184,11 @@ export const test_createAssertStringify_DynamicComposite =
                                     )
                                 )
                                     return "";
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${$number(
                                         value,
                                     )}`;
@@ -184,7 +200,11 @@ export const test_createAssertStringify_DynamicComposite =
                                     return `${JSON.stringify(key)}:${$string(
                                         value,
                                     )}`;
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${(() => {
                                         if ("string" === typeof value)
                                             return $string(value);
@@ -200,10 +220,11 @@ export const test_createAssertStringify_DynamicComposite =
                                     })()}`;
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return `${JSON.stringify(key)}:${value}`;
+                                return "";
                             })
                             .filter((str: any) => "" !== str)
                             .join(",")}`,

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTemplate.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_createAssertStringify_DynamicTemplate = _test_assertStringify(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -70,7 +76,11 @@ export const test_createAssertStringify_DynamicTemplate = _test_assertStringify(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -81,9 +91,9 @@ export const test_createAssertStringify_DynamicTemplate = _test_assertStringify(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||
@@ -126,12 +136,19 @@ export const test_createAssertStringify_DynamicTemplate = _test_assertStringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$number(value)}`;
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return `${JSON.stringify(key)}:${value}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -54,7 +58,11 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     $guard(_exceptionable, {
@@ -83,7 +91,7 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                                 );
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -124,7 +132,11 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
@@ -132,10 +144,11 @@ export const test_createAssertStringify_DynamicUnion = _test_assertStringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return `${JSON.stringify(key)}:${$number(value)}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TemplateAtomic.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_createAssertStringify_TemplateAtomic = _test_assertStringify(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -80,9 +80,9 @@ export const test_createAssertStringify_TemplateAtomic = _test_assertStringify(
                                 value: input.middle_string_empty,
                             })) &&
                         (("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -98,7 +98,7 @@ export const test_createAssertStringify_TemplateAtomic = _test_assertStringify(
                             })) &&
                         (("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TemplateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -61,9 +65,9 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                     ): boolean =>
                         (("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -72,9 +76,9 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                             })) &&
                         (("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -84,9 +88,9 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                         ("the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $guard(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -113,9 +117,9 @@ export const test_createAssertStringify_TemplateUnion = _test_assertStringify(
                                 Number.isFinite(input.mixed)) ||
                             "boolean" === typeof input.mixed ||
                             ("string" === typeof input.mixed &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.mixed,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.mixed)) ||
                             ((("object" === typeof input.mixed &&
                                 null !== input.mixed) ||
                                 $guard(_exceptionable, {

--- a/test/generated/output/createClone/test_createClone_DynamicComposite.ts
+++ b/test/generated/output/createClone/test_createClone_DynamicComposite.ts
@@ -13,7 +13,7 @@ export const test_createClone_DynamicComposite = _test_clone(
                 name: input.name as any,
             } as any;
             for (const [key, value] of Object.entries(input)) {
-                if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key)) {
                     output[key] = value as any;
                     continue;
                 }
@@ -25,11 +25,19 @@ export const test_createClone_DynamicComposite = _test_clone(
                     output[key] = value as any;
                     continue;
                 }
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                     output[key] = value as any;
                     continue;
                 }
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                     output[key] = value as any;
                     continue;
                 }

--- a/test/generated/output/createClone/test_createClone_DynamicTemplate.ts
+++ b/test/generated/output/createClone/test_createClone_DynamicTemplate.ts
@@ -18,11 +18,19 @@ export const test_createClone_DynamicTemplate = _test_clone(
                     output[key] = value as any;
                     continue;
                 }
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                     output[key] = value as any;
                     continue;
                 }
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                     output[key] = value as any;
                     continue;
                 }

--- a/test/generated/output/createClone/test_createClone_DynamicUnion.ts
+++ b/test/generated/output/createClone/test_createClone_DynamicUnion.ts
@@ -10,7 +10,7 @@ export const test_createClone_DynamicUnion = _test_clone(
         const $co0 = (input: any): any => {
             const output = {} as any;
             for (const [key, value] of Object.entries(input)) {
-                if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key)) {
                     output[key] = value as any;
                     continue;
                 }
@@ -24,7 +24,7 @@ export const test_createClone_DynamicUnion = _test_clone(
                 }
                 if (
                     RegExp(
-                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                     ).test(key)
                 ) {
                     output[key] = value as any;

--- a/test/generated/output/createEquals/test_createEquals_DynamicComposite.ts
+++ b/test/generated/output/createEquals/test_createEquals_DynamicComposite.ts
@@ -15,19 +15,27 @@ export const test_createEquals_DynamicComposite = _test_equals(
                     return true;
                 const value = input[key];
                 if (undefined === value) return true;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key))
                     return "number" === typeof value && Number.isFinite(value);
                 if (RegExp(/^(prefix_(.*))/).test(key))
                     return "string" === typeof value;
                 if (RegExp(/((.*)_postfix)$/).test(key))
                     return "string" === typeof value;
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return (
                         "string" === typeof value ||
                         ("number" === typeof value && Number.isFinite(value)) ||
                         "boolean" === typeof value
                     );
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "boolean" === typeof value;
                 return false;
             });

--- a/test/generated/output/createEquals/test_createEquals_DynamicTemplate.ts
+++ b/test/generated/output/createEquals/test_createEquals_DynamicTemplate.ts
@@ -15,9 +15,17 @@ export const test_createEquals_DynamicTemplate = _test_equals(
                     return "string" === typeof value;
                 if (RegExp(/((.*)_postfix)$/).test(key))
                     return "string" === typeof value;
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "number" === typeof value && Number.isFinite(value);
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "boolean" === typeof value;
                 return false;
             });

--- a/test/generated/output/createEquals/test_createEquals_DynamicUnion.ts
+++ b/test/generated/output/createEquals/test_createEquals_DynamicUnion.ts
@@ -11,7 +11,7 @@ export const test_createEquals_DynamicUnion = _test_equals(
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key))
                     return "string" === typeof value;
                 if (RegExp(/^(prefix_(.*))/).test(key))
                     return "string" === typeof value;
@@ -19,7 +19,7 @@ export const test_createEquals_DynamicUnion = _test_equals(
                     return "string" === typeof value;
                 if (
                     RegExp(
-                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                     ).test(key)
                 )
                     return "number" === typeof value && Number.isFinite(value);

--- a/test/generated/output/createEquals/test_createEquals_TemplateAtomic.ts
+++ b/test/generated/output/createEquals/test_createEquals_TemplateAtomic.ts
@@ -16,13 +16,15 @@ export const test_createEquals_TemplateAtomic = _test_equals(
             "string" === typeof input.middle_string_empty &&
             RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
             "string" === typeof input.middle_numeric &&
-            RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+            RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                input.middle_numeric,
+            ) &&
             ("the_false_value" === input.middle_boolean ||
                 "the_true_value" === input.middle_boolean) &&
             "string" === typeof input.ipv4 &&
-            RegExp(/^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/).test(
-                input.ipv4,
-            ) &&
+            RegExp(
+                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+            ).test(input.ipv4) &&
             "string" === typeof input.email &&
             RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&
             (8 === Object.keys(input).length ||

--- a/test/generated/output/createEquals/test_createEquals_TemplateUnion.ts
+++ b/test/generated/output/createEquals/test_createEquals_TemplateUnion.ts
@@ -9,14 +9,20 @@ export const test_createEquals_TemplateUnion = _test_equals(
         const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
             "string" === typeof input.prefix &&
             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                    input.prefix,
+                )) &&
             "string" === typeof input.postfix &&
             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/).test(
+                    input.postfix,
+                )) &&
             ("the_false_value" === input.middle ||
                 "the_true_value" === input.middle ||
                 ("string" === typeof input.middle &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle))) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle))) &&
             null !== input.mixed &&
             undefined !== input.mixed &&
             ("the_A_value" === input.mixed ||
@@ -25,7 +31,9 @@ export const test_createEquals_TemplateUnion = _test_equals(
                     Number.isFinite(input.mixed)) ||
                 "boolean" === typeof input.mixed ||
                 ("string" === typeof input.mixed &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.mixed)) ||
                 ("object" === typeof input.mixed &&
                     null !== input.mixed &&
                     $io1(input.mixed, true && _exceptionable))) &&

--- a/test/generated/output/createIs/test_createIs_DynamicComposite.ts
+++ b/test/generated/output/createIs/test_createIs_DynamicComposite.ts
@@ -13,19 +13,27 @@ export const test_createIs_DynamicComposite = _test_is(
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key))
                     return "number" === typeof value && Number.isFinite(value);
                 if (RegExp(/^(prefix_(.*))/).test(key))
                     return "string" === typeof value;
                 if (RegExp(/((.*)_postfix)$/).test(key))
                     return "string" === typeof value;
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return (
                         "string" === typeof value ||
                         ("number" === typeof value && Number.isFinite(value)) ||
                         "boolean" === typeof value
                     );
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "boolean" === typeof value;
                 return true;
             });

--- a/test/generated/output/createIs/test_createIs_DynamicTemplate.ts
+++ b/test/generated/output/createIs/test_createIs_DynamicTemplate.ts
@@ -15,9 +15,17 @@ export const test_createIs_DynamicTemplate = _test_is(
                     return "string" === typeof value;
                 if (RegExp(/((.*)_postfix)$/).test(key))
                     return "string" === typeof value;
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "number" === typeof value && Number.isFinite(value);
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                )
                     return "boolean" === typeof value;
                 return true;
             });

--- a/test/generated/output/createIs/test_createIs_DynamicUnion.ts
+++ b/test/generated/output/createIs/test_createIs_DynamicUnion.ts
@@ -11,7 +11,7 @@ export const test_createIs_DynamicUnion = _test_is(
             Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key))
                     return "string" === typeof value;
                 if (RegExp(/^(prefix_(.*))/).test(key))
                     return "string" === typeof value;
@@ -19,7 +19,7 @@ export const test_createIs_DynamicUnion = _test_is(
                     return "string" === typeof value;
                 if (
                     RegExp(
-                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                     ).test(key)
                 )
                     return "number" === typeof value && Number.isFinite(value);

--- a/test/generated/output/createIs/test_createIs_TemplateAtomic.ts
+++ b/test/generated/output/createIs/test_createIs_TemplateAtomic.ts
@@ -16,13 +16,15 @@ export const test_createIs_TemplateAtomic = _test_is(
             "string" === typeof input.middle_string_empty &&
             RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
             "string" === typeof input.middle_numeric &&
-            RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+            RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                input.middle_numeric,
+            ) &&
             ("the_false_value" === input.middle_boolean ||
                 "the_true_value" === input.middle_boolean) &&
             "string" === typeof input.ipv4 &&
-            RegExp(/^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/).test(
-                input.ipv4,
-            ) &&
+            RegExp(
+                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+            ).test(input.ipv4) &&
             "string" === typeof input.email &&
             RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
         return "object" === typeof input && null !== input && $io0(input);

--- a/test/generated/output/createIs/test_createIs_TemplateUnion.ts
+++ b/test/generated/output/createIs/test_createIs_TemplateUnion.ts
@@ -9,14 +9,20 @@ export const test_createIs_TemplateUnion = _test_is(
         const $io0 = (input: any): boolean =>
             "string" === typeof input.prefix &&
             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                    input.prefix,
+                )) &&
             "string" === typeof input.postfix &&
             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/).test(
+                    input.postfix,
+                )) &&
             ("the_false_value" === input.middle ||
                 "the_true_value" === input.middle ||
                 ("string" === typeof input.middle &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle))) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle))) &&
             null !== input.mixed &&
             undefined !== input.mixed &&
             ("the_A_value" === input.mixed ||
@@ -25,7 +31,9 @@ export const test_createIs_TemplateUnion = _test_is(
                     Number.isFinite(input.mixed)) ||
                 "boolean" === typeof input.mixed ||
                 ("string" === typeof input.mixed &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.mixed)) ||
                 ("object" === typeof input.mixed &&
                     null !== input.mixed &&
                     $io1(input.mixed)));

--- a/test/generated/output/createIsClone/test_createIsClone_DynamicComposite.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_createIsClone_DynamicComposite = _test_isClone(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_createIsClone_DynamicComposite = _test_isClone(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -45,7 +57,11 @@ export const test_createIsClone_DynamicComposite = _test_isClone(
                     name: input.name as any,
                 } as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -57,11 +73,19 @@ export const test_createIsClone_DynamicComposite = _test_isClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createIsClone/test_createIsClone_DynamicTemplate.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_createIsClone_DynamicTemplate = _test_isClone(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -46,11 +54,19 @@ export const test_createIsClone_DynamicTemplate = _test_isClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createIsClone/test_createIsClone_DynamicUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_createIsClone_DynamicUnion = _test_isClone(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_createIsClone_DynamicUnion = _test_isClone(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -40,7 +44,11 @@ export const test_createIsClone_DynamicUnion = _test_isClone(
             const $co0 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -54,7 +62,7 @@ export const test_createIsClone_DynamicUnion = _test_isClone(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                         output[key] = value as any;

--- a/test/generated/output/createIsClone/test_createIsClone_TemplateAtomic.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_createIsClone_TemplateAtomic = _test_isClone(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/createIsClone/test_createIsClone_TemplateUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_createIsClone_TemplateUnion = _test_isClone(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_createIsClone_TemplateUnion = _test_isClone(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));

--- a/test/generated/output/createIsParse/test_createIsParse_DynamicComposite.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_createIsParse_DynamicComposite = _test_isParse(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_createIsParse_DynamicComposite = _test_isParse(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });

--- a/test/generated/output/createIsParse/test_createIsParse_DynamicTemplate.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_createIsParse_DynamicTemplate = _test_isParse(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });

--- a/test/generated/output/createIsParse/test_createIsParse_DynamicUnion.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_createIsParse_DynamicUnion = _test_isParse(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_createIsParse_DynamicUnion = _test_isParse(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (

--- a/test/generated/output/createIsParse/test_createIsParse_TemplateAtomic.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_createIsParse_TemplateAtomic = _test_isParse(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/createIsParse/test_createIsParse_TemplateUnion.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_createIsParse_TemplateUnion = _test_isParse(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_createIsParse_TemplateUnion = _test_isParse(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));

--- a/test/generated/output/createIsPrune/test_createIsPrune_DynamicComposite.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_createIsPrune_DynamicComposite = _test_isPrune(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_createIsPrune_DynamicComposite = _test_isPrune(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -42,26 +54,44 @@ export const test_createIsPrune_DynamicComposite = _test_isPrune(
                     if (undefined === value) return;
                     if ("id" === key) return;
                     if ("name" === key) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
                         "name" === key ||
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createIsPrune/test_createIsPrune_DynamicTemplate.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_createIsPrune_DynamicTemplate = _test_isPrune(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -40,17 +48,29 @@ export const test_createIsPrune_DynamicTemplate = _test_isPrune(
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createIsPrune/test_createIsPrune_DynamicUnion.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_createIsPrune_DynamicUnion = _test_isPrune(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_createIsPrune_DynamicUnion = _test_isPrune(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -40,7 +44,11 @@ export const test_createIsPrune_DynamicUnion = _test_isPrune(
             const $po0 = (input: any): any => {
                 Object.entries(input).forEach(([key, value]: any) => {
                     if (undefined === value) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
@@ -48,18 +56,20 @@ export const test_createIsPrune_DynamicUnion = _test_isPrune(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         continue;

--- a/test/generated/output/createIsPrune/test_createIsPrune_TemplateAtomic.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_createIsPrune_TemplateAtomic = _test_isPrune(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/createIsPrune/test_createIsPrune_TemplateUnion.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_createIsPrune_TemplateUnion = _test_isPrune(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_createIsPrune_TemplateUnion = _test_isPrune(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));

--- a/test/generated/output/createIsStringify/test_createIsStringify_DynamicComposite.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_createIsStringify_DynamicComposite = _test_isStringify(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_createIsStringify_DynamicComposite = _test_isStringify(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -54,7 +66,11 @@ export const test_createIsStringify_DynamicComposite = _test_isStringify(
                                 )
                             )
                                 return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
@@ -66,7 +82,11 @@ export const test_createIsStringify_DynamicComposite = _test_isStringify(
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${(() => {
                                     if ("string" === typeof value)
                                         return $string(value);
@@ -80,11 +100,12 @@ export const test_createIsStringify_DynamicComposite = _test_isStringify(
                                     });
                                 })()}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}`,

--- a/test/generated/output/createIsStringify/test_createIsStringify_DynamicTemplate.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_createIsStringify_DynamicTemplate = _test_isStringify(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -43,12 +51,19 @@ export const test_createIsStringify_DynamicTemplate = _test_isStringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$number(value)}`;
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return `${JSON.stringify(key)}:${value}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/createIsStringify/test_createIsStringify_DynamicUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_createIsStringify_DynamicUnion = _test_isStringify(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_createIsStringify_DynamicUnion = _test_isStringify(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -43,7 +47,11 @@ export const test_createIsStringify_DynamicUnion = _test_isStringify(
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
@@ -51,10 +59,11 @@ export const test_createIsStringify_DynamicUnion = _test_isStringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return `${JSON.stringify(key)}:${$number(value)}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/createIsStringify/test_createIsStringify_TemplateAtomic.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_createIsStringify_TemplateAtomic = _test_isStringify(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/createIsStringify/test_createIsStringify_TemplateUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_createIsStringify_TemplateUnion = _test_isStringify(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_createIsStringify_TemplateUnion = _test_isStringify(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));

--- a/test/generated/output/createPrune/test_createPrune_DynamicComposite.ts
+++ b/test/generated/output/createPrune/test_createPrune_DynamicComposite.ts
@@ -12,26 +12,38 @@ export const test_createPrune_DynamicComposite = _test_prune(
                 if (undefined === value) return;
                 if ("id" === key) return;
                 if ("name" === key) return;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key)) {
                 }
                 if (RegExp(/^(prefix_(.*))/).test(key)) {
                 }
                 if (RegExp(/((.*)_postfix)$/).test(key)) {
                 }
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                 }
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                 }
             });
             for (const key of Object.keys(input)) {
                 if (
                     "id" === key ||
                     "name" === key ||
-                    RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                    RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key) ||
                     RegExp(/^(prefix_(.*))/).test(key) ||
                     RegExp(/((.*)_postfix)$/).test(key) ||
-                    RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                    RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key) ||
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
                 )
                     continue;
                 delete input[key];

--- a/test/generated/output/createPrune/test_createPrune_DynamicTemplate.ts
+++ b/test/generated/output/createPrune/test_createPrune_DynamicTemplate.ts
@@ -14,17 +14,29 @@ export const test_createPrune_DynamicTemplate = _test_prune(
                 }
                 if (RegExp(/((.*)_postfix)$/).test(key)) {
                 }
-                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                 }
-                if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                if (
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
+                ) {
                 }
             });
             for (const key of Object.keys(input)) {
                 if (
                     RegExp(/^(prefix_(.*))/).test(key) ||
                     RegExp(/((.*)_postfix)$/).test(key) ||
-                    RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                    RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                    RegExp(
+                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key) ||
+                    RegExp(
+                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                    ).test(key)
                 )
                     continue;
                 delete input[key];

--- a/test/generated/output/createPrune/test_createPrune_DynamicUnion.ts
+++ b/test/generated/output/createPrune/test_createPrune_DynamicUnion.ts
@@ -10,7 +10,7 @@ export const test_createPrune_DynamicUnion = _test_prune(
         const $po0 = (input: any): any => {
             Object.entries(input).forEach(([key, value]: any) => {
                 if (undefined === value) return;
-                if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                if (RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key)) {
                 }
                 if (RegExp(/^(prefix_(.*))/).test(key)) {
                 }
@@ -18,18 +18,18 @@ export const test_createPrune_DynamicUnion = _test_prune(
                 }
                 if (
                     RegExp(
-                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                     ).test(key)
                 ) {
                 }
             });
             for (const key of Object.keys(input)) {
                 if (
-                    RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                    RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(key) ||
                     RegExp(/^(prefix_(.*))/).test(key) ||
                     RegExp(/((.*)_postfix)$/).test(key) ||
                     RegExp(
-                        /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                        /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                     ).test(key)
                 )
                     continue;

--- a/test/generated/output/createRandom/test_createRandom_DynamicComposite.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicComposite.ts
@@ -116,7 +116,11 @@ export const test_createRandom_DynamicComposite = _test_random(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -124,14 +128,22 @@ export const test_createRandom_DynamicComposite = _test_random(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -166,7 +178,11 @@ export const test_createRandom_DynamicComposite = _test_random(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -194,7 +210,11 @@ export const test_createRandom_DynamicComposite = _test_random(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -207,9 +227,9 @@ export const test_createRandom_DynamicComposite = _test_random(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/createRandom/test_createRandom_DynamicTemplate.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicTemplate.ts
@@ -89,11 +89,19 @@ export const test_createRandom_DynamicTemplate = _test_random(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -139,7 +147,11 @@ export const test_createRandom_DynamicTemplate = _test_random(
                                     value: value,
                                 })
                             );
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 ("number" === typeof value &&
                                     Number.isFinite(value)) ||
@@ -150,7 +162,9 @@ export const test_createRandom_DynamicTemplate = _test_random(
                                 })
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return (
                                 "boolean" === typeof value ||

--- a/test/generated/output/createRandom/test_createRandom_DynamicUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_DynamicUnion.ts
@@ -83,7 +83,11 @@ export const test_createRandom_DynamicUnion = _test_random(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -91,7 +95,7 @@ export const test_createRandom_DynamicUnion = _test_random(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -123,7 +127,11 @@ export const test_createRandom_DynamicUnion = _test_random(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 $guard(_exceptionable, {
@@ -152,7 +160,7 @@ export const test_createRandom_DynamicUnion = _test_random(
                             );
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (

--- a/test/generated/output/createRandom/test_createRandom_TemplateAtomic.ts
+++ b/test/generated/output/createRandom/test_createRandom_TemplateAtomic.ts
@@ -75,12 +75,14 @@ export const test_createRandom_TemplateAtomic = _test_random(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -129,9 +131,9 @@ export const test_createRandom_TemplateAtomic = _test_random(
                             value: input.middle_string_empty,
                         })) &&
                     (("string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        )) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle_numeric",
                             expected: "`the_${number}_value`",
@@ -146,7 +148,7 @@ export const test_createRandom_TemplateAtomic = _test_random(
                         })) &&
                     (("string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4)) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",

--- a/test/generated/output/createRandom/test_createRandom_TemplateUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_TemplateUnion.ts
@@ -82,16 +82,20 @@ export const test_createRandom_TemplateUnion = _test_random(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -100,7 +104,9 @@ export const test_createRandom_TemplateUnion = _test_random(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));
@@ -128,9 +134,9 @@ export const test_createRandom_TemplateUnion = _test_random(
                 ): boolean =>
                     (("string" === typeof input.prefix &&
                         (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                            RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                input.prefix,
-                            ))) ||
+                            RegExp(
+                                /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(input.prefix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".prefix",
                             expected:
@@ -139,9 +145,9 @@ export const test_createRandom_TemplateUnion = _test_random(
                         })) &&
                     (("string" === typeof input.postfix &&
                         (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                            RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                input.postfix,
-                            ))) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                            ).test(input.postfix))) ||
                         $guard(_exceptionable, {
                             path: _path + ".postfix",
                             expected:
@@ -151,9 +157,9 @@ export const test_createRandom_TemplateUnion = _test_random(
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle",
                             expected:
@@ -180,9 +186,9 @@ export const test_createRandom_TemplateUnion = _test_random(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ((("object" === typeof input.mixed &&
                             null !== input.mixed) ||
                             $guard(_exceptionable, {

--- a/test/generated/output/createStringify/test_createStringify_DynamicComposite.ts
+++ b/test/generated/output/createStringify/test_createStringify_DynamicComposite.ts
@@ -24,13 +24,21 @@ export const test_createStringify_DynamicComposite = _test_stringify(
                             )
                         )
                             return "";
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$number(value)}`;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${(() => {
                                 if ("string" === typeof value)
                                     return $string(value);
@@ -43,9 +51,12 @@ export const test_createStringify_DynamicComposite = _test_stringify(
                                 });
                             })()}`;
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return `${JSON.stringify(key)}:${value}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}`,

--- a/test/generated/output/createStringify/test_createStringify_DynamicTemplate.ts
+++ b/test/generated/output/createStringify/test_createStringify_DynamicTemplate.ts
@@ -17,10 +17,19 @@ export const test_createStringify_DynamicTemplate = _test_stringify(
                         return `${JSON.stringify(key)}:${$string(value)}`;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return `${JSON.stringify(key)}:${$string(value)}`;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return `${JSON.stringify(key)}:${$number(value)}`;
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return `${JSON.stringify(key)}:${value}`;
+                    return "";
                 })
                 .filter((str: any) => "" !== str)
                 .join(",")}}`;

--- a/test/generated/output/createStringify/test_createStringify_DynamicUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createStringify_DynamicUnion = _test_stringify(
             `{${Object.entries(input)
                 .map(([key, value]: [string, any]) => {
                     if (undefined === value) return "";
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return `${JSON.stringify(key)}:${$string(value)}`;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return `${JSON.stringify(key)}:${$string(value)}`;
@@ -21,10 +25,11 @@ export const test_createStringify_DynamicUnion = _test_stringify(
                         return `${JSON.stringify(key)}:${$string(value)}`;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return `${JSON.stringify(key)}:${$number(value)}`;
+                    return "";
                 })
                 .filter((str: any) => "" !== str)
                 .join(",")}}`;

--- a/test/generated/output/createValidate/test_createValidate_DynamicComposite.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_createValidate_DynamicComposite = _test_validate(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -23,14 +27,22 @@ export const test_createValidate_DynamicComposite = _test_validate(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -67,7 +79,11 @@ export const test_createValidate_DynamicComposite = _test_validate(
                                 .map((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -96,9 +112,9 @@ export const test_createValidate_DynamicComposite = _test_validate(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -114,7 +130,7 @@ export const test_createValidate_DynamicComposite = _test_validate(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidate/test_createValidate_DynamicTemplate.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicTemplate.ts
@@ -17,11 +17,19 @@ export const test_createValidate_DynamicTemplate = _test_validate(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -70,9 +78,9 @@ export const test_createValidate_DynamicTemplate = _test_validate(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             ("number" === typeof value &&
@@ -85,7 +93,7 @@ export const test_createValidate_DynamicTemplate = _test_validate(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidate/test_createValidate_DynamicUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_createValidate_DynamicUnion = _test_validate(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_createValidate_DynamicUnion = _test_validate(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -55,7 +59,11 @@ export const test_createValidate_DynamicUnion = _test_validate(
                                 .map((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             "string" === typeof value ||
                                             $report(_exceptionable, {
@@ -84,7 +92,7 @@ export const test_createValidate_DynamicUnion = _test_validate(
                                         );
                                     if (
                                         RegExp(
-                                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidate/test_createValidate_TemplateAtomic.ts
+++ b/test/generated/output/createValidate/test_createValidate_TemplateAtomic.ts
@@ -18,12 +18,14 @@ export const test_createValidate_TemplateAtomic = _test_validate(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -75,9 +77,9 @@ export const test_createValidate_TemplateAtomic = _test_validate(
                                 value: input.middle_string_empty,
                             }),
                         ("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $report(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -93,7 +95,7 @@ export const test_createValidate_TemplateAtomic = _test_validate(
                             }),
                         ("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createValidate/test_createValidate_TemplateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_createValidate_TemplateUnion = _test_validate(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -29,7 +33,9 @@ export const test_createValidate_TemplateUnion = _test_validate(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));
@@ -58,9 +64,9 @@ export const test_createValidate_TemplateUnion = _test_validate(
                     [
                         ("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $report(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -69,9 +75,9 @@ export const test_createValidate_TemplateUnion = _test_validate(
                             }),
                         ("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -81,9 +87,9 @@ export const test_createValidate_TemplateUnion = _test_validate(
                         "the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $report(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -110,9 +116,9 @@ export const test_createValidate_TemplateUnion = _test_validate(
                                     Number.isFinite(input.mixed)) ||
                                 "boolean" === typeof input.mixed ||
                                 ("string" === typeof input.mixed &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.mixed,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.mixed)) ||
                                 ((("object" === typeof input.mixed &&
                                     null !== input.mixed) ||
                                     $report(_exceptionable, {

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicComposite.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -33,7 +41,9 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -75,7 +85,11 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 ("number" === typeof value &&
                                                     Number.isFinite(value)) ||
@@ -105,7 +119,7 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -122,7 +136,7 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -170,7 +184,11 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                     name: input.name as any,
                 } as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -182,11 +200,19 @@ export const test_createValidateClone_DynamicComposite = _test_validateClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicTemplate.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicTemplate.ts
@@ -18,13 +18,19 @@ export const test_createValidateClone_DynamicTemplate = _test_validateClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -77,7 +83,7 @@ export const test_createValidateClone_DynamicTemplate = _test_validateClone(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -91,7 +97,7 @@ export const test_createValidateClone_DynamicTemplate = _test_validateClone(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -146,11 +152,19 @@ export const test_createValidateClone_DynamicTemplate = _test_validateClone(
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                         output[key] = value as any;
                         continue;
                     }

--- a/test/generated/output/createValidateClone/test_createValidateClone_DynamicUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -59,7 +63,11 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 "string" === typeof value ||
                                                 $report(_exceptionable, {
@@ -88,7 +96,7 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -134,7 +142,11 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
             const $co0 = (input: any): any => {
                 const output = {} as any;
                 for (const [key, value] of Object.entries(input)) {
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                         output[key] = value as any;
                         continue;
                     }
@@ -148,7 +160,7 @@ export const test_createValidateClone_DynamicUnion = _test_validateClone(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                         output[key] = value as any;

--- a/test/generated/output/createValidateClone/test_createValidateClone_TemplateAtomic.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_createValidateClone_TemplateAtomic = _test_validateClone(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -84,9 +84,9 @@ export const test_createValidateClone_TemplateAtomic = _test_validateClone(
                                     value: input.middle_string_empty,
                                 }),
                             ("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -102,7 +102,7 @@ export const test_createValidateClone_TemplateAtomic = _test_validateClone(
                                 }),
                             ("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TemplateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TemplateUnion.ts
@@ -12,16 +12,20 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -30,9 +34,9 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -65,9 +69,9 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                         [
                             ("string" === typeof input.prefix &&
                                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                    RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                        input.prefix,
-                                    ))) ||
+                                    RegExp(
+                                        /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(input.prefix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected:
@@ -76,9 +80,9 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                                 }),
                             ("string" === typeof input.postfix &&
                                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                    RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                        input.postfix,
-                                    ))) ||
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                    ).test(input.postfix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected:
@@ -88,9 +92,9 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                             "the_false_value" === input.middle ||
                                 "the_true_value" === input.middle ||
                                 ("string" === typeof input.middle &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle",
                                     expected:
@@ -117,9 +121,9 @@ export const test_createValidateClone_TemplateUnion = _test_validateClone(
                                         Number.isFinite(input.mixed)) ||
                                     "boolean" === typeof input.mixed ||
                                     ("string" === typeof input.mixed &&
-                                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                            input.mixed,
-                                        )) ||
+                                        RegExp(
+                                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                        ).test(input.mixed)) ||
                                     ((("object" === typeof input.mixed &&
                                         null !== input.mixed) ||
                                         $report(_exceptionable, {

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicComposite.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicComposite.ts
@@ -23,7 +23,11 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
                         return true;
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -31,14 +35,22 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });
@@ -83,7 +95,11 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
                                         return true;
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             ("number" === typeof value &&
                                                 Number.isFinite(value)) ||
@@ -112,9 +128,9 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             "string" === typeof value ||
@@ -130,7 +146,7 @@ export const test_createValidateEquals_DynamicComposite = _test_validateEquals(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicTemplate.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicTemplate.ts
@@ -23,11 +23,19 @@ export const test_createValidateEquals_DynamicTemplate = _test_validateEquals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });
@@ -76,9 +84,9 @@ export const test_createValidateEquals_DynamicTemplate = _test_validateEquals(
                                             })
                                         );
                                     if (
-                                        RegExp(/^(value_-?\d+\.?\d*)$/).test(
-                                            key,
-                                        )
+                                        RegExp(
+                                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                        ).test(key)
                                     )
                                         return (
                                             ("number" === typeof value &&
@@ -91,7 +99,7 @@ export const test_createValidateEquals_DynamicTemplate = _test_validateEquals(
                                         );
                                     if (
                                         RegExp(
-                                            /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicUnion.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_DynamicUnion.ts
@@ -19,7 +19,11 @@ export const test_createValidateEquals_DynamicUnion = _test_validateEquals(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -27,7 +31,7 @@ export const test_createValidateEquals_DynamicUnion = _test_validateEquals(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -61,7 +65,11 @@ export const test_createValidateEquals_DynamicUnion = _test_validateEquals(
                                 .map((key: any) => {
                                     const value = input[key];
                                     if (undefined === value) return true;
-                                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                    if (
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(key)
+                                    )
                                         return (
                                             "string" === typeof value ||
                                             $report(_exceptionable, {
@@ -90,7 +98,7 @@ export const test_createValidateEquals_DynamicUnion = _test_validateEquals(
                                         );
                                     if (
                                         RegExp(
-                                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                         ).test(key)
                                     )
                                         return (

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TemplateAtomic.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TemplateAtomic.ts
@@ -24,12 +24,14 @@ export const test_createValidateEquals_TemplateAtomic = _test_validateEquals(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&
@@ -103,9 +105,9 @@ export const test_createValidateEquals_TemplateAtomic = _test_validateEquals(
                                 value: input.middle_string_empty,
                             }),
                         ("string" === typeof input.middle_numeric &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle_numeric,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle_numeric)) ||
                             $report(_exceptionable, {
                                 path: _path + ".middle_numeric",
                                 expected: "`the_${number}_value`",
@@ -121,7 +123,7 @@ export const test_createValidateEquals_TemplateAtomic = _test_validateEquals(
                             }),
                         ("string" === typeof input.ipv4 &&
                             RegExp(
-                                /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                             ).test(input.ipv4)) ||
                             $report(_exceptionable, {
                                 path: _path + ".ipv4",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TemplateUnion.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TemplateUnion.ts
@@ -17,16 +17,20 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
             ): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -35,7 +39,9 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed, true && _exceptionable))) &&
@@ -90,9 +96,9 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
                     [
                         ("string" === typeof input.prefix &&
                             (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                    input.prefix,
-                                ))) ||
+                                RegExp(
+                                    /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(input.prefix))) ||
                             $report(_exceptionable, {
                                 path: _path + ".prefix",
                                 expected:
@@ -101,9 +107,9 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
                             }),
                         ("string" === typeof input.postfix &&
                             (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                    input.postfix,
-                                ))) ||
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                ).test(input.postfix))) ||
                             $report(_exceptionable, {
                                 path: _path + ".postfix",
                                 expected:
@@ -113,9 +119,9 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
                         "the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle)) ||
                             $report(_exceptionable, {
                                 path: _path + ".middle",
                                 expected:
@@ -142,9 +148,9 @@ export const test_createValidateEquals_TemplateUnion = _test_validateEquals(
                                     Number.isFinite(input.mixed)) ||
                                 "boolean" === typeof input.mixed ||
                                 ("string" === typeof input.mixed &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.mixed,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.mixed)) ||
                                 ((("object" === typeof input.mixed &&
                                     null !== input.mixed) ||
                                     $report(_exceptionable, {

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicComposite.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -33,7 +41,9 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -75,7 +85,11 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 ("number" === typeof value &&
                                                     Number.isFinite(value)) ||
@@ -105,7 +119,7 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -122,7 +136,7 @@ export const test_createValidateParse_DynamicComposite = _test_validateParse(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicTemplate.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicTemplate.ts
@@ -18,13 +18,19 @@ export const test_createValidateParse_DynamicTemplate = _test_validateParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -77,7 +83,7 @@ export const test_createValidateParse_DynamicTemplate = _test_validateParse(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -91,7 +97,7 @@ export const test_createValidateParse_DynamicTemplate = _test_validateParse(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/createValidateParse/test_createValidateParse_DynamicUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_createValidateParse_DynamicUnion = _test_validateParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_createValidateParse_DynamicUnion = _test_validateParse(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -59,7 +63,11 @@ export const test_createValidateParse_DynamicUnion = _test_validateParse(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 "string" === typeof value ||
                                                 $report(_exceptionable, {
@@ -88,7 +96,7 @@ export const test_createValidateParse_DynamicUnion = _test_validateParse(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/createValidateParse/test_createValidateParse_TemplateAtomic.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_createValidateParse_TemplateAtomic = _test_validateParse(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -84,9 +84,9 @@ export const test_createValidateParse_TemplateAtomic = _test_validateParse(
                                     value: input.middle_string_empty,
                                 }),
                             ("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -102,7 +102,7 @@ export const test_createValidateParse_TemplateAtomic = _test_validateParse(
                                 }),
                             ("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TemplateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TemplateUnion.ts
@@ -12,16 +12,20 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -30,9 +34,9 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -65,9 +69,9 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                         [
                             ("string" === typeof input.prefix &&
                                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                    RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                        input.prefix,
-                                    ))) ||
+                                    RegExp(
+                                        /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(input.prefix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected:
@@ -76,9 +80,9 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                                 }),
                             ("string" === typeof input.postfix &&
                                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                    RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                        input.postfix,
-                                    ))) ||
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                    ).test(input.postfix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected:
@@ -88,9 +92,9 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                             "the_false_value" === input.middle ||
                                 "the_true_value" === input.middle ||
                                 ("string" === typeof input.middle &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle",
                                     expected:
@@ -117,9 +121,9 @@ export const test_createValidateParse_TemplateUnion = _test_validateParse(
                                         Number.isFinite(input.mixed)) ||
                                     "boolean" === typeof input.mixed ||
                                     ("string" === typeof input.mixed &&
-                                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                            input.mixed,
-                                        )) ||
+                                        RegExp(
+                                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                        ).test(input.mixed)) ||
                                     ((("object" === typeof input.mixed &&
                                         null !== input.mixed) ||
                                         $report(_exceptionable, {

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicComposite.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -33,7 +41,9 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -75,7 +85,11 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 ("number" === typeof value &&
                                                     Number.isFinite(value)) ||
@@ -105,7 +119,7 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -122,7 +136,7 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -167,26 +181,44 @@ export const test_createValidatePrune_DynamicComposite = _test_validatePrune(
                     if (undefined === value) return;
                     if ("id" === key) return;
                     if ("name" === key) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
                         "name" === key ||
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicTemplate.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicTemplate.ts
@@ -18,13 +18,19 @@ export const test_createValidatePrune_DynamicTemplate = _test_validatePrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -77,7 +83,7 @@ export const test_createValidatePrune_DynamicTemplate = _test_validatePrune(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -91,7 +97,7 @@ export const test_createValidatePrune_DynamicTemplate = _test_validatePrune(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -140,17 +146,29 @@ export const test_createValidatePrune_DynamicTemplate = _test_validatePrune(
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicUnion.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -59,7 +63,11 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 "string" === typeof value ||
                                                 $report(_exceptionable, {
@@ -88,7 +96,7 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -134,7 +142,11 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
             const $po0 = (input: any): any => {
                 Object.entries(input).forEach(([key, value]: any) => {
                     if (undefined === value) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
@@ -142,18 +154,20 @@ export const test_createValidatePrune_DynamicUnion = _test_validatePrune(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         continue;

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TemplateAtomic.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_createValidatePrune_TemplateAtomic = _test_validatePrune(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -84,9 +84,9 @@ export const test_createValidatePrune_TemplateAtomic = _test_validatePrune(
                                     value: input.middle_string_empty,
                                 }),
                             ("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -102,7 +102,7 @@ export const test_createValidatePrune_TemplateAtomic = _test_validatePrune(
                                 }),
                             ("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TemplateUnion.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TemplateUnion.ts
@@ -12,16 +12,20 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -30,9 +34,9 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));
@@ -65,9 +69,9 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                         [
                             ("string" === typeof input.prefix &&
                                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                                    RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                        input.prefix,
-                                    ))) ||
+                                    RegExp(
+                                        /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(input.prefix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".prefix",
                                     expected:
@@ -76,9 +80,9 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                                 }),
                             ("string" === typeof input.postfix &&
                                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                                    RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                        input.postfix,
-                                    ))) ||
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                    ).test(input.postfix))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".postfix",
                                     expected:
@@ -88,9 +92,9 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                             "the_false_value" === input.middle ||
                                 "the_true_value" === input.middle ||
                                 ("string" === typeof input.middle &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle",
                                     expected:
@@ -117,9 +121,9 @@ export const test_createValidatePrune_TemplateUnion = _test_validatePrune(
                                         Number.isFinite(input.mixed)) ||
                                     "boolean" === typeof input.mixed ||
                                     ("string" === typeof input.mixed &&
-                                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                            input.mixed,
-                                        )) ||
+                                        RegExp(
+                                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                        ).test(input.mixed)) ||
                                     ((("object" === typeof input.mixed &&
                                         null !== input.mixed) ||
                                         $report(_exceptionable, {

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicComposite.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicComposite.ts
@@ -19,7 +19,11 @@ export const test_createValidateStringify_DynamicComposite =
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -28,7 +32,11 @@ export const test_createValidateStringify_DynamicComposite =
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -36,9 +44,9 @@ export const test_createValidateStringify_DynamicComposite =
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -85,9 +93,9 @@ export const test_createValidateStringify_DynamicComposite =
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     ("number" ===
@@ -132,7 +140,7 @@ export const test_createValidateStringify_DynamicComposite =
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -154,7 +162,7 @@ export const test_createValidateStringify_DynamicComposite =
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -213,7 +221,11 @@ export const test_createValidateStringify_DynamicComposite =
                                     )
                                 )
                                     return "";
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${$number(
                                         value,
                                     )}`;
@@ -225,7 +237,11 @@ export const test_createValidateStringify_DynamicComposite =
                                     return `${JSON.stringify(key)}:${$string(
                                         value,
                                     )}`;
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${(() => {
                                         if ("string" === typeof value)
                                             return $string(value);
@@ -241,10 +257,11 @@ export const test_createValidateStringify_DynamicComposite =
                                     })()}`;
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return `${JSON.stringify(key)}:${value}`;
+                                return "";
                             })
                             .filter((str: any) => "" !== str)
                             .join(",")}`,

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTemplate.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicTemplate.ts
@@ -21,15 +21,19 @@ export const test_createValidateStringify_DynamicTemplate =
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -94,7 +98,7 @@ export const test_createValidateStringify_DynamicTemplate =
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -112,7 +116,7 @@ export const test_createValidateStringify_DynamicTemplate =
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -170,16 +174,21 @@ export const test_createValidateStringify_DynamicTemplate =
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_DynamicUnion.ts
@@ -15,7 +15,11 @@ export const test_createValidateStringify_DynamicUnion =
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -23,7 +27,7 @@ export const test_createValidateStringify_DynamicUnion =
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -63,9 +67,9 @@ export const test_createValidateStringify_DynamicUnion =
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     "string" === typeof value ||
@@ -106,7 +110,7 @@ export const test_createValidateStringify_DynamicUnion =
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -159,7 +163,11 @@ export const test_createValidateStringify_DynamicUnion =
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
@@ -173,12 +181,13 @@ export const test_createValidateStringify_DynamicUnion =
                                 )}`;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TemplateAtomic.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TemplateAtomic.ts
@@ -24,14 +24,14 @@ export const test_createValidateStringify_TemplateAtomic =
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -94,9 +94,9 @@ export const test_createValidateStringify_TemplateAtomic =
                                         value: input.middle_string_empty,
                                     }),
                                 ("string" === typeof input.middle_numeric &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle_numeric,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle_numeric)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle_numeric",
                                         expected: "`the_${number}_value`",
@@ -112,7 +112,7 @@ export const test_createValidateStringify_TemplateAtomic =
                                     }),
                                 ("string" === typeof input.ipv4 &&
                                     RegExp(
-                                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                     ).test(input.ipv4)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".ipv4",

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TemplateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TemplateUnion.ts
@@ -13,20 +13,20 @@ export const test_createValidateStringify_TemplateUnion =
                     const $io0 = (input: any): boolean =>
                         "string" === typeof input.prefix &&
                         (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                            RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                input.prefix,
-                            )) &&
+                            RegExp(
+                                /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(input.prefix)) &&
                         "string" === typeof input.postfix &&
                         (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                            RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                input.postfix,
-                            )) &&
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                            ).test(input.postfix)) &&
                         ("the_false_value" === input.middle ||
                             "the_true_value" === input.middle ||
                             ("string" === typeof input.middle &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle,
-                                ))) &&
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle))) &&
                         null !== input.mixed &&
                         undefined !== input.mixed &&
                         ("the_A_value" === input.mixed ||
@@ -35,9 +35,9 @@ export const test_createValidateStringify_TemplateUnion =
                                 Number.isFinite(input.mixed)) ||
                             "boolean" === typeof input.mixed ||
                             ("string" === typeof input.mixed &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.mixed,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.mixed)) ||
                             ("object" === typeof input.mixed &&
                                 null !== input.mixed &&
                                 $io1(input.mixed)));
@@ -72,9 +72,9 @@ export const test_createValidateStringify_TemplateUnion =
                                     (RegExp(/^prefix_(.*)/).test(
                                         input.prefix,
                                     ) ||
-                                        RegExp(/^prefix_-?\d+\.?\d*$/).test(
-                                            input.prefix,
-                                        ))) ||
+                                        RegExp(
+                                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                        ).test(input.prefix))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".prefix",
                                         expected:
@@ -85,9 +85,9 @@ export const test_createValidateStringify_TemplateUnion =
                                     (RegExp(/(.*)_postfix$/).test(
                                         input.postfix,
                                     ) ||
-                                        RegExp(/^-?\d+\.?\d*_postfix$/).test(
-                                            input.postfix,
-                                        ))) ||
+                                        RegExp(
+                                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                                        ).test(input.postfix))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".postfix",
                                         expected:
@@ -97,9 +97,9 @@ export const test_createValidateStringify_TemplateUnion =
                                 "the_false_value" === input.middle ||
                                     "the_true_value" === input.middle ||
                                     ("string" === typeof input.middle &&
-                                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                            input.middle,
-                                        )) ||
+                                        RegExp(
+                                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                        ).test(input.middle)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle",
                                         expected:
@@ -127,7 +127,7 @@ export const test_createValidateStringify_TemplateUnion =
                                         "boolean" === typeof input.mixed ||
                                         ("string" === typeof input.mixed &&
                                             RegExp(
-                                                /^the_-?\d+\.?\d*_value$/,
+                                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
                                             ).test(input.mixed)) ||
                                         ((("object" === typeof input.mixed &&
                                             null !== input.mixed) ||

--- a/test/generated/output/equals/test_equals_DynamicComposite.ts
+++ b/test/generated/output/equals/test_equals_DynamicComposite.ts
@@ -22,7 +22,11 @@ export const test_equals_DynamicComposite = _test_equals(
                         return true;
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -30,14 +34,22 @@ export const test_equals_DynamicComposite = _test_equals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });

--- a/test/generated/output/equals/test_equals_DynamicTemplate.ts
+++ b/test/generated/output/equals/test_equals_DynamicTemplate.ts
@@ -22,11 +22,19 @@ export const test_equals_DynamicTemplate = _test_equals(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return false;
                 });

--- a/test/generated/output/equals/test_equals_DynamicUnion.ts
+++ b/test/generated/output/equals/test_equals_DynamicUnion.ts
@@ -18,7 +18,11 @@ export const test_equals_DynamicUnion = _test_equals(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -26,7 +30,7 @@ export const test_equals_DynamicUnion = _test_equals(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (

--- a/test/generated/output/equals/test_equals_TemplateAtomic.ts
+++ b/test/generated/output/equals/test_equals_TemplateAtomic.ts
@@ -23,12 +23,14 @@ export const test_equals_TemplateAtomic = _test_equals(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&

--- a/test/generated/output/equals/test_equals_TemplateUnion.ts
+++ b/test/generated/output/equals/test_equals_TemplateUnion.ts
@@ -16,16 +16,20 @@ export const test_equals_TemplateUnion = _test_equals(
             ): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -34,7 +38,9 @@ export const test_equals_TemplateUnion = _test_equals(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed, true && _exceptionable))) &&

--- a/test/generated/output/is/test_is_DynamicComposite.ts
+++ b/test/generated/output/is/test_is_DynamicComposite.ts
@@ -14,7 +14,11 @@ export const test_is_DynamicComposite = _test_is(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -22,14 +26,22 @@ export const test_is_DynamicComposite = _test_is(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });

--- a/test/generated/output/is/test_is_DynamicTemplate.ts
+++ b/test/generated/output/is/test_is_DynamicTemplate.ts
@@ -16,11 +16,19 @@ export const test_is_DynamicTemplate = _test_is(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });

--- a/test/generated/output/is/test_is_DynamicUnion.ts
+++ b/test/generated/output/is/test_is_DynamicUnion.ts
@@ -12,7 +12,11 @@ export const test_is_DynamicUnion = _test_is(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -20,7 +24,7 @@ export const test_is_DynamicUnion = _test_is(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (

--- a/test/generated/output/is/test_is_TemplateAtomic.ts
+++ b/test/generated/output/is/test_is_TemplateAtomic.ts
@@ -17,12 +17,14 @@ export const test_is_TemplateAtomic = _test_is(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/is/test_is_TemplateUnion.ts
+++ b/test/generated/output/is/test_is_TemplateUnion.ts
@@ -10,16 +10,20 @@ export const test_is_TemplateUnion = _test_is(
             const $io0 = (input: any): boolean =>
                 "string" === typeof input.prefix &&
                 (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                    RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                    RegExp(/^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                        input.prefix,
+                    )) &&
                 "string" === typeof input.postfix &&
                 (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                    RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                    RegExp(
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                    ).test(input.postfix)) &&
                 ("the_false_value" === input.middle ||
                     "the_true_value" === input.middle ||
                     ("string" === typeof input.middle &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle,
-                        ))) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle))) &&
                 null !== input.mixed &&
                 undefined !== input.mixed &&
                 ("the_A_value" === input.mixed ||
@@ -28,7 +32,9 @@ export const test_is_TemplateUnion = _test_is(
                         Number.isFinite(input.mixed)) ||
                     "boolean" === typeof input.mixed ||
                     ("string" === typeof input.mixed &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(input.mixed)) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.mixed)) ||
                     ("object" === typeof input.mixed &&
                         null !== input.mixed &&
                         $io1(input.mixed)));

--- a/test/generated/output/isClone/test_isClone_DynamicComposite.ts
+++ b/test/generated/output/isClone/test_isClone_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_isClone_DynamicComposite = _test_isClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_isClone_DynamicComposite = _test_isClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_isClone_DynamicComposite = _test_isClone(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -51,7 +61,11 @@ export const test_isClone_DynamicComposite = _test_isClone(
                         name: input.name as any,
                     } as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -63,12 +77,18 @@ export const test_isClone_DynamicComposite = _test_isClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/isClone/test_isClone_DynamicTemplate.ts
+++ b/test/generated/output/isClone/test_isClone_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_isClone_DynamicTemplate = _test_isClone(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -50,12 +56,18 @@ export const test_isClone_DynamicTemplate = _test_isClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/isClone/test_isClone_DynamicUnion.ts
+++ b/test/generated/output/isClone/test_isClone_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_isClone_DynamicUnion = _test_isClone(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_isClone_DynamicUnion = _test_isClone(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -44,7 +48,11 @@ export const test_isClone_DynamicUnion = _test_isClone(
                 const $co0 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -58,7 +66,7 @@ export const test_isClone_DynamicUnion = _test_isClone(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                             output[key] = value as any;

--- a/test/generated/output/isClone/test_isClone_TemplateAtomic.ts
+++ b/test/generated/output/isClone/test_isClone_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_isClone_TemplateAtomic = _test_isClone(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/isClone/test_isClone_TemplateUnion.ts
+++ b/test/generated/output/isClone/test_isClone_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_isClone_TemplateUnion = _test_isClone(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_isClone_TemplateUnion = _test_isClone(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));

--- a/test/generated/output/isParse/test_isParse_DynamicComposite.ts
+++ b/test/generated/output/isParse/test_isParse_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_isParse_DynamicComposite = _test_isParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_isParse_DynamicComposite = _test_isParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_isParse_DynamicComposite = _test_isParse(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;

--- a/test/generated/output/isParse/test_isParse_DynamicTemplate.ts
+++ b/test/generated/output/isParse/test_isParse_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_isParse_DynamicTemplate = _test_isParse(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;

--- a/test/generated/output/isParse/test_isParse_DynamicUnion.ts
+++ b/test/generated/output/isParse/test_isParse_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_isParse_DynamicUnion = _test_isParse(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_isParse_DynamicUnion = _test_isParse(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (

--- a/test/generated/output/isParse/test_isParse_TemplateAtomic.ts
+++ b/test/generated/output/isParse/test_isParse_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_isParse_TemplateAtomic = _test_isParse(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/isParse/test_isParse_TemplateUnion.ts
+++ b/test/generated/output/isParse/test_isParse_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_isParse_TemplateUnion = _test_isParse(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_isParse_TemplateUnion = _test_isParse(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));

--- a/test/generated/output/isPrune/test_isPrune_DynamicComposite.ts
+++ b/test/generated/output/isPrune/test_isPrune_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_isPrune_DynamicComposite = _test_isPrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_isPrune_DynamicComposite = _test_isPrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_isPrune_DynamicComposite = _test_isPrune(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -48,16 +58,26 @@ export const test_isPrune_DynamicComposite = _test_isPrune(
                         if (undefined === value) return;
                         if ("id" === key) return;
                         if ("name" === key) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -65,11 +85,17 @@ export const test_isPrune_DynamicComposite = _test_isPrune(
                         if (
                             "id" === key ||
                             "name" === key ||
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/isPrune/test_isPrune_DynamicTemplate.ts
+++ b/test/generated/output/isPrune/test_isPrune_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_isPrune_DynamicTemplate = _test_isPrune(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -44,10 +50,16 @@ export const test_isPrune_DynamicTemplate = _test_isPrune(
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -55,8 +67,12 @@ export const test_isPrune_DynamicTemplate = _test_isPrune(
                         if (
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/isPrune/test_isPrune_DynamicUnion.ts
+++ b/test/generated/output/isPrune/test_isPrune_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_isPrune_DynamicUnion = _test_isPrune(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_isPrune_DynamicUnion = _test_isPrune(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -42,7 +46,11 @@ export const test_isPrune_DynamicUnion = _test_isPrune(
                 const $po0 = (input: any): any => {
                     Object.entries(input).forEach(([key, value]: any) => {
                         if (undefined === value) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
@@ -50,18 +58,20 @@ export const test_isPrune_DynamicUnion = _test_isPrune(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                         }
                     });
                     for (const key of Object.keys(input)) {
                         if (
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             continue;

--- a/test/generated/output/isPrune/test_isPrune_TemplateAtomic.ts
+++ b/test/generated/output/isPrune/test_isPrune_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_isPrune_TemplateAtomic = _test_isPrune(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/isPrune/test_isPrune_TemplateUnion.ts
+++ b/test/generated/output/isPrune/test_isPrune_TemplateUnion.ts
@@ -11,16 +11,20 @@ export const test_isPrune_TemplateUnion = _test_isPrune(
                 const $io0 = (input: any): boolean =>
                     "string" === typeof input.prefix &&
                     (RegExp(/^prefix_(.*)/).test(input.prefix) ||
-                        RegExp(/^prefix_-?\d+\.?\d*$/).test(input.prefix)) &&
+                        RegExp(
+                            /^prefix_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                        ).test(input.prefix)) &&
                     "string" === typeof input.postfix &&
                     (RegExp(/(.*)_postfix$/).test(input.postfix) ||
-                        RegExp(/^-?\d+\.?\d*_postfix$/).test(input.postfix)) &&
+                        RegExp(
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_postfix$/,
+                        ).test(input.postfix)) &&
                     ("the_false_value" === input.middle ||
                         "the_true_value" === input.middle ||
                         ("string" === typeof input.middle &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.middle,
-                            ))) &&
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.middle))) &&
                     null !== input.mixed &&
                     undefined !== input.mixed &&
                     ("the_A_value" === input.mixed ||
@@ -29,9 +33,9 @@ export const test_isPrune_TemplateUnion = _test_isPrune(
                             Number.isFinite(input.mixed)) ||
                         "boolean" === typeof input.mixed ||
                         ("string" === typeof input.mixed &&
-                            RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                input.mixed,
-                            )) ||
+                            RegExp(
+                                /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                            ).test(input.mixed)) ||
                         ("object" === typeof input.mixed &&
                             null !== input.mixed &&
                             $io1(input.mixed)));

--- a/test/generated/output/isStringify/test_isStringify_DynamicComposite.ts
+++ b/test/generated/output/isStringify/test_isStringify_DynamicComposite.ts
@@ -15,7 +15,11 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -24,7 +28,11 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -32,7 +40,9 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -60,7 +70,11 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                                     )
                                 )
                                     return "";
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${$number(
                                         value,
                                     )}`;
@@ -72,7 +86,11 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                                     return `${JSON.stringify(key)}:${$string(
                                         value,
                                     )}`;
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${(() => {
                                         if ("string" === typeof value)
                                             return $string(value);
@@ -88,10 +106,11 @@ export const test_isStringify_DynamicComposite = _test_isStringify(
                                     })()}`;
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return `${JSON.stringify(key)}:${value}`;
+                                return "";
                             })
                             .filter((str: any) => "" !== str)
                             .join(",")}`,

--- a/test/generated/output/isStringify/test_isStringify_DynamicTemplate.ts
+++ b/test/generated/output/isStringify/test_isStringify_DynamicTemplate.ts
@@ -17,13 +17,19 @@ export const test_isStringify_DynamicTemplate = _test_isStringify(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -51,16 +57,21 @@ export const test_isStringify_DynamicTemplate = _test_isStringify(
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/isStringify/test_isStringify_DynamicUnion.ts
+++ b/test/generated/output/isStringify/test_isStringify_DynamicUnion.ts
@@ -13,7 +13,11 @@ export const test_isStringify_DynamicUnion = _test_isStringify(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -21,7 +25,7 @@ export const test_isStringify_DynamicUnion = _test_isStringify(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -45,7 +49,11 @@ export const test_isStringify_DynamicUnion = _test_isStringify(
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
@@ -59,12 +67,13 @@ export const test_isStringify_DynamicUnion = _test_isStringify(
                                 )}`;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/isStringify/test_isStringify_TemplateAtomic.ts
+++ b/test/generated/output/isStringify/test_isStringify_TemplateAtomic.ts
@@ -20,14 +20,14 @@ export const test_isStringify_TemplateAtomic = _test_isStringify(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);

--- a/test/generated/output/issues/test_issue_exponential_key_stringify.ts
+++ b/test/generated/output/issues/test_issue_exponential_key_stringify.ts
@@ -1,0 +1,23 @@
+import typia from "typia";
+
+import { DynamicComposite } from "../../../structures/DynamicComposite";
+
+export const test_issue_exponential_key_stringify = () => {
+    const data: DynamicComposite = {
+        id: "id",
+        name: "name",
+        "5.175933557310941e-7": -0.170261004873707,
+        prefix_upzzoug: "udwpvy",
+        sqqfzv_postfix: "xpwmpwr",
+        "value_0.18500123790254852": true,
+        "value_-0.4744943749449395": -0.12959620300810482,
+        "value_-0.41442283348249553": "wchfdtils",
+        "between_tmzivbd_and_-0.45295511336433414": false,
+    };
+    const json: string = typia.stringify(data);
+    const expected: string = JSON.stringify(data);
+    if (json !== expected)
+        throw new Error(
+            "Bug on typia.stringify: failed to understand exponential numbered key.",
+        );
+};

--- a/test/generated/output/prune/test_prune_DynamicComposite.ts
+++ b/test/generated/output/prune/test_prune_DynamicComposite.ts
@@ -13,26 +13,44 @@ export const test_prune_DynamicComposite = _test_prune(
                     if (undefined === value) return;
                     if ("id" === key) return;
                     if ("name" === key) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         "id" === key ||
                         "name" === key ||
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/prune/test_prune_DynamicTemplate.ts
+++ b/test/generated/output/prune/test_prune_DynamicTemplate.ts
@@ -15,17 +15,29 @@ export const test_prune_DynamicTemplate = _test_prune(
                     }
                     if (RegExp(/((.*)_postfix)$/).test(key)) {
                     }
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)) {
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
-                        RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                        RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key) ||
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/prune/test_prune_DynamicUnion.ts
+++ b/test/generated/output/prune/test_prune_DynamicUnion.ts
@@ -11,7 +11,11 @@ export const test_prune_DynamicUnion = _test_prune(
             const $po0 = (input: any): any => {
                 Object.entries(input).forEach(([key, value]: any) => {
                     if (undefined === value) return;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    ) {
                     }
                     if (RegExp(/^(prefix_(.*))/).test(key)) {
                     }
@@ -19,18 +23,20 @@ export const test_prune_DynamicUnion = _test_prune(
                     }
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     ) {
                     }
                 });
                 for (const key of Object.keys(input)) {
                     if (
-                        RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        ) ||
                         RegExp(/^(prefix_(.*))/).test(key) ||
                         RegExp(/((.*)_postfix)$/).test(key) ||
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         continue;

--- a/test/generated/output/random/test_random_DynamicComposite.ts
+++ b/test/generated/output/random/test_random_DynamicComposite.ts
@@ -129,7 +129,11 @@ export const test_random_DynamicComposite = _test_random(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
@@ -137,14 +141,22 @@ export const test_random_DynamicComposite = _test_random(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "string" === typeof value ||
                             ("number" === typeof value &&
                                 Number.isFinite(value)) ||
                             "boolean" === typeof value
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -179,7 +191,11 @@ export const test_random_DynamicComposite = _test_random(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     ("number" === typeof value &&
                                         Number.isFinite(value)) ||
@@ -207,7 +223,11 @@ export const test_random_DynamicComposite = _test_random(
                                         value: value,
                                     })
                                 );
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -220,9 +240,9 @@ export const test_random_DynamicComposite = _test_random(
                                     })
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return (
                                     "boolean" === typeof value ||

--- a/test/generated/output/random/test_random_DynamicTemplate.ts
+++ b/test/generated/output/random/test_random_DynamicTemplate.ts
@@ -96,11 +96,19 @@ export const test_random_DynamicTemplate = _test_random(
                         return "string" === typeof value;
                     if (RegExp(/((.*)_postfix)$/).test(key))
                         return "string" === typeof value;
-                    if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return (
                             "number" === typeof value && Number.isFinite(value)
                         );
-                    if (RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key))
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
                         return "boolean" === typeof value;
                     return true;
                 });
@@ -146,7 +154,11 @@ export const test_random_DynamicTemplate = _test_random(
                                     value: value,
                                 })
                             );
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 ("number" === typeof value &&
                                     Number.isFinite(value)) ||
@@ -157,7 +169,9 @@ export const test_random_DynamicTemplate = _test_random(
                                 })
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return (
                                 "boolean" === typeof value ||

--- a/test/generated/output/random/test_random_DynamicUnion.ts
+++ b/test/generated/output/random/test_random_DynamicUnion.ts
@@ -92,7 +92,11 @@ export const test_random_DynamicUnion = _test_random(
                 Object.keys(input).every((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
                         return "string" === typeof value;
                     if (RegExp(/^(prefix_(.*))/).test(key))
                         return "string" === typeof value;
@@ -100,7 +104,7 @@ export const test_random_DynamicUnion = _test_random(
                         return "string" === typeof value;
                     if (
                         RegExp(
-                            /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                            /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                         ).test(key)
                     )
                         return (
@@ -132,7 +136,11 @@ export const test_random_DynamicUnion = _test_random(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 $guard(_exceptionable, {
@@ -161,7 +169,7 @@ export const test_random_DynamicUnion = _test_random(
                             );
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (

--- a/test/generated/output/random/test_random_TemplateAtomic.ts
+++ b/test/generated/output/random/test_random_TemplateAtomic.ts
@@ -76,12 +76,14 @@ export const test_random_TemplateAtomic = _test_random(
                 "string" === typeof input.middle_string_empty &&
                 RegExp(/^the_(.*)_value$/).test(input.middle_string_empty) &&
                 "string" === typeof input.middle_numeric &&
-                RegExp(/^the_-?\d+\.?\d*_value$/).test(input.middle_numeric) &&
+                RegExp(/^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/).test(
+                    input.middle_numeric,
+                ) &&
                 ("the_false_value" === input.middle_boolean ||
                     "the_true_value" === input.middle_boolean) &&
                 "string" === typeof input.ipv4 &&
                 RegExp(
-                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                 ).test(input.ipv4) &&
                 "string" === typeof input.email &&
                 RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -130,9 +132,9 @@ export const test_random_TemplateAtomic = _test_random(
                             value: input.middle_string_empty,
                         })) &&
                     (("string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        )) ||
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric)) ||
                         $guard(_exceptionable, {
                             path: _path + ".middle_numeric",
                             expected: "`the_${number}_value`",
@@ -147,7 +149,7 @@ export const test_random_TemplateAtomic = _test_random(
                         })) &&
                     (("string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4)) ||
                         $guard(_exceptionable, {
                             path: _path + ".ipv4",

--- a/test/generated/output/stringify/test_stringify_DynamicComposite.ts
+++ b/test/generated/output/stringify/test_stringify_DynamicComposite.ts
@@ -25,7 +25,11 @@ export const test_stringify_DynamicComposite = _test_stringify(
                                 )
                             )
                                 return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
@@ -37,7 +41,11 @@ export const test_stringify_DynamicComposite = _test_stringify(
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${(() => {
                                     if ("string" === typeof value)
                                         return $string(value);
@@ -51,11 +59,12 @@ export const test_stringify_DynamicComposite = _test_stringify(
                                     });
                                 })()}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}`,

--- a/test/generated/output/stringify/test_stringify_DynamicTemplate.ts
+++ b/test/generated/output/stringify/test_stringify_DynamicTemplate.ts
@@ -18,12 +18,19 @@ export const test_stringify_DynamicTemplate = _test_stringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$number(value)}`;
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return `${JSON.stringify(key)}:${value}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/stringify/test_stringify_DynamicUnion.ts
+++ b/test/generated/output/stringify/test_stringify_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_stringify_DynamicUnion = _test_stringify(
                 `{${Object.entries(input)
                     .map(([key, value]: [string, any]) => {
                         if (undefined === value) return "";
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return `${JSON.stringify(key)}:${$string(value)}`;
@@ -22,10 +26,11 @@ export const test_stringify_DynamicUnion = _test_stringify(
                             return `${JSON.stringify(key)}:${$string(value)}`;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return `${JSON.stringify(key)}:${$number(value)}`;
+                        return "";
                     })
                     .filter((str: any) => "" !== str)
                     .join(",")}}`;

--- a/test/generated/output/validate/test_validate_DynamicComposite.ts
+++ b/test/generated/output/validate/test_validate_DynamicComposite.ts
@@ -16,7 +16,11 @@ export const test_validate_DynamicComposite = _test_validate(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -25,7 +29,11 @@ export const test_validate_DynamicComposite = _test_validate(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -33,7 +41,9 @@ export const test_validate_DynamicComposite = _test_validate(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -73,7 +83,11 @@ export const test_validate_DynamicComposite = _test_validate(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 ("number" === typeof value &&
                                                     Number.isFinite(value)) ||
@@ -103,7 +117,7 @@ export const test_validate_DynamicComposite = _test_validate(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -120,7 +134,7 @@ export const test_validate_DynamicComposite = _test_validate(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validate/test_validate_DynamicTemplate.ts
+++ b/test/generated/output/validate/test_validate_DynamicTemplate.ts
@@ -18,13 +18,19 @@ export const test_validate_DynamicTemplate = _test_validate(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return true;
@@ -75,7 +81,7 @@ export const test_validate_DynamicTemplate = _test_validate(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -89,7 +95,7 @@ export const test_validate_DynamicTemplate = _test_validate(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validate/test_validate_DynamicUnion.ts
+++ b/test/generated/output/validate/test_validate_DynamicUnion.ts
@@ -14,7 +14,11 @@ export const test_validate_DynamicUnion = _test_validate(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -22,7 +26,7 @@ export const test_validate_DynamicUnion = _test_validate(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -57,7 +61,11 @@ export const test_validate_DynamicUnion = _test_validate(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 "string" === typeof value ||
                                                 $report(_exceptionable, {
@@ -86,7 +94,7 @@ export const test_validate_DynamicUnion = _test_validate(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validate/test_validate_TemplateAtomic.ts
+++ b/test/generated/output/validate/test_validate_TemplateAtomic.ts
@@ -21,14 +21,14 @@ export const test_validate_TemplateAtomic = _test_validate(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -82,9 +82,9 @@ export const test_validate_TemplateAtomic = _test_validate(
                                     value: input.middle_string_empty,
                                 }),
                             ("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -100,7 +100,7 @@ export const test_validate_TemplateAtomic = _test_validate(
                                 }),
                             ("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/validateClone/test_validateClone_DynamicComposite.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicComposite.ts
@@ -19,7 +19,11 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -28,7 +32,11 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -36,9 +44,9 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -82,9 +90,9 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     ("number" ===
@@ -129,7 +137,7 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -151,7 +159,7 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -201,7 +209,11 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                         name: input.name as any,
                     } as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -213,12 +225,18 @@ export const test_validateClone_DynamicComposite = _test_validateClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/validateClone/test_validateClone_DynamicTemplate.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicTemplate.ts
@@ -21,15 +21,19 @@ export const test_validateClone_DynamicTemplate = _test_validateClone(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -91,7 +95,7 @@ export const test_validateClone_DynamicTemplate = _test_validateClone(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -109,7 +113,7 @@ export const test_validateClone_DynamicTemplate = _test_validateClone(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -166,12 +170,18 @@ export const test_validateClone_DynamicTemplate = _test_validateClone(
                             output[key] = value as any;
                             continue;
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                             output[key] = value as any;
                             continue;

--- a/test/generated/output/validateClone/test_validateClone_DynamicUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_DynamicUnion.ts
@@ -15,7 +15,11 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -23,7 +27,7 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -60,9 +64,9 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     "string" === typeof value ||
@@ -103,7 +107,7 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -155,7 +159,11 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                 const $co0 = (input: any): any => {
                     const output = {} as any;
                     for (const [key, value] of Object.entries(input)) {
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                             output[key] = value as any;
                             continue;
                         }
@@ -169,7 +177,7 @@ export const test_validateClone_DynamicUnion = _test_validateClone(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                             output[key] = value as any;

--- a/test/generated/output/validateClone/test_validateClone_TemplateAtomic.ts
+++ b/test/generated/output/validateClone/test_validateClone_TemplateAtomic.ts
@@ -24,14 +24,14 @@ export const test_validateClone_TemplateAtomic = _test_validateClone(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -92,9 +92,9 @@ export const test_validateClone_TemplateAtomic = _test_validateClone(
                                         value: input.middle_string_empty,
                                     }),
                                 ("string" === typeof input.middle_numeric &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle_numeric,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle_numeric)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle_numeric",
                                         expected: "`the_${number}_value`",
@@ -110,7 +110,7 @@ export const test_validateClone_TemplateAtomic = _test_validateClone(
                                     }),
                                 ("string" === typeof input.ipv4 &&
                                     RegExp(
-                                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                     ).test(input.ipv4)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".ipv4",

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicComposite.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicComposite.ts
@@ -24,7 +24,11 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                             return true;
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
@@ -33,7 +37,11 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "string" === typeof value ||
                                 ("number" === typeof value &&
@@ -41,7 +49,9 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                                 "boolean" === typeof value
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return false;
@@ -89,7 +99,11 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                                             return true;
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 ("number" === typeof value &&
                                                     Number.isFinite(value)) ||
@@ -119,7 +133,7 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -136,7 +150,7 @@ export const test_validateEquals_DynamicComposite = _test_validateEquals(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicTemplate.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicTemplate.ts
@@ -24,13 +24,19 @@ export const test_validateEquals_DynamicTemplate = _test_validateEquals(
                             return "string" === typeof value;
                         if (RegExp(/((.*)_postfix)$/).test(key))
                             return "string" === typeof value;
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        )
                             return (
                                 "number" === typeof value &&
                                 Number.isFinite(value)
                             );
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             return "boolean" === typeof value;
                         return false;
@@ -81,7 +87,7 @@ export const test_validateEquals_DynamicTemplate = _test_validateEquals(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_-?\d+\.?\d*)$/,
+                                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (
@@ -95,7 +101,7 @@ export const test_validateEquals_DynamicTemplate = _test_validateEquals(
                                             );
                                         if (
                                             RegExp(
-                                                /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validateEquals/test_validateEquals_DynamicUnion.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_DynamicUnion.ts
@@ -20,7 +20,11 @@ export const test_validateEquals_DynamicUnion = _test_validateEquals(
                     Object.keys(input).every((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        )
                             return "string" === typeof value;
                         if (RegExp(/^(prefix_(.*))/).test(key))
                             return "string" === typeof value;
@@ -28,7 +32,7 @@ export const test_validateEquals_DynamicUnion = _test_validateEquals(
                             return "string" === typeof value;
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             return (
@@ -63,7 +67,11 @@ export const test_validateEquals_DynamicUnion = _test_validateEquals(
                                     .map((key: any) => {
                                         const value = input[key];
                                         if (undefined === value) return true;
-                                        if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                        if (
+                                            RegExp(
+                                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                            ).test(key)
+                                        )
                                             return (
                                                 "string" === typeof value ||
                                                 $report(_exceptionable, {
@@ -92,7 +100,7 @@ export const test_validateEquals_DynamicUnion = _test_validateEquals(
                                             );
                                         if (
                                             RegExp(
-                                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                             ).test(key)
                                         )
                                             return (

--- a/test/generated/output/validateEquals/test_validateEquals_TemplateAtomic.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TemplateAtomic.ts
@@ -27,14 +27,14 @@ export const test_validateEquals_TemplateAtomic = _test_validateEquals(
                         input.middle_string_empty,
                     ) &&
                     "string" === typeof input.middle_numeric &&
-                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                        input.middle_numeric,
-                    ) &&
+                    RegExp(
+                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                    ).test(input.middle_numeric) &&
                     ("the_false_value" === input.middle_boolean ||
                         "the_true_value" === input.middle_boolean) &&
                     "string" === typeof input.ipv4 &&
                     RegExp(
-                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                     ).test(input.ipv4) &&
                     "string" === typeof input.email &&
                     RegExp(/(.*)@(.*)\.(.*)/).test(input.email) &&
@@ -110,9 +110,9 @@ export const test_validateEquals_TemplateAtomic = _test_validateEquals(
                                     value: input.middle_string_empty,
                                 }),
                             ("string" === typeof input.middle_numeric &&
-                                RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                    input.middle_numeric,
-                                )) ||
+                                RegExp(
+                                    /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                ).test(input.middle_numeric)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".middle_numeric",
                                     expected: "`the_${number}_value`",
@@ -128,7 +128,7 @@ export const test_validateEquals_TemplateAtomic = _test_validateEquals(
                                 }),
                             ("string" === typeof input.ipv4 &&
                                 RegExp(
-                                    /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                 ).test(input.ipv4)) ||
                                 $report(_exceptionable, {
                                     path: _path + ".ipv4",

--- a/test/generated/output/validateParse/test_validateParse_DynamicComposite.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicComposite.ts
@@ -21,7 +21,11 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -30,7 +34,11 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -38,9 +46,9 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -84,9 +92,9 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     ("number" ===
@@ -131,7 +139,7 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -153,7 +161,7 @@ export const test_validateParse_DynamicComposite = _test_validateParse(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (

--- a/test/generated/output/validateParse/test_validateParse_DynamicTemplate.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicTemplate.ts
@@ -23,15 +23,19 @@ export const test_validateParse_DynamicTemplate = _test_validateParse(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -93,7 +97,7 @@ export const test_validateParse_DynamicTemplate = _test_validateParse(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -111,7 +115,7 @@ export const test_validateParse_DynamicTemplate = _test_validateParse(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (

--- a/test/generated/output/validateParse/test_validateParse_DynamicUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_DynamicUnion.ts
@@ -15,7 +15,11 @@ export const test_validateParse_DynamicUnion = _test_validateParse(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -23,7 +27,7 @@ export const test_validateParse_DynamicUnion = _test_validateParse(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -60,9 +64,9 @@ export const test_validateParse_DynamicUnion = _test_validateParse(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     "string" === typeof value ||
@@ -103,7 +107,7 @@ export const test_validateParse_DynamicUnion = _test_validateParse(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (

--- a/test/generated/output/validateParse/test_validateParse_TemplateAtomic.ts
+++ b/test/generated/output/validateParse/test_validateParse_TemplateAtomic.ts
@@ -26,14 +26,14 @@ export const test_validateParse_TemplateAtomic = _test_validateParse(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -94,9 +94,9 @@ export const test_validateParse_TemplateAtomic = _test_validateParse(
                                         value: input.middle_string_empty,
                                     }),
                                 ("string" === typeof input.middle_numeric &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle_numeric,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle_numeric)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle_numeric",
                                         expected: "`the_${number}_value`",
@@ -112,7 +112,7 @@ export const test_validateParse_TemplateAtomic = _test_validateParse(
                                     }),
                                 ("string" === typeof input.ipv4 &&
                                     RegExp(
-                                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                     ).test(input.ipv4)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".ipv4",

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicComposite.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicComposite.ts
@@ -19,7 +19,11 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -28,7 +32,11 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -36,9 +44,9 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -82,9 +90,9 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     ("number" ===
@@ -129,7 +137,7 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -151,7 +159,7 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -198,16 +206,26 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                         if (undefined === value) return;
                         if ("id" === key) return;
                         if ("name" === key) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -215,11 +233,17 @@ export const test_validatePrune_DynamicComposite = _test_validatePrune(
                         if (
                             "id" === key ||
                             "name" === key ||
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicTemplate.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicTemplate.ts
@@ -21,15 +21,19 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -91,7 +95,7 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -109,7 +113,7 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -160,10 +164,16 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                         }
                         if (RegExp(/((.*)_postfix)$/).test(key)) {
                         }
-                        if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
+                        ) {
                         }
                         if (
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         ) {
                         }
                     });
@@ -171,8 +181,12 @@ export const test_validatePrune_DynamicTemplate = _test_validatePrune(
                         if (
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
-                            RegExp(/^(value_-?\d+\.?\d*)$/).test(key) ||
-                            RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(key)
+                            RegExp(
+                                /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key) ||
+                            RegExp(
+                                /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                            ).test(key)
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_DynamicUnion.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_DynamicUnion.ts
@@ -15,7 +15,11 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -23,7 +27,7 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -60,9 +64,9 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     "string" === typeof value ||
@@ -103,7 +107,7 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -153,7 +157,11 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                 const $po0 = (input: any): any => {
                     Object.entries(input).forEach(([key, value]: any) => {
                         if (undefined === value) return;
-                        if (RegExp(/^-?\d+\.?\d*$/).test(key)) {
+                        if (
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key)
+                        ) {
                         }
                         if (RegExp(/^(prefix_(.*))/).test(key)) {
                         }
@@ -161,18 +169,20 @@ export const test_validatePrune_DynamicUnion = _test_validatePrune(
                         }
                         if (
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         ) {
                         }
                     });
                     for (const key of Object.keys(input)) {
                         if (
-                            RegExp(/^-?\d+\.?\d*$/).test(key) ||
+                            RegExp(
+                                /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                            ).test(key) ||
                             RegExp(/^(prefix_(.*))/).test(key) ||
                             RegExp(/((.*)_postfix)$/).test(key) ||
                             RegExp(
-                                /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                             ).test(key)
                         )
                             continue;

--- a/test/generated/output/validatePrune/test_validatePrune_TemplateAtomic.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TemplateAtomic.ts
@@ -24,14 +24,14 @@ export const test_validatePrune_TemplateAtomic = _test_validatePrune(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -92,9 +92,9 @@ export const test_validatePrune_TemplateAtomic = _test_validatePrune(
                                         value: input.middle_string_empty,
                                     }),
                                 ("string" === typeof input.middle_numeric &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle_numeric,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle_numeric)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle_numeric",
                                         expected: "`the_${number}_value`",
@@ -110,7 +110,7 @@ export const test_validatePrune_TemplateAtomic = _test_validatePrune(
                                     }),
                                 ("string" === typeof input.ipv4 &&
                                     RegExp(
-                                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                     ).test(input.ipv4)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".ipv4",

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicComposite.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicComposite.ts
@@ -19,7 +19,11 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
@@ -28,7 +32,11 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "string" === typeof value ||
                                     ("number" === typeof value &&
@@ -36,9 +44,9 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                     "boolean" === typeof value
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -84,9 +92,9 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     ("number" ===
@@ -131,7 +139,7 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -153,7 +161,7 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -212,7 +220,11 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                     )
                                 )
                                     return "";
-                                if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${$number(
                                         value,
                                     )}`;
@@ -224,7 +236,11 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                     return `${JSON.stringify(key)}:${$string(
                                         value,
                                     )}`;
-                                if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                                if (
+                                    RegExp(
+                                        /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                    ).test(key)
+                                )
                                     return `${JSON.stringify(key)}:${(() => {
                                         if ("string" === typeof value)
                                             return $string(value);
@@ -240,10 +256,11 @@ export const test_validateStringify_DynamicComposite = _test_validateStringify(
                                     })()}`;
                                 if (
                                     RegExp(
-                                        /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                        /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                     ).test(key)
                                 )
                                     return `${JSON.stringify(key)}:${value}`;
+                                return "";
                             })
                             .filter((str: any) => "" !== str)
                             .join(",")}`,

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicTemplate.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicTemplate.ts
@@ -21,15 +21,19 @@ export const test_validateStringify_DynamicTemplate = _test_validateStringify(
                                 return "string" === typeof value;
                             if (RegExp(/((.*)_postfix)$/).test(key))
                                 return "string" === typeof value;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return (
                                     "number" === typeof value &&
                                     Number.isFinite(value)
                                 );
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return "boolean" === typeof value;
                             return true;
@@ -93,7 +97,7 @@ export const test_validateStringify_DynamicTemplate = _test_validateStringify(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_-?\d+\.?\d*)$/,
+                                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -111,7 +115,7 @@ export const test_validateStringify_DynamicTemplate = _test_validateStringify(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(between_(.*)_and_-?\d+\.?\d*)$/,
+                                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -169,16 +173,21 @@ export const test_validateStringify_DynamicTemplate = _test_validateStringify(
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
-                            if (RegExp(/^(value_-?\d+\.?\d*)$/).test(key))
+                            if (
+                                RegExp(
+                                    /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
                             if (
-                                RegExp(/^(between_(.*)_and_-?\d+\.?\d*)$/).test(
-                                    key,
-                                )
+                                RegExp(
+                                    /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                                ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${value}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/validateStringify/test_validateStringify_DynamicUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_DynamicUnion.ts
@@ -15,7 +15,11 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                         Object.keys(input).every((key: any) => {
                             const value = input[key];
                             if (undefined === value) return true;
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return "string" === typeof value;
                             if (RegExp(/^(prefix_(.*))/).test(key))
                                 return "string" === typeof value;
@@ -23,7 +27,7 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                                 return "string" === typeof value;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return (
@@ -62,9 +66,9 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                                             if (undefined === value)
                                                 return true;
                                             if (
-                                                RegExp(/^-?\d+\.?\d*$/).test(
-                                                    key,
-                                                )
+                                                RegExp(
+                                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                                ).test(key)
                                             )
                                                 return (
                                                     "string" === typeof value ||
@@ -105,7 +109,7 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                                                 );
                                             if (
                                                 RegExp(
-                                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                                 ).test(key)
                                             )
                                                 return (
@@ -158,7 +162,11 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                     `{${Object.entries(input)
                         .map(([key, value]: [string, any]) => {
                             if (undefined === value) return "";
-                            if (RegExp(/^-?\d+\.?\d*$/).test(key))
+                            if (
+                                RegExp(
+                                    /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
+                                ).test(key)
+                            )
                                 return `${JSON.stringify(key)}:${$string(
                                     value,
                                 )}`;
@@ -172,12 +180,13 @@ export const test_validateStringify_DynamicUnion = _test_validateStringify(
                                 )}`;
                             if (
                                 RegExp(
-                                    /^(value_between_-?\d+\.?\d*_and_-?\d+\.?\d*)$/,
+                                    /^(value_between_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
                                 ).test(key)
                             )
                                 return `${JSON.stringify(key)}:${$number(
                                     value,
                                 )}`;
+                            return "";
                         })
                         .filter((str: any) => "" !== str)
                         .join(",")}}`;

--- a/test/generated/output/validateStringify/test_validateStringify_TemplateAtomic.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TemplateAtomic.ts
@@ -24,14 +24,14 @@ export const test_validateStringify_TemplateAtomic = _test_validateStringify(
                             input.middle_string_empty,
                         ) &&
                         "string" === typeof input.middle_numeric &&
-                        RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                            input.middle_numeric,
-                        ) &&
+                        RegExp(
+                            /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                        ).test(input.middle_numeric) &&
                         ("the_false_value" === input.middle_boolean ||
                             "the_true_value" === input.middle_boolean) &&
                         "string" === typeof input.ipv4 &&
                         RegExp(
-                            /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                            /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                         ).test(input.ipv4) &&
                         "string" === typeof input.email &&
                         RegExp(/(.*)@(.*)\.(.*)/).test(input.email);
@@ -94,9 +94,9 @@ export const test_validateStringify_TemplateAtomic = _test_validateStringify(
                                         value: input.middle_string_empty,
                                     }),
                                 ("string" === typeof input.middle_numeric &&
-                                    RegExp(/^the_-?\d+\.?\d*_value$/).test(
-                                        input.middle_numeric,
-                                    )) ||
+                                    RegExp(
+                                        /^the_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?_value$/,
+                                    ).test(input.middle_numeric)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".middle_numeric",
                                         expected: "`the_${number}_value`",
@@ -112,7 +112,7 @@ export const test_validateStringify_TemplateAtomic = _test_validateStringify(
                                     }),
                                 ("string" === typeof input.ipv4 &&
                                     RegExp(
-                                        /^-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*\.-?\d+\.?\d*$/,
+                                        /^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\.[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/,
                                     ).test(input.ipv4)) ||
                                     $report(_exceptionable, {
                                         path: _path + ".ipv4",

--- a/test/issues/exponential.js
+++ b/test/issues/exponential.js
@@ -1,0 +1,54 @@
+(input) => {
+    const $string = typia_1.default.createStringify.string;
+    const $join = typia_1.default.createStringify.join;
+    const $number = typia_1.default.createStringify.number;
+    const $throws = typia_1.default.createStringify.throws;
+    const $tail = typia_1.default.createStringify.tail;
+    const $so0 = (input) =>
+        `{${$tail(
+            `"id":${$string(input.id)},"name":${$string(
+                input.name,
+            )},${Object.entries(input)
+                .map(([key, value]) => {
+                    if (undefined === value) return "";
+                    if (["id", "name"].some((regular) => regular === key))
+                        return "";
+                    if (
+                        RegExp(/^[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/).test(
+                            key,
+                        )
+                    )
+                        return `${JSON.stringify(key)}:${$number(value)}`;
+                    if (RegExp(/^(prefix_(.*))/).test(key))
+                        return `${JSON.stringify(key)}:${$string(value)}`;
+                    if (RegExp(/((.*)_postfix)$/).test(key))
+                        return `${JSON.stringify(key)}:${$string(value)}`;
+                    if (
+                        RegExp(
+                            /^(value_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
+                        return `${JSON.stringify(key)}:${(() => {
+                            if ("string" === typeof value)
+                                return $string(value);
+                            if ("number" === typeof value)
+                                return $number(value);
+                            if ("boolean" === typeof value) return value;
+                            $throws({
+                                expected: "(boolean | number | string)",
+                                value: value,
+                            });
+                        })()}`;
+                    if (
+                        RegExp(
+                            /^(between_(.*)_and_[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$/,
+                        ).test(key)
+                    )
+                        return `${JSON.stringify(key)}:${value}`;
+                    return "";
+                })
+                .filter((str) => "" !== str)
+                .join(",")}`,
+        )}}`;
+    return $so0(input);
+};

--- a/test/issues/exponential.ts
+++ b/test/issues/exponential.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import typia from "typia";
+
+import { DynamicComposite } from "../structures/DynamicComposite";
+
+const data: DynamicComposite = {
+    id: "id",
+    name: "name",
+    "5.175933557310941e-7": -0.170261004873707,
+    prefix_upzzoug: "udwpvy",
+    sqqfzv_postfix: "xpwmpwr",
+    "value_0.18500123790254852": true,
+    "value_-0.4744943749449395": -0.12959620300810482,
+    "value_-0.41442283348249553": "wchfdtils",
+    "between_tmzivbd_and_-0.45295511336433414": false,
+};
+const json: string = typia.stringify(data);
+console.log(json);
+
+fs.writeFileSync(
+    `${__dirname}/stringify.js`,
+    typia.createStringify<DynamicComposite>().toString(),
+    "utf8",
+);

--- a/test/schemas/json/ajv/DynamicComposite.json
+++ b/test/schemas/json/ajv/DynamicComposite.json
@@ -27,7 +27,7 @@
         ],
         "x-typia-jsDocTags": [],
         "patternProperties": {
-          "^-?\\d+\\.?\\d*$": {
+          "^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
@@ -42,7 +42,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_-?\\d+\\.?\\d*)$": {
+          "^(value_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "oneOf": [
               {
                 "x-typia-required": true,
@@ -63,7 +63,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           },
-          "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
+          "^(between_(.*)_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "boolean"

--- a/test/schemas/json/ajv/DynamicTemplate.json
+++ b/test/schemas/json/ajv/DynamicTemplate.json
@@ -22,12 +22,12 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_-?\\d+\\.?\\d*)$": {
+          "^(value_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
           },
-          "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
+          "^(between_(.*)_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "boolean"

--- a/test/schemas/json/ajv/DynamicUnion.json
+++ b/test/schemas/json/ajv/DynamicUnion.json
@@ -12,7 +12,7 @@
         "properties": {},
         "x-typia-jsDocTags": [],
         "patternProperties": {
-          "^-?\\d+\\.?\\d*$": {
+          "^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "string"
@@ -27,7 +27,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
+          "^(value_between_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"

--- a/test/schemas/json/ajv/TagDefault.json
+++ b/test/schemas/json/ajv/TagDefault.json
@@ -532,7 +532,7 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "pattern": "^(-?\\d+\\.?\\d*|true|false|(prefix_(.*)))",
+                "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|true|false|(prefix_(.*)))",
                 "default": "prefix_B"
               },
               {

--- a/test/schemas/json/ajv/TemplateAtomic.json
+++ b/test/schemas/json/ajv/TemplateAtomic.json
@@ -38,7 +38,7 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
+            "pattern": "^(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value)$"
           },
           "middle_boolean": {
             "x-typia-required": true,
@@ -53,7 +53,7 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*)$"
+            "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$"
           },
           "email": {
             "type": "string",

--- a/test/schemas/json/ajv/TemplateUnion.json
+++ b/test/schemas/json/ajv/TemplateUnion.json
@@ -21,19 +21,19 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^((prefix_(.*))|(prefix_-?\\d+\\.?\\d*))$"
+            "pattern": "^((prefix_(.*))|(prefix_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?))$"
           },
           "postfix": {
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "(((.*)_postfix)|(-?\\d+\\.?\\d*_postfix))$"
+            "pattern": "(((.*)_postfix)|([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_postfix))$"
           },
           "middle": {
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(the_false_value|the_true_value|(the_-?\\d+\\.?\\d*_value))$"
+            "pattern": "^(the_false_value|the_true_value|(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value))$"
           },
           "mixed": {
             "oneOf": [
@@ -41,7 +41,7 @@
                 "type": "string",
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
+                "pattern": "^(the_A_value|the_B_value|[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|true|false|(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value))$"
               },
               {
                 "x-typia-required": true,

--- a/test/schemas/json/swagger/DynamicComposite.json
+++ b/test/schemas/json/swagger/DynamicComposite.json
@@ -27,7 +27,7 @@
         ],
         "x-typia-jsDocTags": [],
         "x-typia-patternProperties": {
-          "^-?\\d+\\.?\\d*$": {
+          "^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
@@ -42,7 +42,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_-?\\d+\\.?\\d*)$": {
+          "^(value_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "oneOf": [
               {
                 "x-typia-required": true,
@@ -63,7 +63,7 @@
             "x-typia-required": true,
             "x-typia-optional": false
           },
-          "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
+          "^(between_(.*)_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "boolean"

--- a/test/schemas/json/swagger/DynamicTemplate.json
+++ b/test/schemas/json/swagger/DynamicTemplate.json
@@ -22,12 +22,12 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_-?\\d+\\.?\\d*)$": {
+          "^(value_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
           },
-          "^(between_(.*)_and_-?\\d+\\.?\\d*)$": {
+          "^(between_(.*)_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "boolean"

--- a/test/schemas/json/swagger/DynamicUnion.json
+++ b/test/schemas/json/swagger/DynamicUnion.json
@@ -12,7 +12,7 @@
         "nullable": false,
         "x-typia-jsDocTags": [],
         "x-typia-patternProperties": {
-          "^-?\\d+\\.?\\d*$": {
+          "^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "string"
@@ -27,7 +27,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "^(value_between_-?\\d+\\.?\\d*_and_-?\\d+\\.?\\d*)$": {
+          "^(value_between_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_and_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"

--- a/test/schemas/json/swagger/TagDefault.json
+++ b/test/schemas/json/swagger/TagDefault.json
@@ -531,7 +531,7 @@
                 ],
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "pattern": "^(-?\\d+\\.?\\d*|true|false|(prefix_(.*)))",
+                "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|true|false|(prefix_(.*)))",
                 "default": "prefix_B"
               },
               {

--- a/test/schemas/json/swagger/TemplateAtomic.json
+++ b/test/schemas/json/swagger/TemplateAtomic.json
@@ -37,7 +37,7 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(the_-?\\d+\\.?\\d*_value)$"
+            "pattern": "^(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value)$"
           },
           "middle_boolean": {
             "x-typia-required": true,
@@ -52,7 +52,7 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*\\.-?\\d+\\.?\\d*)$"
+            "pattern": "^([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\.[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)$"
           },
           "email": {
             "type": "string",

--- a/test/schemas/json/swagger/TemplateUnion.json
+++ b/test/schemas/json/swagger/TemplateUnion.json
@@ -19,19 +19,19 @@
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^((prefix_(.*))|(prefix_-?\\d+\\.?\\d*))$"
+            "pattern": "^((prefix_(.*))|(prefix_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?))$"
           },
           "postfix": {
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "(((.*)_postfix)|(-?\\d+\\.?\\d*_postfix))$"
+            "pattern": "(((.*)_postfix)|([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_postfix))$"
           },
           "middle": {
             "type": "string",
             "x-typia-required": true,
             "x-typia-optional": false,
-            "pattern": "^(the_false_value|the_true_value|(the_-?\\d+\\.?\\d*_value))$"
+            "pattern": "^(the_false_value|the_true_value|(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value))$"
           },
           "mixed": {
             "oneOf": [
@@ -39,7 +39,7 @@
                 "type": "string",
                 "x-typia-required": true,
                 "x-typia-optional": false,
-                "pattern": "^(the_A_value|the_B_value|-?\\d+\\.?\\d*|true|false|(the_-?\\d+\\.?\\d*_value))$"
+                "pattern": "^(the_A_value|the_B_value|[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?|true|false|(the_[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?_value))$"
               },
               {
                 "x-typia-required": true,

--- a/test/structures/DynamicComposite.ts
+++ b/test/structures/DynamicComposite.ts
@@ -21,7 +21,7 @@ export namespace DynamicComposite {
             name: "name",
         };
 
-        ArrayUtil.repeat(TestRandomGenerator.integer(3, 10), () => {
+        ArrayUtil.repeat(TestRandomGenerator.integer(1, 1), () => {
             output[number()] = number();
             output[`prefix_${string()}`] = string();
             output[`${string()}_postfix`] = string();


### PR DESCRIPTION
When `typia.stringify<T>()` be used for an object type which has template typed key containing a number type, and exponential log being used in the template key type, `typia` could not write the property because regex pattern for numeric value of ` typia` had not supported the exponential log value.

This is an extremely rare case, but fixed for extensionality.

```typescript
export interface ISomething {
    [key: `value_${number}`]: boolean | string | number;
}

const something: ISomething = {
    "5.175933557310941e-7": -0.170261004873707,
};
typia.stringify(something);
```
