### PR TITLE
Fix #758 - wrong fixed length bug on `random` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.2.1"
+    "typia": "4.2.2"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/programmers/helpers/RandomRanger.ts
+++ b/src/programmers/helpers/RandomRanger.ts
@@ -26,7 +26,7 @@ export namespace RandomRanger {
 
             props.minimum ??= defs.minimum;
             props.maximum ??= defs.maximum;
-            if (props.maximum <= props.minimum)
+            if (props.maximum < props.minimum)
                 (props.maximum as number) += defs.gap;
 
             return ts.factory.createCallExpression(

--- a/test/generated/output/assert/test_assert_TagArray.ts
+++ b/test/generated/output/assert/test_assert_TagArray.ts
@@ -39,6 +39,15 @@ export const test_assert_TagArray = _test_assert(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -236,6 +245,60 @@ export const test_assert_TagArray = _test_assert(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            })) &&
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/assert/test_assert_TagLength.ts
+++ b/test/generated/output/assert/test_assert_TagLength.ts
@@ -17,7 +17,10 @@ export const test_assert_TagLength = _test_assert(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -93,6 +96,24 @@ export const test_assert_TagLength = _test_assert(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            })) &&
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/assert/test_assert_TagRange.ts
+++ b/test/generated/output/assert/test_assert_TagRange.ts
@@ -32,7 +32,10 @@ export const test_assert_TagRange = _test_assert(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -178,6 +181,24 @@ export const test_assert_TagRange = _test_assert(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            })) &&
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/assertClone/test_assertClone_TagArray.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagArray.ts
@@ -41,6 +41,15 @@ export const test_assertClone_TagArray = _test_assertClone(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -248,6 +257,64 @@ export const test_assertClone_TagArray = _test_assertClone(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                })) &&
+                            ((((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal.every(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -315,6 +382,9 @@ export const test_assertClone_TagArray = _test_assertClone(
                     both: Array.isArray(input.both)
                         ? $cp1(input.both)
                         : (input.both as any),
+                    equal: Array.isArray(input.equal)
+                        ? $cp2(input.equal)
+                        : (input.equal as any),
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/assertClone/test_assertClone_TagLength.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagLength.ts
@@ -18,7 +18,10 @@ export const test_assertClone_TagLength = _test_assertClone(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -94,6 +97,24 @@ export const test_assertClone_TagLength = _test_assertClone(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                })) &&
+                            (("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -146,6 +167,7 @@ export const test_assertClone_TagLength = _test_assertClone(
                     minimum: input.minimum as any,
                     maximum: input.maximum as any,
                     minimum_and_maximum: input.minimum_and_maximum as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/assertClone/test_assertClone_TagRange.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagRange.ts
@@ -33,7 +33,10 @@ export const test_assertClone_TagRange = _test_assertClone(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -188,6 +191,24 @@ export const test_assertClone_TagRange = _test_assertClone(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                })) &&
+                            (("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -245,6 +266,7 @@ export const test_assertClone_TagRange = _test_assertClone(
                     greater_less_equal: input.greater_less_equal as any,
                     greater_equal_less_equal:
                         input.greater_equal_less_equal as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagArray.ts
@@ -46,12 +46,25 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                         (elem: any, _index5: number) =>
                             "string" === typeof elem && $is_uuid(elem),
                     ) &&
-                    (4 === Object.keys(input).length ||
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any, _index6: number) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
+                    ) &&
+                    (5 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
-                                ["items", "minItems", "maxItems", "both"].some(
-                                    (prop: any) => key === prop,
-                                )
+                                [
+                                    "items",
+                                    "minItems",
+                                    "maxItems",
+                                    "both",
+                                    "equal",
+                                ].some((prop: any) => key === prop)
                             )
                                 return true;
                             const value = input[key];
@@ -256,7 +269,61 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                                 expected: "Array<string>",
                                 value: input.both,
                             })) &&
-                        (4 === Object.keys(input).length ||
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                        (5 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input).every((key: any) => {
                                 if (
@@ -265,6 +332,7 @@ export const test_assertEquals_TagArray = _test_assertEquals(
                                         "minItems",
                                         "maxItems",
                                         "both",
+                                        "equal",
                                     ].some((prop: any) => key === prop)
                                 )
                                     return true;

--- a/test/generated/output/assertEquals/test_assertEquals_TagLength.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagLength.ts
@@ -24,7 +24,10 @@ export const test_assertEquals_TagLength = _test_assertEquals(
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
                     7 >= input.minimum_and_maximum.length &&
-                    (4 === Object.keys(input).length ||
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length &&
+                    (5 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
                                 [
@@ -32,6 +35,7 @@ export const test_assertEquals_TagLength = _test_assertEquals(
                                     "minimum",
                                     "maximum",
                                     "minimum_and_maximum",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;
@@ -116,7 +120,25 @@ export const test_assertEquals_TagLength = _test_assertEquals(
                                 expected: "string",
                                 value: input.minimum_and_maximum,
                             })) &&
-                        (4 === Object.keys(input).length ||
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
+                            })) &&
+                        (5 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input).every((key: any) => {
                                 if (
@@ -125,6 +147,7 @@ export const test_assertEquals_TagLength = _test_assertEquals(
                                         "minimum",
                                         "maximum",
                                         "minimum_and_maximum",
+                                        "equal",
                                     ].some((prop: any) => key === prop)
                                 )
                                     return true;

--- a/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
@@ -39,7 +39,10 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
-                    (8 === Object.keys(input).length ||
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal &&
+                    (9 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
                                 [
@@ -51,6 +54,7 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     "greater_equal_less",
                                     "greater_less_equal",
                                     "greater_equal_less_equal",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;
@@ -205,7 +209,25 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
                             })) &&
-                        (8 === Object.keys(input).length ||
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
+                            })) &&
+                        (9 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input).every((key: any) => {
                                 if (
@@ -218,6 +240,7 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                         "greater_equal_less",
                                         "greater_less_equal",
                                         "greater_equal_less_equal",
+                                        "equal",
                                     ].some((prop: any) => key === prop)
                                 )
                                     return true;

--- a/test/generated/output/assertParse/test_assertParse_TagArray.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagArray.ts
@@ -41,6 +41,15 @@ export const test_assertParse_TagArray = _test_assertParse(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -248,6 +257,64 @@ export const test_assertParse_TagArray = _test_assertParse(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                })) &&
+                            ((((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal.every(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||

--- a/test/generated/output/assertParse/test_assertParse_TagLength.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagLength.ts
@@ -18,7 +18,10 @@ export const test_assertParse_TagLength = _test_assertParse(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -94,6 +97,24 @@ export const test_assertParse_TagLength = _test_assertParse(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                })) &&
+                            (("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||

--- a/test/generated/output/assertParse/test_assertParse_TagRange.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagRange.ts
@@ -33,7 +33,10 @@ export const test_assertParse_TagRange = _test_assertParse(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -188,6 +191,24 @@ export const test_assertParse_TagRange = _test_assertParse(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                })) &&
+                            (("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||

--- a/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagArray.ts
@@ -41,6 +41,15 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -248,6 +257,64 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                })) &&
+                            ((((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal.every(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -299,7 +366,8 @@ export const test_assertPrune_TagArray = _test_assertPrune(
                             "items" === key ||
                             "minItems" === key ||
                             "maxItems" === key ||
-                            "both" === key
+                            "both" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_TagLength.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagLength.ts
@@ -18,7 +18,10 @@ export const test_assertPrune_TagLength = _test_assertPrune(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -94,6 +97,24 @@ export const test_assertPrune_TagLength = _test_assertPrune(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                })) &&
+                            (("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -144,7 +165,8 @@ export const test_assertPrune_TagLength = _test_assertPrune(
                             "fixed" === key ||
                             "minimum" === key ||
                             "maximum" === key ||
-                            "minimum_and_maximum" === key
+                            "minimum_and_maximum" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
@@ -33,7 +33,10 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -188,6 +191,24 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                })) &&
+                            (("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -242,7 +263,8 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             "greater_less" === key ||
                             "greater_equal_less" === key ||
                             "greater_less_equal" === key ||
-                            "greater_equal_less_equal" === key
+                            "greater_equal_less_equal" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagArray.ts
@@ -41,6 +41,15 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -248,6 +257,64 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                })) &&
+                            ((((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal.every(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -311,6 +378,8 @@ export const test_assertStringify_TagArray = _test_assertStringify(
                         )
                         .join(",")}]`},"both":${`[${input.both
                         .map((elem: any) => $string(elem))
+                        .join(",")}]`},"equal":${`[${input.equal
+                        .map((elem: any) => $number(elem))
                         .join(",")}]`}}`;
                 return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
             };

--- a/test/generated/output/assertStringify/test_assertStringify_TagLength.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagLength.ts
@@ -18,7 +18,10 @@ export const test_assertStringify_TagLength = _test_assertStringify(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -94,6 +97,24 @@ export const test_assertStringify_TagLength = _test_assertStringify(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                })) &&
+                            (("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -145,7 +166,7 @@ export const test_assertStringify_TagLength = _test_assertStringify(
                                 (elem as any).maximum,
                             )},"minimum_and_maximum":${$string(
                                 (elem as any).minimum_and_maximum,
-                            )}}`,
+                            )},"equal":${$string((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
@@ -33,7 +33,10 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -188,6 +191,24 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                })) &&
+                            (("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }));
                         return (
                             ((Array.isArray(input) ||
@@ -247,7 +268,7 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                 (elem as any).greater_less_equal,
                             )},"greater_equal_less_equal":${$number(
                                 (elem as any).greater_equal_less_equal,
-                            )}}`,
+                            )},"equal":${$number((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/generated/output/clone/test_clone_TagArray.ts
+++ b/test/generated/output/clone/test_clone_TagArray.ts
@@ -32,6 +32,9 @@ export const test_clone_TagArray = _test_clone(
                 both: Array.isArray(input.both)
                     ? $cp1(input.both)
                     : (input.both as any),
+                equal: Array.isArray(input.equal)
+                    ? $cp2(input.equal)
+                    : (input.equal as any),
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         })(input),

--- a/test/generated/output/clone/test_clone_TagLength.ts
+++ b/test/generated/output/clone/test_clone_TagLength.ts
@@ -20,6 +20,7 @@ export const test_clone_TagLength = _test_clone(
                 minimum: input.minimum as any,
                 maximum: input.maximum as any,
                 minimum_and_maximum: input.minimum_and_maximum as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         })(input),

--- a/test/generated/output/clone/test_clone_TagRange.ts
+++ b/test/generated/output/clone/test_clone_TagRange.ts
@@ -24,6 +24,7 @@ export const test_clone_TagRange = _test_clone(
                 greater_equal_less: input.greater_equal_less as any,
                 greater_less_equal: input.greater_less_equal as any,
                 greater_equal_less_equal: input.greater_equal_less_equal as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         })(input),

--- a/test/generated/output/createAssert/test_createAssert_TagArray.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagArray.ts
@@ -36,6 +36,13 @@ export const test_createAssert_TagArray = _test_assert(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -220,6 +227,58 @@ export const test_createAssert_TagArray = _test_assert(
                             path: _path + ".both",
                             expected: "Array<string>",
                             value: input.both,
+                        })) &&
+                    ((((Array.isArray(input.equal) &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@minItems 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@maxItems 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
+                        })) &&
+                        input.equal.every(
+                            (elem: any, _index6: number) =>
+                                ("number" === typeof elem &&
+                                    (10 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@minimum 10)",
+                                            value: elem,
+                                        })) &&
+                                    (10 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@maximum 10)",
+                                            value: elem,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal[" + _index6 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createAssert/test_createAssert_TagLength.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createAssert_TagLength = _test_assert(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -90,6 +93,24 @@ export const test_createAssert_TagLength = _test_assert(
                             path: _path + ".minimum_and_maximum",
                             expected: "string",
                             value: input.minimum_and_maximum,
+                        })) &&
+                    (("string" === typeof input.equal &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@minLength 10)",
+                                value: input.equal,
+                            })) &&
+                        (19 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@maxLength 19)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "string",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createAssert/test_createAssert_TagRange.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createAssert_TagRange = _test_assert(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -175,6 +178,24 @@ export const test_createAssert_TagRange = _test_assert(
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",
                             value: input.greater_equal_less_equal,
+                        })) &&
+                    (("number" === typeof input.equal &&
+                        (10 <= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@minimum 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@maximum 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "number",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagArray.ts
@@ -39,6 +39,15 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -236,6 +245,60 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            })) &&
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -297,6 +360,9 @@ export const test_createAssertClone_TagArray = _test_assertClone(
                 both: Array.isArray(input.both)
                     ? $cp1(input.both)
                     : (input.both as any),
+                equal: Array.isArray(input.equal)
+                    ? $cp2(input.equal)
+                    : (input.equal as any),
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagLength.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagLength.ts
@@ -17,7 +17,10 @@ export const test_createAssertClone_TagLength = _test_assertClone(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -93,6 +96,24 @@ export const test_createAssertClone_TagLength = _test_assertClone(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            })) &&
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -142,6 +163,7 @@ export const test_createAssertClone_TagLength = _test_assertClone(
                 minimum: input.minimum as any,
                 maximum: input.maximum as any,
                 minimum_and_maximum: input.minimum_and_maximum as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
@@ -32,7 +32,10 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -178,6 +181,24 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            })) &&
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -231,6 +252,7 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                 greater_equal_less: input.greater_equal_less as any,
                 greater_less_equal: input.greater_less_equal as any,
                 greater_equal_less_equal: input.greater_equal_less_equal as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagArray.ts
@@ -45,12 +45,23 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                     (elem: any, _index5: number) =>
                         "string" === typeof elem && $is_uuid(elem),
                 ) &&
-                (4 === Object.keys(input).length ||
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any, _index6: number) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
+                ) &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["items", "minItems", "maxItems", "both"].some(
-                                (prop: any) => key === prop,
-                            )
+                            [
+                                "items",
+                                "minItems",
+                                "maxItems",
+                                "both",
+                                "equal",
+                            ].some((prop: any) => key === prop)
                         )
                             return true;
                         const value = input[key];
@@ -244,13 +255,69 @@ export const test_createAssertEquals_TagArray = _test_assertEquals(
                             expected: "Array<string>",
                             value: input.both,
                         })) &&
-                    (4 === Object.keys(input).length ||
+                    ((((Array.isArray(input.equal) &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@minItems 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@maxItems 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
+                        })) &&
+                        input.equal.every(
+                            (elem: any, _index6: number) =>
+                                ("number" === typeof elem &&
+                                    (10 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@minimum 10)",
+                                            value: elem,
+                                        })) &&
+                                    (10 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@maximum 10)",
+                                            value: elem,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal[" + _index6 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
+                        })) &&
+                    (5 === Object.keys(input).length ||
                         false === _exceptionable ||
                         Object.keys(input).every((key: any) => {
                             if (
-                                ["items", "minItems", "maxItems", "both"].some(
-                                    (prop: any) => key === prop,
-                                )
+                                [
+                                    "items",
+                                    "minItems",
+                                    "maxItems",
+                                    "both",
+                                    "equal",
+                                ].some((prop: any) => key === prop)
                             )
                                 return true;
                             const value = input[key];

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagLength.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagLength.ts
@@ -23,7 +23,10 @@ export const test_createAssertEquals_TagLength = _test_assertEquals(
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
                 7 >= input.minimum_and_maximum.length &&
-                (4 === Object.keys(input).length ||
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -31,6 +34,7 @@ export const test_createAssertEquals_TagLength = _test_assertEquals(
                                 "minimum",
                                 "maximum",
                                 "minimum_and_maximum",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;
@@ -115,7 +119,25 @@ export const test_createAssertEquals_TagLength = _test_assertEquals(
                             expected: "string",
                             value: input.minimum_and_maximum,
                         })) &&
-                    (4 === Object.keys(input).length ||
+                    (("string" === typeof input.equal &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@minLength 10)",
+                                value: input.equal,
+                            })) &&
+                        (19 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@maxLength 19)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "string",
+                            value: input.equal,
+                        })) &&
+                    (5 === Object.keys(input).length ||
                         false === _exceptionable ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -124,6 +146,7 @@ export const test_createAssertEquals_TagLength = _test_assertEquals(
                                     "minimum",
                                     "maximum",
                                     "minimum_and_maximum",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
@@ -38,7 +38,10 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
-                (8 === Object.keys(input).length ||
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal &&
+                (9 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -50,6 +53,7 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 "greater_equal_less",
                                 "greater_less_equal",
                                 "greater_equal_less_equal",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;
@@ -204,7 +208,25 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                             expected: "number",
                             value: input.greater_equal_less_equal,
                         })) &&
-                    (8 === Object.keys(input).length ||
+                    (("number" === typeof input.equal &&
+                        (10 <= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@minimum 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@maximum 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "number",
+                            value: input.equal,
+                        })) &&
+                    (9 === Object.keys(input).length ||
                         false === _exceptionable ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -217,6 +239,7 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                     "greater_equal_less",
                                     "greater_less_equal",
                                     "greater_equal_less_equal",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagArray.ts
@@ -39,6 +39,15 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -236,6 +245,60 @@ export const test_createAssertParse_TagArray = _test_assertParse(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            })) &&
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagLength.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagLength.ts
@@ -17,7 +17,10 @@ export const test_createAssertParse_TagLength = _test_assertParse(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -93,6 +96,24 @@ export const test_createAssertParse_TagLength = _test_assertParse(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            })) &&
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
@@ -32,7 +32,10 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -178,6 +181,24 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            })) &&
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagArray.ts
@@ -39,6 +39,15 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -236,6 +245,60 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            })) &&
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -285,7 +348,8 @@ export const test_createAssertPrune_TagArray = _test_assertPrune(
                         "items" === key ||
                         "minItems" === key ||
                         "maxItems" === key ||
-                        "both" === key
+                        "both" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagLength.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagLength.ts
@@ -17,7 +17,10 @@ export const test_createAssertPrune_TagLength = _test_assertPrune(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -93,6 +96,24 @@ export const test_createAssertPrune_TagLength = _test_assertPrune(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            })) &&
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -141,7 +162,8 @@ export const test_createAssertPrune_TagLength = _test_assertPrune(
                         "fixed" === key ||
                         "minimum" === key ||
                         "maximum" === key ||
-                        "minimum_and_maximum" === key
+                        "minimum_and_maximum" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
@@ -32,7 +32,10 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -178,6 +181,24 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            })) &&
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -230,7 +251,8 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         "greater_less" === key ||
                         "greater_equal_less" === key ||
                         "greater_less_equal" === key ||
-                        "greater_equal_less_equal" === key
+                        "greater_equal_less_equal" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagArray.ts
@@ -39,6 +39,15 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -237,6 +246,60 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            })) &&
+                        ((((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal.every(
+                                (elem: any, _index6: number) =>
+                                    ("number" === typeof elem &&
+                                        (10 <= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@minimum 10)",
+                                                value: elem,
+                                            })) &&
+                                        (10 >= elem ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected:
+                                                    "number (@maximum 10)",
+                                                value: elem,
+                                            }))) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal[" + _index6 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -297,6 +360,8 @@ export const test_createAssertStringify_TagArray = _test_assertStringify(
                     )
                     .join(",")}]`},"both":${`[${input.both
                     .map((elem: any) => $string(elem))
+                    .join(",")}]`},"equal":${`[${input.equal
+                    .map((elem: any) => $number(elem))
                     .join(",")}]`}}`;
             return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
         };

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagLength.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagLength.ts
@@ -17,7 +17,10 @@ export const test_createAssertStringify_TagLength = _test_assertStringify(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -93,6 +96,24 @@ export const test_createAssertStringify_TagLength = _test_assertStringify(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            })) &&
+                        (("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -143,7 +164,7 @@ export const test_createAssertStringify_TagLength = _test_assertStringify(
                             (elem as any).maximum,
                         )},"minimum_and_maximum":${$string(
                             (elem as any).minimum_and_maximum,
-                        )}}`,
+                        )},"equal":${$string((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
@@ -32,7 +32,10 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -178,6 +181,24 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            })) &&
+                        (("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }));
                     return (
                         ((Array.isArray(input) ||
@@ -236,7 +257,7 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                             (elem as any).greater_less_equal,
                         )},"greater_equal_less_equal":${$number(
                             (elem as any).greater_equal_less_equal,
-                        )}}`,
+                        )},"equal":${$number((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/createClone/test_createClone_TagArray.ts
+++ b/test/generated/output/createClone/test_createClone_TagArray.ts
@@ -29,6 +29,9 @@ export const test_createClone_TagArray = _test_clone(
             both: Array.isArray(input.both)
                 ? $cp1(input.both)
                 : (input.both as any),
+            equal: Array.isArray(input.equal)
+                ? $cp2(input.equal)
+                : (input.equal as any),
         });
         return Array.isArray(input) ? $cp0(input) : (input as any);
     },

--- a/test/generated/output/createClone/test_createClone_TagLength.ts
+++ b/test/generated/output/createClone/test_createClone_TagLength.ts
@@ -17,6 +17,7 @@ export const test_createClone_TagLength = _test_clone(
             minimum: input.minimum as any,
             maximum: input.maximum as any,
             minimum_and_maximum: input.minimum_and_maximum as any,
+            equal: input.equal as any,
         });
         return Array.isArray(input) ? $cp0(input) : (input as any);
     },

--- a/test/generated/output/createClone/test_createClone_TagRange.ts
+++ b/test/generated/output/createClone/test_createClone_TagRange.ts
@@ -21,6 +21,7 @@ export const test_createClone_TagRange = _test_clone(
             greater_equal_less: input.greater_equal_less as any,
             greater_less_equal: input.greater_less_equal as any,
             greater_equal_less_equal: input.greater_equal_less_equal as any,
+            equal: input.equal as any,
         });
         return Array.isArray(input) ? $cp0(input) : (input as any);
     },

--- a/test/generated/output/createEquals/test_createEquals_TagArray.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagArray.ts
@@ -38,10 +38,17 @@ export const test_createEquals_TagArray = _test_equals(
                 (elem: any, _index5: number) =>
                     "string" === typeof elem && $is_uuid(elem),
             ) &&
-            (4 === Object.keys(input).length ||
+            Array.isArray(input.equal) &&
+            10 <= input.equal.length &&
+            10 >= input.equal.length &&
+            input.equal.every(
+                (elem: any, _index6: number) =>
+                    "number" === typeof elem && 10 <= elem && 10 >= elem,
+            ) &&
+            (5 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (
-                        ["items", "minItems", "maxItems", "both"].some(
+                        ["items", "minItems", "maxItems", "both", "equal"].some(
                             (prop: any) => key === prop,
                         )
                     )

--- a/test/generated/output/createEquals/test_createEquals_TagLength.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createEquals_TagLength = _test_equals(
             "string" === typeof input.minimum_and_maximum &&
             3 <= input.minimum_and_maximum.length &&
             7 >= input.minimum_and_maximum.length &&
-            (4 === Object.keys(input).length ||
+            "string" === typeof input.equal &&
+            10 <= input.equal.length &&
+            19 >= input.equal.length &&
+            (5 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (
                         [
@@ -24,6 +27,7 @@ export const test_createEquals_TagLength = _test_equals(
                             "minimum",
                             "maximum",
                             "minimum_and_maximum",
+                            "equal",
                         ].some((prop: any) => key === prop)
                     )
                         return true;

--- a/test/generated/output/createEquals/test_createEquals_TagRange.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createEquals_TagRange = _test_equals(
             "number" === typeof input.greater_equal_less_equal &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
-            (8 === Object.keys(input).length ||
+            "number" === typeof input.equal &&
+            10 <= input.equal &&
+            10 >= input.equal &&
+            (9 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (
                         [
@@ -43,6 +46,7 @@ export const test_createEquals_TagRange = _test_equals(
                             "greater_equal_less",
                             "greater_less_equal",
                             "greater_equal_less_equal",
+                            "equal",
                         ].some((prop: any) => key === prop)
                     )
                         return true;

--- a/test/generated/output/createIs/test_createIs_TagArray.ts
+++ b/test/generated/output/createIs/test_createIs_TagArray.ts
@@ -35,6 +35,13 @@ export const test_createIs_TagArray = _test_is(
             7 >= input.both.length &&
             input.both.every(
                 (elem: any) => "string" === typeof elem && $is_uuid(elem),
+            ) &&
+            Array.isArray(input.equal) &&
+            10 <= input.equal.length &&
+            10 >= input.equal.length &&
+            input.equal.every(
+                (elem: any) =>
+                    "number" === typeof elem && 10 <= elem && 10 >= elem,
             );
         return (
             Array.isArray(input) &&

--- a/test/generated/output/createIs/test_createIs_TagLength.ts
+++ b/test/generated/output/createIs/test_createIs_TagLength.ts
@@ -15,7 +15,10 @@ export const test_createIs_TagLength = _test_is(
             7 >= input.maximum.length &&
             "string" === typeof input.minimum_and_maximum &&
             3 <= input.minimum_and_maximum.length &&
-            7 >= input.minimum_and_maximum.length;
+            7 >= input.minimum_and_maximum.length &&
+            "string" === typeof input.equal &&
+            10 <= input.equal.length &&
+            19 >= input.equal.length;
         return (
             Array.isArray(input) &&
             input.every(

--- a/test/generated/output/createIs/test_createIs_TagRange.ts
+++ b/test/generated/output/createIs/test_createIs_TagRange.ts
@@ -30,7 +30,10 @@ export const test_createIs_TagRange = _test_is(
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             3 <= input.greater_equal_less_equal &&
-            7 >= input.greater_equal_less_equal;
+            7 >= input.greater_equal_less_equal &&
+            "number" === typeof input.equal &&
+            10 <= input.equal &&
+            10 >= input.equal;
         return (
             Array.isArray(input) &&
             input.every(

--- a/test/generated/output/createIsClone/test_createIsClone_TagArray.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagArray.ts
@@ -36,6 +36,13 @@ export const test_createIsClone_TagArray = _test_isClone(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -69,6 +76,9 @@ export const test_createIsClone_TagArray = _test_isClone(
                 both: Array.isArray(input.both)
                     ? $cp1(input.both)
                     : (input.both as any),
+                equal: Array.isArray(input.equal)
+                    ? $cp2(input.equal)
+                    : (input.equal as any),
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createIsClone/test_createIsClone_TagLength.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createIsClone_TagLength = _test_isClone(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -37,6 +40,7 @@ export const test_createIsClone_TagLength = _test_isClone(
                 minimum: input.minimum as any,
                 maximum: input.maximum as any,
                 minimum_and_maximum: input.minimum_and_maximum as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createIsClone/test_createIsClone_TagRange.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createIsClone_TagRange = _test_isClone(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -56,6 +59,7 @@ export const test_createIsClone_TagRange = _test_isClone(
                 greater_equal_less: input.greater_equal_less as any,
                 greater_less_equal: input.greater_less_equal as any,
                 greater_equal_less_equal: input.greater_equal_less_equal as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createIsParse/test_createIsParse_TagArray.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagArray.ts
@@ -36,6 +36,13 @@ export const test_createIsParse_TagArray = _test_isParse(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&

--- a/test/generated/output/createIsParse/test_createIsParse_TagLength.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createIsParse_TagLength = _test_isParse(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(

--- a/test/generated/output/createIsParse/test_createIsParse_TagRange.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createIsParse_TagRange = _test_isParse(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagArray.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagArray.ts
@@ -36,6 +36,13 @@ export const test_createIsPrune_TagArray = _test_isPrune(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -57,7 +64,8 @@ export const test_createIsPrune_TagArray = _test_isPrune(
                         "items" === key ||
                         "minItems" === key ||
                         "maxItems" === key ||
-                        "both" === key
+                        "both" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagLength.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createIsPrune_TagLength = _test_isPrune(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -36,7 +39,8 @@ export const test_createIsPrune_TagLength = _test_isPrune(
                         "fixed" === key ||
                         "minimum" === key ||
                         "maximum" === key ||
-                        "minimum_and_maximum" === key
+                        "minimum_and_maximum" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagRange.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createIsPrune_TagRange = _test_isPrune(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -55,7 +58,8 @@ export const test_createIsPrune_TagRange = _test_isPrune(
                         "greater_less" === key ||
                         "greater_equal_less" === key ||
                         "greater_less_equal" === key ||
-                        "greater_equal_less_equal" === key
+                        "greater_equal_less_equal" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagArray.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagArray.ts
@@ -36,6 +36,13 @@ export const test_createIsStringify_TagArray = _test_isStringify(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -68,6 +75,8 @@ export const test_createIsStringify_TagArray = _test_isStringify(
                     )
                     .join(",")}]`},"both":${`[${input.both
                     .map((elem: any) => $string(elem))
+                    .join(",")}]`},"equal":${`[${input.equal
+                    .map((elem: any) => $number(elem))
                     .join(",")}]`}}`;
             return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
         };

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagLength.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagLength.ts
@@ -16,7 +16,10 @@ export const test_createIsStringify_TagLength = _test_isStringify(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -38,7 +41,7 @@ export const test_createIsStringify_TagLength = _test_isStringify(
                             (elem as any).maximum,
                         )},"minimum_and_maximum":${$string(
                             (elem as any).minimum_and_maximum,
-                        )}}`,
+                        )},"equal":${$string((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagRange.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagRange.ts
@@ -31,7 +31,10 @@ export const test_createIsStringify_TagRange = _test_isStringify(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -61,7 +64,7 @@ export const test_createIsStringify_TagRange = _test_isStringify(
                             (elem as any).greater_less_equal,
                         )},"greater_equal_less_equal":${$number(
                             (elem as any).greater_equal_less_equal,
-                        )}}`,
+                        )},"equal":${$number((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/createPrune/test_createPrune_TagArray.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagArray.ts
@@ -17,7 +17,8 @@ export const test_createPrune_TagArray = _test_prune(
                     "items" === key ||
                     "minItems" === key ||
                     "maxItems" === key ||
-                    "both" === key
+                    "both" === key ||
+                    "equal" === key
                 )
                     continue;
                 delete input[key];

--- a/test/generated/output/createPrune/test_createPrune_TagLength.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagLength.ts
@@ -16,7 +16,8 @@ export const test_createPrune_TagLength = _test_prune(
                     "fixed" === key ||
                     "minimum" === key ||
                     "maximum" === key ||
-                    "minimum_and_maximum" === key
+                    "minimum_and_maximum" === key ||
+                    "equal" === key
                 )
                     continue;
                 delete input[key];

--- a/test/generated/output/createPrune/test_createPrune_TagRange.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagRange.ts
@@ -20,7 +20,8 @@ export const test_createPrune_TagRange = _test_prune(
                     "greater_less" === key ||
                     "greater_equal_less" === key ||
                     "greater_less_equal" === key ||
-                    "greater_equal_less_equal" === key
+                    "greater_equal_less_equal" === key ||
+                    "equal" === key
                 )
                     continue;
                 delete input[key];

--- a/test/generated/output/createRandom/test_createRandom_TagArray.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagArray.ts
@@ -39,7 +39,7 @@ export const test_createRandom_TagArray = _test_random(
                             value: "3",
                         },
                     ]) ?? (generator?.number ?? $generator.number)(3, 13),
-                (generator?.integer ?? $generator.integer)(3, 6),
+                (generator?.integer ?? $generator.integer)(3, 3),
             ),
             maxItems: (generator?.array ?? $generator.array)(
                 () =>
@@ -106,6 +106,28 @@ export const test_createRandom_TagArray = _test_random(
                     ]) ?? (generator?.uuid ?? $generator.uuid)(),
                 (generator?.integer ?? $generator.integer)(3, 7),
             ),
+            equal: (generator?.array ?? $generator.array)(
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "minItems",
+                            value: "10",
+                        },
+                        {
+                            name: "maxItems",
+                            value: "10",
+                        },
+                        {
+                            name: "minimum",
+                            value: "10",
+                        },
+                        {
+                            name: "maximum",
+                            value: "10",
+                        },
+                    ]) ?? (generator?.number ?? $generator.number)(10, 10),
+                (generator?.integer ?? $generator.integer)(10, 10),
+            ),
         });
         return (generator?.array ?? $generator.array)(() => $ro0());
     },
@@ -140,6 +162,13 @@ export const test_createRandom_TagArray = _test_random(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -324,6 +353,58 @@ export const test_createRandom_TagArray = _test_random(
                             path: _path + ".both",
                             expected: "Array<string>",
                             value: input.both,
+                        })) &&
+                    ((((Array.isArray(input.equal) &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@minItems 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@maxItems 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
+                        })) &&
+                        input.equal.every(
+                            (elem: any, _index6: number) =>
+                                ("number" === typeof elem &&
+                                    (10 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@minimum 10)",
+                                            value: elem,
+                                        })) &&
+                                    (10 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@maximum 10)",
+                                            value: elem,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal[" + _index6 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createRandom/test_createRandom_TagLength.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagLength.ts
@@ -53,6 +53,20 @@ export const test_createRandom_TagLength = _test_random(
                 (generator?.string ?? $generator.string)(
                     (generator?.integer ?? $generator.integer)(3, 7),
                 ),
+            equal:
+                (generator?.customs ?? $generator.customs)?.string?.([
+                    {
+                        name: "minLength",
+                        value: "10",
+                    },
+                    {
+                        name: "maxLength",
+                        value: "19",
+                    },
+                ]) ??
+                (generator?.string ?? $generator.string)(
+                    (generator?.integer ?? $generator.integer)(10, 19),
+                ),
         });
         return (generator?.array ?? $generator.array)(() => $ro0());
     },
@@ -67,7 +81,10 @@ export const test_createRandom_TagLength = _test_random(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -141,6 +158,24 @@ export const test_createRandom_TagLength = _test_random(
                             path: _path + ".minimum_and_maximum",
                             expected: "string",
                             value: input.minimum_and_maximum,
+                        })) &&
+                    (("string" === typeof input.equal &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@minLength 10)",
+                                value: input.equal,
+                            })) &&
+                        (19 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@maxLength 19)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "string",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createRandom/test_createRandom_TagRange.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagRange.ts
@@ -84,6 +84,17 @@ export const test_createRandom_TagRange = _test_random(
                         value: "7",
                     },
                 ]) ?? (generator?.number ?? $generator.number)(3, 7),
+            equal:
+                (generator?.customs ?? $generator.customs)?.number?.([
+                    {
+                        name: "minimum",
+                        value: "10",
+                    },
+                    {
+                        name: "maximum",
+                        value: "10",
+                    },
+                ]) ?? (generator?.number ?? $generator.number)(10, 10),
         });
         return (generator?.array ?? $generator.array)(() => $ro0());
     },
@@ -113,7 +124,10 @@ export const test_createRandom_TagRange = _test_random(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -257,6 +271,24 @@ export const test_createRandom_TagRange = _test_random(
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",
                             value: input.greater_equal_less_equal,
+                        })) &&
+                    (("number" === typeof input.equal &&
+                        (10 <= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@minimum 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@maximum 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "number",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/createStringify/test_createStringify_TagArray.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagArray.ts
@@ -28,6 +28,8 @@ export const test_createStringify_TagArray = _test_stringify(
                 )
                 .join(",")}]`},"both":${`[${input.both
                 .map((elem: any) => $string(elem))
+                .join(",")}]`},"equal":${`[${input.equal
+                .map((elem: any) => $number(elem))
                 .join(",")}]`}}`;
         return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
     },

--- a/test/generated/output/createStringify/test_createStringify_TagLength.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagLength.ts
@@ -18,7 +18,7 @@ export const test_createStringify_TagLength = _test_stringify(
                         (elem as any).maximum,
                     )},"minimum_and_maximum":${$string(
                         (elem as any).minimum_and_maximum,
-                    )}}`,
+                    )},"equal":${$string((elem as any).equal)}}`,
             )
             .join(",")}]`;
     },

--- a/test/generated/output/createStringify/test_createStringify_TagRange.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagRange.ts
@@ -26,7 +26,7 @@ export const test_createStringify_TagRange = _test_stringify(
                         (elem as any).greater_less_equal,
                     )},"greater_equal_less_equal":${$number(
                         (elem as any).greater_equal_less_equal,
-                    )}}`,
+                    )},"equal":${$number((elem as any).equal)}}`,
             )
             .join(",")}]`;
     },

--- a/test/generated/output/createValidate/test_createValidate_TagArray.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagArray.ts
@@ -37,6 +37,13 @@ export const test_createValidate_TagArray = _test_validate(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -251,6 +258,66 @@ export const test_createValidate_TagArray = _test_validate(
                                 path: _path + ".both",
                                 expected: "Array<string>",
                                 value: input.both,
+                            }),
+                        (((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal
+                                .map(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
                             }),
                     ].every((flag: boolean) => flag);
                 return (

--- a/test/generated/output/createValidate/test_createValidate_TagLength.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagLength.ts
@@ -17,7 +17,10 @@ export const test_createValidate_TagLength = _test_validate(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -92,6 +95,24 @@ export const test_createValidate_TagLength = _test_validate(
                                 path: _path + ".minimum_and_maximum",
                                 expected: "string",
                                 value: input.minimum_and_maximum,
+                            }),
+                        ("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
                             }),
                     ].every((flag: boolean) => flag);
                 return (

--- a/test/generated/output/createValidate/test_createValidate_TagRange.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagRange.ts
@@ -32,7 +32,10 @@ export const test_createValidate_TagRange = _test_validate(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -177,6 +180,24 @@ export const test_createValidate_TagRange = _test_validate(
                                 path: _path + ".greater_equal_less_equal",
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
+                            }),
+                        ("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
                             }),
                     ].every((flag: boolean) => flag);
                 return (

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagArray.ts
@@ -40,6 +40,15 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -259,6 +268,66 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                                     expected: "Array<string>",
                                     value: input.both,
                                 }),
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -329,6 +398,9 @@ export const test_createValidateClone_TagArray = _test_validateClone(
                 both: Array.isArray(input.both)
                     ? $cp1(input.both)
                     : (input.both as any),
+                equal: Array.isArray(input.equal)
+                    ? $cp2(input.equal)
+                    : (input.equal as any),
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagLength.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagLength.ts
@@ -18,7 +18,10 @@ export const test_createValidateClone_TagLength = _test_validateClone(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -98,6 +101,24 @@ export const test_createValidateClone_TagLength = _test_validateClone(
                                     expected: "string",
                                     value: input.minimum_and_maximum,
                                 }),
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -156,6 +177,7 @@ export const test_createValidateClone_TagLength = _test_validateClone(
                 minimum: input.minimum as any,
                 maximum: input.maximum as any,
                 minimum_and_maximum: input.minimum_and_maximum as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
@@ -33,7 +33,10 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -192,6 +195,24 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
                                 }),
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -254,6 +275,7 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                 greater_equal_less: input.greater_equal_less as any,
                 greater_less_equal: input.greater_less_equal as any,
                 greater_equal_less_equal: input.greater_equal_less_equal as any,
+                equal: input.equal as any,
             });
             return Array.isArray(input) ? $cp0(input) : (input as any);
         };

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagArray.ts
@@ -46,12 +46,23 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                     (elem: any, _index5: number) =>
                         "string" === typeof elem && $is_uuid(elem),
                 ) &&
-                (4 === Object.keys(input).length ||
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any, _index6: number) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
+                ) &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["items", "minItems", "maxItems", "both"].some(
-                                (prop: any) => key === prop,
-                            )
+                            [
+                                "items",
+                                "minItems",
+                                "maxItems",
+                                "both",
+                                "equal",
+                            ].some((prop: any) => key === prop)
                         )
                             return true;
                         const value = input[key];
@@ -275,7 +286,67 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                                 expected: "Array<string>",
                                 value: input.both,
                             }),
-                        4 === Object.keys(input).length ||
+                        (((Array.isArray(input.equal) &&
+                            (10 <= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@minItems 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array.length (@maxItems 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            })) &&
+                            input.equal
+                                .map(
+                                    (elem: any, _index6: number) =>
+                                        ("number" === typeof elem &&
+                                            (10 <= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@minimum 10)",
+                                                    value: elem,
+                                                })) &&
+                                            (10 >= elem ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected:
+                                                        "number (@maximum 10)",
+                                                    value: elem,
+                                                }))) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array<number>",
+                                value: input.equal,
+                            }),
+                        5 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input)
                                 .map((key: any) => {
@@ -285,6 +356,7 @@ export const test_createValidateEquals_TagArray = _test_validateEquals(
                                             "minItems",
                                             "maxItems",
                                             "both",
+                                            "equal",
                                         ].some((prop: any) => key === prop)
                                     )
                                         return true;

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagLength.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagLength.ts
@@ -24,7 +24,10 @@ export const test_createValidateEquals_TagLength = _test_validateEquals(
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
                 7 >= input.minimum_and_maximum.length &&
-                (4 === Object.keys(input).length ||
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -32,6 +35,7 @@ export const test_createValidateEquals_TagLength = _test_validateEquals(
                                 "minimum",
                                 "maximum",
                                 "minimum_and_maximum",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;
@@ -117,7 +121,25 @@ export const test_createValidateEquals_TagLength = _test_validateEquals(
                                 expected: "string",
                                 value: input.minimum_and_maximum,
                             }),
-                        4 === Object.keys(input).length ||
+                        ("string" === typeof input.equal &&
+                            (10 <= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@minLength 10)",
+                                    value: input.equal,
+                                })) &&
+                            (19 >= input.equal.length ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string (@maxLength 19)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string",
+                                value: input.equal,
+                            }),
+                        5 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input)
                                 .map((key: any) => {
@@ -127,6 +149,7 @@ export const test_createValidateEquals_TagLength = _test_validateEquals(
                                             "minimum",
                                             "maximum",
                                             "minimum_and_maximum",
+                                            "equal",
                                         ].some((prop: any) => key === prop)
                                     )
                                         return true;

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
@@ -39,7 +39,10 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
-                (8 === Object.keys(input).length ||
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal &&
+                (9 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -51,6 +54,7 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                 "greater_equal_less",
                                 "greater_less_equal",
                                 "greater_equal_less_equal",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;
@@ -206,7 +210,25 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                 expected: "number",
                                 value: input.greater_equal_less_equal,
                             }),
-                        8 === Object.keys(input).length ||
+                        ("number" === typeof input.equal &&
+                            (10 <= input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@minimum 10)",
+                                    value: input.equal,
+                                })) &&
+                            (10 >= input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@maximum 10)",
+                                    value: input.equal,
+                                }))) ||
+                            $report(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number",
+                                value: input.equal,
+                            }),
+                        9 === Object.keys(input).length ||
                             false === _exceptionable ||
                             Object.keys(input)
                                 .map((key: any) => {
@@ -220,6 +242,7 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                             "greater_equal_less",
                                             "greater_less_equal",
                                             "greater_equal_less_equal",
+                                            "equal",
                                         ].some((prop: any) => key === prop)
                                     )
                                         return true;

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagArray.ts
@@ -40,6 +40,15 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -258,6 +267,66 @@ export const test_createValidateParse_TagArray = _test_validateParse(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                }),
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagLength.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagLength.ts
@@ -18,7 +18,10 @@ export const test_createValidateParse_TagLength = _test_validateParse(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -97,6 +100,24 @@ export const test_createValidateParse_TagLength = _test_validateParse(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                }),
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
@@ -33,7 +33,10 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -191,6 +194,24 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                }),
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagArray.ts
@@ -40,6 +40,15 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -259,6 +268,66 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                                     expected: "Array<string>",
                                     value: input.both,
                                 }),
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -317,7 +386,8 @@ export const test_createValidatePrune_TagArray = _test_validatePrune(
                         "items" === key ||
                         "minItems" === key ||
                         "maxItems" === key ||
-                        "both" === key
+                        "both" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagLength.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagLength.ts
@@ -18,7 +18,10 @@ export const test_createValidatePrune_TagLength = _test_validatePrune(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -98,6 +101,24 @@ export const test_createValidatePrune_TagLength = _test_validatePrune(
                                     expected: "string",
                                     value: input.minimum_and_maximum,
                                 }),
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -155,7 +176,8 @@ export const test_createValidatePrune_TagLength = _test_validatePrune(
                         "fixed" === key ||
                         "minimum" === key ||
                         "maximum" === key ||
-                        "minimum_and_maximum" === key
+                        "minimum_and_maximum" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
@@ -33,7 +33,10 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -192,6 +195,24 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
                                 }),
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -253,7 +274,8 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                         "greater_less" === key ||
                         "greater_equal_less" === key ||
                         "greater_less_equal" === key ||
-                        "greater_equal_less_equal" === key
+                        "greater_equal_less_equal" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagArray.ts
@@ -40,6 +40,15 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -260,6 +269,66 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                                     expected: "Array<string>",
                                     value: input.both,
                                 }),
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -329,6 +398,8 @@ export const test_createValidateStringify_TagArray = _test_validateStringify(
                     )
                     .join(",")}]`},"both":${`[${input.both
                     .map((elem: any) => $string(elem))
+                    .join(",")}]`},"equal":${`[${input.equal
+                    .map((elem: any) => $number(elem))
                     .join(",")}]`}}`;
             return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
         };

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagLength.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagLength.ts
@@ -18,7 +18,10 @@ export const test_createValidateStringify_TagLength = _test_validateStringify(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -98,6 +101,24 @@ export const test_createValidateStringify_TagLength = _test_validateStringify(
                                     expected: "string",
                                     value: input.minimum_and_maximum,
                                 }),
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -157,7 +178,7 @@ export const test_createValidateStringify_TagLength = _test_validateStringify(
                             (elem as any).maximum,
                         )},"minimum_and_maximum":${$string(
                             (elem as any).minimum_and_maximum,
-                        )}}`,
+                        )},"equal":${$string((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
@@ -33,7 +33,10 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -192,6 +195,24 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
                                 }),
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
+                                }),
                         ].every((flag: boolean) => flag);
                     return (
                         ((Array.isArray(input) ||
@@ -259,7 +280,7 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             (elem as any).greater_less_equal,
                         )},"greater_equal_less_equal":${$number(
                             (elem as any).greater_equal_less_equal,
-                        )}}`,
+                        )},"equal":${$number((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         };

--- a/test/generated/output/equals/test_equals_TagArray.ts
+++ b/test/generated/output/equals/test_equals_TagArray.ts
@@ -45,12 +45,23 @@ export const test_equals_TagArray = _test_equals(
                     (elem: any, _index5: number) =>
                         "string" === typeof elem && $is_uuid(elem),
                 ) &&
-                (4 === Object.keys(input).length ||
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any, _index6: number) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
+                ) &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["items", "minItems", "maxItems", "both"].some(
-                                (prop: any) => key === prop,
-                            )
+                            [
+                                "items",
+                                "minItems",
+                                "maxItems",
+                                "both",
+                                "equal",
+                            ].some((prop: any) => key === prop)
                         )
                             return true;
                         const value = input[key];

--- a/test/generated/output/equals/test_equals_TagLength.ts
+++ b/test/generated/output/equals/test_equals_TagLength.ts
@@ -23,7 +23,10 @@ export const test_equals_TagLength = _test_equals(
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
                 7 >= input.minimum_and_maximum.length &&
-                (4 === Object.keys(input).length ||
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length &&
+                (5 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -31,6 +34,7 @@ export const test_equals_TagLength = _test_equals(
                                 "minimum",
                                 "maximum",
                                 "minimum_and_maximum",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;

--- a/test/generated/output/equals/test_equals_TagRange.ts
+++ b/test/generated/output/equals/test_equals_TagRange.ts
@@ -38,7 +38,10 @@ export const test_equals_TagRange = _test_equals(
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
-                (8 === Object.keys(input).length ||
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal &&
+                (9 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
                             [
@@ -50,6 +53,7 @@ export const test_equals_TagRange = _test_equals(
                                 "greater_equal_less",
                                 "greater_less_equal",
                                 "greater_equal_less_equal",
+                                "equal",
                             ].some((prop: any) => key === prop)
                         )
                             return true;

--- a/test/generated/output/is/test_is_TagArray.ts
+++ b/test/generated/output/is/test_is_TagArray.ts
@@ -36,6 +36,13 @@ export const test_is_TagArray = _test_is(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&

--- a/test/generated/output/is/test_is_TagLength.ts
+++ b/test/generated/output/is/test_is_TagLength.ts
@@ -16,7 +16,10 @@ export const test_is_TagLength = _test_is(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(

--- a/test/generated/output/is/test_is_TagRange.ts
+++ b/test/generated/output/is/test_is_TagRange.ts
@@ -31,7 +31,10 @@ export const test_is_TagRange = _test_is(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(

--- a/test/generated/output/isClone/test_isClone_TagArray.ts
+++ b/test/generated/output/isClone/test_isClone_TagArray.ts
@@ -39,6 +39,15 @@ export const test_isClone_TagArray = _test_isClone(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -79,6 +88,9 @@ export const test_isClone_TagArray = _test_isClone(
                     both: Array.isArray(input.both)
                         ? $cp1(input.both)
                         : (input.both as any),
+                    equal: Array.isArray(input.equal)
+                        ? $cp2(input.equal)
+                        : (input.equal as any),
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/isClone/test_isClone_TagLength.ts
+++ b/test/generated/output/isClone/test_isClone_TagLength.ts
@@ -17,7 +17,10 @@ export const test_isClone_TagLength = _test_isClone(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -42,6 +45,7 @@ export const test_isClone_TagLength = _test_isClone(
                     minimum: input.minimum as any,
                     maximum: input.maximum as any,
                     minimum_and_maximum: input.minimum_and_maximum as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/isClone/test_isClone_TagRange.ts
+++ b/test/generated/output/isClone/test_isClone_TagRange.ts
@@ -32,7 +32,10 @@ export const test_isClone_TagRange = _test_isClone(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -62,6 +65,7 @@ export const test_isClone_TagRange = _test_isClone(
                     greater_less_equal: input.greater_less_equal as any,
                     greater_equal_less_equal:
                         input.greater_equal_less_equal as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/isParse/test_isParse_TagArray.ts
+++ b/test/generated/output/isParse/test_isParse_TagArray.ts
@@ -39,6 +39,15 @@ export const test_isParse_TagArray = _test_isParse(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&

--- a/test/generated/output/isParse/test_isParse_TagLength.ts
+++ b/test/generated/output/isParse/test_isParse_TagLength.ts
@@ -17,7 +17,10 @@ export const test_isParse_TagLength = _test_isParse(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(

--- a/test/generated/output/isParse/test_isParse_TagRange.ts
+++ b/test/generated/output/isParse/test_isParse_TagRange.ts
@@ -32,7 +32,10 @@ export const test_isParse_TagRange = _test_isParse(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(

--- a/test/generated/output/isPrune/test_isPrune_TagArray.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagArray.ts
@@ -39,6 +39,15 @@ export const test_isPrune_TagArray = _test_isPrune(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -63,7 +72,8 @@ export const test_isPrune_TagArray = _test_isPrune(
                             "items" === key ||
                             "minItems" === key ||
                             "maxItems" === key ||
-                            "both" === key
+                            "both" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/isPrune/test_isPrune_TagLength.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagLength.ts
@@ -17,7 +17,10 @@ export const test_isPrune_TagLength = _test_isPrune(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -40,7 +43,8 @@ export const test_isPrune_TagLength = _test_isPrune(
                             "fixed" === key ||
                             "minimum" === key ||
                             "maximum" === key ||
-                            "minimum_and_maximum" === key
+                            "minimum_and_maximum" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/isPrune/test_isPrune_TagRange.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagRange.ts
@@ -32,7 +32,10 @@ export const test_isPrune_TagRange = _test_isPrune(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -59,7 +62,8 @@ export const test_isPrune_TagRange = _test_isPrune(
                             "greater_less" === key ||
                             "greater_equal_less" === key ||
                             "greater_less_equal" === key ||
-                            "greater_equal_less_equal" === key
+                            "greater_equal_less_equal" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/isStringify/test_isStringify_TagArray.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagArray.ts
@@ -39,6 +39,15 @@ export const test_isStringify_TagArray = _test_isStringify(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -75,6 +84,8 @@ export const test_isStringify_TagArray = _test_isStringify(
                         )
                         .join(",")}]`},"both":${`[${input.both
                         .map((elem: any) => $string(elem))
+                        .join(",")}]`},"equal":${`[${input.equal
+                        .map((elem: any) => $number(elem))
                         .join(",")}]`}}`;
                 return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
             };

--- a/test/generated/output/isStringify/test_isStringify_TagLength.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagLength.ts
@@ -17,7 +17,10 @@ export const test_isStringify_TagLength = _test_isStringify(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -41,7 +44,7 @@ export const test_isStringify_TagLength = _test_isStringify(
                                 (elem as any).maximum,
                             )},"minimum_and_maximum":${$string(
                                 (elem as any).minimum_and_maximum,
-                            )}}`,
+                            )},"equal":${$string((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/generated/output/isStringify/test_isStringify_TagRange.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagRange.ts
@@ -32,7 +32,10 @@ export const test_isStringify_TagRange = _test_isStringify(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -64,7 +67,7 @@ export const test_isStringify_TagRange = _test_isStringify(
                                 (elem as any).greater_less_equal,
                             )},"greater_equal_less_equal":${$number(
                                 (elem as any).greater_equal_less_equal,
-                            )}}`,
+                            )},"equal":${$number((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/generated/output/prune/test_prune_TagArray.ts
+++ b/test/generated/output/prune/test_prune_TagArray.ts
@@ -18,7 +18,8 @@ export const test_prune_TagArray = _test_prune(
                         "items" === key ||
                         "minItems" === key ||
                         "maxItems" === key ||
-                        "both" === key
+                        "both" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/prune/test_prune_TagLength.ts
+++ b/test/generated/output/prune/test_prune_TagLength.ts
@@ -17,7 +17,8 @@ export const test_prune_TagLength = _test_prune(
                         "fixed" === key ||
                         "minimum" === key ||
                         "maximum" === key ||
-                        "minimum_and_maximum" === key
+                        "minimum_and_maximum" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/prune/test_prune_TagRange.ts
+++ b/test/generated/output/prune/test_prune_TagRange.ts
@@ -21,7 +21,8 @@ export const test_prune_TagRange = _test_prune(
                         "greater_less" === key ||
                         "greater_equal_less" === key ||
                         "greater_less_equal" === key ||
-                        "greater_equal_less_equal" === key
+                        "greater_equal_less_equal" === key ||
+                        "equal" === key
                     )
                         continue;
                     delete input[key];

--- a/test/generated/output/random/test_random_TagArray.ts
+++ b/test/generated/output/random/test_random_TagArray.ts
@@ -40,7 +40,7 @@ export const test_random_TagArray = _test_random(
                                 value: "3",
                             },
                         ]) ?? (generator?.number ?? $generator.number)(3, 13),
-                    (generator?.integer ?? $generator.integer)(3, 6),
+                    (generator?.integer ?? $generator.integer)(3, 3),
                 ),
                 maxItems: (generator?.array ?? $generator.array)(
                     () =>
@@ -107,6 +107,28 @@ export const test_random_TagArray = _test_random(
                         ]) ?? (generator?.uuid ?? $generator.uuid)(),
                     (generator?.integer ?? $generator.integer)(3, 7),
                 ),
+                equal: (generator?.array ?? $generator.array)(
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.([
+                            {
+                                name: "minItems",
+                                value: "10",
+                            },
+                            {
+                                name: "maxItems",
+                                value: "10",
+                            },
+                            {
+                                name: "minimum",
+                                value: "10",
+                            },
+                            {
+                                name: "maximum",
+                                value: "10",
+                            },
+                        ]) ?? (generator?.number ?? $generator.number)(10, 10),
+                    (generator?.integer ?? $generator.integer)(10, 10),
+                ),
             });
             return (generator?.array ?? $generator.array)(() => $ro0());
         })(),
@@ -141,6 +163,13 @@ export const test_random_TagArray = _test_random(
                 7 >= input.both.length &&
                 input.both.every(
                     (elem: any) => "string" === typeof elem && $is_uuid(elem),
+                ) &&
+                Array.isArray(input.equal) &&
+                10 <= input.equal.length &&
+                10 >= input.equal.length &&
+                input.equal.every(
+                    (elem: any) =>
+                        "number" === typeof elem && 10 <= elem && 10 >= elem,
                 );
             return (
                 Array.isArray(input) &&
@@ -325,6 +354,58 @@ export const test_random_TagArray = _test_random(
                             path: _path + ".both",
                             expected: "Array<string>",
                             value: input.both,
+                        })) &&
+                    ((((Array.isArray(input.equal) &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@minItems 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "Array.length (@maxItems 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
+                        })) &&
+                        input.equal.every(
+                            (elem: any, _index6: number) =>
+                                ("number" === typeof elem &&
+                                    (10 <= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@minimum 10)",
+                                            value: elem,
+                                        })) &&
+                                    (10 >= elem ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".equal[" +
+                                                _index6 +
+                                                "]",
+                                            expected: "number (@maximum 10)",
+                                            value: elem,
+                                        }))) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal[" + _index6 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "Array<number>",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/random/test_random_TagLength.ts
+++ b/test/generated/output/random/test_random_TagLength.ts
@@ -54,6 +54,20 @@ export const test_random_TagLength = _test_random(
                     (generator?.string ?? $generator.string)(
                         (generator?.integer ?? $generator.integer)(3, 7),
                     ),
+                equal:
+                    (generator?.customs ?? $generator.customs)?.string?.([
+                        {
+                            name: "minLength",
+                            value: "10",
+                        },
+                        {
+                            name: "maxLength",
+                            value: "19",
+                        },
+                    ]) ??
+                    (generator?.string ?? $generator.string)(
+                        (generator?.integer ?? $generator.integer)(10, 19),
+                    ),
             });
             return (generator?.array ?? $generator.array)(() => $ro0());
         })(),
@@ -68,7 +82,10 @@ export const test_random_TagLength = _test_random(
                 7 >= input.maximum.length &&
                 "string" === typeof input.minimum_and_maximum &&
                 3 <= input.minimum_and_maximum.length &&
-                7 >= input.minimum_and_maximum.length;
+                7 >= input.minimum_and_maximum.length &&
+                "string" === typeof input.equal &&
+                10 <= input.equal.length &&
+                19 >= input.equal.length;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -142,6 +159,24 @@ export const test_random_TagLength = _test_random(
                             path: _path + ".minimum_and_maximum",
                             expected: "string",
                             value: input.minimum_and_maximum,
+                        })) &&
+                    (("string" === typeof input.equal &&
+                        (10 <= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@minLength 10)",
+                                value: input.equal,
+                            })) &&
+                        (19 >= input.equal.length ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "string (@maxLength 19)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "string",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/random/test_random_TagRange.ts
+++ b/test/generated/output/random/test_random_TagRange.ts
@@ -85,6 +85,17 @@ export const test_random_TagRange = _test_random(
                             value: "7",
                         },
                     ]) ?? (generator?.number ?? $generator.number)(3, 7),
+                equal:
+                    (generator?.customs ?? $generator.customs)?.number?.([
+                        {
+                            name: "minimum",
+                            value: "10",
+                        },
+                        {
+                            name: "maximum",
+                            value: "10",
+                        },
+                    ]) ?? (generator?.number ?? $generator.number)(10, 10),
             });
             return (generator?.array ?? $generator.array)(() => $ro0());
         })(),
@@ -114,7 +125,10 @@ export const test_random_TagRange = _test_random(
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 3 <= input.greater_equal_less_equal &&
-                7 >= input.greater_equal_less_equal;
+                7 >= input.greater_equal_less_equal &&
+                "number" === typeof input.equal &&
+                10 <= input.equal &&
+                10 >= input.equal;
             return (
                 Array.isArray(input) &&
                 input.every(
@@ -258,6 +272,24 @@ export const test_random_TagRange = _test_random(
                             path: _path + ".greater_equal_less_equal",
                             expected: "number",
                             value: input.greater_equal_less_equal,
+                        })) &&
+                    (("number" === typeof input.equal &&
+                        (10 <= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@minimum 10)",
+                                value: input.equal,
+                            })) &&
+                        (10 >= input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@maximum 10)",
+                                value: input.equal,
+                            }))) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".equal",
+                            expected: "number",
+                            value: input.equal,
                         }));
                 return (
                     ((Array.isArray(input) ||

--- a/test/generated/output/stringify/test_stringify_TagArray.ts
+++ b/test/generated/output/stringify/test_stringify_TagArray.ts
@@ -29,6 +29,8 @@ export const test_stringify_TagArray = _test_stringify(
                     )
                     .join(",")}]`},"both":${`[${input.both
                     .map((elem: any) => $string(elem))
+                    .join(",")}]`},"equal":${`[${input.equal
+                    .map((elem: any) => $number(elem))
                     .join(",")}]`}}`;
             return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
         })(input),

--- a/test/generated/output/stringify/test_stringify_TagLength.ts
+++ b/test/generated/output/stringify/test_stringify_TagLength.ts
@@ -19,7 +19,7 @@ export const test_stringify_TagLength = _test_stringify(
                             (elem as any).maximum,
                         )},"minimum_and_maximum":${$string(
                             (elem as any).minimum_and_maximum,
-                        )}}`,
+                        )},"equal":${$string((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         })(input),

--- a/test/generated/output/stringify/test_stringify_TagRange.ts
+++ b/test/generated/output/stringify/test_stringify_TagRange.ts
@@ -27,7 +27,7 @@ export const test_stringify_TagRange = _test_stringify(
                             (elem as any).greater_less_equal,
                         )},"greater_equal_less_equal":${$number(
                             (elem as any).greater_equal_less_equal,
-                        )}}`,
+                        )},"equal":${$number((elem as any).equal)}}`,
                 )
                 .join(",")}]`;
         })(input),

--- a/test/generated/output/validate/test_validate_TagArray.ts
+++ b/test/generated/output/validate/test_validate_TagArray.ts
@@ -40,6 +40,15 @@ export const test_validate_TagArray = _test_validate(
                     input.both.every(
                         (elem: any) =>
                             "string" === typeof elem && $is_uuid(elem),
+                    ) &&
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
                     );
                 return (
                     Array.isArray(input) &&
@@ -256,6 +265,66 @@ export const test_validate_TagArray = _test_validate(
                                     path: _path + ".both",
                                     expected: "Array<string>",
                                     value: input.both,
+                                }),
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/validate/test_validate_TagLength.ts
+++ b/test/generated/output/validate/test_validate_TagLength.ts
@@ -18,7 +18,10 @@ export const test_validate_TagLength = _test_validate(
                     7 >= input.maximum.length &&
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
-                    7 >= input.minimum_and_maximum.length;
+                    7 >= input.minimum_and_maximum.length &&
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -95,6 +98,24 @@ export const test_validate_TagLength = _test_validate(
                                     path: _path + ".minimum_and_maximum",
                                     expected: "string",
                                     value: input.minimum_and_maximum,
+                                }),
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/validate/test_validate_TagRange.ts
+++ b/test/generated/output/validate/test_validate_TagRange.ts
@@ -33,7 +33,10 @@ export const test_validate_TagRange = _test_validate(
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
-                    7 >= input.greater_equal_less_equal;
+                    7 >= input.greater_equal_less_equal &&
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal;
                 return (
                     Array.isArray(input) &&
                     input.every(
@@ -189,6 +192,24 @@ export const test_validate_TagRange = _test_validate(
                                     path: _path + ".greater_equal_less_equal",
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
+                                }),
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
                                 }),
                         ].every((flag: boolean) => flag);
                     return (

--- a/test/generated/output/validateClone/test_validateClone_TagArray.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagArray.ts
@@ -46,6 +46,15 @@ export const test_validateClone_TagArray = _test_validateClone(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -283,6 +292,74 @@ export const test_validateClone_TagArray = _test_validateClone(
                                         expected: "Array<string>",
                                         value: input.both,
                                     }),
+                                (((Array.isArray(input.equal) &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@minItems 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@maxItems 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    })) &&
+                                    input.equal
+                                        .map(
+                                            (elem: any, _index6: number) =>
+                                                ("number" === typeof elem &&
+                                                    (10 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 10)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (10 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 10)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -362,6 +439,9 @@ export const test_validateClone_TagArray = _test_validateClone(
                     both: Array.isArray(input.both)
                         ? $cp1(input.both)
                         : (input.both as any),
+                    equal: Array.isArray(input.equal)
+                        ? $cp2(input.equal)
+                        : (input.equal as any),
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/validateClone/test_validateClone_TagLength.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagLength.ts
@@ -23,7 +23,10 @@ export const test_validateClone_TagLength = _test_validateClone(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -104,6 +107,24 @@ export const test_validateClone_TagLength = _test_validateClone(
                                         expected: "string",
                                         value: input.minimum_and_maximum,
                                     }),
+                                ("string" === typeof input.equal &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@minLength 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (19 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@maxLength 19)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -168,6 +189,7 @@ export const test_validateClone_TagLength = _test_validateClone(
                     minimum: input.minimum as any,
                     maximum: input.maximum as any,
                     minimum_and_maximum: input.minimum_and_maximum as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/validateClone/test_validateClone_TagRange.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagRange.ts
@@ -38,7 +38,10 @@ export const test_validateClone_TagRange = _test_validateClone(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -198,6 +201,24 @@ export const test_validateClone_TagRange = _test_validateClone(
                                         expected: "number",
                                         value: input.greater_equal_less_equal,
                                     }),
+                                ("number" === typeof input.equal &&
+                                    (10 <= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@minimum 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@maximum 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -267,6 +288,7 @@ export const test_validateClone_TagRange = _test_validateClone(
                     greater_less_equal: input.greater_less_equal as any,
                     greater_equal_less_equal:
                         input.greater_equal_less_equal as any,
+                    equal: input.equal as any,
                 });
                 return Array.isArray(input) ? $cp0(input) : (input as any);
             };

--- a/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagArray.ts
@@ -47,12 +47,25 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                         (elem: any, _index5: number) =>
                             "string" === typeof elem && $is_uuid(elem),
                     ) &&
-                    (4 === Object.keys(input).length ||
+                    Array.isArray(input.equal) &&
+                    10 <= input.equal.length &&
+                    10 >= input.equal.length &&
+                    input.equal.every(
+                        (elem: any, _index6: number) =>
+                            "number" === typeof elem &&
+                            10 <= elem &&
+                            10 >= elem,
+                    ) &&
+                    (5 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
-                                ["items", "minItems", "maxItems", "both"].some(
-                                    (prop: any) => key === prop,
-                                )
+                                [
+                                    "items",
+                                    "minItems",
+                                    "maxItems",
+                                    "both",
+                                    "equal",
+                                ].some((prop: any) => key === prop)
                             )
                                 return true;
                             const value = input[key];
@@ -276,7 +289,67 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                     expected: "Array<string>",
                                     value: input.both,
                                 }),
-                            4 === Object.keys(input).length ||
+                            (((Array.isArray(input.equal) &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@minItems 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array.length (@maxItems 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                })) &&
+                                input.equal
+                                    .map(
+                                        (elem: any, _index6: number) =>
+                                            ("number" === typeof elem &&
+                                                (10 <= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@minimum 10)",
+                                                        value: elem,
+                                                    })) &&
+                                                (10 >= elem ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".equal[" +
+                                                            _index6 +
+                                                            "]",
+                                                        expected:
+                                                            "number (@maximum 10)",
+                                                        value: elem,
+                                                    }))) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".equal[" +
+                                                    _index6 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "Array<number>",
+                                    value: input.equal,
+                                }),
+                            5 === Object.keys(input).length ||
                                 false === _exceptionable ||
                                 Object.keys(input)
                                     .map((key: any) => {
@@ -286,6 +359,7 @@ export const test_validateEquals_TagArray = _test_validateEquals(
                                                 "minItems",
                                                 "maxItems",
                                                 "both",
+                                                "equal",
                                             ].some((prop: any) => key === prop)
                                         )
                                             return true;

--- a/test/generated/output/validateEquals/test_validateEquals_TagLength.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagLength.ts
@@ -25,7 +25,10 @@ export const test_validateEquals_TagLength = _test_validateEquals(
                     "string" === typeof input.minimum_and_maximum &&
                     3 <= input.minimum_and_maximum.length &&
                     7 >= input.minimum_and_maximum.length &&
-                    (4 === Object.keys(input).length ||
+                    "string" === typeof input.equal &&
+                    10 <= input.equal.length &&
+                    19 >= input.equal.length &&
+                    (5 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
                                 [
@@ -33,6 +36,7 @@ export const test_validateEquals_TagLength = _test_validateEquals(
                                     "minimum",
                                     "maximum",
                                     "minimum_and_maximum",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;
@@ -118,7 +122,25 @@ export const test_validateEquals_TagLength = _test_validateEquals(
                                     expected: "string",
                                     value: input.minimum_and_maximum,
                                 }),
-                            4 === Object.keys(input).length ||
+                            ("string" === typeof input.equal &&
+                                (10 <= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@minLength 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (19 >= input.equal.length ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string (@maxLength 19)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "string",
+                                    value: input.equal,
+                                }),
+                            5 === Object.keys(input).length ||
                                 false === _exceptionable ||
                                 Object.keys(input)
                                     .map((key: any) => {
@@ -128,6 +150,7 @@ export const test_validateEquals_TagLength = _test_validateEquals(
                                                 "minimum",
                                                 "maximum",
                                                 "minimum_and_maximum",
+                                                "equal",
                                             ].some((prop: any) => key === prop)
                                         )
                                             return true;

--- a/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
@@ -40,7 +40,10 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                     "number" === typeof input.greater_equal_less_equal &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
-                    (8 === Object.keys(input).length ||
+                    "number" === typeof input.equal &&
+                    10 <= input.equal &&
+                    10 >= input.equal &&
+                    (9 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
                                 [
@@ -52,6 +55,7 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                     "greater_equal_less",
                                     "greater_less_equal",
                                     "greater_equal_less_equal",
+                                    "equal",
                                 ].some((prop: any) => key === prop)
                             )
                                 return true;
@@ -216,7 +220,25 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                     expected: "number",
                                     value: input.greater_equal_less_equal,
                                 }),
-                            8 === Object.keys(input).length ||
+                            ("number" === typeof input.equal &&
+                                (10 <= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@minimum 10)",
+                                        value: input.equal,
+                                    })) &&
+                                (10 >= input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@maximum 10)",
+                                        value: input.equal,
+                                    }))) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number",
+                                    value: input.equal,
+                                }),
+                            9 === Object.keys(input).length ||
                                 false === _exceptionable ||
                                 Object.keys(input)
                                     .map((key: any) => {
@@ -230,6 +252,7 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                                 "greater_equal_less",
                                                 "greater_less_equal",
                                                 "greater_equal_less_equal",
+                                                "equal",
                                             ].some((prop: any) => key === prop)
                                         )
                                             return true;

--- a/test/generated/output/validateParse/test_validateParse_TagArray.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagArray.ts
@@ -42,6 +42,15 @@ export const test_validateParse_TagArray = _test_validateParse(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -278,6 +287,74 @@ export const test_validateParse_TagArray = _test_validateParse(
                                         path: _path + ".both",
                                         expected: "Array<string>",
                                         value: input.both,
+                                    }),
+                                (((Array.isArray(input.equal) &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@minItems 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@maxItems 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    })) &&
+                                    input.equal
+                                        .map(
+                                            (elem: any, _index6: number) =>
+                                                ("number" === typeof elem &&
+                                                    (10 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 10)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (10 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 10)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
                                     }),
                             ].every((flag: boolean) => flag);
                         return (

--- a/test/generated/output/validateParse/test_validateParse_TagLength.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagLength.ts
@@ -19,7 +19,10 @@ export const test_validateParse_TagLength = _test_validateParse(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -99,6 +102,24 @@ export const test_validateParse_TagLength = _test_validateParse(
                                         path: _path + ".minimum_and_maximum",
                                         expected: "string",
                                         value: input.minimum_and_maximum,
+                                    }),
+                                ("string" === typeof input.equal &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@minLength 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (19 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@maxLength 19)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string",
+                                        value: input.equal,
                                     }),
                             ].every((flag: boolean) => flag);
                         return (

--- a/test/generated/output/validateParse/test_validateParse_TagRange.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagRange.ts
@@ -34,7 +34,10 @@ export const test_validateParse_TagRange = _test_validateParse(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -193,6 +196,24 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             _path + ".greater_equal_less_equal",
                                         expected: "number",
                                         value: input.greater_equal_less_equal,
+                                    }),
+                                ("number" === typeof input.equal &&
+                                    (10 <= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@minimum 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@maximum 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number",
+                                        value: input.equal,
                                     }),
                             ].every((flag: boolean) => flag);
                         return (

--- a/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagArray.ts
@@ -44,6 +44,15 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -281,6 +290,74 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                                         expected: "Array<string>",
                                         value: input.both,
                                     }),
+                                (((Array.isArray(input.equal) &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@minItems 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@maxItems 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    })) &&
+                                    input.equal
+                                        .map(
+                                            (elem: any, _index6: number) =>
+                                                ("number" === typeof elem &&
+                                                    (10 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 10)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (10 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 10)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -344,7 +421,8 @@ export const test_validatePrune_TagArray = _test_validatePrune(
                             "items" === key ||
                             "minItems" === key ||
                             "maxItems" === key ||
-                            "both" === key
+                            "both" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_TagLength.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagLength.ts
@@ -21,7 +21,10 @@ export const test_validatePrune_TagLength = _test_validatePrune(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -102,6 +105,24 @@ export const test_validatePrune_TagLength = _test_validatePrune(
                                         expected: "string",
                                         value: input.minimum_and_maximum,
                                     }),
+                                ("string" === typeof input.equal &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@minLength 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (19 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@maxLength 19)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -164,7 +185,8 @@ export const test_validatePrune_TagLength = _test_validatePrune(
                             "fixed" === key ||
                             "minimum" === key ||
                             "maximum" === key ||
-                            "minimum_and_maximum" === key
+                            "minimum_and_maximum" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
@@ -36,7 +36,10 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -196,6 +199,24 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                         expected: "number",
                                         value: input.greater_equal_less_equal,
                                     }),
+                                ("number" === typeof input.equal &&
+                                    (10 <= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@minimum 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@maximum 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -262,7 +283,8 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                             "greater_less" === key ||
                             "greater_equal_less" === key ||
                             "greater_less_equal" === key ||
-                            "greater_equal_less_equal" === key
+                            "greater_equal_less_equal" === key ||
+                            "equal" === key
                         )
                             continue;
                         delete input[key];

--- a/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagArray.ts
@@ -44,6 +44,15 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                         input.both.every(
                             (elem: any) =>
                                 "string" === typeof elem && $is_uuid(elem),
+                        ) &&
+                        Array.isArray(input.equal) &&
+                        10 <= input.equal.length &&
+                        10 >= input.equal.length &&
+                        input.equal.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                10 <= elem &&
+                                10 >= elem,
                         );
                     return (
                         Array.isArray(input) &&
@@ -284,6 +293,74 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                                         expected: "Array<string>",
                                         value: input.both,
                                     }),
+                                (((Array.isArray(input.equal) &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@minItems 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected:
+                                                "Array.length (@maxItems 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    })) &&
+                                    input.equal
+                                        .map(
+                                            (elem: any, _index6: number) =>
+                                                ("number" === typeof elem &&
+                                                    (10 <= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@minimum 10)",
+                                                                value: elem,
+                                                            },
+                                                        )) &&
+                                                    (10 >= elem ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".equal[" +
+                                                                    _index6 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number (@maximum 10)",
+                                                                value: elem,
+                                                            },
+                                                        ))) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".equal[" +
+                                                        _index6 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "Array<number>",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -359,6 +436,8 @@ export const test_validateStringify_TagArray = _test_validateStringify(
                         )
                         .join(",")}]`},"both":${`[${input.both
                         .map((elem: any) => $string(elem))
+                        .join(",")}]`},"equal":${`[${input.equal
+                        .map((elem: any) => $number(elem))
                         .join(",")}]`}}`;
                 return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;
             };

--- a/test/generated/output/validateStringify/test_validateStringify_TagLength.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagLength.ts
@@ -21,7 +21,10 @@ export const test_validateStringify_TagLength = _test_validateStringify(
                         7 >= input.maximum.length &&
                         "string" === typeof input.minimum_and_maximum &&
                         3 <= input.minimum_and_maximum.length &&
-                        7 >= input.minimum_and_maximum.length;
+                        7 >= input.minimum_and_maximum.length &&
+                        "string" === typeof input.equal &&
+                        10 <= input.equal.length &&
+                        19 >= input.equal.length;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -104,6 +107,24 @@ export const test_validateStringify_TagLength = _test_validateStringify(
                                         expected: "string",
                                         value: input.minimum_and_maximum,
                                     }),
+                                ("string" === typeof input.equal &&
+                                    (10 <= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@minLength 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (19 >= input.equal.length ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "string (@maxLength 19)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "string",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -167,7 +188,7 @@ export const test_validateStringify_TagLength = _test_validateStringify(
                                 (elem as any).maximum,
                             )},"minimum_and_maximum":${$string(
                                 (elem as any).minimum_and_maximum,
-                            )}}`,
+                            )},"equal":${$string((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
@@ -36,7 +36,10 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         3 <= input.greater_equal_less_equal &&
-                        7 >= input.greater_equal_less_equal;
+                        7 >= input.greater_equal_less_equal &&
+                        "number" === typeof input.equal &&
+                        10 <= input.equal &&
+                        10 >= input.equal;
                     return (
                         Array.isArray(input) &&
                         input.every(
@@ -198,6 +201,24 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                         expected: "number",
                                         value: input.greater_equal_less_equal,
                                     }),
+                                ("number" === typeof input.equal &&
+                                    (10 <= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@minimum 10)",
+                                            value: input.equal,
+                                        })) &&
+                                    (10 >= input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@maximum 10)",
+                                            value: input.equal,
+                                        }))) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number",
+                                        value: input.equal,
+                                    }),
                             ].every((flag: boolean) => flag);
                         return (
                             ((Array.isArray(input) ||
@@ -269,7 +290,7 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 (elem as any).greater_less_equal,
                             )},"greater_equal_less_equal":${$number(
                                 (elem as any).greater_equal_less_equal,
-                            )}}`,
+                            )},"equal":${$number((elem as any).equal)}}`,
                     )
                     .join(",")}]`;
             };

--- a/test/issues/758.js
+++ b/test/issues/758.js
@@ -1,0 +1,44 @@
+generator => {
+    const $generator = typia_1.default.createRandom.generator;
+    const $ro0 = (_recursive = false, _depth = 0) => ({
+        string: (generator?.customs ?? $generator.customs)?.string?.([
+            {
+                name: "minLength",
+                value: "32"
+            },
+            {
+                name: "maxLength",
+                value: "32"
+            }
+        ]) ?? (generator?.string ?? $generator.string)((generator?.integer ?? $generator.integer)(32, 32)),
+        number: (generator?.customs ?? $generator.customs)?.number?.([
+            {
+                name: "minimum",
+                value: "9"
+            },
+            {
+                name: "maximum",
+                value: "9"
+            }
+        ]) ?? (generator?.number ?? $generator.number)(9, 9),
+        array: (generator?.array ?? $generator.array)(() => (generator?.customs ?? $generator.customs)?.number?.([
+            {
+                name: "minItems",
+                value: "5"
+            },
+            {
+                name: "maxItems",
+                value: "5"
+            },
+            {
+                name: "minimum",
+                value: "5"
+            },
+            {
+                name: "maximum",
+                value: "5"
+            }
+        ]) ?? (generator?.number ?? $generator.number)(5, 5), (generator?.integer ?? $generator.integer)(5, 5))
+    });
+    return $ro0();
+}

--- a/test/issues/758.ts
+++ b/test/issues/758.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import typia from "typia";
+
+interface Fixed {
+    /**
+     * @minLength 32
+     * @maxLength 32
+     */
+    string: string;
+
+    /**
+     * @minimum 9
+     * @maximum 9
+     */
+    number: number;
+
+    /**
+     * @minItems 5
+     * @maxItems 5
+     * @minimum 5
+     * @maximum 5
+     */
+    array: number[];
+}
+
+const random = typia.createRandom<Fixed>();
+fs.writeFileSync(__dirname + "/758.js", random.toString(), "utf8");

--- a/test/schemas/json/ajv/TagArray.json
+++ b/test/schemas/json/ajv/TagArray.json
@@ -454,13 +454,140 @@
             },
             "minItems": 3,
             "maxItems": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minItems",
+                "value": 10
+              },
+              {
+                "kind": "maxItems",
+                "value": 10
+              },
+              {
+                "kind": "minimum",
+                "value": 10
+              },
+              {
+                "kind": "maximum",
+                "value": 10
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minItems",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxItems",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "minimum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 10
+                },
+                {
+                  "kind": "maxItems",
+                  "value": 10
+                },
+                {
+                  "kind": "minimum",
+                  "value": 10
+                },
+                {
+                  "kind": "maximum",
+                  "value": 10
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maxItems",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "minimum",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maximum",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number",
+              "minimum": 10,
+              "maximum": 10
+            },
+            "minItems": 10,
+            "maxItems": 10
           }
         },
         "required": [
           "items",
           "minItems",
           "maxItems",
-          "both"
+          "both",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/schemas/json/ajv/TagLength.json
+++ b/test/schemas/json/ajv/TagLength.json
@@ -121,13 +121,51 @@
             "type": "string",
             "minLength": 3,
             "maxLength": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minLength",
+                "value": 10
+              },
+              {
+                "kind": "maxLength",
+                "value": 19
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minLength",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxLength",
+                "text": [
+                  {
+                    "text": "19",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 19
           }
         },
         "required": [
           "fixed",
           "minimum",
           "maximum",
-          "minimum_and_maximum"
+          "minimum_and_maximum",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/schemas/json/ajv/TagRange.json
+++ b/test/schemas/json/ajv/TagRange.json
@@ -262,6 +262,43 @@
             "type": "number",
             "minimum": 3,
             "maximum": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minimum",
+                "value": 10
+              },
+              {
+                "kind": "maximum",
+                "value": 10
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minimum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number",
+            "minimum": 10,
+            "maximum": 10
           }
         },
         "required": [
@@ -272,7 +309,8 @@
           "greater_less",
           "greater_equal_less",
           "greater_less_equal",
-          "greater_equal_less_equal"
+          "greater_equal_less_equal",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/schemas/json/swagger/TagArray.json
+++ b/test/schemas/json/swagger/TagArray.json
@@ -452,6 +452,132 @@
             },
             "minItems": 3,
             "maxItems": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minItems",
+                "value": 10
+              },
+              {
+                "kind": "maxItems",
+                "value": 10
+              },
+              {
+                "kind": "minimum",
+                "value": 10
+              },
+              {
+                "kind": "maximum",
+                "value": 10
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minItems",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxItems",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "minimum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-metaTags": [
+                {
+                  "kind": "minItems",
+                  "value": 10
+                },
+                {
+                  "kind": "maxItems",
+                  "value": 10
+                },
+                {
+                  "kind": "minimum",
+                  "value": 10
+                },
+                {
+                  "kind": "maximum",
+                  "value": 10
+                }
+              ],
+              "x-typia-jsDocTags": [
+                {
+                  "name": "minItems",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maxItems",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "minimum",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                },
+                {
+                  "name": "maximum",
+                  "text": [
+                    {
+                      "text": "10",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number",
+              "minimum": 10,
+              "maximum": 10
+            },
+            "minItems": 10,
+            "maxItems": 10
           }
         },
         "nullable": false,
@@ -459,7 +585,8 @@
           "items",
           "minItems",
           "maxItems",
-          "both"
+          "both",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/schemas/json/swagger/TagLength.json
+++ b/test/schemas/json/swagger/TagLength.json
@@ -119,6 +119,43 @@
             "type": "string",
             "minLength": 3,
             "maxLength": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minLength",
+                "value": 10
+              },
+              {
+                "kind": "maxLength",
+                "value": 19
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minLength",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maxLength",
+                "text": [
+                  {
+                    "text": "19",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 19
           }
         },
         "nullable": false,
@@ -126,7 +163,8 @@
           "fixed",
           "minimum",
           "maximum",
-          "minimum_and_maximum"
+          "minimum_and_maximum",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/schemas/json/swagger/TagRange.json
+++ b/test/schemas/json/swagger/TagRange.json
@@ -260,6 +260,43 @@
             "type": "number",
             "minimum": 3,
             "maximum": 7
+          },
+          "equal": {
+            "x-typia-metaTags": [
+              {
+                "kind": "minimum",
+                "value": 10
+              },
+              {
+                "kind": "maximum",
+                "value": 10
+              }
+            ],
+            "x-typia-jsDocTags": [
+              {
+                "name": "minimum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "maximum",
+                "text": [
+                  {
+                    "text": "10",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number",
+            "minimum": 10,
+            "maximum": 10
           }
         },
         "nullable": false,
@@ -271,7 +308,8 @@
           "greater_less",
           "greater_equal_less",
           "greater_less_equal",
-          "greater_equal_less_equal"
+          "greater_equal_less_equal",
+          "equal"
         ],
         "x-typia-jsDocTags": []
       }

--- a/test/structures/TagArray.ts
+++ b/test/structures/TagArray.ts
@@ -31,6 +31,14 @@ export namespace TagArray {
          * @format uuid
          */
         both: string[];
+
+        /**
+         * @minItems 10
+         * @maxItems 10
+         * @minimum 10
+         * @maximum 10
+         */
+        equal: number[];
     }
 
     // prettier-ignore
@@ -47,6 +55,7 @@ export namespace TagArray {
                     minItems: TestRandomGenerator.array(() => minItems, minItems),
                     maxItems: TestRandomGenerator.array(() => closure(), maxItems),
                     both: TestRandomGenerator.array(() => v4(), both),
+                    equal: TestRandomGenerator.array(() => 10, 10),
                 });
         }
         return output;
@@ -108,6 +117,14 @@ export namespace TagArray {
         (input) => {
             input[10].both = TestRandomGenerator.array(() => v4(), 8);
             return ["$input[10].both"];
+        },
+        (input) => {
+            input[11].equal = TestRandomGenerator.array(() => 10, 9);
+            return ["$input[11].equal"];
+        },
+        (input) => {
+            input[12].equal = [...TestRandomGenerator.array(() => 10, 9), 9];
+            return ["$input[12].equal[9]"];
         },
     ];
 }

--- a/test/structures/TagLength.ts
+++ b/test/structures/TagLength.ts
@@ -26,18 +26,25 @@ export namespace TagLength {
          * @maxLength 7
          */
         minimum_and_maximum: string;
+
+        /**
+         * @minLength 10
+         * @maxLength 19
+         */
+        equal: string;
     }
 
     export function generate(): Type[] {
         const output: Type[] = [];
 
-        ArrayUtil.repeat(4, () => {
+        ArrayUtil.repeat(6, () => {
             for (const minimum_and_maximum of [MINIMUM, MAXIMUM]) {
                 const numeric = {
                     fixed: FIXED,
                     minimum: MINIMUM,
                     maximum: MAXIMUM,
                     minimum_and_maximum,
+                    equal: EQUAL,
                 };
                 const obj: Type = {} as any;
                 for (const [key, value] of Object.entries(numeric))
@@ -48,9 +55,10 @@ export namespace TagLength {
         return output;
     }
 
-    export const FIXED = 5;
-    export const MINIMUM = 3;
-    export const MAXIMUM = 7;
+    const FIXED = 5;
+    const MINIMUM = 3;
+    const MAXIMUM = 7;
+    const EQUAL = 10;
 
     export const SPOILERS: Spoiler<TagLength>[] = [
         (input) => {
@@ -72,6 +80,10 @@ export namespace TagLength {
         (input) => {
             input[4].minimum_and_maximum = "12345678";
             return ["$input[4].minimum_and_maximum"];
+        },
+        (input) => {
+            input[5].equal = "3";
+            return ["$input[5].equal"];
         },
     ];
 }

--- a/test/structures/TagRange.ts
+++ b/test/structures/TagRange.ts
@@ -46,6 +46,12 @@ export namespace TagRange {
          * @maximum 7
          */
         greater_equal_less_equal: number;
+
+        /**
+         * @minimum 10
+         * @maximum 10
+         */
+        equal: number;
     }
 
     // prettier-ignore
@@ -69,6 +75,7 @@ export namespace TagRange {
                 greater_less_equal,
                 greater_equal_less,
                 greater_equal_less_equal,
+                equal: 10,
             });
         return output;
     }
@@ -124,6 +131,10 @@ export namespace TagRange {
         (input) => {
             input[15].greater_equal_less_equal = 8;
             return ["$input[15].greater_equal_less_equal"];
+        },
+        (input) => {
+            input[16].equal = 9;
+            return ["$input[16].equal"];
         },
     ];
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "5.1.6",
-        "typia": "^4.2.0"
+        "typia": "^4.2.2"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -5763,9 +5763,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.2.0.tgz",
-      "integrity": "sha512-ya3IvCsBVbTRVjnMa50glQBZO75ztuOXnMmlY3iRgY+iKtEIfQnhutuQ09RdQSQKDsCH4IK1zj+HWlncTxXhQw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.2.2.tgz",
+      "integrity": "sha512-CGdM8d/jUv/mv9hcFKPuhVIk3KtVUyQ8WOHmbnP5E4OnvTDFtOMbWP9wkTbJ3CYKZdYB37D5u/veffyfqMtF/Q==",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.1.6",
-    "typia": "^4.2.0"
+    "typia": "^4.2.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://typia.io/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://typia.io/playground/</loc><lastmod>2023-08-07T10:43:15.494Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/parse/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/schema/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/json/stringify/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/miscellaneous/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/pure/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/random/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/setup/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/nestjs/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/prisma/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/utilization/trpc/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/assert/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/comment-tags/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/is/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/docs/validators/validate/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://typia.io/playground/</loc><lastmod>2023-08-13T13:56:54.868Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
```typescript
interface Fixed {
    /**
     * @minLength 32
     * @maxLength 32
     */
    string: string;

    /**
     * @minimum 9
     * @maximum 9
     */
    number: number;

    /**
     * @minItems 5
     * @maxItems 5
     * @minimum 5
     * @maximum 5
     */
    array: number[];
}
typia.random<Fixed>()
```

When fixed length type comes like above, `typia.random<T>()` function could not catch the exact fixed value.