### PR TITLE
For TypeScript v5.2 patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "4.3.2"
+    "typia": "4.3.3"
   },
   "peerDependencies": {
     "typescript": ">= 4.7.4"

--- a/src/factories/internal/metadata/iterate_metadata_intersection.ts
+++ b/src/factories/internal/metadata/iterate_metadata_intersection.ts
@@ -51,7 +51,11 @@ export const iterate_metadata_intersection =
                 aliased,
             );
             return true;
-        }
+        } else if (
+            // ONLY OBJECT TYPES -> SPECIAL LOGIC FOR TS V5.2
+            children.every((c) => c.objects.length === 1 && c.size() === 1)
+        )
+            return false;
 
         // ABSORB TO ATOMIC (OR CONSTANT) TYPE
         const atomics: Metadata[] = children.filter(

--- a/src/programmers/helpers/CloneJoiner.ts
+++ b/src/programmers/helpers/CloneJoiner.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 
+import { IdentifierFactory } from "../../factories/IdentifierFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 
@@ -35,30 +36,66 @@ export namespace CloneJoiner {
         const value = ts.factory.createIdentifier("value");
         const output = ts.factory.createIdentifier("output");
 
-        const statements: ts.Statement[] = dynamic.map((entry) =>
-            ts.factory.createIfStatement(
-                ts.factory.createCallExpression(
-                    ts.factory.createIdentifier(
-                        `RegExp(/${metadata_to_pattern(true)(
-                            entry.key,
-                        )}/).test`,
-                    ),
-                    undefined,
-                    [key],
-                ),
-                ts.factory.createBlock([
-                    ts.factory.createExpressionStatement(
-                        ts.factory.createBinaryExpression(
-                            ts.factory.createElementAccessExpression(
-                                output,
-                                key,
+        const statements: ts.Statement[] = [];
+        if (regular.length !== 0)
+            statements.push(
+                ts.factory.createIfStatement(
+                    ts.factory.createCallExpression(
+                        IdentifierFactory.access(
+                            ts.factory.createArrayLiteralExpression(
+                                regular.map((r) =>
+                                    ts.factory.createStringLiteral(
+                                        r.key.getSoleLiteral()!,
+                                    ),
+                                ),
                             ),
-                            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                            entry.expression,
-                        ),
+                        )("some"),
+                        undefined,
+                        [
+                            ts.factory.createArrowFunction(
+                                undefined,
+                                undefined,
+                                [IdentifierFactory.parameter("regular")],
+                                undefined,
+                                undefined,
+                                ts.factory.createStrictEquality(
+                                    ts.factory.createIdentifier("regular"),
+                                    ts.factory.createIdentifier("key"),
+                                ),
+                            ),
+                        ],
                     ),
                     ts.factory.createContinueStatement(),
-                ]),
+                ),
+            );
+        statements.push(
+            ...dynamic.map((entry) =>
+                ts.factory.createIfStatement(
+                    ts.factory.createCallExpression(
+                        ts.factory.createIdentifier(
+                            `RegExp(/${metadata_to_pattern(true)(
+                                entry.key,
+                            )}/).test`,
+                        ),
+                        undefined,
+                        [key],
+                    ),
+                    ts.factory.createBlock([
+                        ts.factory.createExpressionStatement(
+                            ts.factory.createBinaryExpression(
+                                ts.factory.createElementAccessExpression(
+                                    output,
+                                    key,
+                                ),
+                                ts.factory.createToken(
+                                    ts.SyntaxKind.EqualsToken,
+                                ),
+                                entry.expression,
+                            ),
+                        ),
+                        ts.factory.createContinueStatement(),
+                    ]),
+                ),
             ),
         );
 

--- a/src/programmers/internal/check_dynamic_properties.ts
+++ b/src/programmers/internal/check_dynamic_properties.ts
@@ -111,8 +111,7 @@ const check_dynamic_property =
             );
 
         // GATHER CONDITIONS
-        if (props.equals === true && regular.length)
-            add(is_regular_property(regular), props.positive);
+        if (regular.length) add(is_regular_property(regular), props.positive);
         statements.push(
             StatementFactory.constant(
                 "value",

--- a/test/issues/intersection.ts
+++ b/test/issues/intersection.ts
@@ -1,4 +1,5 @@
 import typia from "typia";
 
-type Intersection = typia.Primitive<number & { __x: string }>;
-console.log(typia.createIs<Intersection>().toString());
+type Intersection = { x: number } & Record<string, string>;
+
+console.log(typia.createClone<Intersection>().toString());


### PR DESCRIPTION
```typescript
type Intersection = { x: number } & Record<string | object | symbol, string>;
```

When intersection type with static object and dynamic object with `symbol` typed key comes, there had not been any problem until `TypeScript@5.1`. However, after `TypeScript@5.2` patch, it became an error in `typia`. I think TypeScript may changed internal logic of compiler.

Anyway, I fixed that bug and during the implementation, I found another type of bug. When above `Intersection` type comes, the property `x` must not be doubly checked by validation function of typia like `assert<T>()`. However, `typia` had done it, and I fixed that bug, too.
