### PR TITLE
change Format to Pattern in pattern example

### DIFF
--- a/website/pages/docs/validators/tags.mdx
+++ b/website/pages/docs/validators/tags.mdx
@@ -38,7 +38,7 @@ interface CustomTag {
      */
     string: string;
 
-    pattern: string & tags.Format<"^[a-z]+$">;
+    pattern: string & tags.Pattern<"^[a-z]+$">;
 
     /**
      * Type tag can perform union type.


### PR DESCRIPTION
There is a typo in the example describing how to use pattern in the new tag generics.

Before submitting a Pull Request, please test your code. 
