### PR TITLE
Complement #816 - support `*.tsx` files' generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -26,7 +26,7 @@ export namespace json {
 // PROTOCOL BUFFER
 export namespace protobuf {
     export function message<T>(): string; // Protocol Buffer message
-    export function assertDecode<T>(buffer: Buffer): T; // safe decoder
+    export function assertDecode<T>(buffer: Uint8Array): T; // safe decoder
     export function assertEncode<T>(input: T): Uint8Array; // safe encoder
 }
 

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.0.4"
+    "typia": "5.0.5"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/src/programmers/TypiaProgrammer.ts
+++ b/src/programmers/TypiaProgrammer.ts
@@ -13,14 +13,6 @@ export namespace TypiaProgrammer {
         project: string;
     }
 
-    const is_supported_extension = (filename: string): boolean => {
-        return (
-            filename.endsWith(".ts") ||
-            filename.endsWith(".tsx") ||
-            filename.endsWith(".svelte")
-        );
-    };
-
     export const build = async (
         props: TypiaProgrammer.IProps,
     ): Promise<void> => {
@@ -167,4 +159,11 @@ export namespace TypiaProgrammer {
                 } else if (is_supported_extension(file)) container.push(next);
             }
         };
+
+    const is_supported_extension = (filename: string): boolean => {
+        return (
+            (filename.endsWith(".ts") && !filename.endsWith(".d.ts")) ||
+            (filename.endsWith(".tsx") && !filename.endsWith(".d.tsx"))
+        );
+    };
 }


### PR DESCRIPTION
only with `tsx` supporting.

@tsengia had tried to support both `tsx` and `svelte` files in the generation mode, but `svelte` does not work. Therefore, publish the new patch version only with `tsx` supporting.