### PR TITLE
Change naming strategy of swagger components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.0.5",
+  "version": "5.1.0-dev.20230923",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.0.5",
+  "version": "5.1.0-dev.20230923",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.0.5"
+    "typia": "5.1.0-dev.20230923"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/src/factories/MetadataCollection.ts
+++ b/src/factories/MetadataCollection.ts
@@ -240,6 +240,11 @@ export namespace MetadataCollection {
     }
 
     export const replace = (str: string): string => {
+        let replaced: string = str;
+        for (const [before] of REPLACERS)
+            replaced = replaced.split(before).join("");
+        if (replaced.length !== 0) return replaced;
+
         for (const [before, after] of REPLACERS)
             str = str.split(before).join(after);
         return str;

--- a/test/schemas/json/ajv/ArrayAtomicAlias.json
+++ b/test/schemas/json/ajv/ArrayAtomicAlias.json
@@ -11,34 +11,34 @@
         "type": "array",
         "items": [
           {
-            "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_boolean_gt_"
+            "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasboolean"
           },
           {
-            "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_number_gt_"
+            "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasnumber"
           },
           {
-            "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_"
+            "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasstring"
           }
         ],
         "minItems": 3,
         "maxItems": 3
       },
-      "ArrayAtomicAlias.Alias_lt_boolean_gt_": {
-        "$id": "#/components/schemas/ArrayAtomicAlias.Alias_lt_boolean_gt_",
+      "ArrayAtomicAlias.Aliasboolean": {
+        "$id": "#/components/schemas/ArrayAtomicAlias.Aliasboolean",
         "type": "array",
         "items": {
           "type": "boolean"
         }
       },
-      "ArrayAtomicAlias.Alias_lt_number_gt_": {
-        "$id": "#/components/schemas/ArrayAtomicAlias.Alias_lt_number_gt_",
+      "ArrayAtomicAlias.Aliasnumber": {
+        "$id": "#/components/schemas/ArrayAtomicAlias.Aliasnumber",
         "type": "array",
         "items": {
           "type": "number"
         }
       },
-      "ArrayAtomicAlias.Alias_lt_string_gt_": {
-        "$id": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_",
+      "ArrayAtomicAlias.Aliasstring": {
+        "$id": "#/components/schemas/ArrayAtomicAlias.Aliasstring",
         "type": "array",
         "items": {
           "type": "string"

--- a/test/schemas/json/ajv/AtomicIntersection.json
+++ b/test/schemas/json/ajv/AtomicIntersection.json
@@ -11,28 +11,28 @@
         "type": "array",
         "items": [
           {
-            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+            "$ref": "#/components/schemas/AtomicIntersection.Wrapperboolean"
           },
           {
-            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+            "$ref": "#/components/schemas/AtomicIntersection.Wrappernumber"
           },
           {
-            "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+            "$ref": "#/components/schemas/AtomicIntersection.Wrapperstring"
           }
         ],
         "minItems": 3,
         "maxItems": 3
       },
-      "AtomicIntersection.Wrapper_lt_boolean_gt_": {
-        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_",
+      "AtomicIntersection.Wrapperboolean": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrapperboolean",
         "type": "boolean"
       },
-      "AtomicIntersection.Wrapper_lt_number_gt_": {
-        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_",
+      "AtomicIntersection.Wrappernumber": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrappernumber",
         "type": "number"
       },
-      "AtomicIntersection.Wrapper_lt_string_gt_": {
-        "$id": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_",
+      "AtomicIntersection.Wrapperstring": {
+        "$id": "#/components/schemas/AtomicIntersection.Wrapperstring",
         "type": "string"
       }
     }

--- a/test/schemas/json/ajv/ConstantAtomicWrapper.json
+++ b/test/schemas/json/ajv/ConstantAtomicWrapper.json
@@ -11,20 +11,20 @@
         "type": "array",
         "items": [
           {
-            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_"
+            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerboolean"
           },
           {
-            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_"
+            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointernumber"
           },
           {
-            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_"
+            "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerstring"
           }
         ],
         "minItems": 3,
         "maxItems": 3
       },
-      "ConstantAtomicWrapper.IPointer_lt_boolean_gt_": {
-        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_",
+      "ConstantAtomicWrapper.IPointerboolean": {
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointerboolean",
         "type": "object",
         "properties": {
           "value": {
@@ -38,8 +38,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ConstantAtomicWrapper.IPointer_lt_number_gt_": {
-        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_",
+      "ConstantAtomicWrapper.IPointernumber": {
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointernumber",
         "type": "object",
         "properties": {
           "value": {
@@ -53,8 +53,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ConstantAtomicWrapper.IPointer_lt_string_gt_": {
-        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_",
+      "ConstantAtomicWrapper.IPointerstring": {
+        "$id": "#/components/schemas/ConstantAtomicWrapper.IPointerstring",
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/ajv/ConstantIntersection.json
+++ b/test/schemas/json/ajv/ConstantIntersection.json
@@ -11,34 +11,34 @@
         "type": "array",
         "items": [
           {
-            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+            "$ref": "#/components/schemas/ConstantIntersection.Wrapperfalse"
           },
           {
-            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+            "$ref": "#/components/schemas/ConstantIntersection.Wrapper1"
           },
           {
-            "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+            "$ref": "#/components/schemas/ConstantIntersection.Wrappertwo"
           }
         ],
         "minItems": 3,
         "maxItems": 3
       },
-      "ConstantIntersection.Wrapper_lt_false_gt_": {
-        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_",
+      "ConstantIntersection.Wrapperfalse": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrapperfalse",
         "type": "boolean",
         "enum": [
           false
         ]
       },
-      "ConstantIntersection.Wrapper_lt_1_gt_": {
-        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_",
+      "ConstantIntersection.Wrapper1": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrapper1",
         "type": "number",
         "enum": [
           1
         ]
       },
-      "ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_": {
-        "$id": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_",
+      "ConstantIntersection.Wrappertwo": {
+        "$id": "#/components/schemas/ConstantIntersection.Wrappertwo",
         "type": "string",
         "enum": [
           "two"

--- a/test/schemas/json/ajv/DynamicTree.json
+++ b/test/schemas/json/ajv/DynamicTree.json
@@ -21,7 +21,7 @@
             "type": "number"
           },
           "children": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_"
+            "$ref": "#/components/schemas/RecordstringDynamicTree"
           }
         },
         "required": [
@@ -31,8 +31,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_DynamicTree_gt_": {
-        "$id": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_",
+      "RecordstringDynamicTree": {
+        "$id": "#/components/schemas/RecordstringDynamicTree",
         "type": "object",
         "properties": {},
         "x-typia-jsDocTags": [],

--- a/test/schemas/json/ajv/MapAlias.json
+++ b/test/schemas/json/ajv/MapAlias.json
@@ -11,19 +11,19 @@
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_boolean_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPbooleannumber"
           },
           "number": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_number_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPnumbernumber"
           },
           "strings": {
-            "$ref": "#/components/schemas/MapAlias._Map_lt_string_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias._Mapstringnumber"
           },
           "arrays": {
-            "$ref": "#/components/schemas/MapAlias._Map_lt_Array_lt_number_gt__comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias._MapArraynumbernumber"
           },
           "objects": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_MapAlias.Person_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPMapAlias.Personnumber"
           }
         },
         "required": [
@@ -35,8 +35,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "MapAlias.MAP_lt_boolean_comma__space_number_gt_": {
-        "$id": "#/components/schemas/MapAlias.MAP_lt_boolean_comma__space_number_gt_",
+      "MapAlias.MAPbooleannumber": {
+        "$id": "#/components/schemas/MapAlias.MAPbooleannumber",
         "$ref": "#/components/objects/Map"
       },
       "Map": {
@@ -44,20 +44,20 @@
         "$id": "#/components/objects/Map",
         "properties": {}
       },
-      "MapAlias.MAP_lt_number_comma__space_number_gt_": {
-        "$id": "#/components/schemas/MapAlias.MAP_lt_number_comma__space_number_gt_",
+      "MapAlias.MAPnumbernumber": {
+        "$id": "#/components/schemas/MapAlias.MAPnumbernumber",
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias._Map_lt_string_comma__space_number_gt_": {
-        "$id": "#/components/schemas/MapAlias._Map_lt_string_comma__space_number_gt_",
+      "MapAlias._Mapstringnumber": {
+        "$id": "#/components/schemas/MapAlias._Mapstringnumber",
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias._Map_lt_Array_lt_number_gt__comma__space_number_gt_": {
-        "$id": "#/components/schemas/MapAlias._Map_lt_Array_lt_number_gt__comma__space_number_gt_",
+      "MapAlias._MapArraynumbernumber": {
+        "$id": "#/components/schemas/MapAlias._MapArraynumbernumber",
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias.MAP_lt_MapAlias.Person_comma__space_number_gt_": {
-        "$id": "#/components/schemas/MapAlias.MAP_lt_MapAlias.Person_comma__space_number_gt_",
+      "MapAlias.MAPMapAlias.Personnumber": {
+        "$id": "#/components/schemas/MapAlias.MAPMapAlias.Personnumber",
         "$ref": "#/components/objects/Map"
       }
     }

--- a/test/schemas/json/ajv/ObjectGeneric.json
+++ b/test/schemas/json/ajv/ObjectGeneric.json
@@ -11,20 +11,20 @@
         "type": "array",
         "items": [
           {
-            "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.ISomethingboolean"
           },
           {
-            "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.ISomethingnumber"
           },
           {
-            "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.ISomethingstring"
           }
         ],
         "minItems": 3,
         "maxItems": 3
       },
-      "ObjectGeneric.ISomething_lt_boolean_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_",
+      "ObjectGeneric.ISomethingboolean": {
+        "$id": "#/components/schemas/ObjectGeneric.ISomethingboolean",
         "type": "object",
         "properties": {
           "value": {
@@ -33,14 +33,14 @@
             "type": "boolean"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildbooleanboolean"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildbooleanboolean"
             }
           }
         },
@@ -51,8 +51,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_",
+      "ObjectGeneric.IChildbooleanboolean": {
+        "$id": "#/components/schemas/ObjectGeneric.IChildbooleanboolean",
         "type": "object",
         "properties": {
           "child_value": {
@@ -72,8 +72,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.ISomething_lt_number_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_",
+      "ObjectGeneric.ISomethingnumber": {
+        "$id": "#/components/schemas/ObjectGeneric.ISomethingnumber",
         "type": "object",
         "properties": {
           "value": {
@@ -82,14 +82,14 @@
             "type": "number"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildnumbernumber"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildnumbernumber"
             }
           }
         },
@@ -100,8 +100,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_number_comma__space_number_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_",
+      "ObjectGeneric.IChildnumbernumber": {
+        "$id": "#/components/schemas/ObjectGeneric.IChildnumbernumber",
         "type": "object",
         "properties": {
           "child_value": {
@@ -121,8 +121,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.ISomething_lt_string_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_",
+      "ObjectGeneric.ISomethingstring": {
+        "$id": "#/components/schemas/ObjectGeneric.ISomethingstring",
         "type": "object",
         "properties": {
           "value": {
@@ -131,14 +131,14 @@
             "type": "string"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildstringstring"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildstringstring"
             }
           }
         },
@@ -149,8 +149,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_string_comma__space_string_gt_": {
-        "$id": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_",
+      "ObjectGeneric.IChildstringstring": {
+        "$id": "#/components/schemas/ObjectGeneric.IChildstringstring",
         "type": "object",
         "properties": {
           "child_value": {

--- a/test/schemas/json/ajv/ObjectPropertyNullable.json
+++ b/test/schemas/json/ajv/ObjectPropertyNullable.json
@@ -16,7 +16,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerboolean"
             }
           },
           {
@@ -25,7 +25,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_"
+              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointernumber"
             }
           },
           {
@@ -34,7 +34,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_"
+              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerstring"
             }
           },
           {
@@ -43,15 +43,15 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
+              "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember"
             }
           }
         ],
         "minItems": 4,
         "maxItems": 4
       },
-      "ObjectPropertyNullable.IPointer_lt_boolean_gt_": {
-        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_",
+      "ObjectPropertyNullable.IPointerboolean": {
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointerboolean",
         "type": "object",
         "properties": {
           "value": {
@@ -76,8 +76,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_number_gt_": {
-        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_",
+      "ObjectPropertyNullable.IPointernumber": {
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointernumber",
         "type": "object",
         "properties": {
           "value": {
@@ -102,8 +102,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_string_gt_": {
-        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_",
+      "ObjectPropertyNullable.IPointerstring": {
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointerstring",
         "type": "object",
         "properties": {
           "value": {
@@ -128,8 +128,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_": {
-        "$id": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_",
+      "ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember": {
+        "$id": "#/components/schemas/ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember",
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/ajv/ObjectUnionCompositePointer.json
+++ b/test/schemas/json/ajv/ObjectUnionCompositePointer.json
@@ -15,7 +15,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IPointer_lt_IPoint_space__or__space_ILine_space__or__space_ITriangle_space__or__space_IRectangle_space__or__space_IPolyline_space__or__space_IPolygon_space__or__space_IPointedShape_space__or__space_ICircle_gt_"
+              "$ref": "#/components/schemas/IPointerIPointILineITriangleIRectangleIPolylineIPolygonIPointedShapeICircle"
             }
           }
         },
@@ -24,8 +24,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_IPoint_space__or__space_ILine_space__or__space_ITriangle_space__or__space_IRectangle_space__or__space_IPolyline_space__or__space_IPolygon_space__or__space_IPointedShape_space__or__space_ICircle_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_IPoint_space__or__space_ILine_space__or__space_ITriangle_space__or__space_IRectangle_space__or__space_IPolyline_space__or__space_IPolygon_space__or__space_IPointedShape_space__or__space_ICircle_gt_",
+      "IPointerIPointILineITriangleIRectangleIPolylineIPolygonIPointedShapeICircle": {
+        "$id": "#/components/schemas/IPointerIPointILineITriangleIRectangleIPolylineIPolygonIPointedShapeICircle",
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/ajv/ObjectUnionExplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionExplicit.json
@@ -12,31 +12,31 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpointObjectUnionExplicit.IPoint"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorlineObjectUnionExplicit.ILine"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatortriangleObjectUnionExplicit.ITriangle"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorrectangleObjectUnionExplicit.IRectangle"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolylineObjectUnionExplicit.IPolyline"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolygonObjectUnionExplicit.IPolygon"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorcircleObjectUnionExplicit.ICircle"
             }
           ]
         }
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_",
+      "ObjectUnionExplicit.DiscriminatorpointObjectUnionExplicit.IPoint": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpointObjectUnionExplicit.IPoint",
         "type": "object",
         "properties": {
           "x": {
@@ -65,8 +65,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_",
+      "ObjectUnionExplicit.DiscriminatorlineObjectUnionExplicit.ILine": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorlineObjectUnionExplicit.ILine",
         "type": "object",
         "properties": {
           "p1": {
@@ -112,8 +112,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_",
+      "ObjectUnionExplicit.DiscriminatortriangleObjectUnionExplicit.ITriangle": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatortriangleObjectUnionExplicit.ITriangle",
         "type": "object",
         "properties": {
           "p1": {
@@ -142,8 +142,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_",
+      "ObjectUnionExplicit.DiscriminatorrectangleObjectUnionExplicit.IRectangle": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorrectangleObjectUnionExplicit.IRectangle",
         "type": "object",
         "properties": {
           "p1": {
@@ -176,8 +176,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_",
+      "ObjectUnionExplicit.DiscriminatorpolylineObjectUnionExplicit.IPolyline": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolylineObjectUnionExplicit.IPolyline",
         "type": "object",
         "properties": {
           "points": {
@@ -203,8 +203,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_",
+      "ObjectUnionExplicit.DiscriminatorpolygonObjectUnionExplicit.IPolygon": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolygonObjectUnionExplicit.IPolygon",
         "type": "object",
         "properties": {
           "outer": {
@@ -252,8 +252,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_",
+      "ObjectUnionExplicit.DiscriminatorcircleObjectUnionExplicit.ICircle": {
+        "$id": "#/components/schemas/ObjectUnionExplicit.DiscriminatorcircleObjectUnionExplicit.ICircle",
         "type": "object",
         "properties": {
           "centroid": {

--- a/test/schemas/json/ajv/ObjectUnionExplicitPointer.json
+++ b/test/schemas/json/ajv/ObjectUnionExplicitPointer.json
@@ -15,7 +15,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IPointer_lt_ObjectUnionExplicitPointer.Shape_gt_"
+              "$ref": "#/components/schemas/IPointerObjectUnionExplicitPointer.Shape"
             }
           }
         },
@@ -24,8 +24,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_ObjectUnionExplicitPointer.Shape_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_ObjectUnionExplicitPointer.Shape_gt_",
+      "IPointerObjectUnionExplicitPointer.Shape": {
+        "$id": "#/components/schemas/IPointerObjectUnionExplicitPointer.Shape",
         "type": "object",
         "properties": {
           "value": {
@@ -41,30 +41,30 @@
         "$id": "#/components/schemas/ObjectUnionExplicitPointer.Shape",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicitPointer.IPoint_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpointObjectUnionExplicitPointer.IPoint"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicitPointer.ILine_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorlineObjectUnionExplicitPointer.ILine"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicitPointer.ITriangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatortriangleObjectUnionExplicitPointer.ITriangle"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicitPointer.IRectangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorrectangleObjectUnionExplicitPointer.IRectangle"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicitPointer.IPolyline_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolylineObjectUnionExplicitPointer.IPolyline"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicitPointer.IPolygon_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolygonObjectUnionExplicitPointer.IPolygon"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicitPointer.ICircle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorcircleObjectUnionExplicitPointer.ICircle"
           }
         ]
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicitPointer.IPoint_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicitPointer.IPoint_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorpointObjectUnionExplicitPointer.IPoint": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpointObjectUnionExplicitPointer.IPoint",
         "type": "object",
         "properties": {
           "x": {
@@ -93,8 +93,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicitPointer.ILine_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicitPointer.ILine_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorlineObjectUnionExplicitPointer.ILine": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorlineObjectUnionExplicitPointer.ILine",
         "type": "object",
         "properties": {
           "p1": {
@@ -140,8 +140,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicitPointer.ITriangle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicitPointer.ITriangle_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatortriangleObjectUnionExplicitPointer.ITriangle": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatortriangleObjectUnionExplicitPointer.ITriangle",
         "type": "object",
         "properties": {
           "p1": {
@@ -170,8 +170,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicitPointer.IRectangle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicitPointer.IRectangle_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorrectangleObjectUnionExplicitPointer.IRectangle": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorrectangleObjectUnionExplicitPointer.IRectangle",
         "type": "object",
         "properties": {
           "p1": {
@@ -204,8 +204,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicitPointer.IPolyline_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicitPointer.IPolyline_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorpolylineObjectUnionExplicitPointer.IPolyline": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolylineObjectUnionExplicitPointer.IPolyline",
         "type": "object",
         "properties": {
           "points": {
@@ -231,8 +231,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicitPointer.IPolygon_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicitPointer.IPolygon_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorpolygonObjectUnionExplicitPointer.IPolygon": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolygonObjectUnionExplicitPointer.IPolygon",
         "type": "object",
         "properties": {
           "outer": {
@@ -280,8 +280,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicitPointer.ICircle_gt_": {
-        "$id": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicitPointer.ICircle_gt_",
+      "ObjectUnionExplicitPointer.DiscriminatorcircleObjectUnionExplicitPointer.ICircle": {
+        "$id": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorcircleObjectUnionExplicitPointer.ICircle",
         "type": "object",
         "properties": {
           "centroid": {

--- a/test/schemas/json/ajv/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/ajv/ObjectUnionNonPredictable.json
@@ -15,7 +15,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_"
+              "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperObjectUnionNonPredictable.IUnion"
             }
           }
         },
@@ -24,12 +24,12 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_": {
-        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_",
+      "ObjectUnionNonPredictable.IWrapperObjectUnionNonPredictable.IUnion": {
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapperObjectUnionNonPredictable.IUnion",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_"
+            "$ref": "#/components/schemas/IPointerObjectUnionNonPredictable.IUnion"
           }
         },
         "required": [
@@ -37,8 +37,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_",
+      "IPointerObjectUnionNonPredictable.IUnion": {
+        "$id": "#/components/schemas/IPointerObjectUnionNonPredictable.IUnion",
         "type": "object",
         "properties": {
           "value": {
@@ -54,22 +54,22 @@
         "$id": "#/components/schemas/ObjectUnionNonPredictable.IUnion",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperboolean"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrappernumber"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperstring"
           }
         ]
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_": {
-        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_",
+      "ObjectUnionNonPredictable.IWrapperboolean": {
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapperboolean",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_boolean_gt_"
+            "$ref": "#/components/schemas/IPointerboolean"
           }
         },
         "required": [
@@ -77,8 +77,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_boolean_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_boolean_gt_",
+      "IPointerboolean": {
+        "$id": "#/components/schemas/IPointerboolean",
         "type": "object",
         "properties": {
           "value": {
@@ -92,12 +92,12 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_number_gt_": {
-        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_",
+      "ObjectUnionNonPredictable.IWrappernumber": {
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrappernumber",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_number_gt_"
+            "$ref": "#/components/schemas/IPointernumber"
           }
         },
         "required": [
@@ -105,8 +105,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_number_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_number_gt_",
+      "IPointernumber": {
+        "$id": "#/components/schemas/IPointernumber",
         "type": "object",
         "properties": {
           "value": {
@@ -120,12 +120,12 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_string_gt_": {
-        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_",
+      "ObjectUnionNonPredictable.IWrapperstring": {
+        "$id": "#/components/schemas/ObjectUnionNonPredictable.IWrapperstring",
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_string_gt_"
+            "$ref": "#/components/schemas/IPointerstring"
           }
         },
         "required": [
@@ -133,8 +133,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_string_gt_": {
-        "$id": "#/components/schemas/IPointer_lt_string_gt_",
+      "IPointerstring": {
+        "$id": "#/components/schemas/IPointerstring",
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/ajv/SetAlias.json
+++ b/test/schemas/json/ajv/SetAlias.json
@@ -11,19 +11,19 @@
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_boolean_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETboolean"
           },
           "numbers": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_number_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETnumber"
           },
           "strings": {
-            "$ref": "#/components/schemas/SetAlias._Set_lt_string_gt_"
+            "$ref": "#/components/schemas/SetAlias._Setstring"
           },
           "arrays": {
-            "$ref": "#/components/schemas/SetAlias._Set_lt_Array_lt_number_gt__gt_"
+            "$ref": "#/components/schemas/SetAlias._SetArraynumber"
           },
           "objects": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_SetAlias.Person_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETSetAlias.Person"
           }
         },
         "required": [
@@ -35,8 +35,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "SetAlias.SET_lt_boolean_gt_": {
-        "$id": "#/components/schemas/SetAlias.SET_lt_boolean_gt_",
+      "SetAlias.SETboolean": {
+        "$id": "#/components/schemas/SetAlias.SETboolean",
         "$ref": "#/components/objects/Set"
       },
       "Set": {
@@ -44,20 +44,20 @@
         "$id": "#/components/objects/Set",
         "properties": {}
       },
-      "SetAlias.SET_lt_number_gt_": {
-        "$id": "#/components/schemas/SetAlias.SET_lt_number_gt_",
+      "SetAlias.SETnumber": {
+        "$id": "#/components/schemas/SetAlias.SETnumber",
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias._Set_lt_string_gt_": {
-        "$id": "#/components/schemas/SetAlias._Set_lt_string_gt_",
+      "SetAlias._Setstring": {
+        "$id": "#/components/schemas/SetAlias._Setstring",
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias._Set_lt_Array_lt_number_gt__gt_": {
-        "$id": "#/components/schemas/SetAlias._Set_lt_Array_lt_number_gt__gt_",
+      "SetAlias._SetArraynumber": {
+        "$id": "#/components/schemas/SetAlias._SetArraynumber",
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias.SET_lt_SetAlias.Person_gt_": {
-        "$id": "#/components/schemas/SetAlias.SET_lt_SetAlias.Person_gt_",
+      "SetAlias.SETSetAlias.Person": {
+        "$id": "#/components/schemas/SetAlias.SETSetAlias.Person",
         "$ref": "#/components/objects/Set"
       }
     }

--- a/test/schemas/json/ajv/UltimateUnion.json
+++ b/test/schemas/json/ajv/UltimateUnion.json
@@ -49,13 +49,13 @@
         "$id": "#/components/schemas/IJsonSchema",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
           },
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
           },
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
           },
           {
             "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -89,8 +89,8 @@
           }
         ]
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_": {
-        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_",
+      "IJsonSchema.IEnumerationboolean": {
+        "$id": "#/components/schemas/IJsonSchema.IEnumerationboolean",
         "type": "object",
         "properties": {
           "enum": {
@@ -211,8 +211,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_": {
-        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_",
+      "IJsonSchema.IEnumerationnumber": {
+        "$id": "#/components/schemas/IJsonSchema.IEnumerationnumber",
         "type": "object",
         "properties": {
           "enum": {
@@ -289,8 +289,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_": {
-        "$id": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_",
+      "IJsonSchema.IEnumerationstring": {
+        "$id": "#/components/schemas/IJsonSchema.IEnumerationstring",
         "type": "object",
         "properties": {
           "enum": {
@@ -1261,13 +1261,13 @@
         "type": "object",
         "properties": {
           "schemas": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IObject_space__or__space_IAlias_gt_"
+            "$ref": "#/components/schemas/RecordstringIObjectIAlias"
           }
         },
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_IObject_space__or__space_IAlias_gt_": {
-        "$id": "#/components/schemas/Record_lt_string_comma__space_IObject_space__or__space_IAlias_gt_",
+      "RecordstringIObjectIAlias": {
+        "$id": "#/components/schemas/RecordstringIObjectIAlias",
         "type": "object",
         "properties": {},
         "x-typia-jsDocTags": [],
@@ -1277,43 +1277,43 @@
               "$ref": "#/components/schemas/IJsonComponents.IObject"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IStringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;"
             }
           ],
           "x-typia-required": true,
@@ -1344,21 +1344,21 @@
             "type": "boolean"
           },
           "properties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "patternProperties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "additionalProperties": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -1418,18 +1418,18 @@
             }
           },
           "x-typia-patternProperties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "x-typia-additionalProperties": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -1472,8 +1472,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_IJsonSchema_gt_": {
-        "$id": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_",
+      "RecordstringIJsonSchema": {
+        "$id": "#/components/schemas/RecordstringIJsonSchema",
         "type": "object",
         "properties": {},
         "x-typia-jsDocTags": [],
@@ -1481,8 +1481,8 @@
           "$ref": "#/components/schemas/IJsonSchema"
         }
       },
-      "IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "enum": {
@@ -1569,8 +1569,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "enum": {
@@ -1657,8 +1657,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "enum": {
@@ -1745,8 +1745,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "default": {
@@ -1822,8 +1822,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "INumberid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/INumberid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "minimum": {
@@ -1932,8 +1932,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "minimum": {
@@ -2072,8 +2072,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IStringid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IStringid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "minLength": {
@@ -2197,8 +2197,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "items": {
@@ -2306,8 +2306,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "items": {
@@ -2418,8 +2418,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "oneOf": {
@@ -2484,8 +2484,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "$ref": {
@@ -2547,8 +2547,8 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "deprecated": {
@@ -2602,8 +2602,8 @@
         },
         "x-typia-jsDocTags": []
       },
-      "INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
-        "$id": "#/components/schemas/INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_",
+      "INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;": {
+        "$id": "#/components/schemas/INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;",
         "type": "object",
         "properties": {
           "type": {

--- a/test/schemas/json/swagger/ArrayAtomicAlias.json
+++ b/test/schemas/json/swagger/ArrayAtomicAlias.json
@@ -11,13 +11,13 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasboolean"
             },
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_number_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasnumber"
             },
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasstring"
             }
           ]
         },
@@ -27,32 +27,32 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasboolean"
             },
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_number_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasnumber"
             },
             {
-              "$ref": "#/components/schemas/ArrayAtomicAlias.Alias_lt_string_gt_"
+              "$ref": "#/components/schemas/ArrayAtomicAlias.Aliasstring"
             }
           ],
           "minItems": 3,
           "maxItems": 3
         }
       },
-      "ArrayAtomicAlias.Alias_lt_boolean_gt_": {
+      "ArrayAtomicAlias.Aliasboolean": {
         "type": "array",
         "items": {
           "type": "boolean"
         }
       },
-      "ArrayAtomicAlias.Alias_lt_number_gt_": {
+      "ArrayAtomicAlias.Aliasnumber": {
         "type": "array",
         "items": {
           "type": "number"
         }
       },
-      "ArrayAtomicAlias.Alias_lt_string_gt_": {
+      "ArrayAtomicAlias.Aliasstring": {
         "type": "array",
         "items": {
           "type": "string"

--- a/test/schemas/json/swagger/AtomicIntersection.json
+++ b/test/schemas/json/swagger/AtomicIntersection.json
@@ -11,13 +11,13 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapperboolean"
             },
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrappernumber"
             },
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapperstring"
             }
           ]
         },
@@ -27,26 +27,26 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_boolean_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapperboolean"
             },
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_number_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrappernumber"
             },
             {
-              "$ref": "#/components/schemas/AtomicIntersection.Wrapper_lt_string_gt_"
+              "$ref": "#/components/schemas/AtomicIntersection.Wrapperstring"
             }
           ],
           "minItems": 3,
           "maxItems": 3
         }
       },
-      "AtomicIntersection.Wrapper_lt_boolean_gt_": {
+      "AtomicIntersection.Wrapperboolean": {
         "type": "boolean"
       },
-      "AtomicIntersection.Wrapper_lt_number_gt_": {
+      "AtomicIntersection.Wrappernumber": {
         "type": "number"
       },
-      "AtomicIntersection.Wrapper_lt_string_gt_": {
+      "AtomicIntersection.Wrapperstring": {
         "type": "string"
       }
     }

--- a/test/schemas/json/swagger/ConstantAtomicWrapper.json
+++ b/test/schemas/json/swagger/ConstantAtomicWrapper.json
@@ -11,13 +11,13 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerboolean"
             },
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointernumber"
             },
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerstring"
             }
           ]
         },
@@ -27,20 +27,20 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerboolean"
             },
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_number_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointernumber"
             },
             {
-              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointer_lt_string_gt_"
+              "$ref": "#/components/schemas/ConstantAtomicWrapper.IPointerstring"
             }
           ],
           "minItems": 3,
           "maxItems": 3
         }
       },
-      "ConstantAtomicWrapper.IPointer_lt_boolean_gt_": {
+      "ConstantAtomicWrapper.IPointerboolean": {
         "type": "object",
         "properties": {
           "value": {
@@ -55,7 +55,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ConstantAtomicWrapper.IPointer_lt_number_gt_": {
+      "ConstantAtomicWrapper.IPointernumber": {
         "type": "object",
         "properties": {
           "value": {
@@ -70,7 +70,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ConstantAtomicWrapper.IPointer_lt_string_gt_": {
+      "ConstantAtomicWrapper.IPointerstring": {
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/swagger/ConstantIntersection.json
+++ b/test/schemas/json/swagger/ConstantIntersection.json
@@ -11,13 +11,13 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapperfalse"
             },
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper1"
             },
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrappertwo"
             }
           ]
         },
@@ -27,32 +27,32 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_false_gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapperfalse"
             },
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt_1_gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrapper1"
             },
             {
-              "$ref": "#/components/schemas/ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_"
+              "$ref": "#/components/schemas/ConstantIntersection.Wrappertwo"
             }
           ],
           "minItems": 3,
           "maxItems": 3
         }
       },
-      "ConstantIntersection.Wrapper_lt_false_gt_": {
+      "ConstantIntersection.Wrapperfalse": {
         "type": "boolean",
         "enum": [
           false
         ]
       },
-      "ConstantIntersection.Wrapper_lt_1_gt_": {
+      "ConstantIntersection.Wrapper1": {
         "type": "number",
         "enum": [
           1
         ]
       },
-      "ConstantIntersection.Wrapper_lt__doublequote_two_doublequote__gt_": {
+      "ConstantIntersection.Wrappertwo": {
         "type": "string",
         "enum": [
           "two"

--- a/test/schemas/json/swagger/DynamicTree.json
+++ b/test/schemas/json/swagger/DynamicTree.json
@@ -20,7 +20,7 @@
             "type": "number"
           },
           "children": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_DynamicTree_gt_"
+            "$ref": "#/components/schemas/RecordstringDynamicTree"
           }
         },
         "nullable": false,
@@ -31,7 +31,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_DynamicTree_gt_": {
+      "RecordstringDynamicTree": {
         "type": "object",
         "properties": {},
         "nullable": false,

--- a/test/schemas/json/swagger/MapAlias.json
+++ b/test/schemas/json/swagger/MapAlias.json
@@ -10,19 +10,19 @@
         "type": "object",
         "properties": {
           "boolean": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_boolean_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPbooleannumber"
           },
           "number": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_number_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPnumbernumber"
           },
           "strings": {
-            "$ref": "#/components/schemas/MapAlias._Map_lt_string_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias._Mapstringnumber"
           },
           "arrays": {
-            "$ref": "#/components/schemas/MapAlias._Map_lt_Array_lt_number_gt__comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias._MapArraynumbernumber"
           },
           "objects": {
-            "$ref": "#/components/schemas/MapAlias.MAP_lt_MapAlias.Person_comma__space_number_gt_"
+            "$ref": "#/components/schemas/MapAlias.MAPMapAlias.Personnumber"
           }
         },
         "nullable": false,
@@ -35,7 +35,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "MapAlias.MAP_lt_boolean_comma__space_number_gt_": {
+      "MapAlias.MAPbooleannumber": {
         "$ref": "#/components/objects/Map"
       },
       "Map": {
@@ -43,16 +43,16 @@
         "properties": {},
         "nullable": false
       },
-      "MapAlias.MAP_lt_number_comma__space_number_gt_": {
+      "MapAlias.MAPnumbernumber": {
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias._Map_lt_string_comma__space_number_gt_": {
+      "MapAlias._Mapstringnumber": {
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias._Map_lt_Array_lt_number_gt__comma__space_number_gt_": {
+      "MapAlias._MapArraynumbernumber": {
         "$ref": "#/components/objects/Map"
       },
-      "MapAlias.MAP_lt_MapAlias.Person_comma__space_number_gt_": {
+      "MapAlias.MAPMapAlias.Personnumber": {
         "$ref": "#/components/objects/Map"
       }
     }

--- a/test/schemas/json/swagger/ObjectGeneric.json
+++ b/test/schemas/json/swagger/ObjectGeneric.json
@@ -11,13 +11,13 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingboolean"
             },
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingnumber"
             },
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingstring"
             }
           ]
         },
@@ -27,20 +27,20 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_boolean_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingboolean"
             },
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_number_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingnumber"
             },
             {
-              "$ref": "#/components/schemas/ObjectGeneric.ISomething_lt_string_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.ISomethingstring"
             }
           ],
           "minItems": 3,
           "maxItems": 3
         }
       },
-      "ObjectGeneric.ISomething_lt_boolean_gt_": {
+      "ObjectGeneric.ISomethingboolean": {
         "type": "object",
         "properties": {
           "value": {
@@ -49,14 +49,14 @@
             "type": "boolean"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildbooleanboolean"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildbooleanboolean"
             }
           }
         },
@@ -68,7 +68,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_boolean_comma__space_boolean_gt_": {
+      "ObjectGeneric.IChildbooleanboolean": {
         "type": "object",
         "properties": {
           "child_value": {
@@ -89,7 +89,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.ISomething_lt_number_gt_": {
+      "ObjectGeneric.ISomethingnumber": {
         "type": "object",
         "properties": {
           "value": {
@@ -98,14 +98,14 @@
             "type": "number"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildnumbernumber"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_number_comma__space_number_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildnumbernumber"
             }
           }
         },
@@ -117,7 +117,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_number_comma__space_number_gt_": {
+      "ObjectGeneric.IChildnumbernumber": {
         "type": "object",
         "properties": {
           "child_value": {
@@ -138,7 +138,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.ISomething_lt_string_gt_": {
+      "ObjectGeneric.ISomethingstring": {
         "type": "object",
         "properties": {
           "value": {
@@ -147,14 +147,14 @@
             "type": "string"
           },
           "child": {
-            "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_"
+            "$ref": "#/components/schemas/ObjectGeneric.IChildstringstring"
           },
           "elements": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectGeneric.IChild_lt_string_comma__space_string_gt_"
+              "$ref": "#/components/schemas/ObjectGeneric.IChildstringstring"
             }
           }
         },
@@ -166,7 +166,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectGeneric.IChild_lt_string_comma__space_string_gt_": {
+      "ObjectGeneric.IChildstringstring": {
         "type": "object",
         "properties": {
           "child_value": {

--- a/test/schemas/json/swagger/ObjectPropertyNullable.json
+++ b/test/schemas/json/swagger/ObjectPropertyNullable.json
@@ -13,25 +13,25 @@
             {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerboolean"
               }
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointernumber"
               }
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerstring"
               }
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember"
               }
             }
           ]
@@ -47,7 +47,7 @@
               "x-typia-optional": false,
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_boolean_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerboolean"
               }
             },
             {
@@ -56,7 +56,7 @@
               "x-typia-optional": false,
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_number_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointernumber"
               }
             },
             {
@@ -65,7 +65,7 @@
               "x-typia-optional": false,
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_string_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerstring"
               }
             },
             {
@@ -74,7 +74,7 @@
               "x-typia-optional": false,
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_"
+                "$ref": "#/components/schemas/ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember"
               }
             }
           ],
@@ -82,7 +82,7 @@
           "maxItems": 4
         }
       },
-      "ObjectPropertyNullable.IPointer_lt_boolean_gt_": {
+      "ObjectPropertyNullable.IPointerboolean": {
         "type": "object",
         "properties": {
           "value": {
@@ -98,7 +98,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_number_gt_": {
+      "ObjectPropertyNullable.IPointernumber": {
         "type": "object",
         "properties": {
           "value": {
@@ -114,7 +114,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_string_gt_": {
+      "ObjectPropertyNullable.IPointerstring": {
         "type": "object",
         "properties": {
           "value": {
@@ -130,7 +130,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectPropertyNullable.IPointer_lt_ObjectPropertyNullable.IMember_gt_": {
+      "ObjectPropertyNullable.IPointerObjectPropertyNullable.IMember": {
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/swagger/ObjectUnionCompositePointer.json
+++ b/test/schemas/json/swagger/ObjectUnionCompositePointer.json
@@ -14,7 +14,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IPointer_lt_IPoint_space__or__space_ILine_space__or__space_ITriangle_space__or__space_IRectangle_space__or__space_IPolyline_space__or__space_IPolygon_space__or__space_IPointedShape_space__or__space_ICircle_gt_"
+              "$ref": "#/components/schemas/IPointerIPointILineITriangleIRectangleIPolylineIPolygonIPointedShapeICircle"
             }
           }
         },
@@ -24,7 +24,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_IPoint_space__or__space_ILine_space__or__space_ITriangle_space__or__space_IRectangle_space__or__space_IPolyline_space__or__space_IPolygon_space__or__space_IPointedShape_space__or__space_ICircle_gt_": {
+      "IPointerIPointILineITriangleIRectangleIPolylineIPolygonIPointedShapeICircle": {
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/swagger/ObjectUnionExplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionExplicit.json
@@ -11,30 +11,30 @@
         "items": {
           "oneOf": [
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpointObjectUnionExplicit.IPoint"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorlineObjectUnionExplicit.ILine"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatortriangleObjectUnionExplicit.ITriangle"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorrectangleObjectUnionExplicit.IRectangle"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolylineObjectUnionExplicit.IPolyline"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorpolygonObjectUnionExplicit.IPolygon"
             },
             {
-              "$ref": "#/components/schemas/ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_"
+              "$ref": "#/components/schemas/ObjectUnionExplicit.DiscriminatorcircleObjectUnionExplicit.ICircle"
             }
           ]
         }
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicit.IPoint_gt_": {
+      "ObjectUnionExplicit.DiscriminatorpointObjectUnionExplicit.IPoint": {
         "type": "object",
         "properties": {
           "x": {
@@ -64,7 +64,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicit.ILine_gt_": {
+      "ObjectUnionExplicit.DiscriminatorlineObjectUnionExplicit.ILine": {
         "type": "object",
         "properties": {
           "p1": {
@@ -111,7 +111,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicit.ITriangle_gt_": {
+      "ObjectUnionExplicit.DiscriminatortriangleObjectUnionExplicit.ITriangle": {
         "type": "object",
         "properties": {
           "p1": {
@@ -141,7 +141,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicit.IRectangle_gt_": {
+      "ObjectUnionExplicit.DiscriminatorrectangleObjectUnionExplicit.IRectangle": {
         "type": "object",
         "properties": {
           "p1": {
@@ -175,7 +175,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicit.IPolyline_gt_": {
+      "ObjectUnionExplicit.DiscriminatorpolylineObjectUnionExplicit.IPolyline": {
         "type": "object",
         "properties": {
           "points": {
@@ -202,7 +202,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicit.IPolygon_gt_": {
+      "ObjectUnionExplicit.DiscriminatorpolygonObjectUnionExplicit.IPolygon": {
         "type": "object",
         "properties": {
           "outer": {
@@ -251,7 +251,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicit.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicit.ICircle_gt_": {
+      "ObjectUnionExplicit.DiscriminatorcircleObjectUnionExplicit.ICircle": {
         "type": "object",
         "properties": {
           "centroid": {

--- a/test/schemas/json/swagger/ObjectUnionExplicitPointer.json
+++ b/test/schemas/json/swagger/ObjectUnionExplicitPointer.json
@@ -14,7 +14,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IPointer_lt_ObjectUnionExplicitPointer.Shape_gt_"
+              "$ref": "#/components/schemas/IPointerObjectUnionExplicitPointer.Shape"
             }
           }
         },
@@ -24,7 +24,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_ObjectUnionExplicitPointer.Shape_gt_": {
+      "IPointerObjectUnionExplicitPointer.Shape": {
         "type": "object",
         "properties": {
           "value": {
@@ -40,29 +40,29 @@
       "ObjectUnionExplicitPointer.Shape": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicitPointer.IPoint_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpointObjectUnionExplicitPointer.IPoint"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicitPointer.ILine_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorlineObjectUnionExplicitPointer.ILine"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicitPointer.ITriangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatortriangleObjectUnionExplicitPointer.ITriangle"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicitPointer.IRectangle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorrectangleObjectUnionExplicitPointer.IRectangle"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicitPointer.IPolyline_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolylineObjectUnionExplicitPointer.IPolyline"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicitPointer.IPolygon_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorpolygonObjectUnionExplicitPointer.IPolygon"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicitPointer.ICircle_gt_"
+            "$ref": "#/components/schemas/ObjectUnionExplicitPointer.DiscriminatorcircleObjectUnionExplicitPointer.ICircle"
           }
         ]
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_point_doublequote__comma__space_ObjectUnionExplicitPointer.IPoint_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorpointObjectUnionExplicitPointer.IPoint": {
         "type": "object",
         "properties": {
           "x": {
@@ -92,7 +92,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_line_doublequote__comma__space_ObjectUnionExplicitPointer.ILine_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorlineObjectUnionExplicitPointer.ILine": {
         "type": "object",
         "properties": {
           "p1": {
@@ -139,7 +139,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_triangle_doublequote__comma__space_ObjectUnionExplicitPointer.ITriangle_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatortriangleObjectUnionExplicitPointer.ITriangle": {
         "type": "object",
         "properties": {
           "p1": {
@@ -169,7 +169,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_rectangle_doublequote__comma__space_ObjectUnionExplicitPointer.IRectangle_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorrectangleObjectUnionExplicitPointer.IRectangle": {
         "type": "object",
         "properties": {
           "p1": {
@@ -203,7 +203,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polyline_doublequote__comma__space_ObjectUnionExplicitPointer.IPolyline_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorpolylineObjectUnionExplicitPointer.IPolyline": {
         "type": "object",
         "properties": {
           "points": {
@@ -230,7 +230,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_polygon_doublequote__comma__space_ObjectUnionExplicitPointer.IPolygon_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorpolygonObjectUnionExplicitPointer.IPolygon": {
         "type": "object",
         "properties": {
           "outer": {
@@ -279,7 +279,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionExplicitPointer.Discriminator_lt__doublequote_circle_doublequote__comma__space_ObjectUnionExplicitPointer.ICircle_gt_": {
+      "ObjectUnionExplicitPointer.DiscriminatorcircleObjectUnionExplicitPointer.ICircle": {
         "type": "object",
         "properties": {
           "centroid": {

--- a/test/schemas/json/swagger/ObjectUnionNonPredictable.json
+++ b/test/schemas/json/swagger/ObjectUnionNonPredictable.json
@@ -14,7 +14,7 @@
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_"
+              "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperObjectUnionNonPredictable.IUnion"
             }
           }
         },
@@ -24,11 +24,11 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_ObjectUnionNonPredictable.IUnion_gt_": {
+      "ObjectUnionNonPredictable.IWrapperObjectUnionNonPredictable.IUnion": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_"
+            "$ref": "#/components/schemas/IPointerObjectUnionNonPredictable.IUnion"
           }
         },
         "nullable": false,
@@ -37,7 +37,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_ObjectUnionNonPredictable.IUnion_gt_": {
+      "IPointerObjectUnionNonPredictable.IUnion": {
         "type": "object",
         "properties": {
           "value": {
@@ -53,21 +53,21 @@
       "ObjectUnionNonPredictable.IUnion": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperboolean"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_number_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrappernumber"
           },
           {
-            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapper_lt_string_gt_"
+            "$ref": "#/components/schemas/ObjectUnionNonPredictable.IWrapperstring"
           }
         ]
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_boolean_gt_": {
+      "ObjectUnionNonPredictable.IWrapperboolean": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_boolean_gt_"
+            "$ref": "#/components/schemas/IPointerboolean"
           }
         },
         "nullable": false,
@@ -76,7 +76,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_boolean_gt_": {
+      "IPointerboolean": {
         "type": "object",
         "properties": {
           "value": {
@@ -91,11 +91,11 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_number_gt_": {
+      "ObjectUnionNonPredictable.IWrappernumber": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_number_gt_"
+            "$ref": "#/components/schemas/IPointernumber"
           }
         },
         "nullable": false,
@@ -104,7 +104,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_number_gt_": {
+      "IPointernumber": {
         "type": "object",
         "properties": {
           "value": {
@@ -119,11 +119,11 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ObjectUnionNonPredictable.IWrapper_lt_string_gt_": {
+      "ObjectUnionNonPredictable.IWrapperstring": {
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/IPointer_lt_string_gt_"
+            "$ref": "#/components/schemas/IPointerstring"
           }
         },
         "nullable": false,
@@ -132,7 +132,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IPointer_lt_string_gt_": {
+      "IPointerstring": {
         "type": "object",
         "properties": {
           "value": {

--- a/test/schemas/json/swagger/SetAlias.json
+++ b/test/schemas/json/swagger/SetAlias.json
@@ -10,19 +10,19 @@
         "type": "object",
         "properties": {
           "booleans": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_boolean_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETboolean"
           },
           "numbers": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_number_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETnumber"
           },
           "strings": {
-            "$ref": "#/components/schemas/SetAlias._Set_lt_string_gt_"
+            "$ref": "#/components/schemas/SetAlias._Setstring"
           },
           "arrays": {
-            "$ref": "#/components/schemas/SetAlias._Set_lt_Array_lt_number_gt__gt_"
+            "$ref": "#/components/schemas/SetAlias._SetArraynumber"
           },
           "objects": {
-            "$ref": "#/components/schemas/SetAlias.SET_lt_SetAlias.Person_gt_"
+            "$ref": "#/components/schemas/SetAlias.SETSetAlias.Person"
           }
         },
         "nullable": false,
@@ -35,7 +35,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "SetAlias.SET_lt_boolean_gt_": {
+      "SetAlias.SETboolean": {
         "$ref": "#/components/objects/Set"
       },
       "Set": {
@@ -43,16 +43,16 @@
         "properties": {},
         "nullable": false
       },
-      "SetAlias.SET_lt_number_gt_": {
+      "SetAlias.SETnumber": {
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias._Set_lt_string_gt_": {
+      "SetAlias._Setstring": {
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias._Set_lt_Array_lt_number_gt__gt_": {
+      "SetAlias._SetArraynumber": {
         "$ref": "#/components/objects/Set"
       },
-      "SetAlias.SET_lt_SetAlias.Person_gt_": {
+      "SetAlias.SETSetAlias.Person": {
         "$ref": "#/components/objects/Set"
       }
     }

--- a/test/schemas/json/swagger/UltimateUnion.json
+++ b/test/schemas/json/swagger/UltimateUnion.json
@@ -47,13 +47,13 @@
       "IJsonSchema": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
           },
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
           },
           {
-            "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+            "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
           },
           {
             "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -87,7 +87,7 @@
           }
         ]
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_": {
+      "IJsonSchema.IEnumerationboolean": {
         "type": "object",
         "properties": {
           "enum": {
@@ -209,7 +209,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_": {
+      "IJsonSchema.IEnumerationnumber": {
         "type": "object",
         "properties": {
           "enum": {
@@ -287,7 +287,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_": {
+      "IJsonSchema.IEnumerationstring": {
         "type": "object",
         "properties": {
           "enum": {
@@ -1258,13 +1258,13 @@
         "type": "object",
         "properties": {
           "schemas": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IObject_space__or__space_IAlias_gt_"
+            "$ref": "#/components/schemas/RecordstringIObjectIAlias"
           }
         },
         "nullable": false,
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_IObject_space__or__space_IAlias_gt_": {
+      "RecordstringIObjectIAlias": {
         "type": "object",
         "properties": {},
         "nullable": false,
@@ -1275,43 +1275,43 @@
               "$ref": "#/components/schemas/IJsonComponents.IObject"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IStringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;"
             }
           ],
           "x-typia-required": true,
@@ -1323,43 +1323,43 @@
               "$ref": "#/components/schemas/IJsonComponents.IObject"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INumberid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IStringid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;"
             },
             {
-              "$ref": "#/components/schemas/INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_"
+              "$ref": "#/components/schemas/INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;"
             }
           ],
           "x-typia-required": true,
@@ -1389,21 +1389,21 @@
             "type": "boolean"
           },
           "properties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "patternProperties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "additionalProperties": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -1463,18 +1463,18 @@
             }
           },
           "x-typia-patternProperties": {
-            "$ref": "#/components/schemas/Record_lt_string_comma__space_IJsonSchema_gt_"
+            "$ref": "#/components/schemas/RecordstringIJsonSchema"
           },
           "x-typia-additionalProperties": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_string_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationstring"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_number_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationnumber"
               },
               {
-                "$ref": "#/components/schemas/IJsonSchema.IEnumeration_lt__doublequote_boolean_doublequote__gt_"
+                "$ref": "#/components/schemas/IJsonSchema.IEnumerationboolean"
               },
               {
                 "$ref": "#/components/schemas/IJsonSchema.IBoolean"
@@ -1518,7 +1518,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "Record_lt_string_comma__space_IJsonSchema_gt_": {
+      "RecordstringIJsonSchema": {
         "type": "object",
         "properties": {},
         "nullable": false,
@@ -1530,7 +1530,7 @@
           "$ref": "#/components/schemas/IJsonSchema"
         }
       },
-      "IEnumeration_lt__doublequote_string_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IEnumerationstringid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "enum": {
@@ -1618,7 +1618,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IEnumeration_lt__doublequote_number_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IEnumerationnumberid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "enum": {
@@ -1706,7 +1706,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IEnumeration_lt__doublequote_boolean_doublequote__gt__space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IEnumerationbooleanid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "enum": {
@@ -1794,7 +1794,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IBoolean_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IBooleanid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "default": {
@@ -1871,7 +1871,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "INumber_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "INumberid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "minimum": {
@@ -1981,7 +1981,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IInteger_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IIntegerid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "minimum": {
@@ -2121,7 +2121,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IString_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IStringid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "minLength": {
@@ -2246,7 +2246,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IArray_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IArrayid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "items": {
@@ -2355,7 +2355,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "ITuple_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "ITupleid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "items": {
@@ -2467,7 +2467,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IOneOf_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IOneOfid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "oneOf": {
@@ -2533,7 +2533,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IReference_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IReferenceid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "$ref": {
@@ -2596,7 +2596,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "IUnknown_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "IUnknownid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "deprecated": {
@@ -2651,7 +2651,7 @@
         "nullable": false,
         "x-typia-jsDocTags": []
       },
-      "INullOnly_space__and__space__blt__space__dollar_id?:_space_string_space__or__space_undefined;_space__dollar_recursiveAnchor?:_space_boolean_space__or__space_undefined;_space__bgt_": {
+      "INullOnlyid?:stringundefined;recursiveAnchor?:booleanundefined;": {
         "type": "object",
         "properties": {
           "type": {


### PR DESCRIPTION
When special characters being used in swagger component name, `typia` had changed it to another special character like `_comma_`. However, it seems not a good solution. I've changed it to be just empty string.