### PR TITLE
Fix #827 - change setup wizard logic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.1.3"
+    "typia": "5.1.4"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -23,22 +23,7 @@ export namespace TypiaSetupWizard {
         // INSTALL TYPESCRIPT COMPILERS
         pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
         pack.install({ dev: true, modulo: "ts-node", version: "latest" });
-        pack.install({
-            dev: true,
-            modulo: "typescript",
-            version: (() => {
-                const version: string = (() => {
-                    try {
-                        return require("ts-patch/package.json")?.version ?? "";
-                    } catch {
-                        return "";
-                    }
-                })();
-                return Number(version.split(".")[0] ?? "") >= 3
-                    ? "latest"
-                    : "4.9.5";
-            })(),
-        });
+        pack.install({ dev: true, modulo: "typescript", version: "latest" });
         args.project ??= (() => {
             const runner: string =
                 pack.manager === "npm" ? "npx" : pack.manager;


### PR DESCRIPTION
No more need to consider `ts-patch@2` version, so removed special setup logic related with it.

From now on, setup wizard of typia no more consider the `ts-patch` verison. 

It always setups the latest `ts-patch` and `typescript`. versions.