### PR TITLE
Limit range of `@type int/uint` comment tags.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.3.0"
+    "typia": "4.3.1"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/programmers/internal/check_number.ts
+++ b/src/programmers/internal/check_number.ts
@@ -56,7 +56,7 @@ export const check_number =
                         ),
                     ]);
                 // RANGE LIMIT
-                if (tag.value === "uint32")
+                if (tag.value === "uint" || tag.value === "uint32")
                     entries.push([
                         tag,
                         ts.factory.createLessThanEquals(
@@ -92,7 +92,7 @@ export const check_number =
                             ),
                         ),
                     ]);
-                else if (tag.value === "int32")
+                else if (tag.value === "int" || tag.value === "int32")
                     entries.push([
                         tag,
                         ts.factory.createLogicalAnd(

--- a/test/generated/output/assert/test_assert_TagInfinite.ts
+++ b/test/generated/output/assert/test_assert_TagInfinite.ts
@@ -26,7 +26,9 @@ export const test_assert_TagInfinite = _test_assert(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input))
@@ -107,6 +109,13 @@ export const test_assert_TagInfinite = _test_assert(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/assert/test_assert_TagNaN.ts
+++ b/test/generated/output/assert/test_assert_TagNaN.ts
@@ -26,7 +26,9 @@ export const test_assert_TagNaN = _test_assert(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input))
@@ -107,6 +109,13 @@ export const test_assert_TagNaN = _test_assert(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/assert/test_assert_TagRange.ts
+++ b/test/generated/output/assert/test_assert_TagRange.ts
@@ -20,40 +20,58 @@ export const test_assert_TagRange = _test_assert(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -120,6 +138,13 @@ export const test_assert_TagRange = _test_assert(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -140,6 +165,13 @@ export const test_assert_TagRange = _test_assert(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -154,6 +186,13 @@ export const test_assert_TagRange = _test_assert(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -179,6 +218,13 @@ export const test_assert_TagRange = _test_assert(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -193,6 +239,13 @@ export const test_assert_TagRange = _test_assert(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -223,6 +276,13 @@ export const test_assert_TagRange = _test_assert(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -243,6 +303,13 @@ export const test_assert_TagRange = _test_assert(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -273,6 +340,13 @@ export const test_assert_TagRange = _test_assert(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -292,6 +366,13 @@ export const test_assert_TagRange = _test_assert(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",

--- a/test/generated/output/assert/test_assert_TagType.ts
+++ b/test/generated/output/assert/test_assert_TagType.ts
@@ -20,10 +20,13 @@ export const test_assert_TagType = _test_assert(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -111,6 +114,13 @@ export const test_assert_TagType = _test_assert(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -126,6 +136,12 @@ export const test_assert_TagType = _test_assert(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",

--- a/test/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/generated/output/assert/test_assert_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_assert_UltimateUnion = _test_assert(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_assert_UltimateUnion = _test_assert(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_assert_UltimateUnion = _test_assert(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_assert_UltimateUnion = _test_assert(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2534,6 +2556,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -2544,6 +2573,13 @@ export const test_assert_UltimateUnion = _test_assert(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -2573,6 +2609,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -2952,6 +2995,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -2969,6 +3018,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -3185,6 +3240,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3202,6 +3263,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -3433,6 +3500,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3450,6 +3523,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -5303,6 +5382,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -5313,6 +5399,13 @@ export const test_assert_UltimateUnion = _test_assert(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -5342,6 +5435,13 @@ export const test_assert_UltimateUnion = _test_assert(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -5749,6 +5849,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -5766,6 +5872,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -5996,6 +6108,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6013,6 +6131,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -6258,6 +6382,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6275,6 +6405,12 @@ export const test_assert_UltimateUnion = _test_assert(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",

--- a/test/generated/output/assertClone/test_assertClone_TagRange.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagRange.ts
@@ -21,41 +21,59 @@ export const test_assertClone_TagRange = _test_assertClone(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -131,6 +149,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater",
@@ -152,6 +177,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -166,6 +198,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                             (("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -192,6 +231,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -206,6 +252,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                             (("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -238,6 +291,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -259,6 +319,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                             (("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -292,6 +359,16 @@ export const test_assertClone_TagRange = _test_assertClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $guard(_exceptionable, {
                                         path:
@@ -313,6 +390,13 @@ export const test_assertClone_TagRange = _test_assertClone(
                                 })) &&
                             (("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -356,37 +440,55 @@ export const test_assertClone_TagRange = _test_assertClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $cp0 = (input: any) =>

--- a/test/generated/output/assertClone/test_assertClone_TagType.ts
+++ b/test/generated/output/assertClone/test_assertClone_TagType.ts
@@ -21,10 +21,13 @@ export const test_assertClone_TagType = _test_assertClone(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -121,6 +124,13 @@ export const test_assertClone_TagType = _test_assertClone(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".int",
@@ -136,6 +146,12 @@ export const test_assertClone_TagType = _test_assertClone(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -271,9 +287,12 @@ export const test_assertClone_TagType = _test_assertClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
+++ b/test/generated/output/assertClone/test_assertClone_UltimateUnion.ts
@@ -262,11 +262,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -275,7 +279,9 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -364,13 +370,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -417,12 +425,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -471,11 +481,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -894,11 +906,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -907,7 +923,9 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1004,13 +1022,15 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1061,12 +1081,14 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1119,11 +1141,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2575,6 +2599,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2586,6 +2617,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2615,6 +2653,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3002,6 +3047,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3019,6 +3070,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3239,6 +3296,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3256,6 +3319,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3499,6 +3568,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3516,6 +3591,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5431,6 +5512,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5442,6 +5530,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5471,6 +5566,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -5886,6 +5988,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -5903,6 +6011,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6137,6 +6251,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6154,6 +6274,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6411,6 +6537,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6428,6 +6560,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -7876,18 +8014,23 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -7969,11 +8112,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8019,11 +8164,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8071,10 +8218,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -8487,18 +8636,23 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -8588,11 +8742,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8642,11 +8798,13 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8698,10 +8856,12 @@ export const test_assertClone_UltimateUnion = _test_assertClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/assertEquals/test_assertEquals_TagInfinite.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagInfinite.ts
@@ -31,6 +31,8 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                     "number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
                     Math.floor(input.typed) === input.typed &&
+                    -2147483648 <= input.typed &&
+                    input.typed <= 2147483647 &&
                     (6 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -133,6 +135,13 @@ export const test_assertEquals_TagInfinite = _test_assertEquals(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/assertEquals/test_assertEquals_TagNaN.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagNaN.ts
@@ -31,6 +31,8 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                     "number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
                     Math.floor(input.typed) === input.typed &&
+                    -2147483648 <= input.typed &&
+                    input.typed <= 2147483647 &&
                     (6 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -133,6 +135,13 @@ export const test_assertEquals_TagNaN = _test_assertEquals(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagRange.ts
@@ -37,40 +37,58 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal &&
                     (9 === Object.keys(input).length ||
@@ -173,6 +191,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -193,6 +218,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -207,6 +239,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -232,6 +271,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -246,6 +292,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -276,6 +329,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -296,6 +356,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -326,6 +393,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -345,6 +419,13 @@ export const test_assertEquals_TagRange = _test_assertEquals(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",

--- a/test/generated/output/assertEquals/test_assertEquals_TagType.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_TagType.ts
@@ -37,10 +37,13 @@ export const test_assertEquals_TagType = _test_assertEquals(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -162,6 +165,13 @@ export const test_assertEquals_TagType = _test_assertEquals(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -177,6 +187,12 @@ export const test_assertEquals_TagType = _test_assertEquals(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",

--- a/test/generated/output/assertParse/test_assertParse_TagRange.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagRange.ts
@@ -21,41 +21,59 @@ export const test_assertParse_TagRange = _test_assertParse(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -131,6 +149,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater",
@@ -152,6 +177,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -166,6 +198,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                             (("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -192,6 +231,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -206,6 +252,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                             (("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -238,6 +291,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -259,6 +319,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                             (("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -292,6 +359,16 @@ export const test_assertParse_TagRange = _test_assertParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $guard(_exceptionable, {
                                         path:
@@ -313,6 +390,13 @@ export const test_assertParse_TagRange = _test_assertParse(
                                 })) &&
                             (("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",

--- a/test/generated/output/assertParse/test_assertParse_TagType.ts
+++ b/test/generated/output/assertParse/test_assertParse_TagType.ts
@@ -21,10 +21,13 @@ export const test_assertParse_TagType = _test_assertParse(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -121,6 +124,13 @@ export const test_assertParse_TagType = _test_assertParse(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".int",
@@ -136,6 +146,12 @@ export const test_assertParse_TagType = _test_assertParse(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",

--- a/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
+++ b/test/generated/output/assertParse/test_assertParse_UltimateUnion.ts
@@ -262,11 +262,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -275,7 +279,9 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -364,13 +370,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -417,12 +425,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -471,11 +481,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -894,11 +906,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -907,7 +923,9 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1004,13 +1022,15 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1061,12 +1081,14 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1119,11 +1141,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2575,6 +2599,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2586,6 +2617,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2615,6 +2653,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3002,6 +3047,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3019,6 +3070,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3239,6 +3296,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3256,6 +3319,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3499,6 +3568,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3516,6 +3591,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5431,6 +5512,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5442,6 +5530,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5471,6 +5566,13 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -5886,6 +5988,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -5903,6 +6011,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6137,6 +6251,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6154,6 +6274,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6411,6 +6537,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6428,6 +6560,12 @@ export const test_assertParse_UltimateUnion = _test_assertParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",

--- a/test/generated/output/assertPrune/test_assertPrune_TagInfinite.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagInfinite.ts
@@ -28,7 +28,9 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                         "number" === typeof (input as any).typed &&
                         Number.isFinite((input as any).typed) &&
                         Math.floor((input as any).typed) ===
-                            (input as any).typed
+                            (input as any).typed &&
+                        -2147483648 <= (input as any).typed &&
+                        (input as any).typed <= 2147483647
                     );
                 };
                 if (false === __is(input))
@@ -109,6 +111,13 @@ export const test_assertPrune_TagInfinite = _test_assertPrune(
                             (("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/assertPrune/test_assertPrune_TagNaN.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagNaN.ts
@@ -28,7 +28,9 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                         "number" === typeof (input as any).typed &&
                         Number.isFinite((input as any).typed) &&
                         Math.floor((input as any).typed) ===
-                            (input as any).typed
+                            (input as any).typed &&
+                        -2147483648 <= (input as any).typed &&
+                        (input as any).typed <= 2147483647
                     );
                 };
                 if (false === __is(input))
@@ -109,6 +111,13 @@ export const test_assertPrune_TagNaN = _test_assertPrune(
                             (("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagRange.ts
@@ -21,41 +21,59 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -131,6 +149,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater",
@@ -152,6 +177,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -166,6 +198,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             (("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -192,6 +231,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -206,6 +252,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             (("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -238,6 +291,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -259,6 +319,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                             (("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -292,6 +359,16 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $guard(_exceptionable, {
                                         path:
@@ -313,6 +390,13 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                                 })) &&
                             (("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -356,37 +440,55 @@ export const test_assertPrune_TagRange = _test_assertPrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $pp0 = (input: any) =>

--- a/test/generated/output/assertPrune/test_assertPrune_TagType.ts
+++ b/test/generated/output/assertPrune/test_assertPrune_TagType.ts
@@ -21,10 +21,13 @@ export const test_assertPrune_TagType = _test_assertPrune(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -121,6 +124,13 @@ export const test_assertPrune_TagType = _test_assertPrune(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".int",
@@ -136,6 +146,12 @@ export const test_assertPrune_TagType = _test_assertPrune(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -271,9 +287,12 @@ export const test_assertPrune_TagType = _test_assertPrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagRange.ts
@@ -21,41 +21,59 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -131,6 +149,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater",
@@ -152,6 +177,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -166,6 +198,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             (("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -192,6 +231,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $guard(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -206,6 +252,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             (("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -238,6 +291,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -259,6 +319,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                             (("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -292,6 +359,16 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $guard(_exceptionable, {
                                         path:
@@ -313,6 +390,13 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                                 })) &&
                             (("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -356,37 +440,55 @@ export const test_assertStringify_TagRange = _test_assertStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $number = (typia.assertStringify as any).number;

--- a/test/generated/output/assertStringify/test_assertStringify_TagType.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_TagType.ts
@@ -21,10 +21,13 @@ export const test_assertStringify_TagType = _test_assertStringify(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -121,6 +124,13 @@ export const test_assertStringify_TagType = _test_assertStringify(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".int",
@@ -136,6 +146,12 @@ export const test_assertStringify_TagType = _test_assertStringify(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -271,9 +287,12 @@ export const test_assertStringify_TagType = _test_assertStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
+++ b/test/generated/output/assertStringify/test_assertStringify_UltimateUnion.ts
@@ -262,11 +262,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -275,7 +279,9 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -364,13 +370,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -417,12 +425,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -471,11 +481,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -894,11 +906,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -907,7 +923,9 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1004,13 +1022,15 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1061,12 +1081,14 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1119,11 +1141,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2575,6 +2599,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2586,6 +2617,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2615,6 +2653,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3002,6 +3047,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3019,6 +3070,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3239,6 +3296,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3256,6 +3319,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3499,6 +3568,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3516,6 +3591,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5431,6 +5512,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5442,6 +5530,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5471,6 +5566,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $guard(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -5886,6 +5988,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minLength",
@@ -5903,6 +6011,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6137,6 +6251,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6154,6 +6274,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6411,6 +6537,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6428,6 +6560,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $guard(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -7874,18 +8012,23 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -7967,11 +8110,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8017,11 +8162,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8069,10 +8216,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -8485,18 +8634,23 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -8586,11 +8740,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8640,11 +8796,13 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8696,10 +8854,12 @@ export const test_assertStringify_UltimateUnion = _test_assertStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/clone/test_clone_TagRange.ts
+++ b/test/generated/output/clone/test_clone_TagRange.ts
@@ -10,37 +10,55 @@ export const test_clone_TagRange = _test_clone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $cp0 = (input: any) =>

--- a/test/generated/output/clone/test_clone_TagType.ts
+++ b/test/generated/output/clone/test_clone_TagType.ts
@@ -10,9 +10,12 @@ export const test_clone_TagType = _test_clone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/clone/test_clone_UltimateUnion.ts
+++ b/test/generated/output/clone/test_clone_UltimateUnion.ts
@@ -211,17 +211,23 @@ export const test_clone_UltimateUnion = _test_clone(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -303,11 +309,13 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -353,11 +361,13 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -405,10 +415,12 @@ export const test_clone_UltimateUnion = _test_clone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -806,17 +818,23 @@ export const test_clone_UltimateUnion = _test_clone(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -904,11 +922,13 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -957,11 +977,13 @@ export const test_clone_UltimateUnion = _test_clone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1012,10 +1034,12 @@ export const test_clone_UltimateUnion = _test_clone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createAssert/test_createAssert_TagInfinite.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagInfinite.ts
@@ -25,7 +25,9 @@ export const test_createAssert_TagInfinite = _test_assert(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -106,6 +108,13 @@ export const test_createAssert_TagInfinite = _test_assert(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssert/test_createAssert_TagNaN.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagNaN.ts
@@ -25,7 +25,9 @@ export const test_createAssert_TagNaN = _test_assert(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -106,6 +108,13 @@ export const test_createAssert_TagNaN = _test_assert(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssert/test_createAssert_TagRange.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagRange.ts
@@ -17,40 +17,58 @@ export const test_createAssert_TagRange = _test_assert(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -110,6 +128,13 @@ export const test_createAssert_TagRange = _test_assert(
                                 expected: "number (@type int)",
                                 value: input.greater,
                             })) &&
+                        ((-2147483648 <= input.greater &&
+                            input.greater <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@type int)",
+                                value: input.greater,
+                            })) &&
                         (3 < input.greater ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
@@ -125,6 +150,13 @@ export const test_createAssert_TagRange = _test_assert(
                         Number.isFinite(input.greater_equal) &&
                         (Math.floor(input.greater_equal) ===
                             input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_equal &&
+                            input.greater_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number (@type int)",
@@ -149,6 +181,13 @@ export const test_createAssert_TagRange = _test_assert(
                                 expected: "number (@type int)",
                                 value: input.less,
                             })) &&
+                        ((-2147483648 <= input.less &&
+                            input.less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@type int)",
+                                value: input.less,
+                            })) &&
                         (7 > input.less ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
@@ -168,6 +207,13 @@ export const test_createAssert_TagRange = _test_assert(
                                 expected: "number (@type int)",
                                 value: input.less_equal,
                             })) &&
+                        ((-2147483648 <= input.less_equal &&
+                            input.less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@type int)",
+                                value: input.less_equal,
+                            })) &&
                         (7 >= input.less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
@@ -182,6 +228,13 @@ export const test_createAssert_TagRange = _test_assert(
                     (("number" === typeof input.greater_less &&
                         (Math.floor(input.greater_less) ===
                             input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@type int)",
+                                value: input.greater_less,
+                            })) &&
+                        ((-2147483648 <= input.greater_less &&
+                            input.greater_less <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number (@type int)",
@@ -212,6 +265,13 @@ export const test_createAssert_TagRange = _test_assert(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less &&
+                            input.greater_equal_less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less,
+                            })) &&
                         (3 <= input.greater_equal_less ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
@@ -232,6 +292,13 @@ export const test_createAssert_TagRange = _test_assert(
                     (("number" === typeof input.greater_less_equal &&
                         (Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_less_equal &&
+                            input.greater_less_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number (@type int)",
@@ -262,6 +329,13 @@ export const test_createAssert_TagRange = _test_assert(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less_equal,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less_equal &&
+                            input.greater_equal_less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
                         (3 <= input.greater_equal_less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
@@ -281,6 +355,13 @@ export const test_createAssert_TagRange = _test_assert(
                         })) &&
                     (("number" === typeof input.equal &&
                         (Math.floor(input.equal) === input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@type int)",
+                                value: input.equal,
+                            })) &&
+                        ((-2147483648 <= input.equal &&
+                            input.equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".equal",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssert/test_createAssert_TagType.ts
+++ b/test/generated/output/createAssert/test_createAssert_TagType.ts
@@ -17,10 +17,13 @@ export const test_createAssert_TagType = _test_assert(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -101,6 +104,13 @@ export const test_createAssert_TagType = _test_assert(
                                 path: _path + ".int",
                                 expected: "number (@type int)",
                                 value: input.int,
+                            })) &&
+                        ((-2147483648 <= input.int &&
+                            input.int <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
@@ -116,6 +126,12 @@ export const test_createAssert_TagType = _test_assert(
                                 value: input.uint,
                             })) &&
                         (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (input.uint <= 4294967295 ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number (@type uint)",

--- a/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -253,11 +253,15 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -265,7 +269,9 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -353,12 +359,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -405,12 +413,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -459,11 +469,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -866,11 +878,15 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -878,7 +894,9 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -972,12 +990,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1027,12 +1047,14 @@ export const test_createAssert_UltimateUnion = _test_assert(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1084,11 +1106,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2476,6 +2500,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -2486,6 +2517,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -2515,6 +2553,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -2889,6 +2934,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -2905,6 +2956,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -3118,6 +3175,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -3134,6 +3197,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -3358,6 +3427,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -3374,6 +3449,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -5183,6 +5264,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -5193,6 +5281,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -5222,6 +5317,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -5624,6 +5726,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -5640,6 +5748,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -5867,6 +5981,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -5883,6 +6003,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -6121,6 +6247,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -6137,6 +6269,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagRange.ts
@@ -20,40 +20,58 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -120,6 +138,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -140,6 +165,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -154,6 +186,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -179,6 +218,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -193,6 +239,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -223,6 +276,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -243,6 +303,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -273,6 +340,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -292,6 +366,13 @@ export const test_createAssertClone_TagRange = _test_assertClone(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",
@@ -335,37 +416,55 @@ export const test_createAssertClone_TagRange = _test_assertClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $cp0 = (input: any) =>

--- a/test/generated/output/createAssertClone/test_createAssertClone_TagType.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_TagType.ts
@@ -20,10 +20,13 @@ export const test_createAssertClone_TagType = _test_assertClone(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -111,6 +114,13 @@ export const test_createAssertClone_TagType = _test_assertClone(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -126,6 +136,12 @@ export const test_createAssertClone_TagType = _test_assertClone(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",
@@ -261,9 +277,12 @@ export const test_createAssertClone_TagType = _test_assertClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
+++ b/test/generated/output/createAssertClone/test_createAssertClone_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2534,6 +2556,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -2544,6 +2573,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -2573,6 +2609,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -2952,6 +2995,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -2969,6 +3018,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -3185,6 +3240,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3202,6 +3263,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -3433,6 +3500,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3450,6 +3523,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -5303,6 +5382,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -5313,6 +5399,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -5342,6 +5435,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -5749,6 +5849,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -5766,6 +5872,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -5996,6 +6108,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6013,6 +6131,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -6258,6 +6382,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6275,6 +6405,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -7623,17 +7759,23 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -7715,11 +7857,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -7765,11 +7909,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -7817,10 +7963,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8218,17 +8366,23 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -8316,11 +8470,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -8369,11 +8525,13 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -8424,10 +8582,12 @@ export const test_createAssertClone_UltimateUnion = _test_assertClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagInfinite.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagInfinite.ts
@@ -30,6 +30,8 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
@@ -130,6 +132,13 @@ export const test_createAssertEquals_TagInfinite = _test_assertEquals(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagNaN.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagNaN.ts
@@ -30,6 +30,8 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
@@ -130,6 +132,13 @@ export const test_createAssertEquals_TagNaN = _test_assertEquals(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagRange.ts
@@ -36,40 +36,58 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal &&
                 (9 === Object.keys(input).length ||
@@ -165,6 +183,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 expected: "number (@type int)",
                                 value: input.greater,
                             })) &&
+                        ((-2147483648 <= input.greater &&
+                            input.greater <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@type int)",
+                                value: input.greater,
+                            })) &&
                         (3 < input.greater ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
@@ -180,6 +205,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                         Number.isFinite(input.greater_equal) &&
                         (Math.floor(input.greater_equal) ===
                             input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_equal &&
+                            input.greater_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number (@type int)",
@@ -204,6 +236,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 expected: "number (@type int)",
                                 value: input.less,
                             })) &&
+                        ((-2147483648 <= input.less &&
+                            input.less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@type int)",
+                                value: input.less,
+                            })) &&
                         (7 > input.less ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
@@ -223,6 +262,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 expected: "number (@type int)",
                                 value: input.less_equal,
                             })) &&
+                        ((-2147483648 <= input.less_equal &&
+                            input.less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@type int)",
+                                value: input.less_equal,
+                            })) &&
                         (7 >= input.less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
@@ -237,6 +283,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                     (("number" === typeof input.greater_less &&
                         (Math.floor(input.greater_less) ===
                             input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@type int)",
+                                value: input.greater_less,
+                            })) &&
+                        ((-2147483648 <= input.greater_less &&
+                            input.greater_less <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number (@type int)",
@@ -267,6 +320,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less &&
+                            input.greater_equal_less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less,
+                            })) &&
                         (3 <= input.greater_equal_less ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
@@ -287,6 +347,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                     (("number" === typeof input.greater_less_equal &&
                         (Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_less_equal &&
+                            input.greater_less_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number (@type int)",
@@ -317,6 +384,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less_equal,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less_equal &&
+                            input.greater_equal_less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
                         (3 <= input.greater_equal_less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
@@ -336,6 +410,13 @@ export const test_createAssertEquals_TagRange = _test_assertEquals(
                         })) &&
                     (("number" === typeof input.equal &&
                         (Math.floor(input.equal) === input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@type int)",
+                                value: input.equal,
+                            })) &&
+                        ((-2147483648 <= input.equal &&
+                            input.equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".equal",
                                 expected: "number (@type int)",

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_TagType.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_TagType.ts
@@ -36,10 +36,13 @@ export const test_createAssertEquals_TagType = _test_assertEquals(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -154,6 +157,13 @@ export const test_createAssertEquals_TagType = _test_assertEquals(
                                 path: _path + ".int",
                                 expected: "number (@type int)",
                                 value: input.int,
+                            })) &&
+                        ((-2147483648 <= input.int &&
+                            input.int <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
@@ -169,6 +179,12 @@ export const test_createAssertEquals_TagType = _test_assertEquals(
                                 value: input.uint,
                             })) &&
                         (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (input.uint <= 4294967295 ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number (@type uint)",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagRange.ts
@@ -20,40 +20,58 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -120,6 +138,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -140,6 +165,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -154,6 +186,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -179,6 +218,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -193,6 +239,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -223,6 +276,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -243,6 +303,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -273,6 +340,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -292,6 +366,13 @@ export const test_createAssertParse_TagRange = _test_assertParse(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",

--- a/test/generated/output/createAssertParse/test_createAssertParse_TagType.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_TagType.ts
@@ -20,10 +20,13 @@ export const test_createAssertParse_TagType = _test_assertParse(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -111,6 +114,13 @@ export const test_createAssertParse_TagType = _test_assertParse(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -126,6 +136,12 @@ export const test_createAssertParse_TagType = _test_assertParse(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",

--- a/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
+++ b/test/generated/output/createAssertParse/test_createAssertParse_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2534,6 +2556,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -2544,6 +2573,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -2573,6 +2609,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -2952,6 +2995,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -2969,6 +3018,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -3185,6 +3240,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3202,6 +3263,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -3433,6 +3500,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3450,6 +3523,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -5303,6 +5382,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -5313,6 +5399,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -5342,6 +5435,13 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -5749,6 +5849,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -5766,6 +5872,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -5996,6 +6108,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6013,6 +6131,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -6258,6 +6382,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6275,6 +6405,12 @@ export const test_createAssertParse_UltimateUnion = _test_assertParse(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagInfinite.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagInfinite.ts
@@ -26,7 +26,9 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input))
@@ -107,6 +109,13 @@ export const test_createAssertPrune_TagInfinite = _test_assertPrune(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagNaN.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagNaN.ts
@@ -26,7 +26,9 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input))
@@ -107,6 +109,13 @@ export const test_createAssertPrune_TagNaN = _test_assertPrune(
                         (("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagRange.ts
@@ -20,40 +20,58 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -120,6 +138,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -140,6 +165,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -154,6 +186,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -179,6 +218,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -193,6 +239,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -223,6 +276,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -243,6 +303,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -273,6 +340,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -292,6 +366,13 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",
@@ -335,37 +416,55 @@ export const test_createAssertPrune_TagRange = _test_assertPrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $pp0 = (input: any) =>

--- a/test/generated/output/createAssertPrune/test_createAssertPrune_TagType.ts
+++ b/test/generated/output/createAssertPrune/test_createAssertPrune_TagType.ts
@@ -20,10 +20,13 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -111,6 +114,13 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -126,6 +136,12 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",
@@ -261,9 +277,12 @@ export const test_createAssertPrune_TagType = _test_assertPrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagRange.ts
@@ -20,40 +20,58 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -120,6 +138,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater",
@@ -140,6 +165,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -154,6 +186,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         (("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -179,6 +218,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -193,6 +239,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         (("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -223,6 +276,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -243,6 +303,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                         (("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -273,6 +340,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $guard(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -292,6 +366,13 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
                             })) &&
                         (("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",
@@ -335,37 +416,55 @@ export const test_createAssertStringify_TagRange = _test_assertStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $number = (typia.createAssertStringify as any).number;

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_TagType.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_TagType.ts
@@ -20,10 +20,13 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -111,6 +114,13 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".int",
@@ -126,6 +136,12 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",
@@ -261,9 +277,12 @@ export const test_createAssertStringify_TagType = _test_assertStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
+++ b/test/generated/output/createAssertStringify/test_createAssertStringify_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2534,6 +2556,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -2544,6 +2573,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -2573,6 +2609,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -2952,6 +2995,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -2969,6 +3018,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -3185,6 +3240,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3202,6 +3263,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -3433,6 +3500,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3450,6 +3523,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -5303,6 +5382,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minimum",
@@ -5313,6 +5399,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -5342,6 +5435,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $guard(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -5749,6 +5849,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minLength",
@@ -5766,6 +5872,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -5996,6 +6108,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6013,6 +6131,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -6258,6 +6382,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $guard(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6275,6 +6405,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $guard(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -7621,17 +7757,23 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -7713,11 +7855,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -7763,11 +7907,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -7815,10 +7961,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8216,17 +8364,23 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -8314,11 +8468,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -8367,11 +8523,13 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -8422,10 +8580,12 @@ export const test_createAssertStringify_UltimateUnion = _test_assertStringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createClone/test_createClone_TagRange.ts
+++ b/test/generated/output/createClone/test_createClone_TagRange.ts
@@ -9,35 +9,53 @@ export const test_createClone_TagRange = _test_clone(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.greater &&
             Math.floor(input.greater) === input.greater &&
+            -2147483648 <= input.greater &&
+            input.greater <= 2147483647 &&
             3 < input.greater &&
             "number" === typeof input.greater_equal &&
             Math.floor(input.greater_equal) === input.greater_equal &&
+            -2147483648 <= input.greater_equal &&
+            input.greater_equal <= 2147483647 &&
             3 <= input.greater_equal &&
             "number" === typeof input.less &&
             Math.floor(input.less) === input.less &&
+            -2147483648 <= input.less &&
+            input.less <= 2147483647 &&
             7 > input.less &&
             "number" === typeof input.less_equal &&
             Math.floor(input.less_equal) === input.less_equal &&
+            -2147483648 <= input.less_equal &&
+            input.less_equal <= 2147483647 &&
             7 >= input.less_equal &&
             "number" === typeof input.greater_less &&
             Math.floor(input.greater_less) === input.greater_less &&
+            -2147483648 <= input.greater_less &&
+            input.greater_less <= 2147483647 &&
             3 < input.greater_less &&
             7 > input.greater_less &&
             "number" === typeof input.greater_equal_less &&
             Math.floor(input.greater_equal_less) === input.greater_equal_less &&
+            -2147483648 <= input.greater_equal_less &&
+            input.greater_equal_less <= 2147483647 &&
             3 <= input.greater_equal_less &&
             7 > input.greater_equal_less &&
             "number" === typeof input.greater_less_equal &&
             Math.floor(input.greater_less_equal) === input.greater_less_equal &&
+            -2147483648 <= input.greater_less_equal &&
+            input.greater_less_equal <= 2147483647 &&
             3 < input.greater_less_equal &&
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             Math.floor(input.greater_equal_less_equal) ===
                 input.greater_equal_less_equal &&
+            -2147483648 <= input.greater_equal_less_equal &&
+            input.greater_equal_less_equal <= 2147483647 &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
             "number" === typeof input.equal &&
             Math.floor(input.equal) === input.equal &&
+            -2147483648 <= input.equal &&
+            input.equal <= 2147483647 &&
             10 <= input.equal &&
             10 >= input.equal;
         const $cp0 = (input: any) =>

--- a/test/generated/output/createClone/test_createClone_TagType.ts
+++ b/test/generated/output/createClone/test_createClone_TagType.ts
@@ -9,9 +9,12 @@ export const test_createClone_TagType = _test_clone(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.int &&
             Math.floor(input.int) === input.int &&
+            -2147483648 <= input.int &&
+            input.int <= 2147483647 &&
             "number" === typeof input.uint &&
             Math.floor(input.uint) === input.uint &&
             0 <= input.uint &&
+            input.uint <= 4294967295 &&
             "number" === typeof input.int32 &&
             Math.floor(input.int32) === input.int32 &&
             -2147483648 <= input.int32 &&

--- a/test/generated/output/createClone/test_createClone_UltimateUnion.ts
+++ b/test/generated/output/createClone/test_createClone_UltimateUnion.ts
@@ -205,17 +205,23 @@ export const test_createClone_UltimateUnion = _test_clone(
         const $io22 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
                 "boolean" === typeof input.exclusiveMaximum) &&
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
@@ -295,11 +301,13 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -343,11 +351,13 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.minItems ||
                 ("number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -394,10 +404,12 @@ export const test_createClone_UltimateUnion = _test_clone(
             "number" === typeof input.minItems &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -783,17 +795,23 @@ export const test_createClone_UltimateUnion = _test_clone(
         const $io39 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
                 "boolean" === typeof input.exclusiveMaximum) &&
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
@@ -879,11 +897,13 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -930,11 +950,13 @@ export const test_createClone_UltimateUnion = _test_clone(
             (undefined === input.minItems ||
                 ("number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -984,10 +1006,12 @@ export const test_createClone_UltimateUnion = _test_clone(
             "number" === typeof input.minItems &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createEquals/test_createEquals_TagInfinite.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagInfinite.ts
@@ -23,6 +23,8 @@ export const test_createEquals_TagInfinite = _test_equals(
             "number" === typeof input.typed &&
             Number.isFinite(input.typed) &&
             Math.floor(input.typed) === input.typed &&
+            -2147483648 <= input.typed &&
+            input.typed <= 2147483647 &&
             (6 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (

--- a/test/generated/output/createEquals/test_createEquals_TagNaN.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagNaN.ts
@@ -23,6 +23,8 @@ export const test_createEquals_TagNaN = _test_equals(
             "number" === typeof input.typed &&
             Number.isFinite(input.typed) &&
             Math.floor(input.typed) === input.typed &&
+            -2147483648 <= input.typed &&
+            input.typed <= 2147483647 &&
             (6 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (

--- a/test/generated/output/createEquals/test_createEquals_TagRange.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagRange.ts
@@ -26,38 +26,56 @@ export const test_createEquals_TagRange = _test_equals(
             "number" === typeof input.greater &&
             Number.isFinite(input.greater) &&
             Math.floor(input.greater) === input.greater &&
+            -2147483648 <= input.greater &&
+            input.greater <= 2147483647 &&
             3 < input.greater &&
             "number" === typeof input.greater_equal &&
             Number.isFinite(input.greater_equal) &&
             Math.floor(input.greater_equal) === input.greater_equal &&
+            -2147483648 <= input.greater_equal &&
+            input.greater_equal <= 2147483647 &&
             3 <= input.greater_equal &&
             "number" === typeof input.less &&
             Number.isFinite(input.less) &&
             Math.floor(input.less) === input.less &&
+            -2147483648 <= input.less &&
+            input.less <= 2147483647 &&
             7 > input.less &&
             "number" === typeof input.less_equal &&
             Number.isFinite(input.less_equal) &&
             Math.floor(input.less_equal) === input.less_equal &&
+            -2147483648 <= input.less_equal &&
+            input.less_equal <= 2147483647 &&
             7 >= input.less_equal &&
             "number" === typeof input.greater_less &&
             Math.floor(input.greater_less) === input.greater_less &&
+            -2147483648 <= input.greater_less &&
+            input.greater_less <= 2147483647 &&
             3 < input.greater_less &&
             7 > input.greater_less &&
             "number" === typeof input.greater_equal_less &&
             Math.floor(input.greater_equal_less) === input.greater_equal_less &&
+            -2147483648 <= input.greater_equal_less &&
+            input.greater_equal_less <= 2147483647 &&
             3 <= input.greater_equal_less &&
             7 > input.greater_equal_less &&
             "number" === typeof input.greater_less_equal &&
             Math.floor(input.greater_less_equal) === input.greater_less_equal &&
+            -2147483648 <= input.greater_less_equal &&
+            input.greater_less_equal <= 2147483647 &&
             3 < input.greater_less_equal &&
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             Math.floor(input.greater_equal_less_equal) ===
                 input.greater_equal_less_equal &&
+            -2147483648 <= input.greater_equal_less_equal &&
+            input.greater_equal_less_equal <= 2147483647 &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
             "number" === typeof input.equal &&
             Math.floor(input.equal) === input.equal &&
+            -2147483648 <= input.equal &&
+            input.equal <= 2147483647 &&
             10 <= input.equal &&
             10 >= input.equal &&
             (9 === Object.keys(input).length ||

--- a/test/generated/output/createEquals/test_createEquals_TagType.ts
+++ b/test/generated/output/createEquals/test_createEquals_TagType.ts
@@ -26,10 +26,13 @@ export const test_createEquals_TagType = _test_equals(
             "number" === typeof input.int &&
             Number.isFinite(input.int) &&
             Math.floor(input.int) === input.int &&
+            -2147483648 <= input.int &&
+            input.int <= 2147483647 &&
             "number" === typeof input.uint &&
             Number.isFinite(input.uint) &&
             Math.floor(input.uint) === input.uint &&
             0 <= input.uint &&
+            input.uint <= 4294967295 &&
             "number" === typeof input.int32 &&
             Number.isFinite(input.int32) &&
             Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/createIs/test_createIs_TagInfinite.ts
+++ b/test/generated/output/createIs/test_createIs_TagInfinite.ts
@@ -24,7 +24,9 @@ export const test_createIs_TagInfinite = _test_is(
             0 === (input as any).multipleOf % 3 &&
             "number" === typeof (input as any).typed &&
             Number.isFinite((input as any).typed) &&
-            Math.floor((input as any).typed) === (input as any).typed
+            Math.floor((input as any).typed) === (input as any).typed &&
+            -2147483648 <= (input as any).typed &&
+            (input as any).typed <= 2147483647
         );
     },
     TagInfinite.SPOILERS,

--- a/test/generated/output/createIs/test_createIs_TagNaN.ts
+++ b/test/generated/output/createIs/test_createIs_TagNaN.ts
@@ -24,7 +24,9 @@ export const test_createIs_TagNaN = _test_is(
             0 === (input as any).multipleOf % 3 &&
             "number" === typeof (input as any).typed &&
             Number.isFinite((input as any).typed) &&
-            Math.floor((input as any).typed) === (input as any).typed
+            Math.floor((input as any).typed) === (input as any).typed &&
+            -2147483648 <= (input as any).typed &&
+            (input as any).typed <= 2147483647
         );
     },
     TagNaN.SPOILERS,

--- a/test/generated/output/createIs/test_createIs_TagRange.ts
+++ b/test/generated/output/createIs/test_createIs_TagRange.ts
@@ -16,38 +16,56 @@ export const test_createIs_TagRange = _test_is(
             "number" === typeof input.greater &&
             Number.isFinite(input.greater) &&
             Math.floor(input.greater) === input.greater &&
+            -2147483648 <= input.greater &&
+            input.greater <= 2147483647 &&
             3 < input.greater &&
             "number" === typeof input.greater_equal &&
             Number.isFinite(input.greater_equal) &&
             Math.floor(input.greater_equal) === input.greater_equal &&
+            -2147483648 <= input.greater_equal &&
+            input.greater_equal <= 2147483647 &&
             3 <= input.greater_equal &&
             "number" === typeof input.less &&
             Number.isFinite(input.less) &&
             Math.floor(input.less) === input.less &&
+            -2147483648 <= input.less &&
+            input.less <= 2147483647 &&
             7 > input.less &&
             "number" === typeof input.less_equal &&
             Number.isFinite(input.less_equal) &&
             Math.floor(input.less_equal) === input.less_equal &&
+            -2147483648 <= input.less_equal &&
+            input.less_equal <= 2147483647 &&
             7 >= input.less_equal &&
             "number" === typeof input.greater_less &&
             Math.floor(input.greater_less) === input.greater_less &&
+            -2147483648 <= input.greater_less &&
+            input.greater_less <= 2147483647 &&
             3 < input.greater_less &&
             7 > input.greater_less &&
             "number" === typeof input.greater_equal_less &&
             Math.floor(input.greater_equal_less) === input.greater_equal_less &&
+            -2147483648 <= input.greater_equal_less &&
+            input.greater_equal_less <= 2147483647 &&
             3 <= input.greater_equal_less &&
             7 > input.greater_equal_less &&
             "number" === typeof input.greater_less_equal &&
             Math.floor(input.greater_less_equal) === input.greater_less_equal &&
+            -2147483648 <= input.greater_less_equal &&
+            input.greater_less_equal <= 2147483647 &&
             3 < input.greater_less_equal &&
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             Math.floor(input.greater_equal_less_equal) ===
                 input.greater_equal_less_equal &&
+            -2147483648 <= input.greater_equal_less_equal &&
+            input.greater_equal_less_equal <= 2147483647 &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
             "number" === typeof input.equal &&
             Math.floor(input.equal) === input.equal &&
+            -2147483648 <= input.equal &&
+            input.equal <= 2147483647 &&
             10 <= input.equal &&
             10 >= input.equal;
         return "object" === typeof input && null !== input && $io0(input);

--- a/test/generated/output/createIs/test_createIs_TagType.ts
+++ b/test/generated/output/createIs/test_createIs_TagType.ts
@@ -16,10 +16,13 @@ export const test_createIs_TagType = _test_is(
             "number" === typeof input.int &&
             Number.isFinite(input.int) &&
             Math.floor(input.int) === input.int &&
+            -2147483648 <= input.int &&
+            input.int <= 2147483647 &&
             "number" === typeof input.uint &&
             Number.isFinite(input.uint) &&
             Math.floor(input.uint) === input.uint &&
             0 <= input.uint &&
+            input.uint <= 4294967295 &&
             "number" === typeof input.int32 &&
             Number.isFinite(input.int32) &&
             Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/createIs/test_createIs_UltimateUnion.ts
+++ b/test/generated/output/createIs/test_createIs_UltimateUnion.ts
@@ -247,11 +247,15 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
@@ -259,7 +263,9 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
                     Number.isFinite(input.multipleOf) &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 ("number" === typeof input["default"] &&
                     Number.isFinite(input["default"]))) &&
@@ -345,12 +351,14 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input.minLength &&
                     Number.isFinite(input.minLength) &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Number.isFinite(input.maxLength) &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -395,12 +403,14 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input.minItems &&
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Number.isFinite(input.maxItems) &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -448,11 +458,13 @@ export const test_createIs_UltimateUnion = _test_is(
             Number.isFinite(input.minItems) &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Number.isFinite(input.maxItems) &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -843,11 +855,15 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
                     Number.isFinite(input.minimum) &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
                     Number.isFinite(input.maximum) &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
@@ -855,7 +871,9 @@ export const test_createIs_UltimateUnion = _test_is(
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
                     Number.isFinite(input.multipleOf) &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 ("number" === typeof input["default"] &&
                     Number.isFinite(input["default"]))) &&
@@ -947,12 +965,14 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input.minLength &&
                     Number.isFinite(input.minLength) &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Number.isFinite(input.maxLength) &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -1000,12 +1020,14 @@ export const test_createIs_UltimateUnion = _test_is(
                 ("number" === typeof input.minItems &&
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Number.isFinite(input.maxItems) &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -1056,11 +1078,13 @@ export const test_createIs_UltimateUnion = _test_is(
             Number.isFinite(input.minItems) &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Number.isFinite(input.maxItems) &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createIsClone/test_createIsClone_TagRange.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagRange.ts
@@ -17,40 +17,58 @@ export const test_createIsClone_TagRange = _test_isClone(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -59,37 +77,55 @@ export const test_createIsClone_TagRange = _test_isClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $cp0 = (input: any) =>

--- a/test/generated/output/createIsClone/test_createIsClone_TagType.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_TagType.ts
@@ -17,10 +17,13 @@ export const test_createIsClone_TagType = _test_isClone(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -51,9 +54,12 @@ export const test_createIsClone_TagType = _test_isClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
+++ b/test/generated/output/createIsClone/test_createIsClone_UltimateUnion.ts
@@ -253,11 +253,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -265,7 +269,9 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -353,12 +359,14 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -405,12 +413,14 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -459,11 +469,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -866,11 +878,15 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -878,7 +894,9 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -972,12 +990,14 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1027,12 +1047,14 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1084,11 +1106,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1568,17 +1592,23 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -1660,11 +1690,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1710,11 +1742,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1762,10 +1796,12 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2163,17 +2199,23 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -2261,11 +2303,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -2314,11 +2358,13 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -2369,10 +2415,12 @@ export const test_createIsClone_UltimateUnion = _test_isClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createIsParse/test_createIsParse_TagRange.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagRange.ts
@@ -17,40 +17,58 @@ export const test_createIsParse_TagRange = _test_isParse(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);

--- a/test/generated/output/createIsParse/test_createIsParse_TagType.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_TagType.ts
@@ -17,10 +17,13 @@ export const test_createIsParse_TagType = _test_isParse(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
+++ b/test/generated/output/createIsParse/test_createIsParse_UltimateUnion.ts
@@ -253,11 +253,15 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -265,7 +269,9 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -353,12 +359,14 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -405,12 +413,14 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -459,11 +469,13 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -866,11 +878,15 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -878,7 +894,9 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -972,12 +990,14 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1027,12 +1047,14 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1084,11 +1106,13 @@ export const test_createIsParse_UltimateUnion = _test_isParse(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagInfinite.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagInfinite.ts
@@ -25,7 +25,9 @@ export const test_createIsPrune_TagInfinite = _test_isPrune(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         const prune = (input: TagInfinite): void => {

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagNaN.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagNaN.ts
@@ -25,7 +25,9 @@ export const test_createIsPrune_TagNaN = _test_isPrune(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         const prune = (input: TagNaN): void => {

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagRange.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagRange.ts
@@ -17,40 +17,58 @@ export const test_createIsPrune_TagRange = _test_isPrune(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -59,37 +77,55 @@ export const test_createIsPrune_TagRange = _test_isPrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $pp0 = (input: any) =>

--- a/test/generated/output/createIsPrune/test_createIsPrune_TagType.ts
+++ b/test/generated/output/createIsPrune/test_createIsPrune_TagType.ts
@@ -17,10 +17,13 @@ export const test_createIsPrune_TagType = _test_isPrune(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -51,9 +54,12 @@ export const test_createIsPrune_TagType = _test_isPrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagRange.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagRange.ts
@@ -17,40 +17,58 @@ export const test_createIsStringify_TagRange = _test_isStringify(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -59,37 +77,55 @@ export const test_createIsStringify_TagRange = _test_isStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $number = (typia.createIsStringify as any).number;

--- a/test/generated/output/createIsStringify/test_createIsStringify_TagType.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_TagType.ts
@@ -17,10 +17,13 @@ export const test_createIsStringify_TagType = _test_isStringify(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -51,9 +54,12 @@ export const test_createIsStringify_TagType = _test_isStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
+++ b/test/generated/output/createIsStringify/test_createIsStringify_UltimateUnion.ts
@@ -253,11 +253,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -265,7 +269,9 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -353,12 +359,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -405,12 +413,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -459,11 +469,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -866,11 +878,15 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -878,7 +894,9 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -972,12 +990,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1027,12 +1047,14 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1084,11 +1106,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -1566,17 +1590,23 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -1658,11 +1688,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1708,11 +1740,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1760,10 +1794,12 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2161,17 +2197,23 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -2259,11 +2301,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -2312,11 +2356,13 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -2367,10 +2413,12 @@ export const test_createIsStringify_UltimateUnion = _test_isStringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createPrune/test_createPrune_TagRange.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagRange.ts
@@ -9,35 +9,53 @@ export const test_createPrune_TagRange = _test_prune(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.greater &&
             Math.floor(input.greater) === input.greater &&
+            -2147483648 <= input.greater &&
+            input.greater <= 2147483647 &&
             3 < input.greater &&
             "number" === typeof input.greater_equal &&
             Math.floor(input.greater_equal) === input.greater_equal &&
+            -2147483648 <= input.greater_equal &&
+            input.greater_equal <= 2147483647 &&
             3 <= input.greater_equal &&
             "number" === typeof input.less &&
             Math.floor(input.less) === input.less &&
+            -2147483648 <= input.less &&
+            input.less <= 2147483647 &&
             7 > input.less &&
             "number" === typeof input.less_equal &&
             Math.floor(input.less_equal) === input.less_equal &&
+            -2147483648 <= input.less_equal &&
+            input.less_equal <= 2147483647 &&
             7 >= input.less_equal &&
             "number" === typeof input.greater_less &&
             Math.floor(input.greater_less) === input.greater_less &&
+            -2147483648 <= input.greater_less &&
+            input.greater_less <= 2147483647 &&
             3 < input.greater_less &&
             7 > input.greater_less &&
             "number" === typeof input.greater_equal_less &&
             Math.floor(input.greater_equal_less) === input.greater_equal_less &&
+            -2147483648 <= input.greater_equal_less &&
+            input.greater_equal_less <= 2147483647 &&
             3 <= input.greater_equal_less &&
             7 > input.greater_equal_less &&
             "number" === typeof input.greater_less_equal &&
             Math.floor(input.greater_less_equal) === input.greater_less_equal &&
+            -2147483648 <= input.greater_less_equal &&
+            input.greater_less_equal <= 2147483647 &&
             3 < input.greater_less_equal &&
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             Math.floor(input.greater_equal_less_equal) ===
                 input.greater_equal_less_equal &&
+            -2147483648 <= input.greater_equal_less_equal &&
+            input.greater_equal_less_equal <= 2147483647 &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
             "number" === typeof input.equal &&
             Math.floor(input.equal) === input.equal &&
+            -2147483648 <= input.equal &&
+            input.equal <= 2147483647 &&
             10 <= input.equal &&
             10 >= input.equal;
         const $pp0 = (input: any) =>

--- a/test/generated/output/createPrune/test_createPrune_TagType.ts
+++ b/test/generated/output/createPrune/test_createPrune_TagType.ts
@@ -9,9 +9,12 @@ export const test_createPrune_TagType = _test_prune(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.int &&
             Math.floor(input.int) === input.int &&
+            -2147483648 <= input.int &&
+            input.int <= 2147483647 &&
             "number" === typeof input.uint &&
             Math.floor(input.uint) === input.uint &&
             0 <= input.uint &&
+            input.uint <= 4294967295 &&
             "number" === typeof input.int32 &&
             Math.floor(input.int32) === input.int32 &&
             -2147483648 <= input.int32 &&

--- a/test/generated/output/createRandom/test_createRandom_TagInfinite.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagInfinite.ts
@@ -77,7 +77,9 @@ export const test_createRandom_TagInfinite = _test_random(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -158,6 +160,13 @@ export const test_createRandom_TagInfinite = _test_random(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createRandom/test_createRandom_TagNaN.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagNaN.ts
@@ -75,7 +75,9 @@ export const test_createRandom_TagNaN = _test_random(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -156,6 +158,13 @@ export const test_createRandom_TagNaN = _test_random(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/createRandom/test_createRandom_TagRange.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagRange.ts
@@ -154,40 +154,58 @@ export const test_createRandom_TagRange = _test_random(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -247,6 +265,13 @@ export const test_createRandom_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater,
                             })) &&
+                        ((-2147483648 <= input.greater &&
+                            input.greater <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@type int)",
+                                value: input.greater,
+                            })) &&
                         (3 < input.greater ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
@@ -262,6 +287,13 @@ export const test_createRandom_TagRange = _test_random(
                         Number.isFinite(input.greater_equal) &&
                         (Math.floor(input.greater_equal) ===
                             input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_equal &&
+                            input.greater_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number (@type int)",
@@ -286,6 +318,13 @@ export const test_createRandom_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.less,
                             })) &&
+                        ((-2147483648 <= input.less &&
+                            input.less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@type int)",
+                                value: input.less,
+                            })) &&
                         (7 > input.less ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
@@ -305,6 +344,13 @@ export const test_createRandom_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.less_equal,
                             })) &&
+                        ((-2147483648 <= input.less_equal &&
+                            input.less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@type int)",
+                                value: input.less_equal,
+                            })) &&
                         (7 >= input.less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
@@ -319,6 +365,13 @@ export const test_createRandom_TagRange = _test_random(
                     (("number" === typeof input.greater_less &&
                         (Math.floor(input.greater_less) ===
                             input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@type int)",
+                                value: input.greater_less,
+                            })) &&
+                        ((-2147483648 <= input.greater_less &&
+                            input.greater_less <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number (@type int)",
@@ -349,6 +402,13 @@ export const test_createRandom_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less &&
+                            input.greater_equal_less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less,
+                            })) &&
                         (3 <= input.greater_equal_less ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
@@ -369,6 +429,13 @@ export const test_createRandom_TagRange = _test_random(
                     (("number" === typeof input.greater_less_equal &&
                         (Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_less_equal &&
+                            input.greater_less_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number (@type int)",
@@ -399,6 +466,13 @@ export const test_createRandom_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less_equal,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less_equal &&
+                            input.greater_equal_less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
                         (3 <= input.greater_equal_less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
@@ -418,6 +492,13 @@ export const test_createRandom_TagRange = _test_random(
                         })) &&
                     (("number" === typeof input.equal &&
                         (Math.floor(input.equal) === input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@type int)",
+                                value: input.equal,
+                            })) &&
+                        ((-2147483648 <= input.equal &&
+                            input.equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".equal",
                                 expected: "number (@type int)",

--- a/test/generated/output/createRandom/test_createRandom_TagType.ts
+++ b/test/generated/output/createRandom/test_createRandom_TagType.ts
@@ -82,10 +82,13 @@ export const test_createRandom_TagType = _test_random(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -166,6 +169,13 @@ export const test_createRandom_TagType = _test_random(
                                 path: _path + ".int",
                                 expected: "number (@type int)",
                                 value: input.int,
+                            })) &&
+                        ((-2147483648 <= input.int &&
+                            input.int <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
@@ -181,6 +191,12 @@ export const test_createRandom_TagType = _test_random(
                                 value: input.uint,
                             })) &&
                         (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (input.uint <= 4294967295 ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number (@type uint)",

--- a/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
+++ b/test/generated/output/createRandom/test_createRandom_UltimateUnion.ts
@@ -4596,11 +4596,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -4608,7 +4612,9 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -4696,12 +4702,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -4748,12 +4756,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -4802,11 +4812,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -5209,11 +5221,15 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -5221,7 +5237,9 @@ export const test_createRandom_UltimateUnion = _test_random(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -5315,12 +5333,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -5370,12 +5390,14 @@ export const test_createRandom_UltimateUnion = _test_random(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -5427,11 +5449,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -6819,6 +6843,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -6829,6 +6860,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -6858,6 +6896,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -7232,6 +7277,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -7248,6 +7299,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -7461,6 +7518,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -7477,6 +7540,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -7701,6 +7770,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -7717,6 +7792,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -9526,6 +9607,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -9536,6 +9624,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -9565,6 +9660,13 @@ export const test_createRandom_UltimateUnion = _test_random(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -9967,6 +10069,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -9983,6 +10091,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -10210,6 +10324,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -10226,6 +10346,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -10464,6 +10590,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -10480,6 +10612,12 @@ export const test_createRandom_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",

--- a/test/generated/output/createStringify/test_createStringify_TagRange.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagRange.ts
@@ -9,35 +9,53 @@ export const test_createStringify_TagRange = _test_stringify(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.greater &&
             Math.floor(input.greater) === input.greater &&
+            -2147483648 <= input.greater &&
+            input.greater <= 2147483647 &&
             3 < input.greater &&
             "number" === typeof input.greater_equal &&
             Math.floor(input.greater_equal) === input.greater_equal &&
+            -2147483648 <= input.greater_equal &&
+            input.greater_equal <= 2147483647 &&
             3 <= input.greater_equal &&
             "number" === typeof input.less &&
             Math.floor(input.less) === input.less &&
+            -2147483648 <= input.less &&
+            input.less <= 2147483647 &&
             7 > input.less &&
             "number" === typeof input.less_equal &&
             Math.floor(input.less_equal) === input.less_equal &&
+            -2147483648 <= input.less_equal &&
+            input.less_equal <= 2147483647 &&
             7 >= input.less_equal &&
             "number" === typeof input.greater_less &&
             Math.floor(input.greater_less) === input.greater_less &&
+            -2147483648 <= input.greater_less &&
+            input.greater_less <= 2147483647 &&
             3 < input.greater_less &&
             7 > input.greater_less &&
             "number" === typeof input.greater_equal_less &&
             Math.floor(input.greater_equal_less) === input.greater_equal_less &&
+            -2147483648 <= input.greater_equal_less &&
+            input.greater_equal_less <= 2147483647 &&
             3 <= input.greater_equal_less &&
             7 > input.greater_equal_less &&
             "number" === typeof input.greater_less_equal &&
             Math.floor(input.greater_less_equal) === input.greater_less_equal &&
+            -2147483648 <= input.greater_less_equal &&
+            input.greater_less_equal <= 2147483647 &&
             3 < input.greater_less_equal &&
             7 >= input.greater_less_equal &&
             "number" === typeof input.greater_equal_less_equal &&
             Math.floor(input.greater_equal_less_equal) ===
                 input.greater_equal_less_equal &&
+            -2147483648 <= input.greater_equal_less_equal &&
+            input.greater_equal_less_equal <= 2147483647 &&
             3 <= input.greater_equal_less_equal &&
             7 >= input.greater_equal_less_equal &&
             "number" === typeof input.equal &&
             Math.floor(input.equal) === input.equal &&
+            -2147483648 <= input.equal &&
+            input.equal <= 2147483647 &&
             10 <= input.equal &&
             10 >= input.equal;
         const $number = (typia.createStringify as any).number;

--- a/test/generated/output/createStringify/test_createStringify_TagType.ts
+++ b/test/generated/output/createStringify/test_createStringify_TagType.ts
@@ -9,9 +9,12 @@ export const test_createStringify_TagType = _test_stringify(
         const $io1 = (input: any): boolean =>
             "number" === typeof input.int &&
             Math.floor(input.int) === input.int &&
+            -2147483648 <= input.int &&
+            input.int <= 2147483647 &&
             "number" === typeof input.uint &&
             Math.floor(input.uint) === input.uint &&
             0 <= input.uint &&
+            input.uint <= 4294967295 &&
             "number" === typeof input.int32 &&
             Math.floor(input.int32) === input.int32 &&
             -2147483648 <= input.int32 &&

--- a/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
+++ b/test/generated/output/createStringify/test_createStringify_UltimateUnion.ts
@@ -205,17 +205,23 @@ export const test_createStringify_UltimateUnion = _test_stringify(
         const $io22 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
                 "boolean" === typeof input.exclusiveMaximum) &&
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
@@ -295,11 +301,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -343,11 +351,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.minItems ||
                 ("number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -394,10 +404,12 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             "number" === typeof input.minItems &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&
@@ -783,17 +795,23 @@ export const test_createStringify_UltimateUnion = _test_stringify(
         const $io39 = (input: any): boolean =>
             (undefined === input.minimum ||
                 ("number" === typeof input.minimum &&
-                    Math.floor(input.minimum) === input.minimum)) &&
+                    Math.floor(input.minimum) === input.minimum &&
+                    -2147483648 <= input.minimum &&
+                    input.minimum <= 2147483647)) &&
             (undefined === input.maximum ||
                 ("number" === typeof input.maximum &&
-                    Math.floor(input.maximum) === input.maximum)) &&
+                    Math.floor(input.maximum) === input.maximum &&
+                    -2147483648 <= input.maximum &&
+                    input.maximum <= 2147483647)) &&
             (undefined === input.exclusiveMinimum ||
                 "boolean" === typeof input.exclusiveMinimum) &&
             (undefined === input.exclusiveMaximum ||
                 "boolean" === typeof input.exclusiveMaximum) &&
             (undefined === input.multipleOf ||
                 ("number" === typeof input.multipleOf &&
-                    Math.floor(input.multipleOf) === input.multipleOf)) &&
+                    Math.floor(input.multipleOf) === input.multipleOf &&
+                    -2147483648 <= input.multipleOf &&
+                    input.multipleOf <= 2147483647)) &&
             (undefined === input["default"] ||
                 "number" === typeof input["default"]) &&
             "integer" === input.type &&
@@ -879,11 +897,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.minLength ||
                 ("number" === typeof input.minLength &&
                     Math.floor(input.minLength) === input.minLength &&
-                    0 <= input.minLength)) &&
+                    0 <= input.minLength &&
+                    input.minLength <= 4294967295)) &&
             (undefined === input.maxLength ||
                 ("number" === typeof input.maxLength &&
                     Math.floor(input.maxLength) === input.maxLength &&
-                    0 <= input.maxLength)) &&
+                    0 <= input.maxLength &&
+                    input.maxLength <= 4294967295)) &&
             (undefined === input.pattern ||
                 "string" === typeof input.pattern) &&
             (undefined === input.format || "string" === typeof input.format) &&
@@ -930,11 +950,13 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             (undefined === input.minItems ||
                 ("number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
-                    0 <= input.minItems)) &&
+                    0 <= input.minItems &&
+                    input.minItems <= 4294967295)) &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             (undefined === input["x-typia-tuple"] ||
                 ("object" === typeof input["x-typia-tuple"] &&
                     null !== input["x-typia-tuple"] &&
@@ -984,10 +1006,12 @@ export const test_createStringify_UltimateUnion = _test_stringify(
             "number" === typeof input.minItems &&
             Math.floor(input.minItems) === input.minItems &&
             0 <= input.minItems &&
+            input.minItems <= 4294967295 &&
             (undefined === input.maxItems ||
                 ("number" === typeof input.maxItems &&
                     Math.floor(input.maxItems) === input.maxItems &&
-                    0 <= input.maxItems)) &&
+                    0 <= input.maxItems &&
+                    input.maxItems <= 4294967295)) &&
             "array" === input.type &&
             (undefined === input.nullable ||
                 "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createValidate/test_createValidate_TagInfinite.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagInfinite.ts
@@ -26,7 +26,9 @@ export const test_createValidate_TagInfinite = _test_validate(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input)) {
@@ -108,6 +110,13 @@ export const test_createValidate_TagInfinite = _test_validate(
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidate/test_createValidate_TagNaN.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagNaN.ts
@@ -26,7 +26,9 @@ export const test_createValidate_TagNaN = _test_validate(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input)) {
@@ -108,6 +110,13 @@ export const test_createValidate_TagNaN = _test_validate(
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidate/test_createValidate_TagRange.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagRange.ts
@@ -18,40 +18,58 @@ export const test_createValidate_TagRange = _test_validate(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -128,6 +146,13 @@ export const test_createValidate_TagRange = _test_validate(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
@@ -148,6 +173,13 @@ export const test_createValidate_TagRange = _test_validate(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -162,6 +194,13 @@ export const test_createValidate_TagRange = _test_validate(
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -187,6 +226,13 @@ export const test_createValidate_TagRange = _test_validate(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -201,6 +247,13 @@ export const test_createValidate_TagRange = _test_validate(
                         ("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -231,6 +284,13 @@ export const test_createValidate_TagRange = _test_validate(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -251,6 +311,13 @@ export const test_createValidate_TagRange = _test_validate(
                         ("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -281,6 +348,13 @@ export const test_createValidate_TagRange = _test_validate(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -300,6 +374,13 @@ export const test_createValidate_TagRange = _test_validate(
                             }),
                         ("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidate/test_createValidate_TagType.ts
+++ b/test/generated/output/createValidate/test_createValidate_TagType.ts
@@ -18,10 +18,13 @@ export const test_createValidate_TagType = _test_validate(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -119,6 +122,13 @@ export const test_createValidate_TagType = _test_validate(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
@@ -134,6 +144,12 @@ export const test_createValidate_TagType = _test_validate(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",

--- a/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -254,11 +254,15 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -266,7 +270,9 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -354,12 +360,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -406,12 +414,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -460,11 +470,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -867,11 +879,15 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -879,7 +895,9 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -973,12 +991,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1028,12 +1048,14 @@ export const test_createValidate_UltimateUnion = _test_validate(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1085,11 +1107,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -2586,6 +2610,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
@@ -2596,6 +2627,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -2625,6 +2663,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -3016,6 +3061,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minLength",
@@ -3033,6 +3084,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -3255,6 +3312,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3272,6 +3335,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -3517,6 +3586,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
@@ -3534,6 +3609,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -5473,6 +5554,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minimum",
                                         expected: "number (@type int)",
                                         value: input.minimum,
+                                    })) &&
+                                ((-2147483648 <= input.minimum &&
+                                    input.minimum <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minimum",
+                                        expected: "number (@type int)",
+                                        value: input.minimum,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minimum",
@@ -5483,6 +5571,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
                                 (Math.floor(input.maximum) === input.maximum ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maximum",
+                                        expected: "number (@type int)",
+                                        value: input.maximum,
+                                    })) &&
+                                ((-2147483648 <= input.maximum &&
+                                    input.maximum <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".maximum",
                                         expected: "number (@type int)",
@@ -5512,6 +5607,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                 Number.isFinite(input.multipleOf) &&
                                 (Math.floor(input.multipleOf) ===
                                     input.multipleOf ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".multipleOf",
+                                        expected: "number (@type int)",
+                                        value: input.multipleOf,
+                                    })) &&
+                                ((-2147483648 <= input.multipleOf &&
+                                    input.multipleOf <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".multipleOf",
                                         expected: "number (@type int)",
@@ -5931,6 +6033,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minLength",
                                         expected: "number (@type uint)",
                                         value: input.minLength,
+                                    })) &&
+                                (input.minLength <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minLength",
+                                        expected: "number (@type uint)",
+                                        value: input.minLength,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minLength",
@@ -5948,6 +6056,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxLength,
                                     })) &&
                                 (0 <= input.maxLength ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxLength",
+                                        expected: "number (@type uint)",
+                                        value: input.maxLength,
+                                    })) &&
+                                (input.maxLength <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxLength",
                                         expected: "number (@type uint)",
@@ -6184,6 +6298,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6201,6 +6321,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",
@@ -6460,6 +6586,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $report(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".minItems",
@@ -6477,6 +6609,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
                                         value: input.maxItems,
                                     })) &&
                                 (0 <= input.maxItems ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".maxItems",
+                                        expected: "number (@type uint)",
+                                        value: input.maxItems,
+                                    })) &&
+                                (input.maxItems <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".maxItems",
                                         expected: "number (@type uint)",

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagRange.ts
@@ -21,40 +21,58 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -135,6 +153,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -156,6 +181,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -170,6 +202,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -196,6 +235,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -210,6 +256,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -242,6 +295,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -263,6 +323,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -296,6 +363,16 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -317,6 +394,13 @@ export const test_createValidateClone_TagRange = _test_validateClone(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -367,37 +451,55 @@ export const test_createValidateClone_TagRange = _test_validateClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $cp0 = (input: any) =>

--- a/test/generated/output/createValidateClone/test_createValidateClone_TagType.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_TagType.ts
@@ -21,10 +21,13 @@ export const test_createValidateClone_TagType = _test_validateClone(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -126,6 +129,13 @@ export const test_createValidateClone_TagType = _test_validateClone(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -141,6 +151,12 @@ export const test_createValidateClone_TagType = _test_validateClone(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -283,9 +299,12 @@ export const test_createValidateClone_TagType = _test_validateClone(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
+++ b/test/generated/output/createValidateClone/test_createValidateClone_UltimateUnion.ts
@@ -259,11 +259,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -271,8 +275,9 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -360,12 +365,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -412,12 +419,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -466,11 +475,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -886,11 +897,15 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -898,8 +913,9 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -995,12 +1011,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1051,12 +1069,14 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1109,11 +1129,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2644,6 +2666,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2655,6 +2684,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2684,6 +2720,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3085,6 +3128,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3102,6 +3151,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3329,6 +3384,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3346,6 +3407,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3599,6 +3666,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3616,6 +3689,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5624,6 +5703,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5635,6 +5721,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5664,6 +5757,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -6093,6 +6193,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -6110,6 +6216,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6351,6 +6463,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6368,6 +6486,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6635,6 +6759,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6652,6 +6782,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -8070,17 +8206,23 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -8162,11 +8304,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -8212,11 +8356,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -8264,10 +8410,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -8665,17 +8813,23 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -8763,11 +8917,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -8816,11 +8972,13 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -8871,10 +9029,12 @@ export const test_createValidateClone_UltimateUnion = _test_validateClone(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagInfinite.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagInfinite.ts
@@ -31,6 +31,8 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
@@ -132,6 +134,13 @@ export const test_createValidateEquals_TagInfinite = _test_validateEquals(
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagNaN.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagNaN.ts
@@ -31,6 +31,8 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
@@ -132,6 +134,13 @@ export const test_createValidateEquals_TagNaN = _test_validateEquals(
                         ("number" === typeof input.typed &&
                             Number.isFinite(input.typed) &&
                             (Math.floor(input.typed) === input.typed ||
+                                $report(_exceptionable, {
+                                    path: _path + ".typed",
+                                    expected: "number (@type int)",
+                                    value: input.typed,
+                                })) &&
+                            ((-2147483648 <= input.typed &&
+                                input.typed <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".typed",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagRange.ts
@@ -37,40 +37,58 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal &&
                 (9 === Object.keys(input).length ||
@@ -189,6 +207,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                     expected: "number (@type int)",
                                     value: input.greater,
                                 })) &&
+                            ((-2147483648 <= input.greater &&
+                                input.greater <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater",
+                                    expected: "number (@type int)",
+                                    value: input.greater,
+                                })) &&
                             (3 < input.greater ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater",
@@ -209,6 +234,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal &&
+                                input.greater_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal,
+                                })) &&
                             (3 <= input.greater_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal",
@@ -223,6 +255,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         ("number" === typeof input.less &&
                             Number.isFinite(input.less) &&
                             (Math.floor(input.less) === input.less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less",
+                                    expected: "number (@type int)",
+                                    value: input.less,
+                                })) &&
+                            ((-2147483648 <= input.less &&
+                                input.less <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".less",
                                     expected: "number (@type int)",
@@ -248,6 +287,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                     expected: "number (@type int)",
                                     value: input.less_equal,
                                 })) &&
+                            ((-2147483648 <= input.less_equal &&
+                                input.less_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.less_equal,
+                                })) &&
                             (7 >= input.less_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".less_equal",
@@ -262,6 +308,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         ("number" === typeof input.greater_less &&
                             (Math.floor(input.greater_less) ===
                                 input.greater_less ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less,
+                                })) &&
+                            ((-2147483648 <= input.greater_less &&
+                                input.greater_less <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less",
                                     expected: "number (@type int)",
@@ -292,6 +345,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less &&
+                                input.greater_equal_less <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less,
+                                })) &&
                             (3 <= input.greater_equal_less ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less",
@@ -312,6 +372,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                         ("number" === typeof input.greater_less_equal &&
                             (Math.floor(input.greater_less_equal) ===
                                 input.greater_less_equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_less_equal,
+                                })) &&
+                            ((-2147483648 <= input.greater_less_equal &&
+                                input.greater_less_equal <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_less_equal",
                                     expected: "number (@type int)",
@@ -342,6 +409,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                                     expected: "number (@type int)",
                                     value: input.greater_equal_less_equal,
                                 })) &&
+                            ((-2147483648 <= input.greater_equal_less_equal &&
+                                input.greater_equal_less_equal <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".greater_equal_less_equal",
+                                    expected: "number (@type int)",
+                                    value: input.greater_equal_less_equal,
+                                })) &&
                             (3 <= input.greater_equal_less_equal ||
                                 $report(_exceptionable, {
                                     path: _path + ".greater_equal_less_equal",
@@ -361,6 +435,13 @@ export const test_createValidateEquals_TagRange = _test_validateEquals(
                             }),
                         ("number" === typeof input.equal &&
                             (Math.floor(input.equal) === input.equal ||
+                                $report(_exceptionable, {
+                                    path: _path + ".equal",
+                                    expected: "number (@type int)",
+                                    value: input.equal,
+                                })) &&
+                            ((-2147483648 <= input.equal &&
+                                input.equal <= 2147483647) ||
                                 $report(_exceptionable, {
                                     path: _path + ".equal",
                                     expected: "number (@type int)",

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_TagType.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_TagType.ts
@@ -37,10 +37,13 @@ export const test_createValidateEquals_TagType = _test_validateEquals(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -178,6 +181,13 @@ export const test_createValidateEquals_TagType = _test_validateEquals(
                                     path: _path + ".int",
                                     expected: "number (@type int)",
                                     value: input.int,
+                                })) &&
+                            ((-2147483648 <= input.int &&
+                                input.int <= 2147483647) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".int",
+                                    expected: "number (@type int)",
+                                    value: input.int,
                                 }))) ||
                             $report(_exceptionable, {
                                 path: _path + ".int",
@@ -193,6 +203,12 @@ export const test_createValidateEquals_TagType = _test_validateEquals(
                                     value: input.uint,
                                 })) &&
                             (0 <= input.uint ||
+                                $report(_exceptionable, {
+                                    path: _path + ".uint",
+                                    expected: "number (@type uint)",
+                                    value: input.uint,
+                                })) &&
+                            (input.uint <= 4294967295 ||
                                 $report(_exceptionable, {
                                     path: _path + ".uint",
                                     expected: "number (@type uint)",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagRange.ts
@@ -21,40 +21,58 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -135,6 +153,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -156,6 +181,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -170,6 +202,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -196,6 +235,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -210,6 +256,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -242,6 +295,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -263,6 +323,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -296,6 +363,16 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -317,6 +394,13 @@ export const test_createValidateParse_TagRange = _test_validateParse(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",

--- a/test/generated/output/createValidateParse/test_createValidateParse_TagType.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_TagType.ts
@@ -21,10 +21,13 @@ export const test_createValidateParse_TagType = _test_validateParse(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -126,6 +129,13 @@ export const test_createValidateParse_TagType = _test_validateParse(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -141,6 +151,12 @@ export const test_createValidateParse_TagType = _test_validateParse(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",

--- a/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
+++ b/test/generated/output/createValidateParse/test_createValidateParse_UltimateUnion.ts
@@ -259,11 +259,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -271,8 +275,9 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -360,12 +365,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -412,12 +419,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -466,11 +475,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -886,11 +897,15 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -898,8 +913,9 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -995,12 +1011,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1051,12 +1069,14 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1109,11 +1129,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2644,6 +2666,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2655,6 +2684,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2684,6 +2720,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3085,6 +3128,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3102,6 +3151,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3329,6 +3384,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3346,6 +3407,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3599,6 +3666,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3616,6 +3689,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5624,6 +5703,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5635,6 +5721,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5664,6 +5757,13 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -6093,6 +6193,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -6110,6 +6216,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6351,6 +6463,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6368,6 +6486,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6635,6 +6759,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6652,6 +6782,12 @@ export const test_createValidateParse_UltimateUnion = _test_validateParse(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagInfinite.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagInfinite.ts
@@ -27,7 +27,9 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input)) {
@@ -111,6 +113,13 @@ export const test_createValidatePrune_TagInfinite = _test_validatePrune(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagNaN.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagNaN.ts
@@ -27,7 +27,9 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input)) {
@@ -111,6 +113,13 @@ export const test_createValidatePrune_TagNaN = _test_validatePrune(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagRange.ts
@@ -21,40 +21,58 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -135,6 +153,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -156,6 +181,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -170,6 +202,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -196,6 +235,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -210,6 +256,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -242,6 +295,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -263,6 +323,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -296,6 +363,16 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -317,6 +394,13 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -367,37 +451,55 @@ export const test_createValidatePrune_TagRange = _test_validatePrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $pp0 = (input: any) =>

--- a/test/generated/output/createValidatePrune/test_createValidatePrune_TagType.ts
+++ b/test/generated/output/createValidatePrune/test_createValidatePrune_TagType.ts
@@ -21,10 +21,13 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -126,6 +129,13 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -141,6 +151,12 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -283,9 +299,12 @@ export const test_createValidatePrune_TagType = _test_validatePrune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagRange.ts
@@ -21,40 +21,58 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -135,6 +153,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -156,6 +181,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -170,6 +202,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -196,6 +235,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -210,6 +256,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -242,6 +295,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -263,6 +323,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -296,6 +363,16 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -317,6 +394,13 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",
@@ -367,37 +451,55 @@ export const test_createValidateStringify_TagRange = _test_validateStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $number = (typia.createValidateStringify as any).number;

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_TagType.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_TagType.ts
@@ -21,10 +21,13 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -126,6 +129,13 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -141,6 +151,12 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",
@@ -283,9 +299,12 @@ export const test_createValidateStringify_TagType = _test_validateStringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
+++ b/test/generated/output/createValidateStringify/test_createValidateStringify_UltimateUnion.ts
@@ -263,11 +263,15 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -276,7 +280,9 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -365,13 +371,15 @@ export const test_createValidateStringify_UltimateUnion =
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -418,12 +426,14 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -472,11 +482,13 @@ export const test_createValidateStringify_UltimateUnion =
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -895,11 +907,15 @@ export const test_createValidateStringify_UltimateUnion =
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -908,7 +924,9 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1005,13 +1023,15 @@ export const test_createValidateStringify_UltimateUnion =
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1062,12 +1082,14 @@ export const test_createValidateStringify_UltimateUnion =
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1120,11 +1142,13 @@ export const test_createValidateStringify_UltimateUnion =
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2734,6 +2758,13 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -2745,6 +2776,13 @@ export const test_createValidateStringify_UltimateUnion =
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -2776,6 +2814,13 @@ export const test_createValidateStringify_UltimateUnion =
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -3215,6 +3260,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -3232,6 +3283,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -3477,6 +3534,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3494,6 +3557,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -3766,6 +3835,12 @@ export const test_createValidateStringify_UltimateUnion =
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3783,6 +3858,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -6005,6 +6086,13 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -6016,6 +6104,13 @@ export const test_createValidateStringify_UltimateUnion =
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -6047,6 +6142,13 @@ export const test_createValidateStringify_UltimateUnion =
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -6516,6 +6618,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -6533,6 +6641,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -6793,6 +6907,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -6810,6 +6930,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -7097,6 +7223,12 @@ export const test_createValidateStringify_UltimateUnion =
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -7114,6 +7246,12 @@ export const test_createValidateStringify_UltimateUnion =
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -8689,18 +8827,23 @@ export const test_createValidateStringify_UltimateUnion =
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -8782,11 +8925,13 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8832,11 +8977,13 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8884,10 +9031,12 @@ export const test_createValidateStringify_UltimateUnion =
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9300,18 +9449,23 @@ export const test_createValidateStringify_UltimateUnion =
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -9401,11 +9555,13 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -9455,11 +9611,13 @@ export const test_createValidateStringify_UltimateUnion =
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -9511,10 +9669,12 @@ export const test_createValidateStringify_UltimateUnion =
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/equals/test_equals_TagInfinite.ts
+++ b/test/generated/output/equals/test_equals_TagInfinite.ts
@@ -27,6 +27,8 @@ export const test_equals_TagInfinite = _test_equals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (

--- a/test/generated/output/equals/test_equals_TagNaN.ts
+++ b/test/generated/output/equals/test_equals_TagNaN.ts
@@ -27,6 +27,8 @@ export const test_equals_TagNaN = _test_equals(
                 "number" === typeof input.typed &&
                 Number.isFinite(input.typed) &&
                 Math.floor(input.typed) === input.typed &&
+                -2147483648 <= input.typed &&
+                input.typed <= 2147483647 &&
                 (6 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (

--- a/test/generated/output/equals/test_equals_TagRange.ts
+++ b/test/generated/output/equals/test_equals_TagRange.ts
@@ -33,40 +33,58 @@ export const test_equals_TagRange = _test_equals(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal &&
                 (9 === Object.keys(input).length ||

--- a/test/generated/output/equals/test_equals_TagType.ts
+++ b/test/generated/output/equals/test_equals_TagType.ts
@@ -33,10 +33,13 @@ export const test_equals_TagType = _test_equals(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/is/test_is_TagInfinite.ts
+++ b/test/generated/output/is/test_is_TagInfinite.ts
@@ -25,7 +25,9 @@ export const test_is_TagInfinite = _test_is(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         })(input),
     TagInfinite.SPOILERS,

--- a/test/generated/output/is/test_is_TagNaN.ts
+++ b/test/generated/output/is/test_is_TagNaN.ts
@@ -25,7 +25,9 @@ export const test_is_TagNaN = _test_is(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         })(input),
     TagNaN.SPOILERS,

--- a/test/generated/output/is/test_is_TagRange.ts
+++ b/test/generated/output/is/test_is_TagRange.ts
@@ -17,40 +17,58 @@ export const test_is_TagRange = _test_is(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);

--- a/test/generated/output/is/test_is_TagType.ts
+++ b/test/generated/output/is/test_is_TagType.ts
@@ -17,10 +17,13 @@ export const test_is_TagType = _test_is(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/is/test_is_UltimateUnion.ts
+++ b/test/generated/output/is/test_is_UltimateUnion.ts
@@ -253,11 +253,15 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -265,7 +269,9 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -353,12 +359,14 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -405,12 +413,14 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -459,11 +469,13 @@ export const test_is_UltimateUnion = _test_is(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -866,11 +878,15 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -878,7 +894,9 @@ export const test_is_UltimateUnion = _test_is(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -972,12 +990,14 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -1027,12 +1047,14 @@ export const test_is_UltimateUnion = _test_is(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1084,11 +1106,13 @@ export const test_is_UltimateUnion = _test_is(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/isClone/test_isClone_TagRange.ts
+++ b/test/generated/output/isClone/test_isClone_TagRange.ts
@@ -20,40 +20,58 @@ export const test_isClone_TagRange = _test_isClone(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -64,37 +82,55 @@ export const test_isClone_TagRange = _test_isClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $cp0 = (input: any) =>

--- a/test/generated/output/isClone/test_isClone_TagType.ts
+++ b/test/generated/output/isClone/test_isClone_TagType.ts
@@ -20,10 +20,13 @@ export const test_isClone_TagType = _test_isClone(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -56,9 +59,12 @@ export const test_isClone_TagType = _test_isClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/isClone/test_isClone_UltimateUnion.ts
+++ b/test/generated/output/isClone/test_isClone_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_isClone_UltimateUnion = _test_isClone(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1612,18 +1634,23 @@ export const test_isClone_UltimateUnion = _test_isClone(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -1705,11 +1732,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1755,11 +1784,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1807,10 +1838,12 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2223,18 +2256,23 @@ export const test_isClone_UltimateUnion = _test_isClone(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -2324,11 +2362,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -2378,11 +2418,13 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -2434,10 +2476,12 @@ export const test_isClone_UltimateUnion = _test_isClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/isParse/test_isParse_TagRange.ts
+++ b/test/generated/output/isParse/test_isParse_TagRange.ts
@@ -20,40 +20,58 @@ export const test_isParse_TagRange = _test_isParse(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (

--- a/test/generated/output/isParse/test_isParse_TagType.ts
+++ b/test/generated/output/isParse/test_isParse_TagType.ts
@@ -20,10 +20,13 @@ export const test_isParse_TagType = _test_isParse(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&

--- a/test/generated/output/isParse/test_isParse_UltimateUnion.ts
+++ b/test/generated/output/isParse/test_isParse_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_isParse_UltimateUnion = _test_isParse(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_isParse_UltimateUnion = _test_isParse(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/isPrune/test_isPrune_TagInfinite.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagInfinite.ts
@@ -26,7 +26,9 @@ export const test_isPrune_TagInfinite = _test_isPrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             const prune = (input: TagInfinite): void => {

--- a/test/generated/output/isPrune/test_isPrune_TagNaN.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagNaN.ts
@@ -26,7 +26,9 @@ export const test_isPrune_TagNaN = _test_isPrune(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             const prune = (input: TagNaN): void => {

--- a/test/generated/output/isPrune/test_isPrune_TagRange.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagRange.ts
@@ -20,40 +20,58 @@ export const test_isPrune_TagRange = _test_isPrune(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -64,37 +82,55 @@ export const test_isPrune_TagRange = _test_isPrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $pp0 = (input: any) =>

--- a/test/generated/output/isPrune/test_isPrune_TagType.ts
+++ b/test/generated/output/isPrune/test_isPrune_TagType.ts
@@ -20,10 +20,13 @@ export const test_isPrune_TagType = _test_isPrune(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -56,9 +59,12 @@ export const test_isPrune_TagType = _test_isPrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/isStringify/test_isStringify_TagRange.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagRange.ts
@@ -20,40 +20,58 @@ export const test_isStringify_TagRange = _test_isStringify(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -64,37 +82,55 @@ export const test_isStringify_TagRange = _test_isStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $number = (typia.isStringify as any).number;

--- a/test/generated/output/isStringify/test_isStringify_TagType.ts
+++ b/test/generated/output/isStringify/test_isStringify_TagType.ts
@@ -20,10 +20,13 @@ export const test_isStringify_TagType = _test_isStringify(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -56,9 +59,12 @@ export const test_isStringify_TagType = _test_isStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
+++ b/test/generated/output/isStringify/test_isStringify_UltimateUnion.ts
@@ -258,11 +258,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -270,8 +274,9 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -359,12 +364,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -411,12 +418,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -465,11 +474,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -885,11 +896,15 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -897,8 +912,9 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -994,12 +1010,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1050,12 +1068,14 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1108,11 +1128,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -1610,18 +1632,23 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -1703,11 +1730,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1753,11 +1782,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1805,10 +1836,12 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2221,18 +2254,23 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -2322,11 +2360,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -2376,11 +2416,13 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -2432,10 +2474,12 @@ export const test_isStringify_UltimateUnion = _test_isStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/prune/test_prune_TagRange.ts
+++ b/test/generated/output/prune/test_prune_TagRange.ts
@@ -10,37 +10,55 @@ export const test_prune_TagRange = _test_prune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $pp0 = (input: any) =>

--- a/test/generated/output/prune/test_prune_TagType.ts
+++ b/test/generated/output/prune/test_prune_TagType.ts
@@ -10,9 +10,12 @@ export const test_prune_TagType = _test_prune(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/random/test_random_TagInfinite.ts
+++ b/test/generated/output/random/test_random_TagInfinite.ts
@@ -78,7 +78,9 @@ export const test_random_TagInfinite = _test_random(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -159,6 +161,13 @@ export const test_random_TagInfinite = _test_random(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/random/test_random_TagNaN.ts
+++ b/test/generated/output/random/test_random_TagNaN.ts
@@ -78,7 +78,9 @@ export const test_random_TagNaN = _test_random(
                 0 === (input as any).multipleOf % 3 &&
                 "number" === typeof (input as any).typed &&
                 Number.isFinite((input as any).typed) &&
-                Math.floor((input as any).typed) === (input as any).typed
+                Math.floor((input as any).typed) === (input as any).typed &&
+                -2147483648 <= (input as any).typed &&
+                (input as any).typed <= 2147483647
             );
         };
         if (false === __is(input))
@@ -159,6 +161,13 @@ export const test_random_TagNaN = _test_random(
                     (("number" === typeof input.typed &&
                         Number.isFinite(input.typed) &&
                         (Math.floor(input.typed) === input.typed ||
+                            $guard(_exceptionable, {
+                                path: _path + ".typed",
+                                expected: "number (@type int)",
+                                value: input.typed,
+                            })) &&
+                        ((-2147483648 <= input.typed &&
+                            input.typed <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".typed",
                                 expected: "number (@type int)",

--- a/test/generated/output/random/test_random_TagRange.ts
+++ b/test/generated/output/random/test_random_TagRange.ts
@@ -155,40 +155,58 @@ export const test_random_TagRange = _test_random(
                 "number" === typeof input.greater &&
                 Number.isFinite(input.greater) &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Number.isFinite(input.greater_equal) &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Number.isFinite(input.less) &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Number.isFinite(input.less_equal) &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             return "object" === typeof input && null !== input && $io0(input);
@@ -248,6 +266,13 @@ export const test_random_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater,
                             })) &&
+                        ((-2147483648 <= input.greater &&
+                            input.greater <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater",
+                                expected: "number (@type int)",
+                                value: input.greater,
+                            })) &&
                         (3 < input.greater ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater",
@@ -263,6 +288,13 @@ export const test_random_TagRange = _test_random(
                         Number.isFinite(input.greater_equal) &&
                         (Math.floor(input.greater_equal) ===
                             input.greater_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_equal &&
+                            input.greater_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal",
                                 expected: "number (@type int)",
@@ -287,6 +319,13 @@ export const test_random_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.less,
                             })) &&
+                        ((-2147483648 <= input.less &&
+                            input.less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less",
+                                expected: "number (@type int)",
+                                value: input.less,
+                            })) &&
                         (7 > input.less ||
                             $guard(_exceptionable, {
                                 path: _path + ".less",
@@ -306,6 +345,13 @@ export const test_random_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.less_equal,
                             })) &&
+                        ((-2147483648 <= input.less_equal &&
+                            input.less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".less_equal",
+                                expected: "number (@type int)",
+                                value: input.less_equal,
+                            })) &&
                         (7 >= input.less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".less_equal",
@@ -320,6 +366,13 @@ export const test_random_TagRange = _test_random(
                     (("number" === typeof input.greater_less &&
                         (Math.floor(input.greater_less) ===
                             input.greater_less ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less",
+                                expected: "number (@type int)",
+                                value: input.greater_less,
+                            })) &&
+                        ((-2147483648 <= input.greater_less &&
+                            input.greater_less <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less",
                                 expected: "number (@type int)",
@@ -350,6 +403,13 @@ export const test_random_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less &&
+                            input.greater_equal_less <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less,
+                            })) &&
                         (3 <= input.greater_equal_less ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less",
@@ -370,6 +430,13 @@ export const test_random_TagRange = _test_random(
                     (("number" === typeof input.greater_less_equal &&
                         (Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_less_equal,
+                            })) &&
+                        ((-2147483648 <= input.greater_less_equal &&
+                            input.greater_less_equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_less_equal",
                                 expected: "number (@type int)",
@@ -400,6 +467,13 @@ export const test_random_TagRange = _test_random(
                                 expected: "number (@type int)",
                                 value: input.greater_equal_less_equal,
                             })) &&
+                        ((-2147483648 <= input.greater_equal_less_equal &&
+                            input.greater_equal_less_equal <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".greater_equal_less_equal",
+                                expected: "number (@type int)",
+                                value: input.greater_equal_less_equal,
+                            })) &&
                         (3 <= input.greater_equal_less_equal ||
                             $guard(_exceptionable, {
                                 path: _path + ".greater_equal_less_equal",
@@ -419,6 +493,13 @@ export const test_random_TagRange = _test_random(
                         })) &&
                     (("number" === typeof input.equal &&
                         (Math.floor(input.equal) === input.equal ||
+                            $guard(_exceptionable, {
+                                path: _path + ".equal",
+                                expected: "number (@type int)",
+                                value: input.equal,
+                            })) &&
+                        ((-2147483648 <= input.equal &&
+                            input.equal <= 2147483647) ||
                             $guard(_exceptionable, {
                                 path: _path + ".equal",
                                 expected: "number (@type int)",

--- a/test/generated/output/random/test_random_TagType.ts
+++ b/test/generated/output/random/test_random_TagType.ts
@@ -85,10 +85,13 @@ export const test_random_TagType = _test_random(
                 "number" === typeof input.int &&
                 Number.isFinite(input.int) &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Number.isFinite(input.uint) &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Number.isFinite(input.int32) &&
                 Math.floor(input.int32) === input.int32 &&
@@ -169,6 +172,13 @@ export const test_random_TagType = _test_random(
                                 path: _path + ".int",
                                 expected: "number (@type int)",
                                 value: input.int,
+                            })) &&
+                        ((-2147483648 <= input.int &&
+                            input.int <= 2147483647) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".int",
+                                expected: "number (@type int)",
+                                value: input.int,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".int",
@@ -184,6 +194,12 @@ export const test_random_TagType = _test_random(
                                 value: input.uint,
                             })) &&
                         (0 <= input.uint ||
+                            $guard(_exceptionable, {
+                                path: _path + ".uint",
+                                expected: "number (@type uint)",
+                                value: input.uint,
+                            })) &&
+                        (input.uint <= 4294967295 ||
                             $guard(_exceptionable, {
                                 path: _path + ".uint",
                                 expected: "number (@type uint)",

--- a/test/generated/output/random/test_random_UltimateUnion.ts
+++ b/test/generated/output/random/test_random_UltimateUnion.ts
@@ -4894,11 +4894,15 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -4906,7 +4910,9 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -4994,12 +5000,14 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -5046,12 +5054,14 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -5100,11 +5110,13 @@ export const test_random_UltimateUnion = _test_random(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -5507,11 +5519,15 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
                         Number.isFinite(input.minimum) &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
                         Number.isFinite(input.maximum) &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
@@ -5519,7 +5535,9 @@ export const test_random_UltimateUnion = _test_random(
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
                         Number.isFinite(input.multipleOf) &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     ("number" === typeof input["default"] &&
                         Number.isFinite(input["default"]))) &&
@@ -5613,12 +5631,14 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input.minLength &&
                         Number.isFinite(input.minLength) &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Number.isFinite(input.maxLength) &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -5668,12 +5688,14 @@ export const test_random_UltimateUnion = _test_random(
                     ("number" === typeof input.minItems &&
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -5725,11 +5747,13 @@ export const test_random_UltimateUnion = _test_random(
                 Number.isFinite(input.minItems) &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Number.isFinite(input.maxItems) &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -7117,6 +7141,13 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -7127,6 +7158,13 @@ export const test_random_UltimateUnion = _test_random(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -7156,6 +7194,13 @@ export const test_random_UltimateUnion = _test_random(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -7530,6 +7575,12 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -7546,6 +7597,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -7759,6 +7816,12 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -7775,6 +7838,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -7999,6 +8068,12 @@ export const test_random_UltimateUnion = _test_random(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -8015,6 +8090,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -9824,6 +9905,13 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minimum",
                                     expected: "number (@type int)",
                                     value: input.minimum,
+                                })) &&
+                            ((-2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minimum",
+                                    expected: "number (@type int)",
+                                    value: input.minimum,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minimum",
@@ -9834,6 +9922,13 @@ export const test_random_UltimateUnion = _test_random(
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
                             (Math.floor(input.maximum) === input.maximum ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maximum",
+                                    expected: "number (@type int)",
+                                    value: input.maximum,
+                                })) &&
+                            ((-2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maximum",
                                     expected: "number (@type int)",
@@ -9863,6 +9958,13 @@ export const test_random_UltimateUnion = _test_random(
                             Number.isFinite(input.multipleOf) &&
                             (Math.floor(input.multipleOf) ===
                                 input.multipleOf ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".multipleOf",
+                                    expected: "number (@type int)",
+                                    value: input.multipleOf,
+                                })) &&
+                            ((-2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647) ||
                                 $guard(_exceptionable, {
                                     path: _path + ".multipleOf",
                                     expected: "number (@type int)",
@@ -10265,6 +10367,12 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minLength",
                                     expected: "number (@type uint)",
                                     value: input.minLength,
+                                })) &&
+                            (input.minLength <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minLength",
+                                    expected: "number (@type uint)",
+                                    value: input.minLength,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minLength",
@@ -10281,6 +10389,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxLength,
                                 })) &&
                             (0 <= input.maxLength ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxLength",
+                                    expected: "number (@type uint)",
+                                    value: input.maxLength,
+                                })) &&
+                            (input.maxLength <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxLength",
                                     expected: "number (@type uint)",
@@ -10508,6 +10622,12 @@ export const test_random_UltimateUnion = _test_random(
                                     path: _path + ".minItems",
                                     expected: "number (@type uint)",
                                     value: input.minItems,
+                                })) &&
+                            (input.minItems <= 4294967295 ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".minItems",
+                                    expected: "number (@type uint)",
+                                    value: input.minItems,
                                 }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -10524,6 +10644,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",
@@ -10762,6 +10888,12 @@ export const test_random_UltimateUnion = _test_random(
                                 path: _path + ".minItems",
                                 expected: "number (@type uint)",
                                 value: input.minItems,
+                            })) &&
+                        (input.minItems <= 4294967295 ||
+                            $guard(_exceptionable, {
+                                path: _path + ".minItems",
+                                expected: "number (@type uint)",
+                                value: input.minItems,
                             }))) ||
                         $guard(_exceptionable, {
                             path: _path + ".minItems",
@@ -10778,6 +10910,12 @@ export const test_random_UltimateUnion = _test_random(
                                     value: input.maxItems,
                                 })) &&
                             (0 <= input.maxItems ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".maxItems",
+                                    expected: "number (@type uint)",
+                                    value: input.maxItems,
+                                })) &&
+                            (input.maxItems <= 4294967295 ||
                                 $guard(_exceptionable, {
                                     path: _path + ".maxItems",
                                     expected: "number (@type uint)",

--- a/test/generated/output/stringify/test_stringify_TagRange.ts
+++ b/test/generated/output/stringify/test_stringify_TagRange.ts
@@ -10,37 +10,55 @@ export const test_stringify_TagRange = _test_stringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.greater &&
                 Math.floor(input.greater) === input.greater &&
+                -2147483648 <= input.greater &&
+                input.greater <= 2147483647 &&
                 3 < input.greater &&
                 "number" === typeof input.greater_equal &&
                 Math.floor(input.greater_equal) === input.greater_equal &&
+                -2147483648 <= input.greater_equal &&
+                input.greater_equal <= 2147483647 &&
                 3 <= input.greater_equal &&
                 "number" === typeof input.less &&
                 Math.floor(input.less) === input.less &&
+                -2147483648 <= input.less &&
+                input.less <= 2147483647 &&
                 7 > input.less &&
                 "number" === typeof input.less_equal &&
                 Math.floor(input.less_equal) === input.less_equal &&
+                -2147483648 <= input.less_equal &&
+                input.less_equal <= 2147483647 &&
                 7 >= input.less_equal &&
                 "number" === typeof input.greater_less &&
                 Math.floor(input.greater_less) === input.greater_less &&
+                -2147483648 <= input.greater_less &&
+                input.greater_less <= 2147483647 &&
                 3 < input.greater_less &&
                 7 > input.greater_less &&
                 "number" === typeof input.greater_equal_less &&
                 Math.floor(input.greater_equal_less) ===
                     input.greater_equal_less &&
+                -2147483648 <= input.greater_equal_less &&
+                input.greater_equal_less <= 2147483647 &&
                 3 <= input.greater_equal_less &&
                 7 > input.greater_equal_less &&
                 "number" === typeof input.greater_less_equal &&
                 Math.floor(input.greater_less_equal) ===
                     input.greater_less_equal &&
+                -2147483648 <= input.greater_less_equal &&
+                input.greater_less_equal <= 2147483647 &&
                 3 < input.greater_less_equal &&
                 7 >= input.greater_less_equal &&
                 "number" === typeof input.greater_equal_less_equal &&
                 Math.floor(input.greater_equal_less_equal) ===
                     input.greater_equal_less_equal &&
+                -2147483648 <= input.greater_equal_less_equal &&
+                input.greater_equal_less_equal <= 2147483647 &&
                 3 <= input.greater_equal_less_equal &&
                 7 >= input.greater_equal_less_equal &&
                 "number" === typeof input.equal &&
                 Math.floor(input.equal) === input.equal &&
+                -2147483648 <= input.equal &&
+                input.equal <= 2147483647 &&
                 10 <= input.equal &&
                 10 >= input.equal;
             const $number = (typia.stringify as any).number;

--- a/test/generated/output/stringify/test_stringify_TagType.ts
+++ b/test/generated/output/stringify/test_stringify_TagType.ts
@@ -10,9 +10,12 @@ export const test_stringify_TagType = _test_stringify(
             const $io1 = (input: any): boolean =>
                 "number" === typeof input.int &&
                 Math.floor(input.int) === input.int &&
+                -2147483648 <= input.int &&
+                input.int <= 2147483647 &&
                 "number" === typeof input.uint &&
                 Math.floor(input.uint) === input.uint &&
                 0 <= input.uint &&
+                input.uint <= 4294967295 &&
                 "number" === typeof input.int32 &&
                 Math.floor(input.int32) === input.int32 &&
                 -2147483648 <= input.int32 &&

--- a/test/generated/output/stringify/test_stringify_UltimateUnion.ts
+++ b/test/generated/output/stringify/test_stringify_UltimateUnion.ts
@@ -211,17 +211,23 @@ export const test_stringify_UltimateUnion = _test_stringify(
             const $io22 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -303,11 +309,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -353,11 +361,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -405,10 +415,12 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&
@@ -806,17 +818,23 @@ export const test_stringify_UltimateUnion = _test_stringify(
             const $io39 = (input: any): boolean =>
                 (undefined === input.minimum ||
                     ("number" === typeof input.minimum &&
-                        Math.floor(input.minimum) === input.minimum)) &&
+                        Math.floor(input.minimum) === input.minimum &&
+                        -2147483648 <= input.minimum &&
+                        input.minimum <= 2147483647)) &&
                 (undefined === input.maximum ||
                     ("number" === typeof input.maximum &&
-                        Math.floor(input.maximum) === input.maximum)) &&
+                        Math.floor(input.maximum) === input.maximum &&
+                        -2147483648 <= input.maximum &&
+                        input.maximum <= 2147483647)) &&
                 (undefined === input.exclusiveMinimum ||
                     "boolean" === typeof input.exclusiveMinimum) &&
                 (undefined === input.exclusiveMaximum ||
                     "boolean" === typeof input.exclusiveMaximum) &&
                 (undefined === input.multipleOf ||
                     ("number" === typeof input.multipleOf &&
-                        Math.floor(input.multipleOf) === input.multipleOf)) &&
+                        Math.floor(input.multipleOf) === input.multipleOf &&
+                        -2147483648 <= input.multipleOf &&
+                        input.multipleOf <= 2147483647)) &&
                 (undefined === input["default"] ||
                     "number" === typeof input["default"]) &&
                 "integer" === input.type &&
@@ -904,11 +922,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.minLength ||
                     ("number" === typeof input.minLength &&
                         Math.floor(input.minLength) === input.minLength &&
-                        0 <= input.minLength)) &&
+                        0 <= input.minLength &&
+                        input.minLength <= 4294967295)) &&
                 (undefined === input.maxLength ||
                     ("number" === typeof input.maxLength &&
                         Math.floor(input.maxLength) === input.maxLength &&
-                        0 <= input.maxLength)) &&
+                        0 <= input.maxLength &&
+                        input.maxLength <= 4294967295)) &&
                 (undefined === input.pattern ||
                     "string" === typeof input.pattern) &&
                 (undefined === input.format ||
@@ -957,11 +977,13 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 (undefined === input.minItems ||
                     ("number" === typeof input.minItems &&
                         Math.floor(input.minItems) === input.minItems &&
-                        0 <= input.minItems)) &&
+                        0 <= input.minItems &&
+                        input.minItems <= 4294967295)) &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 (undefined === input["x-typia-tuple"] ||
                     ("object" === typeof input["x-typia-tuple"] &&
                         null !== input["x-typia-tuple"] &&
@@ -1012,10 +1034,12 @@ export const test_stringify_UltimateUnion = _test_stringify(
                 "number" === typeof input.minItems &&
                 Math.floor(input.minItems) === input.minItems &&
                 0 <= input.minItems &&
+                input.minItems <= 4294967295 &&
                 (undefined === input.maxItems ||
                     ("number" === typeof input.maxItems &&
                         Math.floor(input.maxItems) === input.maxItems &&
-                        0 <= input.maxItems)) &&
+                        0 <= input.maxItems &&
+                        input.maxItems <= 4294967295)) &&
                 "array" === input.type &&
                 (undefined === input.nullable ||
                     "boolean" === typeof input.nullable) &&

--- a/test/generated/output/validate/test_validate_TagInfinite.ts
+++ b/test/generated/output/validate/test_validate_TagInfinite.ts
@@ -27,7 +27,9 @@ export const test_validate_TagInfinite = _test_validate(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input)) {
@@ -109,6 +111,13 @@ export const test_validate_TagInfinite = _test_validate(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/validate/test_validate_TagNaN.ts
+++ b/test/generated/output/validate/test_validate_TagNaN.ts
@@ -27,7 +27,9 @@ export const test_validate_TagNaN = _test_validate(
                     0 === (input as any).multipleOf % 3 &&
                     "number" === typeof (input as any).typed &&
                     Number.isFinite((input as any).typed) &&
-                    Math.floor((input as any).typed) === (input as any).typed
+                    Math.floor((input as any).typed) === (input as any).typed &&
+                    -2147483648 <= (input as any).typed &&
+                    (input as any).typed <= 2147483647
                 );
             };
             if (false === __is(input)) {
@@ -109,6 +111,13 @@ export const test_validate_TagNaN = _test_validate(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/validate/test_validate_TagRange.ts
+++ b/test/generated/output/validate/test_validate_TagRange.ts
@@ -21,40 +21,58 @@ export const test_validate_TagRange = _test_validate(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 return (
@@ -133,6 +151,13 @@ export const test_validate_TagRange = _test_validate(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -154,6 +179,13 @@ export const test_validate_TagRange = _test_validate(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -168,6 +200,13 @@ export const test_validate_TagRange = _test_validate(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -194,6 +233,13 @@ export const test_validate_TagRange = _test_validate(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -208,6 +254,13 @@ export const test_validate_TagRange = _test_validate(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -240,6 +293,13 @@ export const test_validate_TagRange = _test_validate(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -261,6 +321,13 @@ export const test_validate_TagRange = _test_validate(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -294,6 +361,16 @@ export const test_validate_TagRange = _test_validate(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -315,6 +392,13 @@ export const test_validate_TagRange = _test_validate(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",

--- a/test/generated/output/validate/test_validate_TagType.ts
+++ b/test/generated/output/validate/test_validate_TagType.ts
@@ -21,10 +21,13 @@ export const test_validate_TagType = _test_validate(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -124,6 +127,13 @@ export const test_validate_TagType = _test_validate(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -139,6 +149,12 @@ export const test_validate_TagType = _test_validate(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",

--- a/test/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/generated/output/validate/test_validate_UltimateUnion.ts
@@ -259,11 +259,15 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -271,8 +275,9 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -360,12 +365,14 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -412,12 +419,14 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -466,11 +475,13 @@ export const test_validate_UltimateUnion = _test_validate(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -886,11 +897,15 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
                             Number.isFinite(input.minimum) &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
                             Number.isFinite(input.maximum) &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
@@ -898,8 +913,9 @@ export const test_validate_UltimateUnion = _test_validate(
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
                             Number.isFinite(input.multipleOf) &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         ("number" === typeof input["default"] &&
                             Number.isFinite(input["default"]))) &&
@@ -995,12 +1011,14 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input.minLength &&
                             Number.isFinite(input.minLength) &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Number.isFinite(input.maxLength) &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -1051,12 +1069,14 @@ export const test_validate_UltimateUnion = _test_validate(
                         ("number" === typeof input.minItems &&
                             Number.isFinite(input.minItems) &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -1109,11 +1129,13 @@ export const test_validate_UltimateUnion = _test_validate(
                     Number.isFinite(input.minItems) &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Number.isFinite(input.maxItems) &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -2642,6 +2664,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -2653,6 +2682,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -2682,6 +2718,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -3083,6 +3126,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -3100,6 +3149,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -3327,6 +3382,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3344,6 +3405,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -3597,6 +3664,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -3614,6 +3687,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -5622,6 +5701,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minimum",
                                             expected: "number (@type int)",
                                             value: input.minimum,
+                                        })) &&
+                                    ((-2147483648 <= input.minimum &&
+                                        input.minimum <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minimum",
+                                            expected: "number (@type int)",
+                                            value: input.minimum,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minimum",
@@ -5633,6 +5719,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                     Number.isFinite(input.maximum) &&
                                     (Math.floor(input.maximum) ===
                                         input.maximum ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maximum",
+                                            expected: "number (@type int)",
+                                            value: input.maximum,
+                                        })) &&
+                                    ((-2147483648 <= input.maximum &&
+                                        input.maximum <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".maximum",
                                             expected: "number (@type int)",
@@ -5662,6 +5755,13 @@ export const test_validate_UltimateUnion = _test_validate(
                                     Number.isFinite(input.multipleOf) &&
                                     (Math.floor(input.multipleOf) ===
                                         input.multipleOf ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".multipleOf",
+                                            expected: "number (@type int)",
+                                            value: input.multipleOf,
+                                        })) &&
+                                    ((-2147483648 <= input.multipleOf &&
+                                        input.multipleOf <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".multipleOf",
                                             expected: "number (@type int)",
@@ -6091,6 +6191,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minLength",
                                             expected: "number (@type uint)",
                                             value: input.minLength,
+                                        })) &&
+                                    (input.minLength <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minLength",
+                                            expected: "number (@type uint)",
+                                            value: input.minLength,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minLength",
@@ -6108,6 +6214,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxLength,
                                         })) &&
                                     (0 <= input.maxLength ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxLength",
+                                            expected: "number (@type uint)",
+                                            value: input.maxLength,
+                                        })) &&
+                                    (input.maxLength <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxLength",
                                             expected: "number (@type uint)",
@@ -6349,6 +6461,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6366,6 +6484,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",
@@ -6633,6 +6757,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                         path: _path + ".minItems",
                                         expected: "number (@type uint)",
                                         value: input.minItems,
+                                    })) &&
+                                (input.minItems <= 4294967295 ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".minItems",
+                                        expected: "number (@type uint)",
+                                        value: input.minItems,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".minItems",
@@ -6650,6 +6780,12 @@ export const test_validate_UltimateUnion = _test_validate(
                                             value: input.maxItems,
                                         })) &&
                                     (0 <= input.maxItems ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".maxItems",
+                                            expected: "number (@type uint)",
+                                            value: input.maxItems,
+                                        })) &&
+                                    (input.maxItems <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".maxItems",
                                             expected: "number (@type uint)",

--- a/test/generated/output/validateClone/test_validateClone_TagRange.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagRange.ts
@@ -22,41 +22,59 @@ export const test_validateClone_TagRange = _test_validateClone(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -139,6 +157,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                             expected: "number (@type int)",
                                             value: input.greater,
                                         })) &&
+                                    ((-2147483648 <= input.greater &&
+                                        input.greater <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater",
+                                            expected: "number (@type int)",
+                                            value: input.greater,
+                                        })) &&
                                     (3 < input.greater ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater",
@@ -160,6 +185,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                             expected: "number (@type int)",
                                             value: input.greater_equal,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal &&
+                                        input.greater_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal,
+                                        })) &&
                                     (3 <= input.greater_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal",
@@ -174,6 +206,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 ("number" === typeof input.less &&
                                     Number.isFinite(input.less) &&
                                     (Math.floor(input.less) === input.less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less",
+                                            expected: "number (@type int)",
+                                            value: input.less,
+                                        })) &&
+                                    ((-2147483648 <= input.less &&
+                                        input.less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".less",
                                             expected: "number (@type int)",
@@ -200,6 +239,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                             expected: "number (@type int)",
                                             value: input.less_equal,
                                         })) &&
+                                    ((-2147483648 <= input.less_equal &&
+                                        input.less_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.less_equal,
+                                        })) &&
                                     (7 >= input.less_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".less_equal",
@@ -214,6 +260,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 ("number" === typeof input.greater_less &&
                                     (Math.floor(input.greater_less) ===
                                         input.greater_less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less &&
+                                        input.greater_less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less",
                                             expected: "number (@type int)",
@@ -246,6 +299,14 @@ export const test_validateClone_TagRange = _test_validateClone(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal_less &&
+                                        input.greater_equal_less <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less,
+                                        })) &&
                                     (3 <= input.greater_equal_less ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal_less",
@@ -267,6 +328,14 @@ export const test_validateClone_TagRange = _test_validateClone(
                                 ("number" === typeof input.greater_less_equal &&
                                     (Math.floor(input.greater_less_equal) ===
                                         input.greater_less_equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less_equal,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less_equal &&
+                                        input.greater_less_equal <=
+                                            2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less_equal",
                                             expected: "number (@type int)",
@@ -302,6 +371,17 @@ export const test_validateClone_TagRange = _test_validateClone(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less_equal,
                                         })) &&
+                                    ((-2147483648 <=
+                                        input.greater_equal_less_equal &&
+                                        input.greater_equal_less_equal <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".greater_equal_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less_equal,
+                                        })) &&
                                     (3 <= input.greater_equal_less_equal ||
                                         $report(_exceptionable, {
                                             path:
@@ -326,6 +406,13 @@ export const test_validateClone_TagRange = _test_validateClone(
                                     }),
                                 ("number" === typeof input.equal &&
                                     (Math.floor(input.equal) === input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@type int)",
+                                            value: input.equal,
+                                        })) &&
+                                    ((-2147483648 <= input.equal &&
+                                        input.equal <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".equal",
                                             expected: "number (@type int)",
@@ -376,37 +463,55 @@ export const test_validateClone_TagRange = _test_validateClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $cp0 = (input: any) =>

--- a/test/generated/output/validateClone/test_validateClone_TagType.ts
+++ b/test/generated/output/validateClone/test_validateClone_TagType.ts
@@ -22,10 +22,13 @@ export const test_validateClone_TagType = _test_validateClone(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -128,6 +131,13 @@ export const test_validateClone_TagType = _test_validateClone(
                                             path: _path + ".int",
                                             expected: "number (@type int)",
                                             value: input.int,
+                                        })) &&
+                                    ((-2147483648 <= input.int &&
+                                        input.int <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".int",
+                                            expected: "number (@type int)",
+                                            value: input.int,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".int",
@@ -143,6 +153,12 @@ export const test_validateClone_TagType = _test_validateClone(
                                             value: input.uint,
                                         })) &&
                                     (0 <= input.uint ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".uint",
+                                            expected: "number (@type uint)",
+                                            value: input.uint,
+                                        })) &&
+                                    (input.uint <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".uint",
                                             expected: "number (@type uint)",
@@ -287,9 +303,12 @@ export const test_validateClone_TagType = _test_validateClone(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
+++ b/test/generated/output/validateClone/test_validateClone_UltimateUnion.ts
@@ -263,11 +263,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -276,7 +280,9 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -365,13 +371,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -418,12 +426,14 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -472,11 +482,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -895,11 +907,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -908,7 +924,9 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1005,13 +1023,15 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1062,12 +1082,14 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1120,11 +1142,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2731,6 +2755,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -2742,6 +2773,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -2773,6 +2811,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -3212,6 +3257,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -3229,6 +3280,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -3474,6 +3531,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3491,6 +3554,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -3763,6 +3832,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3780,6 +3855,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -6002,6 +6083,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -6013,6 +6101,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -6044,6 +6139,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -6513,6 +6615,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -6530,6 +6638,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -6790,6 +6904,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -6807,6 +6927,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -7094,6 +7220,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -7111,6 +7243,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -8688,18 +8826,23 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -8781,11 +8924,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8831,11 +8976,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8883,10 +9030,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9299,18 +9448,23 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -9400,11 +9554,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -9454,11 +9610,13 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -9510,10 +9668,12 @@ export const test_validateClone_UltimateUnion = _test_validateClone(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/generated/output/validateEquals/test_validateEquals_TagInfinite.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagInfinite.ts
@@ -32,6 +32,8 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                     "number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
                     Math.floor(input.typed) === input.typed &&
+                    -2147483648 <= input.typed &&
+                    input.typed <= 2147483647 &&
                     (6 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -135,6 +137,13 @@ export const test_validateEquals_TagInfinite = _test_validateEquals(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/validateEquals/test_validateEquals_TagNaN.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagNaN.ts
@@ -32,6 +32,8 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                     "number" === typeof input.typed &&
                     Number.isFinite(input.typed) &&
                     Math.floor(input.typed) === input.typed &&
+                    -2147483648 <= input.typed &&
+                    input.typed <= 2147483647 &&
                     (6 === Object.keys(input).length ||
                         Object.keys(input).every((key: any) => {
                             if (
@@ -135,6 +137,13 @@ export const test_validateEquals_TagNaN = _test_validateEquals(
                             ("number" === typeof input.typed &&
                                 Number.isFinite(input.typed) &&
                                 (Math.floor(input.typed) === input.typed ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".typed",
+                                        expected: "number (@type int)",
+                                        value: input.typed,
+                                    })) &&
+                                ((-2147483648 <= input.typed &&
+                                    input.typed <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".typed",
                                         expected: "number (@type int)",

--- a/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagRange.ts
@@ -38,40 +38,58 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                     "number" === typeof input.greater &&
                     Number.isFinite(input.greater) &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Number.isFinite(input.greater_equal) &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Number.isFinite(input.less) &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Number.isFinite(input.less_equal) &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal &&
                     (9 === Object.keys(input).length ||
@@ -192,6 +210,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                         expected: "number (@type int)",
                                         value: input.greater,
                                     })) &&
+                                ((-2147483648 <= input.greater &&
+                                    input.greater <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater",
+                                        expected: "number (@type int)",
+                                        value: input.greater,
+                                    })) &&
                                 (3 < input.greater ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater",
@@ -213,6 +238,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                         expected: "number (@type int)",
                                         value: input.greater_equal,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal &&
+                                    input.greater_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal,
+                                    })) &&
                                 (3 <= input.greater_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal",
@@ -227,6 +259,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             ("number" === typeof input.less &&
                                 Number.isFinite(input.less) &&
                                 (Math.floor(input.less) === input.less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less",
+                                        expected: "number (@type int)",
+                                        value: input.less,
+                                    })) &&
+                                ((-2147483648 <= input.less &&
+                                    input.less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".less",
                                         expected: "number (@type int)",
@@ -253,6 +292,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                         expected: "number (@type int)",
                                         value: input.less_equal,
                                     })) &&
+                                ((-2147483648 <= input.less_equal &&
+                                    input.less_equal <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.less_equal,
+                                    })) &&
                                 (7 >= input.less_equal ||
                                     $report(_exceptionable, {
                                         path: _path + ".less_equal",
@@ -267,6 +313,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             ("number" === typeof input.greater_less &&
                                 (Math.floor(input.greater_less) ===
                                     input.greater_less ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less &&
+                                    input.greater_less <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less",
                                         expected: "number (@type int)",
@@ -299,6 +352,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less,
                                     })) &&
+                                ((-2147483648 <= input.greater_equal_less &&
+                                    input.greater_equal_less <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_equal_less",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less,
+                                    })) &&
                                 (3 <= input.greater_equal_less ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_equal_less",
@@ -320,6 +380,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                             ("number" === typeof input.greater_less_equal &&
                                 (Math.floor(input.greater_less_equal) ===
                                     input.greater_less_equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".greater_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_less_equal,
+                                    })) &&
+                                ((-2147483648 <= input.greater_less_equal &&
+                                    input.greater_less_equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".greater_less_equal",
                                         expected: "number (@type int)",
@@ -353,6 +420,16 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                         expected: "number (@type int)",
                                         value: input.greater_equal_less_equal,
                                     })) &&
+                                ((-2147483648 <=
+                                    input.greater_equal_less_equal &&
+                                    input.greater_equal_less_equal <=
+                                        2147483647) ||
+                                    $report(_exceptionable, {
+                                        path:
+                                            _path + ".greater_equal_less_equal",
+                                        expected: "number (@type int)",
+                                        value: input.greater_equal_less_equal,
+                                    })) &&
                                 (3 <= input.greater_equal_less_equal ||
                                     $report(_exceptionable, {
                                         path:
@@ -374,6 +451,13 @@ export const test_validateEquals_TagRange = _test_validateEquals(
                                 }),
                             ("number" === typeof input.equal &&
                                 (Math.floor(input.equal) === input.equal ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".equal",
+                                        expected: "number (@type int)",
+                                        value: input.equal,
+                                    })) &&
+                                ((-2147483648 <= input.equal &&
+                                    input.equal <= 2147483647) ||
                                     $report(_exceptionable, {
                                         path: _path + ".equal",
                                         expected: "number (@type int)",

--- a/test/generated/output/validateEquals/test_validateEquals_TagType.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_TagType.ts
@@ -38,10 +38,13 @@ export const test_validateEquals_TagType = _test_validateEquals(
                     "number" === typeof input.int &&
                     Number.isFinite(input.int) &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Number.isFinite(input.uint) &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Number.isFinite(input.int32) &&
                     Math.floor(input.int32) === input.int32 &&
@@ -181,6 +184,13 @@ export const test_validateEquals_TagType = _test_validateEquals(
                                         path: _path + ".int",
                                         expected: "number (@type int)",
                                         value: input.int,
+                                    })) &&
+                                ((-2147483648 <= input.int &&
+                                    input.int <= 2147483647) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".int",
+                                        expected: "number (@type int)",
+                                        value: input.int,
                                     }))) ||
                                 $report(_exceptionable, {
                                     path: _path + ".int",
@@ -196,6 +206,12 @@ export const test_validateEquals_TagType = _test_validateEquals(
                                         value: input.uint,
                                     })) &&
                                 (0 <= input.uint ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".uint",
+                                        expected: "number (@type uint)",
+                                        value: input.uint,
+                                    })) &&
+                                (input.uint <= 4294967295 ||
                                     $report(_exceptionable, {
                                         path: _path + ".uint",
                                         expected: "number (@type uint)",

--- a/test/generated/output/validateParse/test_validateParse_TagRange.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagRange.ts
@@ -22,41 +22,59 @@ export const test_validateParse_TagRange = _test_validateParse(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -139,6 +157,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             expected: "number (@type int)",
                                             value: input.greater,
                                         })) &&
+                                    ((-2147483648 <= input.greater &&
+                                        input.greater <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater",
+                                            expected: "number (@type int)",
+                                            value: input.greater,
+                                        })) &&
                                     (3 < input.greater ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater",
@@ -160,6 +185,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             expected: "number (@type int)",
                                             value: input.greater_equal,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal &&
+                                        input.greater_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal,
+                                        })) &&
                                     (3 <= input.greater_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal",
@@ -174,6 +206,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 ("number" === typeof input.less &&
                                     Number.isFinite(input.less) &&
                                     (Math.floor(input.less) === input.less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less",
+                                            expected: "number (@type int)",
+                                            value: input.less,
+                                        })) &&
+                                    ((-2147483648 <= input.less &&
+                                        input.less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".less",
                                             expected: "number (@type int)",
@@ -200,6 +239,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             expected: "number (@type int)",
                                             value: input.less_equal,
                                         })) &&
+                                    ((-2147483648 <= input.less_equal &&
+                                        input.less_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.less_equal,
+                                        })) &&
                                     (7 >= input.less_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".less_equal",
@@ -214,6 +260,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 ("number" === typeof input.greater_less &&
                                     (Math.floor(input.greater_less) ===
                                         input.greater_less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less &&
+                                        input.greater_less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less",
                                             expected: "number (@type int)",
@@ -246,6 +299,14 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal_less &&
+                                        input.greater_equal_less <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less,
+                                        })) &&
                                     (3 <= input.greater_equal_less ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal_less",
@@ -267,6 +328,14 @@ export const test_validateParse_TagRange = _test_validateParse(
                                 ("number" === typeof input.greater_less_equal &&
                                     (Math.floor(input.greater_less_equal) ===
                                         input.greater_less_equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less_equal,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less_equal &&
+                                        input.greater_less_equal <=
+                                            2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less_equal",
                                             expected: "number (@type int)",
@@ -302,6 +371,17 @@ export const test_validateParse_TagRange = _test_validateParse(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less_equal,
                                         })) &&
+                                    ((-2147483648 <=
+                                        input.greater_equal_less_equal &&
+                                        input.greater_equal_less_equal <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".greater_equal_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less_equal,
+                                        })) &&
                                     (3 <= input.greater_equal_less_equal ||
                                         $report(_exceptionable, {
                                             path:
@@ -326,6 +406,13 @@ export const test_validateParse_TagRange = _test_validateParse(
                                     }),
                                 ("number" === typeof input.equal &&
                                     (Math.floor(input.equal) === input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@type int)",
+                                            value: input.equal,
+                                        })) &&
+                                    ((-2147483648 <= input.equal &&
+                                        input.equal <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".equal",
                                             expected: "number (@type int)",

--- a/test/generated/output/validateParse/test_validateParse_TagType.ts
+++ b/test/generated/output/validateParse/test_validateParse_TagType.ts
@@ -22,10 +22,13 @@ export const test_validateParse_TagType = _test_validateParse(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -128,6 +131,13 @@ export const test_validateParse_TagType = _test_validateParse(
                                             path: _path + ".int",
                                             expected: "number (@type int)",
                                             value: input.int,
+                                        })) &&
+                                    ((-2147483648 <= input.int &&
+                                        input.int <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".int",
+                                            expected: "number (@type int)",
+                                            value: input.int,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".int",
@@ -143,6 +153,12 @@ export const test_validateParse_TagType = _test_validateParse(
                                             value: input.uint,
                                         })) &&
                                     (0 <= input.uint ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".uint",
+                                            expected: "number (@type uint)",
+                                            value: input.uint,
+                                        })) &&
+                                    (input.uint <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".uint",
                                             expected: "number (@type uint)",

--- a/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
+++ b/test/generated/output/validateParse/test_validateParse_UltimateUnion.ts
@@ -263,11 +263,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -276,7 +280,9 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -365,13 +371,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -418,12 +426,14 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -472,11 +482,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -895,11 +907,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -908,7 +924,9 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1005,13 +1023,15 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1062,12 +1082,14 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1120,11 +1142,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2731,6 +2755,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -2742,6 +2773,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -2773,6 +2811,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -3212,6 +3257,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -3229,6 +3280,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -3474,6 +3531,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3491,6 +3554,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -3763,6 +3832,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3780,6 +3855,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -6002,6 +6083,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -6013,6 +6101,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -6044,6 +6139,13 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -6513,6 +6615,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -6530,6 +6638,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -6790,6 +6904,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -6807,6 +6927,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -7094,6 +7220,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -7111,6 +7243,12 @@ export const test_validateParse_UltimateUnion = _test_validateParse(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",

--- a/test/generated/output/validatePrune/test_validatePrune_TagInfinite.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagInfinite.ts
@@ -29,7 +29,9 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                         "number" === typeof (input as any).typed &&
                         Number.isFinite((input as any).typed) &&
                         Math.floor((input as any).typed) ===
-                            (input as any).typed
+                            (input as any).typed &&
+                        -2147483648 <= (input as any).typed &&
+                        (input as any).typed <= 2147483647
                     );
                 };
                 if (false === __is(input)) {
@@ -111,6 +113,13 @@ export const test_validatePrune_TagInfinite = _test_validatePrune(
                                 ("number" === typeof input.typed &&
                                     Number.isFinite(input.typed) &&
                                     (Math.floor(input.typed) === input.typed ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".typed",
+                                            expected: "number (@type int)",
+                                            value: input.typed,
+                                        })) &&
+                                    ((-2147483648 <= input.typed &&
+                                        input.typed <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".typed",
                                             expected: "number (@type int)",

--- a/test/generated/output/validatePrune/test_validatePrune_TagNaN.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagNaN.ts
@@ -29,7 +29,9 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                         "number" === typeof (input as any).typed &&
                         Number.isFinite((input as any).typed) &&
                         Math.floor((input as any).typed) ===
-                            (input as any).typed
+                            (input as any).typed &&
+                        -2147483648 <= (input as any).typed &&
+                        (input as any).typed <= 2147483647
                     );
                 };
                 if (false === __is(input)) {
@@ -111,6 +113,13 @@ export const test_validatePrune_TagNaN = _test_validatePrune(
                                 ("number" === typeof input.typed &&
                                     Number.isFinite(input.typed) &&
                                     (Math.floor(input.typed) === input.typed ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".typed",
+                                            expected: "number (@type int)",
+                                            value: input.typed,
+                                        })) &&
+                                    ((-2147483648 <= input.typed &&
+                                        input.typed <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".typed",
                                             expected: "number (@type int)",

--- a/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagRange.ts
@@ -22,41 +22,59 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -139,6 +157,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                             expected: "number (@type int)",
                                             value: input.greater,
                                         })) &&
+                                    ((-2147483648 <= input.greater &&
+                                        input.greater <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater",
+                                            expected: "number (@type int)",
+                                            value: input.greater,
+                                        })) &&
                                     (3 < input.greater ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater",
@@ -160,6 +185,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                             expected: "number (@type int)",
                                             value: input.greater_equal,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal &&
+                                        input.greater_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal,
+                                        })) &&
                                     (3 <= input.greater_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal",
@@ -174,6 +206,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 ("number" === typeof input.less &&
                                     Number.isFinite(input.less) &&
                                     (Math.floor(input.less) === input.less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less",
+                                            expected: "number (@type int)",
+                                            value: input.less,
+                                        })) &&
+                                    ((-2147483648 <= input.less &&
+                                        input.less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".less",
                                             expected: "number (@type int)",
@@ -200,6 +239,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                             expected: "number (@type int)",
                                             value: input.less_equal,
                                         })) &&
+                                    ((-2147483648 <= input.less_equal &&
+                                        input.less_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.less_equal,
+                                        })) &&
                                     (7 >= input.less_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".less_equal",
@@ -214,6 +260,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 ("number" === typeof input.greater_less &&
                                     (Math.floor(input.greater_less) ===
                                         input.greater_less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less &&
+                                        input.greater_less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less",
                                             expected: "number (@type int)",
@@ -246,6 +299,14 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal_less &&
+                                        input.greater_equal_less <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less,
+                                        })) &&
                                     (3 <= input.greater_equal_less ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal_less",
@@ -267,6 +328,14 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                 ("number" === typeof input.greater_less_equal &&
                                     (Math.floor(input.greater_less_equal) ===
                                         input.greater_less_equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less_equal,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less_equal &&
+                                        input.greater_less_equal <=
+                                            2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less_equal",
                                             expected: "number (@type int)",
@@ -302,6 +371,17 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less_equal,
                                         })) &&
+                                    ((-2147483648 <=
+                                        input.greater_equal_less_equal &&
+                                        input.greater_equal_less_equal <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".greater_equal_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less_equal,
+                                        })) &&
                                     (3 <= input.greater_equal_less_equal ||
                                         $report(_exceptionable, {
                                             path:
@@ -326,6 +406,13 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                                     }),
                                 ("number" === typeof input.equal &&
                                     (Math.floor(input.equal) === input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@type int)",
+                                            value: input.equal,
+                                        })) &&
+                                    ((-2147483648 <= input.equal &&
+                                        input.equal <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".equal",
                                             expected: "number (@type int)",
@@ -376,37 +463,55 @@ export const test_validatePrune_TagRange = _test_validatePrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $pp0 = (input: any) =>

--- a/test/generated/output/validatePrune/test_validatePrune_TagType.ts
+++ b/test/generated/output/validatePrune/test_validatePrune_TagType.ts
@@ -22,10 +22,13 @@ export const test_validatePrune_TagType = _test_validatePrune(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -128,6 +131,13 @@ export const test_validatePrune_TagType = _test_validatePrune(
                                             path: _path + ".int",
                                             expected: "number (@type int)",
                                             value: input.int,
+                                        })) &&
+                                    ((-2147483648 <= input.int &&
+                                        input.int <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".int",
+                                            expected: "number (@type int)",
+                                            value: input.int,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".int",
@@ -143,6 +153,12 @@ export const test_validatePrune_TagType = _test_validatePrune(
                                             value: input.uint,
                                         })) &&
                                     (0 <= input.uint ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".uint",
+                                            expected: "number (@type uint)",
+                                            value: input.uint,
+                                        })) &&
+                                    (input.uint <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".uint",
                                             expected: "number (@type uint)",
@@ -287,9 +303,12 @@ export const test_validatePrune_TagType = _test_validatePrune(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagRange.ts
@@ -22,41 +22,59 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                         "number" === typeof input.greater &&
                         Number.isFinite(input.greater) &&
                         Math.floor(input.greater) === input.greater &&
+                        -2147483648 <= input.greater &&
+                        input.greater <= 2147483647 &&
                         3 < input.greater &&
                         "number" === typeof input.greater_equal &&
                         Number.isFinite(input.greater_equal) &&
                         Math.floor(input.greater_equal) ===
                             input.greater_equal &&
+                        -2147483648 <= input.greater_equal &&
+                        input.greater_equal <= 2147483647 &&
                         3 <= input.greater_equal &&
                         "number" === typeof input.less &&
                         Number.isFinite(input.less) &&
                         Math.floor(input.less) === input.less &&
+                        -2147483648 <= input.less &&
+                        input.less <= 2147483647 &&
                         7 > input.less &&
                         "number" === typeof input.less_equal &&
                         Number.isFinite(input.less_equal) &&
                         Math.floor(input.less_equal) === input.less_equal &&
+                        -2147483648 <= input.less_equal &&
+                        input.less_equal <= 2147483647 &&
                         7 >= input.less_equal &&
                         "number" === typeof input.greater_less &&
                         Math.floor(input.greater_less) === input.greater_less &&
+                        -2147483648 <= input.greater_less &&
+                        input.greater_less <= 2147483647 &&
                         3 < input.greater_less &&
                         7 > input.greater_less &&
                         "number" === typeof input.greater_equal_less &&
                         Math.floor(input.greater_equal_less) ===
                             input.greater_equal_less &&
+                        -2147483648 <= input.greater_equal_less &&
+                        input.greater_equal_less <= 2147483647 &&
                         3 <= input.greater_equal_less &&
                         7 > input.greater_equal_less &&
                         "number" === typeof input.greater_less_equal &&
                         Math.floor(input.greater_less_equal) ===
                             input.greater_less_equal &&
+                        -2147483648 <= input.greater_less_equal &&
+                        input.greater_less_equal <= 2147483647 &&
                         3 < input.greater_less_equal &&
                         7 >= input.greater_less_equal &&
                         "number" === typeof input.greater_equal_less_equal &&
                         Math.floor(input.greater_equal_less_equal) ===
                             input.greater_equal_less_equal &&
+                        -2147483648 <= input.greater_equal_less_equal &&
+                        input.greater_equal_less_equal <= 2147483647 &&
                         3 <= input.greater_equal_less_equal &&
                         7 >= input.greater_equal_less_equal &&
                         "number" === typeof input.equal &&
                         Math.floor(input.equal) === input.equal &&
+                        -2147483648 <= input.equal &&
+                        input.equal <= 2147483647 &&
                         10 <= input.equal &&
                         10 >= input.equal;
                     return (
@@ -141,6 +159,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                             expected: "number (@type int)",
                                             value: input.greater,
                                         })) &&
+                                    ((-2147483648 <= input.greater &&
+                                        input.greater <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater",
+                                            expected: "number (@type int)",
+                                            value: input.greater,
+                                        })) &&
                                     (3 < input.greater ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater",
@@ -162,6 +187,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                             expected: "number (@type int)",
                                             value: input.greater_equal,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal &&
+                                        input.greater_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal,
+                                        })) &&
                                     (3 <= input.greater_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal",
@@ -176,6 +208,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 ("number" === typeof input.less &&
                                     Number.isFinite(input.less) &&
                                     (Math.floor(input.less) === input.less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less",
+                                            expected: "number (@type int)",
+                                            value: input.less,
+                                        })) &&
+                                    ((-2147483648 <= input.less &&
+                                        input.less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".less",
                                             expected: "number (@type int)",
@@ -202,6 +241,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                             expected: "number (@type int)",
                                             value: input.less_equal,
                                         })) &&
+                                    ((-2147483648 <= input.less_equal &&
+                                        input.less_equal <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.less_equal,
+                                        })) &&
                                     (7 >= input.less_equal ||
                                         $report(_exceptionable, {
                                             path: _path + ".less_equal",
@@ -216,6 +262,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 ("number" === typeof input.greater_less &&
                                     (Math.floor(input.greater_less) ===
                                         input.greater_less ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less &&
+                                        input.greater_less <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less",
                                             expected: "number (@type int)",
@@ -248,6 +301,14 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less,
                                         })) &&
+                                    ((-2147483648 <= input.greater_equal_less &&
+                                        input.greater_equal_less <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_equal_less",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less,
+                                        })) &&
                                     (3 <= input.greater_equal_less ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_equal_less",
@@ -269,6 +330,14 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                 ("number" === typeof input.greater_less_equal &&
                                     (Math.floor(input.greater_less_equal) ===
                                         input.greater_less_equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".greater_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_less_equal,
+                                        })) &&
+                                    ((-2147483648 <= input.greater_less_equal &&
+                                        input.greater_less_equal <=
+                                            2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".greater_less_equal",
                                             expected: "number (@type int)",
@@ -304,6 +373,17 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                             expected: "number (@type int)",
                                             value: input.greater_equal_less_equal,
                                         })) &&
+                                    ((-2147483648 <=
+                                        input.greater_equal_less_equal &&
+                                        input.greater_equal_less_equal <=
+                                            2147483647) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".greater_equal_less_equal",
+                                            expected: "number (@type int)",
+                                            value: input.greater_equal_less_equal,
+                                        })) &&
                                     (3 <= input.greater_equal_less_equal ||
                                         $report(_exceptionable, {
                                             path:
@@ -328,6 +408,13 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                                     }),
                                 ("number" === typeof input.equal &&
                                     (Math.floor(input.equal) === input.equal ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".equal",
+                                            expected: "number (@type int)",
+                                            value: input.equal,
+                                        })) &&
+                                    ((-2147483648 <= input.equal &&
+                                        input.equal <= 2147483647) ||
                                         $report(_exceptionable, {
                                             path: _path + ".equal",
                                             expected: "number (@type int)",
@@ -378,37 +465,55 @@ export const test_validateStringify_TagRange = _test_validateStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.greater &&
                     Math.floor(input.greater) === input.greater &&
+                    -2147483648 <= input.greater &&
+                    input.greater <= 2147483647 &&
                     3 < input.greater &&
                     "number" === typeof input.greater_equal &&
                     Math.floor(input.greater_equal) === input.greater_equal &&
+                    -2147483648 <= input.greater_equal &&
+                    input.greater_equal <= 2147483647 &&
                     3 <= input.greater_equal &&
                     "number" === typeof input.less &&
                     Math.floor(input.less) === input.less &&
+                    -2147483648 <= input.less &&
+                    input.less <= 2147483647 &&
                     7 > input.less &&
                     "number" === typeof input.less_equal &&
                     Math.floor(input.less_equal) === input.less_equal &&
+                    -2147483648 <= input.less_equal &&
+                    input.less_equal <= 2147483647 &&
                     7 >= input.less_equal &&
                     "number" === typeof input.greater_less &&
                     Math.floor(input.greater_less) === input.greater_less &&
+                    -2147483648 <= input.greater_less &&
+                    input.greater_less <= 2147483647 &&
                     3 < input.greater_less &&
                     7 > input.greater_less &&
                     "number" === typeof input.greater_equal_less &&
                     Math.floor(input.greater_equal_less) ===
                         input.greater_equal_less &&
+                    -2147483648 <= input.greater_equal_less &&
+                    input.greater_equal_less <= 2147483647 &&
                     3 <= input.greater_equal_less &&
                     7 > input.greater_equal_less &&
                     "number" === typeof input.greater_less_equal &&
                     Math.floor(input.greater_less_equal) ===
                         input.greater_less_equal &&
+                    -2147483648 <= input.greater_less_equal &&
+                    input.greater_less_equal <= 2147483647 &&
                     3 < input.greater_less_equal &&
                     7 >= input.greater_less_equal &&
                     "number" === typeof input.greater_equal_less_equal &&
                     Math.floor(input.greater_equal_less_equal) ===
                         input.greater_equal_less_equal &&
+                    -2147483648 <= input.greater_equal_less_equal &&
+                    input.greater_equal_less_equal <= 2147483647 &&
                     3 <= input.greater_equal_less_equal &&
                     7 >= input.greater_equal_less_equal &&
                     "number" === typeof input.equal &&
                     Math.floor(input.equal) === input.equal &&
+                    -2147483648 <= input.equal &&
+                    input.equal <= 2147483647 &&
                     10 <= input.equal &&
                     10 >= input.equal;
                 const $number = (typia.validateStringify as any).number;

--- a/test/generated/output/validateStringify/test_validateStringify_TagType.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_TagType.ts
@@ -22,10 +22,13 @@ export const test_validateStringify_TagType = _test_validateStringify(
                         "number" === typeof input.int &&
                         Number.isFinite(input.int) &&
                         Math.floor(input.int) === input.int &&
+                        -2147483648 <= input.int &&
+                        input.int <= 2147483647 &&
                         "number" === typeof input.uint &&
                         Number.isFinite(input.uint) &&
                         Math.floor(input.uint) === input.uint &&
                         0 <= input.uint &&
+                        input.uint <= 4294967295 &&
                         "number" === typeof input.int32 &&
                         Number.isFinite(input.int32) &&
                         Math.floor(input.int32) === input.int32 &&
@@ -130,6 +133,13 @@ export const test_validateStringify_TagType = _test_validateStringify(
                                             path: _path + ".int",
                                             expected: "number (@type int)",
                                             value: input.int,
+                                        })) &&
+                                    ((-2147483648 <= input.int &&
+                                        input.int <= 2147483647) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".int",
+                                            expected: "number (@type int)",
+                                            value: input.int,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".int",
@@ -145,6 +155,12 @@ export const test_validateStringify_TagType = _test_validateStringify(
                                             value: input.uint,
                                         })) &&
                                     (0 <= input.uint ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".uint",
+                                            expected: "number (@type uint)",
+                                            value: input.uint,
+                                        })) &&
+                                    (input.uint <= 4294967295 ||
                                         $report(_exceptionable, {
                                             path: _path + ".uint",
                                             expected: "number (@type uint)",
@@ -289,9 +305,12 @@ export const test_validateStringify_TagType = _test_validateStringify(
                 const $io1 = (input: any): boolean =>
                     "number" === typeof input.int &&
                     Math.floor(input.int) === input.int &&
+                    -2147483648 <= input.int &&
+                    input.int <= 2147483647 &&
                     "number" === typeof input.uint &&
                     Math.floor(input.uint) === input.uint &&
                     0 <= input.uint &&
+                    input.uint <= 4294967295 &&
                     "number" === typeof input.int32 &&
                     Math.floor(input.int32) === input.int32 &&
                     -2147483648 <= input.int32 &&

--- a/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
+++ b/test/generated/output/validateStringify/test_validateStringify_UltimateUnion.ts
@@ -263,11 +263,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -276,7 +280,9 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -365,13 +371,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -418,12 +426,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -472,11 +482,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -895,11 +907,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         (undefined === input.minimum ||
                             ("number" === typeof input.minimum &&
                                 Number.isFinite(input.minimum) &&
-                                Math.floor(input.minimum) === input.minimum)) &&
+                                Math.floor(input.minimum) === input.minimum &&
+                                -2147483648 <= input.minimum &&
+                                input.minimum <= 2147483647)) &&
                         (undefined === input.maximum ||
                             ("number" === typeof input.maximum &&
                                 Number.isFinite(input.maximum) &&
-                                Math.floor(input.maximum) === input.maximum)) &&
+                                Math.floor(input.maximum) === input.maximum &&
+                                -2147483648 <= input.maximum &&
+                                input.maximum <= 2147483647)) &&
                         (undefined === input.exclusiveMinimum ||
                             "boolean" === typeof input.exclusiveMinimum) &&
                         (undefined === input.exclusiveMaximum ||
@@ -908,7 +924,9 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input.multipleOf &&
                                 Number.isFinite(input.multipleOf) &&
                                 Math.floor(input.multipleOf) ===
-                                    input.multipleOf)) &&
+                                    input.multipleOf &&
+                                -2147483648 <= input.multipleOf &&
+                                input.multipleOf <= 2147483647)) &&
                         (undefined === input["default"] ||
                             ("number" === typeof input["default"] &&
                                 Number.isFinite(input["default"]))) &&
@@ -1005,13 +1023,15 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                 Number.isFinite(input.minLength) &&
                                 Math.floor(input.minLength) ===
                                     input.minLength &&
-                                0 <= input.minLength)) &&
+                                0 <= input.minLength &&
+                                input.minLength <= 4294967295)) &&
                         (undefined === input.maxLength ||
                             ("number" === typeof input.maxLength &&
                                 Number.isFinite(input.maxLength) &&
                                 Math.floor(input.maxLength) ===
                                     input.maxLength &&
-                                0 <= input.maxLength)) &&
+                                0 <= input.maxLength &&
+                                input.maxLength <= 4294967295)) &&
                         (undefined === input.pattern ||
                             "string" === typeof input.pattern) &&
                         (undefined === input.format ||
@@ -1062,12 +1082,14 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                             ("number" === typeof input.minItems &&
                                 Number.isFinite(input.minItems) &&
                                 Math.floor(input.minItems) === input.minItems &&
-                                0 <= input.minItems)) &&
+                                0 <= input.minItems &&
+                                input.minItems <= 4294967295)) &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         (undefined === input["x-typia-tuple"] ||
                             ("object" === typeof input["x-typia-tuple"] &&
                                 null !== input["x-typia-tuple"] &&
@@ -1120,11 +1142,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                         Number.isFinite(input.minItems) &&
                         Math.floor(input.minItems) === input.minItems &&
                         0 <= input.minItems &&
+                        input.minItems <= 4294967295 &&
                         (undefined === input.maxItems ||
                             ("number" === typeof input.maxItems &&
                                 Number.isFinite(input.maxItems) &&
                                 Math.floor(input.maxItems) === input.maxItems &&
-                                0 <= input.maxItems)) &&
+                                0 <= input.maxItems &&
+                                input.maxItems <= 4294967295)) &&
                         "array" === input.type &&
                         (undefined === input.nullable ||
                             "boolean" === typeof input.nullable) &&
@@ -2733,6 +2757,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -2744,6 +2775,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -2775,6 +2813,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -3214,6 +3259,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -3231,6 +3282,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -3476,6 +3533,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3493,6 +3556,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -3765,6 +3834,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -3782,6 +3857,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -6004,6 +6085,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minimum",
                                                 expected: "number (@type int)",
                                                 value: input.minimum,
+                                            })) &&
+                                        ((-2147483648 <= input.minimum &&
+                                            input.minimum <= 2147483647) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minimum",
+                                                expected: "number (@type int)",
+                                                value: input.minimum,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minimum",
@@ -6015,6 +6103,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         Number.isFinite(input.maximum) &&
                                         (Math.floor(input.maximum) ===
                                             input.maximum ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maximum",
+                                                expected: "number (@type int)",
+                                                value: input.maximum,
+                                            })) &&
+                                        ((-2147483648 <= input.maximum &&
+                                            input.maximum <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maximum",
                                                 expected: "number (@type int)",
@@ -6046,6 +6141,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                         Number.isFinite(input.multipleOf) &&
                                         (Math.floor(input.multipleOf) ===
                                             input.multipleOf ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".multipleOf",
+                                                expected: "number (@type int)",
+                                                value: input.multipleOf,
+                                            })) &&
+                                        ((-2147483648 <= input.multipleOf &&
+                                            input.multipleOf <= 2147483647) ||
                                             $report(_exceptionable, {
                                                 path: _path + ".multipleOf",
                                                 expected: "number (@type int)",
@@ -6515,6 +6617,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minLength",
                                                 expected: "number (@type uint)",
                                                 value: input.minLength,
+                                            })) &&
+                                        (input.minLength <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minLength",
+                                                expected: "number (@type uint)",
+                                                value: input.minLength,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minLength",
@@ -6532,6 +6640,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxLength,
                                             })) &&
                                         (0 <= input.maxLength ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxLength",
+                                                expected: "number (@type uint)",
+                                                value: input.maxLength,
+                                            })) &&
+                                        (input.maxLength <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxLength",
                                                 expected: "number (@type uint)",
@@ -6792,6 +6906,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 path: _path + ".minItems",
                                                 expected: "number (@type uint)",
                                                 value: input.minItems,
+                                            })) &&
+                                        (input.minItems <= 4294967295 ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".minItems",
+                                                expected: "number (@type uint)",
+                                                value: input.minItems,
                                             }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -6809,6 +6929,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -7096,6 +7222,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                             path: _path + ".minItems",
                                             expected: "number (@type uint)",
                                             value: input.minItems,
+                                        })) &&
+                                    (input.minItems <= 4294967295 ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".minItems",
+                                            expected: "number (@type uint)",
+                                            value: input.minItems,
                                         }))) ||
                                     $report(_exceptionable, {
                                         path: _path + ".minItems",
@@ -7113,6 +7245,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                                                 value: input.maxItems,
                                             })) &&
                                         (0 <= input.maxItems ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".maxItems",
+                                                expected: "number (@type uint)",
+                                                value: input.maxItems,
+                                            })) &&
+                                        (input.maxItems <= 4294967295 ||
                                             $report(_exceptionable, {
                                                 path: _path + ".maxItems",
                                                 expected: "number (@type uint)",
@@ -8688,18 +8826,23 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 const $io22 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -8781,11 +8924,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -8831,11 +8976,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -8883,10 +9030,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&
@@ -9299,18 +9448,23 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                 const $io39 = (input: any): boolean =>
                     (undefined === input.minimum ||
                         ("number" === typeof input.minimum &&
-                            Math.floor(input.minimum) === input.minimum)) &&
+                            Math.floor(input.minimum) === input.minimum &&
+                            -2147483648 <= input.minimum &&
+                            input.minimum <= 2147483647)) &&
                     (undefined === input.maximum ||
                         ("number" === typeof input.maximum &&
-                            Math.floor(input.maximum) === input.maximum)) &&
+                            Math.floor(input.maximum) === input.maximum &&
+                            -2147483648 <= input.maximum &&
+                            input.maximum <= 2147483647)) &&
                     (undefined === input.exclusiveMinimum ||
                         "boolean" === typeof input.exclusiveMinimum) &&
                     (undefined === input.exclusiveMaximum ||
                         "boolean" === typeof input.exclusiveMaximum) &&
                     (undefined === input.multipleOf ||
                         ("number" === typeof input.multipleOf &&
-                            Math.floor(input.multipleOf) ===
-                                input.multipleOf)) &&
+                            Math.floor(input.multipleOf) === input.multipleOf &&
+                            -2147483648 <= input.multipleOf &&
+                            input.multipleOf <= 2147483647)) &&
                     (undefined === input["default"] ||
                         "number" === typeof input["default"]) &&
                     "integer" === input.type &&
@@ -9400,11 +9554,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input.minLength ||
                         ("number" === typeof input.minLength &&
                             Math.floor(input.minLength) === input.minLength &&
-                            0 <= input.minLength)) &&
+                            0 <= input.minLength &&
+                            input.minLength <= 4294967295)) &&
                     (undefined === input.maxLength ||
                         ("number" === typeof input.maxLength &&
                             Math.floor(input.maxLength) === input.maxLength &&
-                            0 <= input.maxLength)) &&
+                            0 <= input.maxLength &&
+                            input.maxLength <= 4294967295)) &&
                     (undefined === input.pattern ||
                         "string" === typeof input.pattern) &&
                     (undefined === input.format ||
@@ -9454,11 +9610,13 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     (undefined === input.minItems ||
                         ("number" === typeof input.minItems &&
                             Math.floor(input.minItems) === input.minItems &&
-                            0 <= input.minItems)) &&
+                            0 <= input.minItems &&
+                            input.minItems <= 4294967295)) &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     (undefined === input["x-typia-tuple"] ||
                         ("object" === typeof input["x-typia-tuple"] &&
                             null !== input["x-typia-tuple"] &&
@@ -9510,10 +9668,12 @@ export const test_validateStringify_UltimateUnion = _test_validateStringify(
                     "number" === typeof input.minItems &&
                     Math.floor(input.minItems) === input.minItems &&
                     0 <= input.minItems &&
+                    input.minItems <= 4294967295 &&
                     (undefined === input.maxItems ||
                         ("number" === typeof input.maxItems &&
                             Math.floor(input.maxItems) === input.maxItems &&
-                            0 <= input.maxItems)) &&
+                            0 <= input.maxItems &&
+                            input.maxItems <= 4294967295)) &&
                     "array" === input.type &&
                     (undefined === input.nullable ||
                         "boolean" === typeof input.nullable) &&

--- a/test/structures/TagType.ts
+++ b/test/structures/TagType.ts
@@ -94,6 +94,18 @@ export namespace TagType {
             ])
             .flat(),
         (input) => {
+            input.value[0].uint = 4294967296;
+            return ["$input.value[0].uint"];
+        },
+        (input) => {
+            input.value[1].int = -2147483649;
+            return ["$input.value[1].int"];
+        },
+        (input) => {
+            input.value[2].int = 2147483648;
+            return ["$input.value[2].int"];
+        },
+        (input) => {
             input.value[0].uint32 = 4294967296;
             return ["$input.value[0].uint32"];
         },

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.1.6",
-    "typia": "^4.3.0"
+    "typia": "^4.3.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/website/pages/docs/validators/tags.mdx
+++ b/website/pages/docs/validators/tags.mdx
@@ -21,7 +21,7 @@ export const checkCommentTag = typia.createIs<CommentTag>();
 
 interface CommentTag {
     /**
-     * @type uint32
+     * @type uint
      */
     type: number;
 
@@ -99,13 +99,11 @@ I think below list is not hard to understand.
 
   - number
     - `@type {string}`
-      - `int`: `Math.floor(x) === x`
-      - `uint`: `Math.floor(x) === x && x >= 0`
-        - `int32`: `-2^31 <= x <= 2^31 - 1`
-        - `uint32`: `0 <= x <= 2^32 - 1`
-        - `uint64`: `0 <= x <= 2^64 - 1`
-        - `int64`: `-2^63 <= x <= 2^63 - 1`
-      - `float`: `-1.175494351e38 <= x <= 3.4028235e38`
+      - `int` / `int32`
+      - `uint` / `uint32`
+      - `int64`
+      - `uint64`
+      - `float`
     - `@minimum {number}`
     - `@maximum {number}`
     - `@exclusiveMinimum {number}`


### PR DESCRIPTION
Have forgotten to limit range of `@type int` and `@type uint` comment tags. 

From now on, range of `int` and `uint` would be restricted like `int32` and `uint32`.

Also, guide documents (https://typia.io/docs) has been updated too.
