### PR TITLE
Fix samchon/nestia#628 - `exactOptionalPropertyTypes`'s with `Partial<T>` and `Required<T>` types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.1.4"
+    "typia": "5.1.5"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/packages/typescript-json/tsconfig.json
+++ b/packages/typescript-json/tsconfig.json
@@ -88,7 +88,7 @@
     "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */

--- a/src/TypeGuardError.ts
+++ b/src/TypeGuardError.ts
@@ -28,9 +28,9 @@ export class TypeGuardError extends Error {
 export namespace TypeGuardError {
     export interface IProps {
         method: string;
-        path?: string;
+        path?: undefined | string;
         expected: string;
         value: any;
-        message?: string;
+        message?: undefined | string;
     }
 }

--- a/src/executable/TypiaGenerateWizard.ts
+++ b/src/executable/TypiaGenerateWizard.ts
@@ -55,7 +55,7 @@ export namespace TypiaGenerateWizard {
                     })
                 )[name];
             };
-        const configure = async () => {
+        const configure = async (): Promise<string> => {
             const files: string[] = await (
                 await fs.promises.readdir(process.cwd())
             ).filter(
@@ -65,7 +65,7 @@ export namespace TypiaGenerateWizard {
             );
             if (files.length === 0)
                 throw new URIError(`Unable to find "tsconfig.json" file.`);
-            else if (files.length === 1) return files[0];
+            else if (files.length === 1) return files[0]!;
             return select("tsconfig")("TS Config File")(files);
         };
 

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -87,11 +87,15 @@ export namespace TypiaSetupWizard {
                         name: name,
                         message: message,
                         choices: choices,
-                        filter,
+                        ...(filter
+                            ? {
+                                  filter,
+                              }
+                            : {}),
                     })
                 )[name];
             };
-        const configure = async () => {
+        const configure = async (): Promise<string | null> => {
             const fileList: string[] = await (
                 await fs.promises.readdir(process.cwd())
             )
@@ -113,7 +117,7 @@ export namespace TypiaSetupWizard {
                 if (process.cwd() !== pack.directory)
                     throw new URIError(`Unable to find "tsconfig.json" file.`);
                 return null;
-            } else if (fileList.length === 1) return fileList[0];
+            } else if (fileList.length === 1) return fileList[0]!;
             return select("tsconfig")("TS Config File")(fileList);
         };
 

--- a/src/factories/MetadataTypeTagFactory.ts
+++ b/src/factories/MetadataTypeTagFactory.ts
@@ -316,7 +316,7 @@ interface ITypeTag {
     name: string;
     target: Array<"bigint" | "number" | "string" | "array">;
     kind: string;
-    value?: boolean | bigint | number | string;
+    value?: undefined | boolean | bigint | number | string;
     validate: Record<string, string>;
     exclusive: boolean | string[];
 }

--- a/src/programmers/CheckerProgrammer.ts
+++ b/src/programmers/CheckerProgrammer.ts
@@ -67,22 +67,24 @@ export namespace CheckerProgrammer {
                 entries: IExpressionEntry[],
             ): ts.Expression;
             array(input: ts.Expression, arrow: ts.ArrowFunction): ts.Expression;
-            tuple?(exprs: ts.Expression[]): ts.Expression;
+            tuple?: undefined | ((exprs: ts.Expression[]) => ts.Expression);
 
             failure(
                 value: ts.Expression,
                 expected: string,
-                explore?: FeatureProgrammer.IExplore,
+                explore?: undefined | FeatureProgrammer.IExplore,
             ): ts.Expression;
             is?(expression: ts.Expression): ts.Expression;
             required?(exp: ts.Expression): ts.Expression;
-            full?: (
-                condition: ts.Expression,
-            ) => (
-                input: ts.Expression,
-                expected: string,
-                explore: IExplore,
-            ) => ts.Expression;
+            full?:
+                | undefined
+                | ((
+                      condition: ts.Expression,
+                  ) => (
+                      input: ts.Expression,
+                      expected: string,
+                      explore: IExplore,
+                  ) => ts.Expression);
         }
     }
     export type IExplore = FeatureProgrammer.IExplore;

--- a/src/programmers/FeatureProgrammer.ts
+++ b/src/programmers/FeatureProgrammer.ts
@@ -40,7 +40,9 @@ export namespace FeatureProgrammer {
          */
         trace: boolean;
 
-        addition?(collection: MetadataCollection): ts.Statement[];
+        addition?:
+            | undefined
+            | ((collection: MetadataCollection) => ts.Statement[]);
 
         /**
          * Initializer of metadata.
@@ -68,8 +70,8 @@ export namespace FeatureProgrammer {
     }
     export namespace IConfig {
         export interface ITypes {
-            input: (type: ts.Type, name?: string) => ts.TypeNode;
-            output: (type: ts.Type, name?: string) => ts.TypeNode;
+            input: (type: ts.Type, name?: undefined | string) => ts.TypeNode;
+            output: (type: ts.Type, name?: undefined | string) => ts.TypeNode;
         }
 
         export interface IObjector<
@@ -113,7 +115,7 @@ export namespace FeatureProgrammer {
             failure(
                 value: ts.Expression,
                 expected: string,
-                explore?: IExplore,
+                explore?: undefined | IExplore,
             ): ts.Statement;
 
             /**
@@ -129,7 +131,7 @@ export namespace FeatureProgrammer {
              * @returns Transformed expression
              * @deprecated
              */
-            is?(exp: ts.Expression): ts.Expression;
+            is?: undefined | ((exp: ts.Expression) => ts.Expression);
 
             /**
              * Transformer of non-undefined type checking by discrimination.
@@ -146,7 +148,7 @@ export namespace FeatureProgrammer {
              * @returns Transformed expression
              * @deprecated
              */
-            required?(exp: ts.Expression): ts.Expression;
+            required?: undefined | ((exp: ts.Expression) => ts.Expression);
 
             /**
              * Conditon wrapper when unable to specify any object type.
@@ -158,22 +160,28 @@ export namespace FeatureProgrammer {
              * @param condition Current condition
              * @returns A function wrapped current condition
              */
-            full?: (
-                condition: ts.Expression,
-            ) => (
-                input: ts.Expression,
-                expected: string,
-                explore: IExplore,
-            ) => ts.Expression;
+            full?:
+                | undefined
+                | ((
+                      condition: ts.Expression,
+                  ) => (
+                      input: ts.Expression,
+                      expected: string,
+                      explore: IExplore,
+                  ) => ts.Expression);
 
             /**
              * Return type.
              */
-            type?: ts.TypeNode;
+            type?: undefined | ts.TypeNode;
         }
         export interface IGenerator {
-            objects?(): (col: MetadataCollection) => ts.VariableStatement[];
-            unions?(): (col: MetadataCollection) => ts.VariableStatement[];
+            objects?:
+                | undefined
+                | (() => (col: MetadataCollection) => ts.VariableStatement[]);
+            unions?:
+                | undefined
+                | (() => (col: MetadataCollection) => ts.VariableStatement[]);
             arrays(): (col: MetadataCollection) => ts.VariableStatement[];
             tuples(): (col: MetadataCollection) => ts.VariableStatement[];
         }
@@ -184,7 +192,7 @@ export namespace FeatureProgrammer {
         source: "top" | "function";
         from: "top" | "array" | "object";
         postfix: string;
-        start?: number;
+        start?: undefined | number;
     }
 
     export interface Decoder<

--- a/src/programmers/helpers/RandomRanger.ts
+++ b/src/programmers/helpers/RandomRanger.ts
@@ -168,6 +168,6 @@ interface IRange {
     maximum: IScalar;
 }
 interface IScalar {
-    value?: number;
+    value?: undefined | number;
     exclusive: boolean;
 }

--- a/src/programmers/internal/application_object.ts
+++ b/src/programmers/internal/application_object.ts
@@ -157,6 +157,6 @@ const join =
     };
 
 interface ISuperfluous {
-    additionalProperties?: [Metadata, IJsonSchema];
+    additionalProperties?: undefined | [Metadata, IJsonSchema];
     patternProperties: Record<string, [Metadata, IJsonSchema]>;
 }

--- a/src/programmers/internal/check_object.ts
+++ b/src/programmers/internal/check_object.ts
@@ -36,11 +36,11 @@ export namespace check_object {
         equals: boolean;
         assert: boolean;
         undefined: boolean;
-        halt?: (exp: ts.Expression) => ts.Expression;
+        halt?: undefined | ((exp: ts.Expression) => ts.Expression);
         reduce: (a: ts.Expression, b: ts.Expression) => ts.Expression;
         positive: ts.Expression;
         superfluous: (value: ts.Expression) => ts.Expression;
-        entries?: ts.Identifier;
+        entries?: undefined | ts.Identifier;
     }
 }
 

--- a/src/schemas/json/IJsonComponents.ts
+++ b/src/schemas/json/IJsonComponents.ts
@@ -3,32 +3,34 @@ import { IJsDocTagInfo } from "../metadata/IJsDocTagInfo";
 import { IJsonSchema } from "./IJsonSchema";
 
 export interface IJsonComponents {
-    schemas?: Record<string, IJsonComponents.IObject | IJsonComponents.IAlias>;
+    schemas?:
+        | undefined
+        | Record<string, IJsonComponents.IObject | IJsonComponents.IAlias>;
 }
 export namespace IJsonComponents {
     export interface IObject {
-        $id?: string;
+        $id?: undefined | string;
         type: "object";
 
         /**
          * Only when swagger mode.
          */
-        nullable?: boolean;
+        nullable?: undefined | boolean;
 
         properties: Record<string, IJsonSchema>;
-        patternProperties?: Record<string, IJsonSchema>;
-        additionalProperties?: IJsonSchema;
+        patternProperties?: undefined | Record<string, IJsonSchema>;
+        additionalProperties?: undefined | IJsonSchema;
 
-        required?: string[];
-        description?: string;
-        "x-typia-jsDocTags"?: IJsDocTagInfo[];
-        "x-typia-patternProperties"?: Record<string, IJsonSchema>;
-        "x-typia-additionalProperties"?: IJsonSchema;
+        required?: undefined | string[];
+        description?: undefined | string;
+        "x-typia-jsDocTags"?: undefined | IJsDocTagInfo[];
+        "x-typia-patternProperties"?: undefined | Record<string, IJsonSchema>;
+        "x-typia-additionalProperties"?: undefined | IJsonSchema;
     }
 
     export type IAlias = IJsonSchema & IIdentified;
     interface IIdentified {
-        $id?: string;
-        $recursiveAnchor?: boolean;
+        $id?: undefined | string;
+        $recursiveAnchor?: undefined | boolean;
     }
 }

--- a/src/schemas/json/IJsonSchema.ts
+++ b/src/schemas/json/IJsonSchema.ts
@@ -22,7 +22,7 @@ export namespace IJsonSchema {
         | INullOnly;
 
     export interface IUnknown extends IAttribute {
-        type?: undefined;
+        type?: undefined | undefined;
     }
 
     /* -----------------------------------------------------------
@@ -35,33 +35,33 @@ export namespace IJsonSchema {
     }
     export interface IAtomic<Literal extends Exclude<Atomic.Literal, "bigint">>
         extends ISignificant<Literal> {
-        default?: Atomic.Mapper[Literal];
+        default?: undefined | Atomic.Mapper[Literal];
     }
     export interface IString extends IAtomic<"string"> {
-        minLength?: number & Type<"uint32">;
-        maxLength?: number & Type<"uint32">;
-        pattern?: string;
-        format?: string;
-        "x-typia-typeTags"?: IMetadataTypeTag[];
+        minLength?: undefined | (number & Type<"uint32">);
+        maxLength?: undefined | (number & Type<"uint32">);
+        pattern?: undefined | string;
+        format?: undefined | string;
+        "x-typia-typeTags"?: undefined | IMetadataTypeTag[];
     }
     export interface INumber extends IAtomic<"number"> {
-        minimum?: number;
-        maximum?: number;
-        exclusiveMinimum?: boolean;
-        exclusiveMaximum?: boolean;
-        multipleOf?: number;
-        "x-typia-typeTags"?: IMetadataTypeTag[];
+        minimum?: undefined | number;
+        maximum?: undefined | number;
+        exclusiveMinimum?: undefined | boolean;
+        exclusiveMaximum?: undefined | boolean;
+        multipleOf?: undefined | number;
+        "x-typia-typeTags"?: undefined | IMetadataTypeTag[];
     }
     export interface IInteger extends IAtomic<"integer"> {
-        minimum?: number & Type<"int32">;
-        maximum?: number & Type<"int32">;
-        exclusiveMinimum?: boolean;
-        exclusiveMaximum?: boolean;
-        multipleOf?: number & Type<"int32">;
-        "x-typia-typeTags"?: IMetadataTypeTag[];
+        minimum?: undefined | (number & Type<"int32">);
+        maximum?: undefined | (number & Type<"int32">);
+        exclusiveMinimum?: undefined | boolean;
+        exclusiveMaximum?: undefined | boolean;
+        multipleOf?: undefined | (number & Type<"int32">);
+        "x-typia-typeTags"?: undefined | IMetadataTypeTag[];
     }
     export interface IBoolean extends IAtomic<"boolean"> {
-        "x-typia-typeTags"?: IMetadataTypeTag[];
+        "x-typia-typeTags"?: undefined | IMetadataTypeTag[];
     }
 
     /* -----------------------------------------------------------
@@ -69,14 +69,14 @@ export namespace IJsonSchema {
     ----------------------------------------------------------- */
     export interface IArray extends ISignificant<"array"> {
         items: IJsonSchema;
-        minItems?: number & Type<"uint32">;
-        maxItems?: number & Type<"uint32">;
-        "x-typia-tuple"?: ITuple;
+        minItems?: undefined | (number & Type<"uint32">);
+        maxItems?: undefined | (number & Type<"uint32">);
+        "x-typia-tuple"?: undefined | ITuple;
     }
     export interface ITuple extends ISignificant<"array"> {
         items: IJsonSchema[];
         minItems: number & Type<"uint32">;
-        maxItems?: number & Type<"uint32">;
+        maxItems?: undefined | (number & Type<"uint32">);
     }
     export interface IReference extends IAttribute {
         $ref: string;
@@ -98,15 +98,15 @@ export namespace IJsonSchema {
         /**
          * Only when swagger mode.
          */
-        nullable?: boolean;
+        nullable?: undefined | boolean;
     }
     export interface IAttribute {
-        deprecated?: boolean;
-        title?: string;
-        description?: string;
-        "x-typia-jsDocTags"?: IJsDocTagInfo[];
-        "x-typia-required"?: boolean;
-        "x-typia-optional"?: boolean;
-        "x-typia-rest"?: boolean;
+        deprecated?: undefined | boolean;
+        title?: undefined | string;
+        description?: undefined | string;
+        "x-typia-jsDocTags"?: undefined | IJsDocTagInfo[];
+        "x-typia-required"?: undefined | boolean;
+        "x-typia-optional"?: undefined | boolean;
+        "x-typia-rest"?: undefined | boolean;
     }
 }

--- a/src/schemas/metadata/IMetadataObject.ts
+++ b/src/schemas/metadata/IMetadataObject.ts
@@ -4,7 +4,7 @@ import { IMetadataProperty } from "./IMetadataProperty";
 export interface IMetadataObject {
     name: string;
     properties: IMetadataProperty[];
-    description?: string;
+    description?: undefined | string;
     jsDocTags: IJsDocTagInfo[];
 
     index: number;

--- a/src/transformers/ITransformOptions.ts
+++ b/src/transformers/ITransformOptions.ts
@@ -15,7 +15,7 @@ export interface ITransformOptions {
      *
      * @default false
      */
-    finite?: boolean;
+    finite?: undefined | boolean;
 
     /**
      * Whether to validate finite number or not.
@@ -34,7 +34,7 @@ export interface ITransformOptions {
      *
      * @default false
      */
-    numeric?: boolean;
+    numeric?: undefined | boolean;
 
     /**
      * Whether to validate functional type or not.
@@ -43,7 +43,7 @@ export interface ITransformOptions {
      *
      * @default false
      */
-    functional?: boolean;
+    functional?: undefined | boolean;
 
     /**
      * Whether to check undefined value or not.
@@ -58,5 +58,5 @@ export interface ITransformOptions {
      *
      * @default true
      */
-    undefined?: boolean;
+    undefined?: undefined | boolean;
 }

--- a/test/features/assert/test_assert_ObjectPartial.ts
+++ b/test/features/assert/test_assert_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_assert_ObjectPartial = _test_assert(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) => typia.assert<ObjectPartial>(input));

--- a/test/features/assert/test_assert_ObjectPartialAndRequired.ts
+++ b/test/features/assert/test_assert_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_assert_ObjectPartialAndRequired = _test_assert(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.assert<ObjectPartialAndRequired>(input),
+);

--- a/test/features/assert/test_assert_ObjectRequired.ts
+++ b/test/features/assert/test_assert_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_assert_ObjectRequired = _test_assert(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.assert<ObjectRequired>(input),
+);

--- a/test/features/assertEquals/test_assertEquals_ObjectPartial.ts
+++ b/test/features/assertEquals/test_assertEquals_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_assertEquals_ObjectPartial = _test_assertEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.assertEquals<ObjectPartial>(input),
+);

--- a/test/features/assertEquals/test_assertEquals_ObjectPartialAndRequired.ts
+++ b/test/features/assertEquals/test_assertEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_assertEquals_ObjectPartialAndRequired = _test_assertEquals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.assertEquals<ObjectPartialAndRequired>(input),
+);

--- a/test/features/assertEquals/test_assertEquals_ObjectRequired.ts
+++ b/test/features/assertEquals/test_assertEquals_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_assertEquals_ObjectRequired = _test_assertEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.assertEquals<ObjectRequired>(input),
+);

--- a/test/features/createAssert/test_createAssert_ObjectPartial.ts
+++ b/test/features/createAssert/test_createAssert_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createAssert_ObjectPartial = _test_assert(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createAssert<ObjectPartial>());

--- a/test/features/createAssert/test_createAssert_ObjectPartialAndRequired.ts
+++ b/test/features/createAssert/test_createAssert_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createAssert_ObjectPartialAndRequired = _test_assert(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.createAssert<ObjectPartialAndRequired>(),
+);

--- a/test/features/createAssert/test_createAssert_ObjectRequired.ts
+++ b/test/features/createAssert/test_createAssert_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_assert } from "../../internal/_test_assert";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createAssert_ObjectRequired = _test_assert(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createAssert<ObjectRequired>());

--- a/test/features/createAssertEquals/test_createAssertEquals_ObjectPartial.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createAssertEquals_ObjectPartial = _test_assertEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createAssertEquals<ObjectPartial>());

--- a/test/features/createAssertEquals/test_createAssertEquals_ObjectPartialAndRequired.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createAssertEquals_ObjectPartialAndRequired =
+    _test_assertEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.createAssertEquals<ObjectPartialAndRequired>());

--- a/test/features/createAssertEquals/test_createAssertEquals_ObjectRequired.ts
+++ b/test/features/createAssertEquals/test_createAssertEquals_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_assertEquals } from "../../internal/_test_assertEquals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createAssertEquals_ObjectRequired = _test_assertEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createAssertEquals<ObjectRequired>());

--- a/test/features/createEquals/test_createEquals_ObjectPartial.ts
+++ b/test/features/createEquals/test_createEquals_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createEquals_ObjectPartial = _test_equals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createEquals<ObjectPartial>());

--- a/test/features/createEquals/test_createEquals_ObjectPartialAndRequired.ts
+++ b/test/features/createEquals/test_createEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createEquals_ObjectPartialAndRequired = _test_equals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.createEquals<ObjectPartialAndRequired>(),
+);

--- a/test/features/createEquals/test_createEquals_ObjectRequired.ts
+++ b/test/features/createEquals/test_createEquals_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createEquals_ObjectRequired = _test_equals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createEquals<ObjectRequired>());

--- a/test/features/createIs/test_createIs_ObjectPartial.ts
+++ b/test/features/createIs/test_createIs_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createIs_ObjectPartial = _test_is(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createIs<ObjectPartial>());

--- a/test/features/createIs/test_createIs_ObjectPartialAndRequired.ts
+++ b/test/features/createIs/test_createIs_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createIs_ObjectPartialAndRequired = _test_is(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.createIs<ObjectPartialAndRequired>(),
+);

--- a/test/features/createIs/test_createIs_ObjectRequired.ts
+++ b/test/features/createIs/test_createIs_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createIs_ObjectRequired = _test_is(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createIs<ObjectRequired>());

--- a/test/features/createRandom/test_createRandom_ObjectPartial.ts
+++ b/test/features/createRandom/test_createRandom_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createRandom_ObjectPartial = _test_random(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    random: typia.createRandom<ObjectPartial>(),
+    assert: typia.createAssert<ObjectPartial>(),
+});

--- a/test/features/createRandom/test_createRandom_ObjectPartialAndRequired.ts
+++ b/test/features/createRandom/test_createRandom_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createRandom_ObjectPartialAndRequired = _test_random(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+    random: typia.createRandom<ObjectPartialAndRequired>(),
+    assert: typia.createAssert<ObjectPartialAndRequired>(),
+});

--- a/test/features/createRandom/test_createRandom_ObjectRequired.ts
+++ b/test/features/createRandom/test_createRandom_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createRandom_ObjectRequired = _test_random(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    random: typia.createRandom<ObjectRequired>(),
+    assert: typia.createAssert<ObjectRequired>(),
+});

--- a/test/features/createValidate/test_createValidate_ObjectPartial.ts
+++ b/test/features/createValidate/test_createValidate_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createValidate_ObjectPartial = _test_validate(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createValidate<ObjectPartial>());

--- a/test/features/createValidate/test_createValidate_ObjectPartialAndRequired.ts
+++ b/test/features/createValidate/test_createValidate_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createValidate_ObjectPartialAndRequired = _test_validate(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.createValidate<ObjectPartialAndRequired>(),
+);

--- a/test/features/createValidate/test_createValidate_ObjectRequired.ts
+++ b/test/features/createValidate/test_createValidate_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createValidate_ObjectRequired = _test_validate(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createValidate<ObjectRequired>());

--- a/test/features/createValidateEquals/test_createValidateEquals_ObjectPartial.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_createValidateEquals_ObjectPartial = _test_validateEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.createValidateEquals<ObjectPartial>());

--- a/test/features/createValidateEquals/test_createValidateEquals_ObjectPartialAndRequired.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_createValidateEquals_ObjectPartialAndRequired =
+    _test_validateEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.createValidateEquals<ObjectPartialAndRequired>());

--- a/test/features/createValidateEquals/test_createValidateEquals_ObjectRequired.ts
+++ b/test/features/createValidateEquals/test_createValidateEquals_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_createValidateEquals_ObjectRequired = _test_validateEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.createValidateEquals<ObjectRequired>());

--- a/test/features/equals/test_equals_ObjectPartial.ts
+++ b/test/features/equals/test_equals_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_equals_ObjectPartial = _test_equals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) => typia.equals<ObjectPartial>(input));

--- a/test/features/equals/test_equals_ObjectPartialAndRequired.ts
+++ b/test/features/equals/test_equals_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_equals_ObjectPartialAndRequired = _test_equals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.equals<ObjectPartialAndRequired>(input),
+);

--- a/test/features/equals/test_equals_ObjectRequired.ts
+++ b/test/features/equals/test_equals_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_equals } from "../../internal/_test_equals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_equals_ObjectRequired = _test_equals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.equals<ObjectRequired>(input),
+);

--- a/test/features/is/test_is_ObjectPartial.ts
+++ b/test/features/is/test_is_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_is_ObjectPartial = _test_is("ObjectPartial")<ObjectPartial>(
+    ObjectPartial,
+)((input) => typia.is<ObjectPartial>(input));

--- a/test/features/is/test_is_ObjectPartialAndRequired.ts
+++ b/test/features/is/test_is_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_is_ObjectPartialAndRequired = _test_is(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.is<ObjectPartialAndRequired>(input),
+);

--- a/test/features/is/test_is_ObjectRequired.ts
+++ b/test/features/is/test_is_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_is } from "../../internal/_test_is";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_is_ObjectRequired = _test_is(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) => typia.is<ObjectRequired>(input));

--- a/test/features/json.application/ajv/test_application_ajv_ObjectPartial.ts
+++ b/test/features/json.application/ajv/test_application_ajv_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_application_ajv_ObjectPartial = _test_json_application(
+    "ajv",
+)("ObjectPartial")(typia.json.application<[ObjectPartial], "ajv">());

--- a/test/features/json.application/ajv/test_application_ajv_ObjectPartialAndRequired.ts
+++ b/test/features/json.application/ajv/test_application_ajv_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_application_ajv_ObjectPartialAndRequired =
+    _test_json_application("ajv")("ObjectPartialAndRequired")(
+        typia.json.application<[ObjectPartialAndRequired], "ajv">(),
+    );

--- a/test/features/json.application/ajv/test_application_ajv_ObjectRequired.ts
+++ b/test/features/json.application/ajv/test_application_ajv_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_application_ajv_ObjectRequired = _test_json_application(
+    "ajv",
+)("ObjectRequired")(typia.json.application<[ObjectRequired], "ajv">());

--- a/test/features/json.application/swagger/test_application_swagger_ObjectPartial.ts
+++ b/test/features/json.application/swagger/test_application_swagger_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_application_swagger_ObjectPartial =
+    _test_json_application("swagger")("ObjectPartial")(
+        typia.json.application<[ObjectPartial], "swagger">(),
+    );

--- a/test/features/json.application/swagger/test_application_swagger_ObjectPartialAndRequired.ts
+++ b/test/features/json.application/swagger/test_application_swagger_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_application_swagger_ObjectPartialAndRequired =
+    _test_json_application("swagger")("ObjectPartialAndRequired")(
+        typia.json.application<[ObjectPartialAndRequired], "swagger">(),
+    );

--- a/test/features/json.application/swagger/test_application_swagger_ObjectRequired.ts
+++ b/test/features/json.application/swagger/test_application_swagger_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../internal/_test_json_application";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_application_swagger_ObjectRequired =
+    _test_json_application("swagger")("ObjectRequired")(
+        typia.json.application<[ObjectRequired], "swagger">(),
+    );

--- a/test/features/json.assertParse/test_json_assertParse_ObjectPartial.ts
+++ b/test/features/json.assertParse/test_json_assertParse_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_assertParse_ObjectPartial = _test_json_assertParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.json.assertParse<ObjectPartial>(input),
+);

--- a/test/features/json.assertParse/test_json_assertParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.assertParse/test_json_assertParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_assertParse_ObjectPartialAndRequired =
+    _test_json_assertParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.json.assertParse<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/json.assertParse/test_json_assertParse_ObjectRequired.ts
+++ b/test/features/json.assertParse/test_json_assertParse_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_assertParse_ObjectRequired = _test_json_assertParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.json.assertParse<ObjectRequired>(input),
+);

--- a/test/features/json.assertStringify/test_json_assertStringify_ObjectPartial.ts
+++ b/test/features/json.assertStringify/test_json_assertStringify_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_assertStringify_ObjectPartial =
+    _test_json_assertStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input) => typia.json.assertStringify<ObjectPartial>(input),
+    );

--- a/test/features/json.assertStringify/test_json_assertStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.assertStringify/test_json_assertStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_assertStringify_ObjectPartialAndRequired =
+    _test_json_assertStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.json.assertStringify<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/json.assertStringify/test_json_assertStringify_ObjectRequired.ts
+++ b/test/features/json.assertStringify/test_json_assertStringify_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_assertStringify_ObjectRequired =
+    _test_json_assertStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input) => typia.json.assertStringify<ObjectRequired>(input));

--- a/test/features/json.createAssertParse/test_json_createAssertParse_ObjectPartial.ts
+++ b/test/features/json.createAssertParse/test_json_createAssertParse_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createAssertParse_ObjectPartial = _test_json_assertParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.json.createAssertParse<ObjectPartial>());

--- a/test/features/json.createAssertParse/test_json_createAssertParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.createAssertParse/test_json_createAssertParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createAssertParse_ObjectPartialAndRequired =
+    _test_json_assertParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.json.createAssertParse<ObjectPartialAndRequired>(),
+    );

--- a/test/features/json.createAssertParse/test_json_createAssertParse_ObjectRequired.ts
+++ b/test/features/json.createAssertParse/test_json_createAssertParse_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_assertParse } from "../../internal/_test_json_assertParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createAssertParse_ObjectRequired =
+    _test_json_assertParse("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.json.createAssertParse<ObjectRequired>(),
+    );

--- a/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectPartial.ts
+++ b/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createAssertStringify_ObjectPartial =
+    _test_json_assertStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        typia.json.createAssertStringify<ObjectPartial>(),
+    );

--- a/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createAssertStringify_ObjectPartialAndRequired =
+    _test_json_assertStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.json.createAssertStringify<ObjectPartialAndRequired>(),
+    );

--- a/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectRequired.ts
+++ b/test/features/json.createAssertStringify/test_json_createAssertStringify_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_assertStringify } from "../../internal/_test_json_assertStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createAssertStringify_ObjectRequired =
+    _test_json_assertStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )(typia.json.createAssertStringify<ObjectRequired>());

--- a/test/features/json.createIsParse/test_json_createIsParse_ObjectPartial.ts
+++ b/test/features/json.createIsParse/test_json_createIsParse_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createIsParse_ObjectPartial = _test_json_isParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.json.createIsParse<ObjectPartial>());

--- a/test/features/json.createIsParse/test_json_createIsParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.createIsParse/test_json_createIsParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createIsParse_ObjectPartialAndRequired =
+    _test_json_isParse("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.json.createIsParse<ObjectPartialAndRequired>());

--- a/test/features/json.createIsParse/test_json_createIsParse_ObjectRequired.ts
+++ b/test/features/json.createIsParse/test_json_createIsParse_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createIsParse_ObjectRequired = _test_json_isParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.json.createIsParse<ObjectRequired>());

--- a/test/features/json.createIsStringify/test_json_createIsStringify_ObjectPartial.ts
+++ b/test/features/json.createIsStringify/test_json_createIsStringify_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createIsStringify_ObjectPartial = _test_json_isStringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.json.createIsStringify<ObjectPartial>());

--- a/test/features/json.createIsStringify/test_json_createIsStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.createIsStringify/test_json_createIsStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createIsStringify_ObjectPartialAndRequired =
+    _test_json_isStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.json.createIsStringify<ObjectPartialAndRequired>(),
+    );

--- a/test/features/json.createIsStringify/test_json_createIsStringify_ObjectRequired.ts
+++ b/test/features/json.createIsStringify/test_json_createIsStringify_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createIsStringify_ObjectRequired =
+    _test_json_isStringify("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.json.createIsStringify<ObjectRequired>(),
+    );

--- a/test/features/json.createStringify/test_json_createStringify_ObjectPartial.ts
+++ b/test/features/json.createStringify/test_json_createStringify_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createStringify_ObjectPartial = _test_json_stringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.json.createStringify<ObjectPartial>());

--- a/test/features/json.createStringify/test_json_createStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.createStringify/test_json_createStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createStringify_ObjectPartialAndRequired =
+    _test_json_stringify("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.json.createStringify<ObjectPartialAndRequired>());

--- a/test/features/json.createStringify/test_json_createStringify_ObjectRequired.ts
+++ b/test/features/json.createStringify/test_json_createStringify_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createStringify_ObjectRequired = _test_json_stringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.json.createStringify<ObjectRequired>());

--- a/test/features/json.createValidateParse/test_json_createValidateParse_ObjectPartial.ts
+++ b/test/features/json.createValidateParse/test_json_createValidateParse_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createValidateParse_ObjectPartial =
+    _test_json_validateParse("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        typia.json.createValidateParse<ObjectPartial>(),
+    );

--- a/test/features/json.createValidateParse/test_json_createValidateParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.createValidateParse/test_json_createValidateParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createValidateParse_ObjectPartialAndRequired =
+    _test_json_validateParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.json.createValidateParse<ObjectPartialAndRequired>(),
+    );

--- a/test/features/json.createValidateParse/test_json_createValidateParse_ObjectRequired.ts
+++ b/test/features/json.createValidateParse/test_json_createValidateParse_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createValidateParse_ObjectRequired =
+    _test_json_validateParse("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.json.createValidateParse<ObjectRequired>(),
+    );

--- a/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectPartial.ts
+++ b/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_createValidateStringify_ObjectPartial =
+    _test_json_validateStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        typia.json.createValidateStringify<ObjectPartial>(),
+    );

--- a/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_createValidateStringify_ObjectPartialAndRequired =
+    _test_json_validateStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.json.createValidateStringify<ObjectPartialAndRequired>(),
+    );

--- a/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectRequired.ts
+++ b/test/features/json.createValidateStringify/test_json_createValidateStringify_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_createValidateStringify_ObjectRequired =
+    _test_json_validateStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )(typia.json.createValidateStringify<ObjectRequired>());

--- a/test/features/json.isParse/test_json_isParse_ObjectPartial.ts
+++ b/test/features/json.isParse/test_json_isParse_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_isParse_ObjectPartial = _test_json_isParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.json.isParse<ObjectPartial>(input),
+);

--- a/test/features/json.isParse/test_json_isParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.isParse/test_json_isParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_isParse_ObjectPartialAndRequired = _test_json_isParse(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.json.isParse<ObjectPartialAndRequired>(input),
+);

--- a/test/features/json.isParse/test_json_isParse_ObjectRequired.ts
+++ b/test/features/json.isParse/test_json_isParse_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_isParse } from "../../internal/_test_json_isParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_isParse_ObjectRequired = _test_json_isParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.json.isParse<ObjectRequired>(input),
+);

--- a/test/features/json.isStringify/test_json_isStringify_ObjectPartial.ts
+++ b/test/features/json.isStringify/test_json_isStringify_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_isStringify_ObjectPartial = _test_json_isStringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.json.isStringify<ObjectPartial>(input),
+);

--- a/test/features/json.isStringify/test_json_isStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.isStringify/test_json_isStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_isStringify_ObjectPartialAndRequired =
+    _test_json_isStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.json.isStringify<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/json.isStringify/test_json_isStringify_ObjectRequired.ts
+++ b/test/features/json.isStringify/test_json_isStringify_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_isStringify } from "../../internal/_test_json_isStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_isStringify_ObjectRequired = _test_json_isStringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.json.isStringify<ObjectRequired>(input),
+);

--- a/test/features/json.stringify/test_json_stringify_ObjectPartial.ts
+++ b/test/features/json.stringify/test_json_stringify_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_stringify_ObjectPartial = _test_json_stringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.json.stringify<ObjectPartial>(input),
+);

--- a/test/features/json.stringify/test_json_stringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.stringify/test_json_stringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_stringify_ObjectPartialAndRequired =
+    _test_json_stringify("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input) => typia.json.stringify<ObjectPartialAndRequired>(input));

--- a/test/features/json.stringify/test_json_stringify_ObjectRequired.ts
+++ b/test/features/json.stringify/test_json_stringify_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_stringify } from "../../internal/_test_json_stringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_stringify_ObjectRequired = _test_json_stringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.json.stringify<ObjectRequired>(input),
+);

--- a/test/features/json.validateParse/test_json_validateParse_ObjectPartial.ts
+++ b/test/features/json.validateParse/test_json_validateParse_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_validateParse_ObjectPartial = _test_json_validateParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.json.validateParse<ObjectPartial>(input),
+);

--- a/test/features/json.validateParse/test_json_validateParse_ObjectPartialAndRequired.ts
+++ b/test/features/json.validateParse/test_json_validateParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_validateParse_ObjectPartialAndRequired =
+    _test_json_validateParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.json.validateParse<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/json.validateParse/test_json_validateParse_ObjectRequired.ts
+++ b/test/features/json.validateParse/test_json_validateParse_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_json_validateParse } from "../../internal/_test_json_validateParse";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_validateParse_ObjectRequired = _test_json_validateParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.json.validateParse<ObjectRequired>(input),
+);

--- a/test/features/json.validateStringify/test_json_validateStringify_ObjectPartial.ts
+++ b/test/features/json.validateStringify/test_json_validateStringify_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_json_validateStringify_ObjectPartial =
+    _test_json_validateStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input) => typia.json.validateStringify<ObjectPartial>(input),
+    );

--- a/test/features/json.validateStringify/test_json_validateStringify_ObjectPartialAndRequired.ts
+++ b/test/features/json.validateStringify/test_json_validateStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_json_validateStringify_ObjectPartialAndRequired =
+    _test_json_validateStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.json.validateStringify<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/json.validateStringify/test_json_validateStringify_ObjectRequired.ts
+++ b/test/features/json.validateStringify/test_json_validateStringify_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_json_validateStringify } from "../../internal/_test_json_validateStringify";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_json_validateStringify_ObjectRequired =
+    _test_json_validateStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input) => typia.json.validateStringify<ObjectRequired>(input));

--- a/test/features/misc.assertClone/test_misc_assertClone_ObjectPartial.ts
+++ b/test/features/misc.assertClone/test_misc_assertClone_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_assertClone_ObjectPartial = _test_misc_assertClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.assertClone<ObjectPartial>(input),
+);

--- a/test/features/misc.assertClone/test_misc_assertClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.assertClone/test_misc_assertClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_assertClone_ObjectPartialAndRequired =
+    _test_misc_assertClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.misc.assertClone<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/misc.assertClone/test_misc_assertClone_ObjectRequired.ts
+++ b/test/features/misc.assertClone/test_misc_assertClone_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_assertClone_ObjectRequired = _test_misc_assertClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.assertClone<ObjectRequired>(input),
+);

--- a/test/features/misc.assertPrune/test_misc_assertPrune_ObjectPartial.ts
+++ b/test/features/misc.assertPrune/test_misc_assertPrune_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_assertPrune_ObjectPartial = _test_misc_assertPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.assertPrune<ObjectPartial>(input),
+);

--- a/test/features/misc.assertPrune/test_misc_assertPrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.assertPrune/test_misc_assertPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_assertPrune_ObjectPartialAndRequired =
+    _test_misc_assertPrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.misc.assertPrune<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/misc.assertPrune/test_misc_assertPrune_ObjectRequired.ts
+++ b/test/features/misc.assertPrune/test_misc_assertPrune_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_assertPrune_ObjectRequired = _test_misc_assertPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.assertPrune<ObjectRequired>(input),
+);

--- a/test/features/misc.clone/test_misc_clone_ObjectPartial.ts
+++ b/test/features/misc.clone/test_misc_clone_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_clone_ObjectPartial = _test_misc_clone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.clone<ObjectPartial>(input),
+);

--- a/test/features/misc.clone/test_misc_clone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.clone/test_misc_clone_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_clone_ObjectPartialAndRequired = _test_misc_clone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.misc.clone<ObjectPartialAndRequired>(input),
+);

--- a/test/features/misc.clone/test_misc_clone_ObjectRequired.ts
+++ b/test/features/misc.clone/test_misc_clone_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_clone_ObjectRequired = _test_misc_clone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.clone<ObjectRequired>(input),
+);

--- a/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectPartial.ts
+++ b/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createAssertClone_ObjectPartial = _test_misc_assertClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createAssertClone<ObjectPartial>());

--- a/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createAssertClone_ObjectPartialAndRequired =
+    _test_misc_assertClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.misc.createAssertClone<ObjectPartialAndRequired>(),
+    );

--- a/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectRequired.ts
+++ b/test/features/misc.createAssertClone/test_misc_createAssertClone_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_assertClone } from "../../internal/_test_misc_assertClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createAssertClone_ObjectRequired =
+    _test_misc_assertClone("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.misc.createAssertClone<ObjectRequired>(),
+    );

--- a/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartial.ts
+++ b/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createAssertPrune_ObjectPartial = _test_misc_assertPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createAssertPrune<ObjectPartial>());

--- a/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createAssertPrune_ObjectPartialAndRequired =
+    _test_misc_assertPrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.misc.createAssertPrune<ObjectPartialAndRequired>(),
+    );

--- a/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectRequired.ts
+++ b/test/features/misc.createAssertPrune/test_misc_createAssertPrune_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_assertPrune } from "../../internal/_test_misc_assertPrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createAssertPrune_ObjectRequired =
+    _test_misc_assertPrune("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.misc.createAssertPrune<ObjectRequired>(),
+    );

--- a/test/features/misc.createClone/test_misc_createClone_ObjectPartial.ts
+++ b/test/features/misc.createClone/test_misc_createClone_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createClone_ObjectPartial = _test_misc_clone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createClone<ObjectPartial>());

--- a/test/features/misc.createClone/test_misc_createClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createClone/test_misc_createClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createClone_ObjectPartialAndRequired = _test_misc_clone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.misc.createClone<ObjectPartialAndRequired>(),
+);

--- a/test/features/misc.createClone/test_misc_createClone_ObjectRequired.ts
+++ b/test/features/misc.createClone/test_misc_createClone_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_clone } from "../../internal/_test_misc_clone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createClone_ObjectRequired = _test_misc_clone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.misc.createClone<ObjectRequired>());

--- a/test/features/misc.createIsClone/test_misc_createIsClone_ObjectPartial.ts
+++ b/test/features/misc.createIsClone/test_misc_createIsClone_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createIsClone_ObjectPartial = _test_misc_isClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createIsClone<ObjectPartial>());

--- a/test/features/misc.createIsClone/test_misc_createIsClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createIsClone/test_misc_createIsClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createIsClone_ObjectPartialAndRequired =
+    _test_misc_isClone("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.misc.createIsClone<ObjectPartialAndRequired>());

--- a/test/features/misc.createIsClone/test_misc_createIsClone_ObjectRequired.ts
+++ b/test/features/misc.createIsClone/test_misc_createIsClone_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createIsClone_ObjectRequired = _test_misc_isClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.misc.createIsClone<ObjectRequired>());

--- a/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectPartial.ts
+++ b/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createIsPrune_ObjectPartial = _test_misc_isPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createIsPrune<ObjectPartial>());

--- a/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createIsPrune_ObjectPartialAndRequired =
+    _test_misc_isPrune("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )(typia.misc.createIsPrune<ObjectPartialAndRequired>());

--- a/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectRequired.ts
+++ b/test/features/misc.createIsPrune/test_misc_createIsPrune_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createIsPrune_ObjectRequired = _test_misc_isPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.misc.createIsPrune<ObjectRequired>());

--- a/test/features/misc.createPrune/test_misc_createPrune_ObjectPartial.ts
+++ b/test/features/misc.createPrune/test_misc_createPrune_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createPrune_ObjectPartial = _test_misc_prune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(typia.misc.createPrune<ObjectPartial>());

--- a/test/features/misc.createPrune/test_misc_createPrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createPrune/test_misc_createPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createPrune_ObjectPartialAndRequired = _test_misc_prune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    typia.misc.createPrune<ObjectPartialAndRequired>(),
+);

--- a/test/features/misc.createPrune/test_misc_createPrune_ObjectRequired.ts
+++ b/test/features/misc.createPrune/test_misc_createPrune_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createPrune_ObjectRequired = _test_misc_prune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(typia.misc.createPrune<ObjectRequired>());

--- a/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectPartial.ts
+++ b/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createValidateClone_ObjectPartial =
+    _test_misc_validateClone("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        typia.misc.createValidateClone<ObjectPartial>(),
+    );

--- a/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createValidateClone_ObjectPartialAndRequired =
+    _test_misc_validateClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.misc.createValidateClone<ObjectPartialAndRequired>(),
+    );

--- a/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectRequired.ts
+++ b/test/features/misc.createValidateClone/test_misc_createValidateClone_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createValidateClone_ObjectRequired =
+    _test_misc_validateClone("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.misc.createValidateClone<ObjectRequired>(),
+    );

--- a/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartial.ts
+++ b/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_createValidatePrune_ObjectPartial =
+    _test_misc_validatePrune("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        typia.misc.createValidatePrune<ObjectPartial>(),
+    );

--- a/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createValidatePrune_ObjectPartialAndRequired =
+    _test_misc_validatePrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        typia.misc.createValidatePrune<ObjectPartialAndRequired>(),
+    );

--- a/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectRequired.ts
+++ b/test/features/misc.createValidatePrune/test_misc_createValidatePrune_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_createValidatePrune_ObjectRequired =
+    _test_misc_validatePrune("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        typia.misc.createValidatePrune<ObjectRequired>(),
+    );

--- a/test/features/misc.isClone/test_misc_isClone_ObjectPartial.ts
+++ b/test/features/misc.isClone/test_misc_isClone_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_isClone_ObjectPartial = _test_misc_isClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.isClone<ObjectPartial>(input),
+);

--- a/test/features/misc.isClone/test_misc_isClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.isClone/test_misc_isClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_isClone_ObjectPartialAndRequired = _test_misc_isClone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.misc.isClone<ObjectPartialAndRequired>(input),
+);

--- a/test/features/misc.isClone/test_misc_isClone_ObjectRequired.ts
+++ b/test/features/misc.isClone/test_misc_isClone_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isClone } from "../../internal/_test_misc_isClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_isClone_ObjectRequired = _test_misc_isClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.isClone<ObjectRequired>(input),
+);

--- a/test/features/misc.isPrune/test_misc_isPrune_ObjectPartial.ts
+++ b/test/features/misc.isPrune/test_misc_isPrune_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_isPrune_ObjectPartial = _test_misc_isPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.isPrune<ObjectPartial>(input),
+);

--- a/test/features/misc.isPrune/test_misc_isPrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.isPrune/test_misc_isPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_isPrune_ObjectPartialAndRequired = _test_misc_isPrune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.misc.isPrune<ObjectPartialAndRequired>(input),
+);

--- a/test/features/misc.isPrune/test_misc_isPrune_ObjectRequired.ts
+++ b/test/features/misc.isPrune/test_misc_isPrune_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_isPrune } from "../../internal/_test_misc_isPrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_isPrune_ObjectRequired = _test_misc_isPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.isPrune<ObjectRequired>(input),
+);

--- a/test/features/misc.prune/test_misc_prune_ObjectPartial.ts
+++ b/test/features/misc.prune/test_misc_prune_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_prune_ObjectPartial = _test_misc_prune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.prune<ObjectPartial>(input),
+);

--- a/test/features/misc.prune/test_misc_prune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.prune/test_misc_prune_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_prune_ObjectPartialAndRequired = _test_misc_prune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.misc.prune<ObjectPartialAndRequired>(input),
+);

--- a/test/features/misc.prune/test_misc_prune_ObjectRequired.ts
+++ b/test/features/misc.prune/test_misc_prune_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_prune } from "../../internal/_test_misc_prune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_prune_ObjectRequired = _test_misc_prune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.prune<ObjectRequired>(input),
+);

--- a/test/features/misc.validateClone/test_misc_validateClone_ObjectPartial.ts
+++ b/test/features/misc.validateClone/test_misc_validateClone_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_validateClone_ObjectPartial = _test_misc_validateClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.validateClone<ObjectPartial>(input),
+);

--- a/test/features/misc.validateClone/test_misc_validateClone_ObjectPartialAndRequired.ts
+++ b/test/features/misc.validateClone/test_misc_validateClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_validateClone_ObjectPartialAndRequired =
+    _test_misc_validateClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.misc.validateClone<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/misc.validateClone/test_misc_validateClone_ObjectRequired.ts
+++ b/test/features/misc.validateClone/test_misc_validateClone_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_validateClone } from "../../internal/_test_misc_validateClone";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_validateClone_ObjectRequired = _test_misc_validateClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.validateClone<ObjectRequired>(input),
+);

--- a/test/features/misc.validatePrune/test_misc_validatePrune_ObjectPartial.ts
+++ b/test/features/misc.validatePrune/test_misc_validatePrune_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_misc_validatePrune_ObjectPartial = _test_misc_validatePrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.misc.validatePrune<ObjectPartial>(input),
+);

--- a/test/features/misc.validatePrune/test_misc_validatePrune_ObjectPartialAndRequired.ts
+++ b/test/features/misc.validatePrune/test_misc_validatePrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_misc_validatePrune_ObjectPartialAndRequired =
+    _test_misc_validatePrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        typia.misc.validatePrune<ObjectPartialAndRequired>(input),
+    );

--- a/test/features/misc.validatePrune/test_misc_validatePrune_ObjectRequired.ts
+++ b/test/features/misc.validatePrune/test_misc_validatePrune_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_misc_validatePrune } from "../../internal/_test_misc_validatePrune";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_misc_validatePrune_ObjectRequired = _test_misc_validatePrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.misc.validatePrune<ObjectRequired>(input),
+);

--- a/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartial.ts
+++ b/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_assertDecode_ObjectPartial =
+    _test_protobuf_assertDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertDecode: (input) =>
+            typia.protobuf.assertDecode<ObjectPartial>(input),
+        encode: typia.protobuf.createEncode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_assertDecode_ObjectPartialAndRequired =
+    _test_protobuf_assertDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertDecode: (input) =>
+            typia.protobuf.assertDecode<ObjectPartialAndRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectRequired.ts
+++ b/test/features/protobuf.assertDecode/test_protobuf_assertDecode_ObjectRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_assertDecode_ObjectRequired =
+    _test_protobuf_assertDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertDecode: (input) =>
+            typia.protobuf.assertDecode<ObjectRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartial.ts
+++ b/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartial.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_assertEncode_ObjectPartial =
+    _test_protobuf_assertEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertEncode: (input) =>
+            typia.protobuf.assertEncode<ObjectPartial>(input),
+        message: typia.protobuf.message<ObjectPartial>(),
+        decode: typia.protobuf.createDecode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_assertEncode_ObjectPartialAndRequired =
+    _test_protobuf_assertEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertEncode: (input) =>
+            typia.protobuf.assertEncode<ObjectPartialAndRequired>(input),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectRequired.ts
+++ b/test/features/protobuf.assertEncode/test_protobuf_assertEncode_ObjectRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_assertEncode_ObjectRequired =
+    _test_protobuf_assertEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertEncode: (input) =>
+            typia.protobuf.assertEncode<ObjectRequired>(input),
+        message: typia.protobuf.message<ObjectRequired>(),
+        decode: typia.protobuf.createDecode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartial.ts
+++ b/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createAssertDecode_ObjectPartial =
+    _test_protobuf_assertDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertDecode: typia.protobuf.createAssertDecode<ObjectPartial>(),
+        encode: typia.protobuf.createEncode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createAssertDecode_ObjectPartialAndRequired =
+    _test_protobuf_assertDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertDecode:
+            typia.protobuf.createAssertDecode<ObjectPartialAndRequired>(),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectRequired.ts
+++ b/test/features/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_assertDecode } from "../../internal/_test_protobuf_assertDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createAssertDecode_ObjectRequired =
+    _test_protobuf_assertDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertDecode: typia.protobuf.createAssertDecode<ObjectRequired>(),
+        encode: typia.protobuf.createEncode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartial.ts
+++ b/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createAssertEncode_ObjectPartial =
+    _test_protobuf_assertEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertEncode: typia.protobuf.createAssertEncode<ObjectPartial>(),
+        message: typia.protobuf.message<ObjectPartial>(),
+        decode: typia.protobuf.createDecode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createAssertEncode_ObjectPartialAndRequired =
+    _test_protobuf_assertEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertEncode:
+            typia.protobuf.createAssertEncode<ObjectPartialAndRequired>(),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectRequired.ts
+++ b/test/features/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_assertEncode } from "../../internal/_test_protobuf_assertEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createAssertEncode_ObjectRequired =
+    _test_protobuf_assertEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertEncode: typia.protobuf.createAssertEncode<ObjectRequired>(),
+        message: typia.protobuf.message<ObjectRequired>(),
+        decode: typia.protobuf.createDecode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectPartial.ts
+++ b/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createDecode_ObjectPartial = _test_protobuf_decode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    decode: typia.protobuf.createDecode<ObjectPartial>(),
+    encode: typia.protobuf.createEncode<ObjectPartial>(),
+});

--- a/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createDecode_ObjectPartialAndRequired =
+    _test_protobuf_decode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectRequired.ts
+++ b/test/features/protobuf.createDecode/test_protobuf_createDecode_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createDecode_ObjectRequired = _test_protobuf_decode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    decode: typia.protobuf.createDecode<ObjectRequired>(),
+    encode: typia.protobuf.createEncode<ObjectRequired>(),
+});

--- a/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectPartial.ts
+++ b/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectPartial.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createEncode_ObjectPartial = _test_protobuf_encode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    encode: typia.protobuf.createEncode<ObjectPartial>(),
+    message: typia.protobuf.message<ObjectPartial>(),
+    decode: typia.protobuf.createDecode<ObjectPartial>(),
+});

--- a/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createEncode_ObjectPartialAndRequired =
+    _test_protobuf_encode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectRequired.ts
+++ b/test/features/protobuf.createEncode/test_protobuf_createEncode_ObjectRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createEncode_ObjectRequired = _test_protobuf_encode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    encode: typia.protobuf.createEncode<ObjectRequired>(),
+    message: typia.protobuf.message<ObjectRequired>(),
+    decode: typia.protobuf.createDecode<ObjectRequired>(),
+});

--- a/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartial.ts
+++ b/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createIsDecode_ObjectPartial =
+    _test_protobuf_isDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        isDecode: typia.protobuf.createIsDecode<ObjectPartial>(),
+        encode: typia.protobuf.createEncode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createIsDecode_ObjectPartialAndRequired =
+    _test_protobuf_isDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isDecode: typia.protobuf.createIsDecode<ObjectPartialAndRequired>(),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectRequired.ts
+++ b/test/features/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createIsDecode_ObjectRequired =
+    _test_protobuf_isDecode("ObjectRequired")<ObjectRequired>(ObjectRequired)({
+        isDecode: typia.protobuf.createIsDecode<ObjectRequired>(),
+        encode: typia.protobuf.createEncode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartial.ts
+++ b/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createIsEncode_ObjectPartial =
+    _test_protobuf_isEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        isEncode: typia.protobuf.createIsEncode<ObjectPartial>(),
+        message: typia.protobuf.message<ObjectPartial>(),
+        decode: typia.protobuf.createDecode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createIsEncode_ObjectPartialAndRequired =
+    _test_protobuf_isEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isEncode: typia.protobuf.createIsEncode<ObjectPartialAndRequired>(),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectRequired.ts
+++ b/test/features/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createIsEncode_ObjectRequired =
+    _test_protobuf_isEncode("ObjectRequired")<ObjectRequired>(ObjectRequired)({
+        isEncode: typia.protobuf.createIsEncode<ObjectRequired>(),
+        message: typia.protobuf.message<ObjectRequired>(),
+        decode: typia.protobuf.createDecode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartial.ts
+++ b/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartial.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createValidateDecode_ObjectPartial =
+    _test_protobuf_validateDecode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateDecode: typia.protobuf.createValidateDecode<ObjectPartial>(),
+        encode: typia.protobuf.createEncode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createValidateDecode_ObjectPartialAndRequired =
+    _test_protobuf_validateDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateDecode:
+            typia.protobuf.createValidateDecode<ObjectPartialAndRequired>(),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectRequired.ts
+++ b/test/features/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createValidateDecode_ObjectRequired =
+    _test_protobuf_validateDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateDecode: typia.protobuf.createValidateDecode<ObjectRequired>(),
+        encode: typia.protobuf.createEncode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartial.ts
+++ b/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartial.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_createValidateEncode_ObjectPartial =
+    _test_protobuf_validateEncode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateEncode: typia.protobuf.createValidateEncode<ObjectPartial>(),
+        message: typia.protobuf.message<ObjectPartial>(),
+        decode: typia.protobuf.createDecode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createValidateEncode_ObjectPartialAndRequired =
+    _test_protobuf_validateEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateEncode:
+            typia.protobuf.createValidateEncode<ObjectPartialAndRequired>(),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectRequired.ts
+++ b/test/features/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_createValidateEncode_ObjectRequired =
+    _test_protobuf_validateEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateEncode: typia.protobuf.createValidateEncode<ObjectRequired>(),
+        message: typia.protobuf.message<ObjectRequired>(),
+        decode: typia.protobuf.createDecode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.decode/test_protobuf_decode_ObjectPartial.ts
+++ b/test/features/protobuf.decode/test_protobuf_decode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_decode_ObjectPartial = _test_protobuf_decode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    decode: (input) => typia.protobuf.decode<ObjectPartial>(input),
+    encode: typia.protobuf.createEncode<ObjectPartial>(),
+});

--- a/test/features/protobuf.decode/test_protobuf_decode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.decode/test_protobuf_decode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_decode_ObjectPartialAndRequired =
+    _test_protobuf_decode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        decode: (input) =>
+            typia.protobuf.decode<ObjectPartialAndRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.decode/test_protobuf_decode_ObjectRequired.ts
+++ b/test/features/protobuf.decode/test_protobuf_decode_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_decode } from "../../internal/_test_protobuf_decode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_decode_ObjectRequired = _test_protobuf_decode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    decode: (input) => typia.protobuf.decode<ObjectRequired>(input),
+    encode: typia.protobuf.createEncode<ObjectRequired>(),
+});

--- a/test/features/protobuf.encode/test_protobuf_encode_ObjectPartial.ts
+++ b/test/features/protobuf.encode/test_protobuf_encode_ObjectPartial.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_encode_ObjectPartial = _test_protobuf_encode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    encode: (input) => typia.protobuf.encode<ObjectPartial>(input),
+    message: typia.protobuf.message<ObjectPartial>(),
+    decode: typia.protobuf.createDecode<ObjectPartial>(),
+});

--- a/test/features/protobuf.encode/test_protobuf_encode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.encode/test_protobuf_encode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_encode_ObjectPartialAndRequired =
+    _test_protobuf_encode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        encode: (input) =>
+            typia.protobuf.encode<ObjectPartialAndRequired>(input),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.encode/test_protobuf_encode_ObjectRequired.ts
+++ b/test/features/protobuf.encode/test_protobuf_encode_ObjectRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_encode } from "../../internal/_test_protobuf_encode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_encode_ObjectRequired = _test_protobuf_encode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    encode: (input) => typia.protobuf.encode<ObjectRequired>(input),
+    message: typia.protobuf.message<ObjectRequired>(),
+    decode: typia.protobuf.createDecode<ObjectRequired>(),
+});

--- a/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectPartial.ts
+++ b/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_isDecode_ObjectPartial = _test_protobuf_isDecode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    isDecode: (input) => typia.protobuf.isDecode<ObjectPartial>(input),
+    encode: typia.protobuf.createEncode<ObjectPartial>(),
+});

--- a/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_isDecode_ObjectPartialAndRequired =
+    _test_protobuf_isDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isDecode: (input) =>
+            typia.protobuf.isDecode<ObjectPartialAndRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectRequired.ts
+++ b/test/features/protobuf.isDecode/test_protobuf_isDecode_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_protobuf_isDecode } from "../../internal/_test_protobuf_isDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_isDecode_ObjectRequired = _test_protobuf_isDecode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    isDecode: (input) => typia.protobuf.isDecode<ObjectRequired>(input),
+    encode: typia.protobuf.createEncode<ObjectRequired>(),
+});

--- a/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectPartial.ts
+++ b/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectPartial.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_isEncode_ObjectPartial = _test_protobuf_isEncode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    isEncode: (input) => typia.protobuf.isEncode<ObjectPartial>(input),
+    message: typia.protobuf.message<ObjectPartial>(),
+    decode: typia.protobuf.createDecode<ObjectPartial>(),
+});

--- a/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_isEncode_ObjectPartialAndRequired =
+    _test_protobuf_isEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isEncode: (input) =>
+            typia.protobuf.isEncode<ObjectPartialAndRequired>(input),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectRequired.ts
+++ b/test/features/protobuf.isEncode/test_protobuf_isEncode_ObjectRequired.ts
@@ -1,0 +1,11 @@
+import typia from "../../../src";
+import { _test_protobuf_isEncode } from "../../internal/_test_protobuf_isEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_isEncode_ObjectRequired = _test_protobuf_isEncode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    isEncode: (input) => typia.protobuf.isEncode<ObjectRequired>(input),
+    message: typia.protobuf.message<ObjectRequired>(),
+    decode: typia.protobuf.createDecode<ObjectRequired>(),
+});

--- a/test/features/protobuf.message/test_protobuf_message_ObjectPartial.ts
+++ b/test/features/protobuf.message/test_protobuf_message_ObjectPartial.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_protobuf_message } from "../../internal/_test_protobuf_message";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_message_ObjectPartial = _test_protobuf_message(
+    "ObjectPartial",
+)(typia.protobuf.message<ObjectPartial>());

--- a/test/features/protobuf.message/test_protobuf_message_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.message/test_protobuf_message_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_protobuf_message } from "../../internal/_test_protobuf_message";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_message_ObjectPartialAndRequired =
+    _test_protobuf_message("ObjectPartialAndRequired")(
+        typia.protobuf.message<ObjectPartialAndRequired>(),
+    );

--- a/test/features/protobuf.message/test_protobuf_message_ObjectRequired.ts
+++ b/test/features/protobuf.message/test_protobuf_message_ObjectRequired.ts
@@ -1,0 +1,7 @@
+import typia from "../../../src";
+import { _test_protobuf_message } from "../../internal/_test_protobuf_message";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_message_ObjectRequired = _test_protobuf_message(
+    "ObjectRequired",
+)(typia.protobuf.message<ObjectRequired>());

--- a/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartial.ts
+++ b/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartial.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_validateDecode_ObjectPartial =
+    _test_protobuf_validateDecode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateDecode: (input) =>
+            typia.protobuf.validateDecode<ObjectPartial>(input),
+        encode: typia.protobuf.createEncode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_validateDecode_ObjectPartialAndRequired =
+    _test_protobuf_validateDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateDecode: (input) =>
+            typia.protobuf.validateDecode<ObjectPartialAndRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectRequired.ts
+++ b/test/features/protobuf.validateDecode/test_protobuf_validateDecode_ObjectRequired.ts
@@ -1,0 +1,12 @@
+import typia from "../../../src";
+import { _test_protobuf_validateDecode } from "../../internal/_test_protobuf_validateDecode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_validateDecode_ObjectRequired =
+    _test_protobuf_validateDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateDecode: (input) =>
+            typia.protobuf.validateDecode<ObjectRequired>(input),
+        encode: typia.protobuf.createEncode<ObjectRequired>(),
+    });

--- a/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartial.ts
+++ b/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartial.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_protobuf_validateEncode_ObjectPartial =
+    _test_protobuf_validateEncode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateEncode: (input) =>
+            typia.protobuf.validateEncode<ObjectPartial>(input),
+        message: typia.protobuf.message<ObjectPartial>(),
+        decode: typia.protobuf.createDecode<ObjectPartial>(),
+    });

--- a/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartialAndRequired.ts
+++ b/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_validateEncode_ObjectPartialAndRequired =
+    _test_protobuf_validateEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateEncode: (input) =>
+            typia.protobuf.validateEncode<ObjectPartialAndRequired>(input),
+        message: typia.protobuf.message<ObjectPartialAndRequired>(),
+        decode: typia.protobuf.createDecode<ObjectPartialAndRequired>(),
+    });

--- a/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectRequired.ts
+++ b/test/features/protobuf.validateEncode/test_protobuf_validateEncode_ObjectRequired.ts
@@ -1,0 +1,13 @@
+import typia from "../../../src";
+import { _test_protobuf_validateEncode } from "../../internal/_test_protobuf_validateEncode";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_protobuf_validateEncode_ObjectRequired =
+    _test_protobuf_validateEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateEncode: (input) =>
+            typia.protobuf.validateEncode<ObjectRequired>(input),
+        message: typia.protobuf.message<ObjectRequired>(),
+        decode: typia.protobuf.createDecode<ObjectRequired>(),
+    });

--- a/test/features/random/test_random_ObjectPartial.ts
+++ b/test/features/random/test_random_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_random_ObjectPartial = _test_random(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    random: () => typia.random<ObjectPartial>(),
+    assert: typia.createAssert<ObjectPartial>(),
+});

--- a/test/features/random/test_random_ObjectPartialAndRequired.ts
+++ b/test/features/random/test_random_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_random_ObjectPartialAndRequired = _test_random(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+    random: () => typia.random<ObjectPartialAndRequired>(),
+    assert: typia.createAssert<ObjectPartialAndRequired>(),
+});

--- a/test/features/random/test_random_ObjectRequired.ts
+++ b/test/features/random/test_random_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "../../../src";
+import { _test_random } from "../../internal/_test_random";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_random_ObjectRequired = _test_random(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    random: () => typia.random<ObjectRequired>(),
+    assert: typia.createAssert<ObjectRequired>(),
+});

--- a/test/features/validate/test_validate_ObjectPartial.ts
+++ b/test/features/validate/test_validate_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_validate_ObjectPartial = _test_validate(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.validate<ObjectPartial>(input),
+);

--- a/test/features/validate/test_validate_ObjectPartialAndRequired.ts
+++ b/test/features/validate/test_validate_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_validate_ObjectPartialAndRequired = _test_validate(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    typia.validate<ObjectPartialAndRequired>(input),
+);

--- a/test/features/validate/test_validate_ObjectRequired.ts
+++ b/test/features/validate/test_validate_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validate } from "../../internal/_test_validate";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_validate_ObjectRequired = _test_validate(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.validate<ObjectRequired>(input),
+);

--- a/test/features/validateEquals/test_validateEquals_ObjectPartial.ts
+++ b/test/features/validateEquals/test_validateEquals_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_validateEquals_ObjectPartial = _test_validateEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    typia.validateEquals<ObjectPartial>(input),
+);

--- a/test/features/validateEquals/test_validateEquals_ObjectPartialAndRequired.ts
+++ b/test/features/validateEquals/test_validateEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_validateEquals_ObjectPartialAndRequired =
+    _test_validateEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input) => typia.validateEquals<ObjectPartialAndRequired>(input));

--- a/test/features/validateEquals/test_validateEquals_ObjectRequired.ts
+++ b/test/features/validateEquals/test_validateEquals_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../src";
+import { _test_validateEquals } from "../../internal/_test_validateEquals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_validateEquals_ObjectRequired = _test_validateEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    typia.validateEquals<ObjectRequired>(input),
+);

--- a/test/generated/output/assert/test_assert_ObjectPartial.ts
+++ b/test/generated/output/assert/test_assert_ObjectPartial.ts
@@ -1,0 +1,210 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_assert_ObjectPartial = _test_assert(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): ObjectPartial => {
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.assert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assert/test_assert_ObjectPartialAndRequired.ts
+++ b/test/generated/output/assert/test_assert_ObjectPartialAndRequired.ts
@@ -1,0 +1,119 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_assert_ObjectPartialAndRequired = _test_assert(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): ObjectPartialAndRequired => {
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.assert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assert/test_assert_ObjectRequired.ts
+++ b/test/generated/output/assert/test_assert_ObjectRequired.ts
@@ -1,0 +1,207 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_assert_ObjectRequired = _test_assert(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): ObjectRequired => {
+        const __is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $guard = (typia.assert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assert/test_assert_ObjectUnionImplicit.ts
+++ b/test/generated/output/assert/test_assert_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_assert_ObjectUnionImplicit = _test_assert(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -523,6 +523,13 @@ export const test_assert_ObjectUnionImplicit = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -542,13 +549,6 @@ export const test_assert_ObjectUnionImplicit = _test_assert(
                             expected:
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
-                        })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
                         })) &&
                     (null === input.area ||
                         undefined === input.area ||

--- a/test/generated/output/assertEquals/test_assertEquals_ObjectPartial.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_ObjectPartial.ts
@@ -1,0 +1,294 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_assertEquals_ObjectPartial = _test_assertEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): ObjectPartial => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartial => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index2: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input, true)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.assertEquals as any).guard;
+                const $join = (typia.assertEquals as any).join;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                    (0 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "boolean",
+                                    "number",
+                                    "string",
+                                    "array",
+                                    "object",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        })) &&
+                    (5 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "boolean",
+                                    "number",
+                                    "string",
+                                    "array",
+                                    "object",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assertEquals/test_assertEquals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,165 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_assertEquals_ObjectPartialAndRequired = _test_assertEquals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): ObjectPartialAndRequired => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartialAndRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object, true && _exceptionable))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (2 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "string",
+                                "number",
+                                "boolean",
+                                "object",
+                                "array",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.assertEquals as any).guard;
+                const $join = (typia.assertEquals as any).join;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (2 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "string",
+                                    "number",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assertEquals/test_assertEquals_ObjectRequired.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_ObjectRequired.ts
@@ -1,0 +1,293 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_assertEquals_ObjectRequired = _test_assertEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): ObjectRequired => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $guard = (typia.assertEquals as any).guard;
+                const $join = (typia.assertEquals as any).join;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        })) &&
+                    (5 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "boolean",
+                                    "number",
+                                    "string",
+                                    "array",
+                                    "object",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                    (0 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "boolean",
+                                    "number",
+                                    "string",
+                                    "array",
+                                    "object",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    })(input),
+);

--- a/test/generated/output/assertEquals/test_assertEquals_ObjectUnionImplicit.ts
+++ b/test/generated/output/assertEquals/test_assertEquals_ObjectUnionImplicit.ts
@@ -209,12 +209,12 @@ export const test_assertEquals_ObjectUnionImplicit = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid, true && _exceptionable))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,7 +222,7 @@ export const test_assertEquals_ObjectUnionImplicit = _test_assertEquals(
                 (1 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["centroid", "radius", "area"].some(
+                            ["radius", "centroid", "area"].some(
                                 (prop: any) => key === prop,
                             )
                         )
@@ -761,6 +761,13 @@ export const test_assertEquals_ObjectUnionImplicit = _test_assertEquals(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -781,13 +788,6 @@ export const test_assertEquals_ObjectUnionImplicit = _test_assertEquals(
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
                         })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
-                        })) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -801,7 +801,7 @@ export const test_assertEquals_ObjectUnionImplicit = _test_assertEquals(
                         false === _exceptionable ||
                         Object.keys(input).every((key: any) => {
                             if (
-                                ["centroid", "radius", "area"].some(
+                                ["radius", "centroid", "area"].some(
                                     (prop: any) => key === prop,
                                 )
                             )

--- a/test/generated/output/createAssert/test_createAssert_ObjectPartial.ts
+++ b/test/generated/output/createAssert/test_createAssert_ObjectPartial.ts
@@ -1,0 +1,205 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createAssert_ObjectPartial = _test_assert(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): ObjectPartial => {
+    const __is = (input: any): input is ObjectPartial => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input)
+        );
+    };
+    if (false === __is(input))
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartial => {
+            const $guard = (typia.createAssert as any).guard;
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "(boolean | undefined)",
+                        value: input.boolean,
+                    })) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "(number | undefined)",
+                        value: input.number,
+                    })) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "(string | undefined)",
+                        value: input.string,
+                    })) &&
+                (undefined === input.array ||
+                    ((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "(Array<number> | undefined)",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectPartial.IBase | null | undefined)",
+                        value: input.object,
+                    }));
+            const $ao1 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                ("boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "boolean",
+                        value: input.boolean,
+                    })) &&
+                (("number" === typeof input.number &&
+                    Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "number",
+                        value: input.number,
+                    })) &&
+                ("string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "string",
+                        value: input.string,
+                    })) &&
+                (((Array.isArray(input.array) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                    input.array.every(
+                        (elem: any, _index2: number) =>
+                            ("number" === typeof elem &&
+                                Number.isFinite(elem)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array[" + _index2 + "]",
+                                expected: "number",
+                                value: elem,
+                            }),
+                    )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectPartial.IBase | null)",
+                        value: input.object,
+                    }));
+            return (
+                ((("object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })) &&
+                    $ao0(input, _path + "", true)) ||
+                $guard(true, {
+                    path: _path + "",
+                    expected: "Partial<ObjectPartial.IBase>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+    return input;
+});

--- a/test/generated/output/createAssert/test_createAssert_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createAssert/test_createAssert_ObjectPartialAndRequired.ts
@@ -1,0 +1,119 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createAssert_ObjectPartialAndRequired = _test_assert(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (input: any): ObjectPartialAndRequired => {
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+);

--- a/test/generated/output/createAssert/test_createAssert_ObjectRequired.ts
+++ b/test/generated/output/createAssert/test_createAssert_ObjectRequired.ts
@@ -1,0 +1,202 @@
+import typia from "../../../../src";
+import { _test_assert } from "../../../internal/_test_assert";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createAssert_ObjectRequired = _test_assert(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: any): ObjectRequired => {
+    const __is = (input: any): input is ObjectRequired => {
+        const $io0 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        return "object" === typeof input && null !== input && $io0(input);
+    };
+    if (false === __is(input))
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is ObjectRequired => {
+            const $guard = (typia.createAssert as any).guard;
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                ("boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "boolean",
+                        value: input.boolean,
+                    })) &&
+                (("number" === typeof input.number &&
+                    Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "number",
+                        value: input.number,
+                    })) &&
+                ("string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "string",
+                        value: input.string,
+                    })) &&
+                (((Array.isArray(input.array) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            ("number" === typeof elem &&
+                                Number.isFinite(elem)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array[" + _index1 + "]",
+                                expected: "number",
+                                value: elem,
+                            }),
+                    )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectRequired.IBase | null)",
+                        value: input.object,
+                    }));
+            const $ao1 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "(boolean | undefined)",
+                        value: input.boolean,
+                    })) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "(number | undefined)",
+                        value: input.number,
+                    })) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "(string | undefined)",
+                        value: input.string,
+                    })) &&
+                (undefined === input.array ||
+                    ((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "(Array<number> | undefined)",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectRequired.IBase | null | undefined)",
+                        value: input.object,
+                    }));
+            return (
+                ((("object" === typeof input && null !== input) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })) &&
+                    $ao0(input, _path + "", true)) ||
+                $guard(true, {
+                    path: _path + "",
+                    expected: "Required<ObjectRequired.IBase>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+    return input;
+});

--- a/test/generated/output/createAssert/test_createAssert_ObjectUnionImplicit.ts
+++ b/test/generated/output/createAssert/test_createAssert_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_createAssert_ObjectUnionImplicit = _test_assert(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -523,6 +523,13 @@ export const test_createAssert_ObjectUnionImplicit = _test_assert(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -542,13 +549,6 @@ export const test_createAssert_ObjectUnionImplicit = _test_assert(
                             expected:
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
-                        })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
                         })) &&
                     (null === input.area ||
                         undefined === input.area ||

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectPartial.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectPartial.ts
@@ -1,0 +1,275 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createAssertEquals_ObjectPartial = _test_assertEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): ObjectPartial => {
+    const __is = (
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is ObjectPartial => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index2: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input, true)
+        );
+    };
+    if (false === __is(input))
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartial => {
+            const $guard = (typia.createAssertEquals as any).guard;
+            const $join = (typia.createAssertEquals as any).join;
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "(boolean | undefined)",
+                        value: input.boolean,
+                    })) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "(number | undefined)",
+                        value: input.number,
+                    })) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "(string | undefined)",
+                        value: input.string,
+                    })) &&
+                (undefined === input.array ||
+                    ((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "(Array<number> | undefined)",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectPartial.IBase | null | undefined)",
+                        value: input.object,
+                    })) &&
+                (0 === Object.keys(input).length ||
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return $guard(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                        });
+                    }));
+            const $ao1 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                ("boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "boolean",
+                        value: input.boolean,
+                    })) &&
+                (("number" === typeof input.number &&
+                    Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "number",
+                        value: input.number,
+                    })) &&
+                ("string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "string",
+                        value: input.string,
+                    })) &&
+                (((Array.isArray(input.array) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                    input.array.every(
+                        (elem: any, _index2: number) =>
+                            ("number" === typeof elem &&
+                                Number.isFinite(elem)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array[" + _index2 + "]",
+                                expected: "number",
+                                value: elem,
+                            }),
+                    )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectPartial.IBase | null)",
+                        value: input.object,
+                    })) &&
+                (5 === Object.keys(input).length ||
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return $guard(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                        });
+                    }));
+            return (
+                ((("object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })) &&
+                    $ao0(input, _path + "", true)) ||
+                $guard(true, {
+                    path: _path + "",
+                    expected: "Partial<ObjectPartial.IBase>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+    return input;
+});

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,164 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createAssertEquals_ObjectPartialAndRequired =
+    _test_assertEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: any): ObjectPartialAndRequired => {
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartialAndRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object, true && _exceptionable))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (2 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "string",
+                                "number",
+                                "boolean",
+                                "object",
+                                "array",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.createAssertEquals as any).guard;
+                const $join = (typia.createAssertEquals as any).join;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (2 === Object.keys(input).length ||
+                        false === _exceptionable ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "string",
+                                    "number",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return $guard(_exceptionable, {
+                                path: _path + $join(key),
+                                expected: "undefined",
+                                value: value,
+                            });
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    });

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectRequired.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectRequired.ts
@@ -1,0 +1,272 @@
+import typia from "../../../../src";
+import { _test_assertEquals } from "../../../internal/_test_assertEquals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createAssertEquals_ObjectRequired = _test_assertEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: any): ObjectRequired => {
+    const __is = (
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is ObjectRequired => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index1: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index2: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    };
+    if (false === __is(input))
+        ((
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+        ): input is ObjectRequired => {
+            const $guard = (typia.createAssertEquals as any).guard;
+            const $join = (typia.createAssertEquals as any).join;
+            const $ao0 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                ("boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "boolean",
+                        value: input.boolean,
+                    })) &&
+                (("number" === typeof input.number &&
+                    Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "number",
+                        value: input.number,
+                    })) &&
+                ("string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "string",
+                        value: input.string,
+                    })) &&
+                (((Array.isArray(input.array) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            ("number" === typeof elem &&
+                                Number.isFinite(elem)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array[" + _index1 + "]",
+                                expected: "number",
+                                value: elem,
+                            }),
+                    )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "Array<number>",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectRequired.IBase | null)",
+                        value: input.object,
+                    })) &&
+                (5 === Object.keys(input).length ||
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return $guard(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                        });
+                    }));
+            const $ao1 = (
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean ||
+                    $guard(_exceptionable, {
+                        path: _path + ".boolean",
+                        expected: "(boolean | undefined)",
+                        value: input.boolean,
+                    })) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".number",
+                        expected: "(number | undefined)",
+                        value: input.number,
+                    })) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string ||
+                    $guard(_exceptionable, {
+                        path: _path + ".string",
+                        expected: "(string | undefined)",
+                        value: input.string,
+                    })) &&
+                (undefined === input.array ||
+                    ((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".array",
+                        expected: "(Array<number> | undefined)",
+                        value: input.array,
+                    })) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ((("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        })) &&
+                        $ao1(
+                            input.object,
+                            _path + ".object",
+                            true && _exceptionable,
+                        )) ||
+                    $guard(_exceptionable, {
+                        path: _path + ".object",
+                        expected: "(ObjectRequired.IBase | null | undefined)",
+                        value: input.object,
+                    })) &&
+                (0 === Object.keys(input).length ||
+                    false === _exceptionable ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return $guard(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                        });
+                    }));
+            return (
+                ((("object" === typeof input && null !== input) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })) &&
+                    $ao0(input, _path + "", true)) ||
+                $guard(true, {
+                    path: _path + "",
+                    expected: "Required<ObjectRequired.IBase>",
+                    value: input,
+                })
+            );
+        })(input, "$input", true);
+    return input;
+});

--- a/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionImplicit.ts
+++ b/test/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionImplicit.ts
@@ -209,12 +209,12 @@ export const test_createAssertEquals_ObjectUnionImplicit = _test_assertEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid, true && _exceptionable))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,7 +222,7 @@ export const test_createAssertEquals_ObjectUnionImplicit = _test_assertEquals(
                 (1 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["centroid", "radius", "area"].some(
+                            ["radius", "centroid", "area"].some(
                                 (prop: any) => key === prop,
                             )
                         )
@@ -761,6 +761,13 @@ export const test_createAssertEquals_ObjectUnionImplicit = _test_assertEquals(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -781,13 +788,6 @@ export const test_createAssertEquals_ObjectUnionImplicit = _test_assertEquals(
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
                         })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
-                        })) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -801,7 +801,7 @@ export const test_createAssertEquals_ObjectUnionImplicit = _test_assertEquals(
                         false === _exceptionable ||
                         Object.keys(input).every((key: any) => {
                             if (
-                                ["centroid", "radius", "area"].some(
+                                ["radius", "centroid", "area"].some(
                                     (prop: any) => key === prop,
                                 )
                             )

--- a/test/generated/output/createEquals/test_createEquals_ObjectPartial.ts
+++ b/test/generated/output/createEquals/test_createEquals_ObjectPartial.ts
@@ -1,0 +1,72 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createEquals_ObjectPartial = _test_equals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: any, _exceptionable: boolean = true): input is ObjectPartial => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index2: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input, true)
+        );
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createEquals/test_createEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,42 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createEquals_ObjectPartialAndRequired = _test_equals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is ObjectPartialAndRequired => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object, true && _exceptionable))) &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index1: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (2 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["string", "number", "boolean", "object", "array"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_ObjectRequired.ts
+++ b/test/generated/output/createEquals/test_createEquals_ObjectRequired.ts
@@ -1,0 +1,69 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createEquals_ObjectRequired = _test_equals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: any, _exceptionable: boolean = true): input is ObjectRequired => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index1: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index2: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    },
+);

--- a/test/generated/output/createEquals/test_createEquals_ObjectUnionImplicit.ts
+++ b/test/generated/output/createEquals/test_createEquals_ObjectUnionImplicit.ts
@@ -179,12 +179,12 @@ export const test_createEquals_ObjectUnionImplicit = _test_equals(
                     return false;
                 }));
         const $io6 = (input: any, _exceptionable: boolean = true): boolean =>
+            "number" === typeof input.radius &&
+            Number.isFinite(input.radius) &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid, true && _exceptionable))) &&
-            "number" === typeof input.radius &&
-            Number.isFinite(input.radius) &&
             (null === input.area ||
                 undefined === input.area ||
                 ("number" === typeof input.area &&
@@ -192,7 +192,7 @@ export const test_createEquals_ObjectUnionImplicit = _test_equals(
             (1 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (
-                        ["centroid", "radius", "area"].some(
+                        ["radius", "centroid", "area"].some(
                             (prop: any) => key === prop,
                         )
                     )

--- a/test/generated/output/createIs/test_createIs_ObjectPartial.ts
+++ b/test/generated/output/createIs/test_createIs_ObjectPartial.ts
@@ -1,0 +1,44 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createIs_ObjectPartial = _test_is(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): input is ObjectPartial => {
+    const $io0 = (input: any): boolean =>
+        (undefined === input.boolean || "boolean" === typeof input.boolean) &&
+        (undefined === input.number ||
+            ("number" === typeof input.number &&
+                Number.isFinite(input.number))) &&
+        (undefined === input.string || "string" === typeof input.string) &&
+        (undefined === input.array ||
+            (Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ))) &&
+        (null === input.object ||
+            undefined === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                $io1(input.object)));
+    const $io1 = (input: any): boolean =>
+        "boolean" === typeof input.boolean &&
+        "number" === typeof input.number &&
+        Number.isFinite(input.number) &&
+        "string" === typeof input.string &&
+        Array.isArray(input.array) &&
+        input.array.every(
+            (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+        ) &&
+        (null === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                $io1(input.object)));
+    return (
+        "object" === typeof input &&
+        null !== input &&
+        false === Array.isArray(input) &&
+        $io0(input)
+    );
+});

--- a/test/generated/output/createIs/test_createIs_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createIs/test_createIs_ObjectPartialAndRequired.ts
@@ -1,0 +1,27 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createIs_ObjectPartialAndRequired = _test_is(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (input: any): input is ObjectPartialAndRequired => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            );
+        return "object" === typeof input && null !== input && $io0(input);
+    },
+);

--- a/test/generated/output/createIs/test_createIs_ObjectRequired.ts
+++ b/test/generated/output/createIs/test_createIs_ObjectRequired.ts
@@ -1,0 +1,41 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createIs_ObjectRequired = _test_is(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: any): input is ObjectRequired => {
+    const $io0 = (input: any): boolean =>
+        "boolean" === typeof input.boolean &&
+        "number" === typeof input.number &&
+        Number.isFinite(input.number) &&
+        "string" === typeof input.string &&
+        Array.isArray(input.array) &&
+        input.array.every(
+            (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+        ) &&
+        (null === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                false === Array.isArray(input.object) &&
+                $io1(input.object)));
+    const $io1 = (input: any): boolean =>
+        (undefined === input.boolean || "boolean" === typeof input.boolean) &&
+        (undefined === input.number ||
+            ("number" === typeof input.number &&
+                Number.isFinite(input.number))) &&
+        (undefined === input.string || "string" === typeof input.string) &&
+        (undefined === input.array ||
+            (Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ))) &&
+        (null === input.object ||
+            undefined === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                false === Array.isArray(input.object) &&
+                $io1(input.object)));
+    return "object" === typeof input && null !== input && $io0(input);
+});

--- a/test/generated/output/createIs/test_createIs_ObjectUnionImplicit.ts
+++ b/test/generated/output/createIs/test_createIs_ObjectUnionImplicit.ts
@@ -104,12 +104,12 @@ export const test_createIs_ObjectUnionImplicit = _test_is(
                 ("number" === typeof input.area &&
                     Number.isFinite(input.area)));
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
+            Number.isFinite(input.radius) &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
-            Number.isFinite(input.radius) &&
             (null === input.area ||
                 undefined === input.area ||
                 ("number" === typeof input.area &&

--- a/test/generated/output/createRandom/test_createRandom_ObjectPartial.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectPartial.ts
@@ -1,0 +1,279 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createRandom_ObjectPartial = _test_random(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    random: (
+        generator?: Partial<typia.IRandomGenerator>,
+    ): typia.Resolved<ObjectPartial> => {
+        const $generator = (typia.createRandom as any).generator;
+        const $pick = (typia.createRandom as any).pick;
+        const $ro0 = (
+            _recursive: boolean = false,
+            _depth: number = 0,
+        ): any => ({
+            boolean: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
+            number: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+            ])(),
+            string: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+            ])(),
+            array: $pick([
+                () => undefined,
+                () =>
+                    (generator?.array ?? $generator.array)(
+                        () =>
+                            (
+                                generator?.customs ?? $generator.customs
+                            )?.number?.([]) ??
+                            (generator?.number ?? $generator.number)(0, 100),
+                    ),
+            ])(),
+            object: $pick([
+                () => undefined,
+                () => null,
+                () => $ro1(_recursive, _recursive ? 1 + _depth : _depth),
+            ])(),
+        });
+        const $ro1 = (_recursive: boolean = true, _depth: number = 0): any => ({
+            boolean: (generator?.boolean ?? $generator.boolean)(),
+            number:
+                (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                (generator?.number ?? $generator.number)(0, 100),
+            string:
+                (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                (generator?.string ?? $generator.string)(),
+            array:
+                _recursive && 5 < _depth
+                    ? []
+                    : 5 >= _depth
+                    ? (generator?.array ?? $generator.array)(
+                          () =>
+                              (
+                                  generator?.customs ?? $generator.customs
+                              )?.number?.([]) ??
+                              (generator?.number ?? $generator.number)(0, 100),
+                      )
+                    : [],
+            object: $pick([
+                () => null,
+                () => $ro1(true, _recursive ? 1 + _depth : _depth),
+            ])(),
+        });
+        return $ro0();
+    },
+    assert: (input: any): ObjectPartial => {
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/createRandom/test_createRandom_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectPartialAndRequired.ts
@@ -1,0 +1,160 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createRandom_ObjectPartialAndRequired = _test_random(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+    random: (
+        generator?: Partial<typia.IRandomGenerator>,
+    ): typia.Resolved<ObjectPartialAndRequired> => {
+        const $generator = (typia.createRandom as any).generator;
+        const $pick = (typia.createRandom as any).pick;
+        const $ro0 = (_recursive: boolean = true, _depth: number = 0): any => ({
+            string: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+            ])(),
+            number: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+            ])(),
+            boolean: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
+            object: $pick([
+                () => null,
+                () => $ro0(true, _recursive ? 1 + _depth : _depth),
+            ])(),
+            array:
+                _recursive && 5 < _depth
+                    ? []
+                    : 5 >= _depth
+                    ? (generator?.array ?? $generator.array)(
+                          () =>
+                              (
+                                  generator?.customs ?? $generator.customs
+                              )?.number?.([]) ??
+                              (generator?.number ?? $generator.number)(0, 100),
+                      )
+                    : [],
+        });
+        return $ro0();
+    },
+    assert: (input: any): ObjectPartialAndRequired => {
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/createRandom/test_createRandom_ObjectRequired.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectRequired.ts
@@ -1,0 +1,276 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createRandom_ObjectRequired = _test_random(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    random: (
+        generator?: Partial<typia.IRandomGenerator>,
+    ): typia.Resolved<ObjectRequired> => {
+        const $generator = (typia.createRandom as any).generator;
+        const $pick = (typia.createRandom as any).pick;
+        const $ro0 = (
+            _recursive: boolean = false,
+            _depth: number = 0,
+        ): any => ({
+            boolean: (generator?.boolean ?? $generator.boolean)(),
+            number:
+                (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                (generator?.number ?? $generator.number)(0, 100),
+            string:
+                (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                (generator?.string ?? $generator.string)(),
+            array: (generator?.array ?? $generator.array)(
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+            ),
+            object: $pick([
+                () => null,
+                () => $ro1(_recursive, _recursive ? 1 + _depth : _depth),
+            ])(),
+        });
+        const $ro1 = (_recursive: boolean = true, _depth: number = 0): any => ({
+            boolean: $pick([
+                () => undefined,
+                () => (generator?.boolean ?? $generator.boolean)(),
+            ])(),
+            number: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+            ])(),
+            string: $pick([
+                () => undefined,
+                () =>
+                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+            ])(),
+            array: $pick([
+                () => undefined,
+                () =>
+                    _recursive && 5 < _depth
+                        ? []
+                        : 5 >= _depth
+                        ? (generator?.array ?? $generator.array)(
+                              () =>
+                                  (
+                                      generator?.customs ?? $generator.customs
+                                  )?.number?.([]) ??
+                                  (generator?.number ?? $generator.number)(
+                                      0,
+                                      100,
+                                  ),
+                          )
+                        : [],
+            ])(),
+            object: $pick([
+                () => undefined,
+                () => null,
+                () => $ro1(true, _recursive ? 1 + _depth : _depth),
+            ])(),
+        });
+        return $ro0();
+    },
+    assert: (input: any): ObjectRequired => {
+        const __is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/createRandom/test_createRandom_ObjectUnionImplicit.ts
+++ b/test/generated/output/createRandom/test_createRandom_ObjectUnionImplicit.ts
@@ -147,13 +147,13 @@ export const test_createRandom_ObjectUnionImplicit = _test_random(
             _recursive: boolean = false,
             _depth: number = 0,
         ): any => ({
+            radius:
+                (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                (generator?.number ?? $generator.number)(0, 100),
             centroid: $pick([
                 () => undefined,
                 () => $ro0(_recursive, _recursive ? 1 + _depth : _depth),
             ])(),
-            radius:
-                (generator?.customs ?? $generator.customs)?.number?.([]) ??
-                (generator?.number ?? $generator.number)(0, 100),
             area: $pick([
                 () => undefined,
                 () => null,
@@ -274,12 +274,12 @@ export const test_createRandom_ObjectUnionImplicit = _test_random(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -692,6 +692,13 @@ export const test_createRandom_ObjectUnionImplicit = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -711,13 +718,6 @@ export const test_createRandom_ObjectUnionImplicit = _test_random(
                             expected:
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
-                        })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
                         })) &&
                     (null === input.area ||
                         undefined === input.area ||

--- a/test/generated/output/createValidate/test_createValidate_ObjectPartial.ts
+++ b/test/generated/output/createValidate/test_createValidate_ObjectPartial.ts
@@ -1,0 +1,233 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createValidate_ObjectPartial = _test_validate(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: any): typia.IValidation<ObjectPartial> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidate/test_createValidate_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createValidate/test_createValidate_ObjectPartialAndRequired.ts
@@ -1,0 +1,135 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createValidate_ObjectPartialAndRequired = _test_validate(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (input: any): typia.IValidation<ObjectPartialAndRequired> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo0(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidate/test_createValidate_ObjectRequired.ts
+++ b/test/generated/output/createValidate/test_createValidate_ObjectRequired.ts
@@ -1,0 +1,230 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createValidate_ObjectRequired = _test_validate(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: any): typia.IValidation<ObjectRequired> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidate/test_createValidate_ObjectUnionImplicit.ts
+++ b/test/generated/output/createValidate/test_createValidate_ObjectUnionImplicit.ts
@@ -106,12 +106,12 @@ export const test_createValidate_ObjectUnionImplicit = _test_validate(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -561,6 +561,13 @@ export const test_createValidate_ObjectUnionImplicit = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
+                        ("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            }),
                         undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -580,13 +587,6 @@ export const test_createValidate_ObjectUnionImplicit = _test_validate(
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            }),
-                        ("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             }),
                         null === input.area ||
                             undefined === input.area ||

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectPartial.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectPartial.ts
@@ -1,0 +1,321 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_createValidateEquals_ObjectPartial = _test_validateEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: any): typia.IValidation<ObjectPartial> => {
+        const errors = [] as any[];
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartial => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index2: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input, true)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidateEquals as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $join = (typia.createValidateEquals as any).join;
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                        0 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }),
+                        5 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,182 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_createValidateEquals_ObjectPartialAndRequired =
+    _test_validateEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: any): typia.IValidation<ObjectPartialAndRequired> => {
+        const errors = [] as any[];
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartialAndRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object, true && _exceptionable))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (2 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "string",
+                                "number",
+                                "boolean",
+                                "object",
+                                "array",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidateEquals as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $join = (typia.createValidateEquals as any).join;
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo0(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        2 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "object",
+                                            "array",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    });

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectRequired.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectRequired.ts
@@ -1,0 +1,320 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_createValidateEquals_ObjectRequired = _test_validateEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: any): typia.IValidation<ObjectRequired> => {
+        const errors = [] as any[];
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.createValidateEquals as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $join = (typia.createValidateEquals as any).join;
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }),
+                        5 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                        0 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    },
+);

--- a/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionImplicit.ts
+++ b/test/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionImplicit.ts
@@ -210,12 +210,12 @@ export const test_createValidateEquals_ObjectUnionImplicit =
                 input: any,
                 _exceptionable: boolean = true,
             ): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid, true && _exceptionable))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -223,7 +223,7 @@ export const test_createValidateEquals_ObjectUnionImplicit =
                 (1 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["centroid", "radius", "area"].some(
+                            ["radius", "centroid", "area"].some(
                                 (prop: any) => key === prop,
                             )
                         )
@@ -811,6 +811,13 @@ export const test_createValidateEquals_ObjectUnionImplicit =
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
+                        ("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            }),
                         undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -831,13 +838,6 @@ export const test_createValidateEquals_ObjectUnionImplicit =
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
                             }),
-                        ("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
-                            }),
                         null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -852,7 +852,7 @@ export const test_createValidateEquals_ObjectUnionImplicit =
                             Object.keys(input)
                                 .map((key: any) => {
                                     if (
-                                        ["centroid", "radius", "area"].some(
+                                        ["radius", "centroid", "area"].some(
                                             (prop: any) => key === prop,
                                         )
                                     )

--- a/test/generated/output/equals/test_equals_ObjectPartial.ts
+++ b/test/generated/output/equals/test_equals_ObjectPartial.ts
@@ -1,0 +1,72 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_equals_ObjectPartial = _test_equals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any, _exceptionable: boolean = true): input is ObjectPartial => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index2: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input, true)
+        );
+    })(input),
+);

--- a/test/generated/output/equals/test_equals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/equals/test_equals_ObjectPartialAndRequired.ts
@@ -1,0 +1,42 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_equals_ObjectPartialAndRequired = _test_equals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((
+        input: any,
+        _exceptionable: boolean = true,
+    ): input is ObjectPartialAndRequired => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object, true && _exceptionable))) &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index1: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (2 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["string", "number", "boolean", "object", "array"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    })(input),
+);

--- a/test/generated/output/equals/test_equals_ObjectRequired.ts
+++ b/test/generated/output/equals/test_equals_ObjectRequired.ts
@@ -1,0 +1,69 @@
+import typia from "../../../../src";
+import { _test_equals } from "../../../internal/_test_equals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_equals_ObjectRequired = _test_equals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any, _exceptionable: boolean = true): input is ObjectRequired => {
+        const $io0 = (input: any, _exceptionable: boolean = true): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any, _index1: number) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (5 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        const $io1 = (input: any, _exceptionable: boolean = true): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index2: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object, true && _exceptionable))) &&
+            (0 === Object.keys(input).length ||
+                Object.keys(input).every((key: any) => {
+                    if (
+                        ["boolean", "number", "string", "array", "object"].some(
+                            (prop: any) => key === prop,
+                        )
+                    )
+                        return true;
+                    const value = input[key];
+                    if (undefined === value) return true;
+                    return false;
+                }));
+        return "object" === typeof input && null !== input && $io0(input, true);
+    })(input),
+);

--- a/test/generated/output/equals/test_equals_ObjectUnionImplicit.ts
+++ b/test/generated/output/equals/test_equals_ObjectUnionImplicit.ts
@@ -179,12 +179,12 @@ export const test_equals_ObjectUnionImplicit = _test_equals(
                     return false;
                 }));
         const $io6 = (input: any, _exceptionable: boolean = true): boolean =>
+            "number" === typeof input.radius &&
+            Number.isFinite(input.radius) &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid, true && _exceptionable))) &&
-            "number" === typeof input.radius &&
-            Number.isFinite(input.radius) &&
             (null === input.area ||
                 undefined === input.area ||
                 ("number" === typeof input.area &&
@@ -192,7 +192,7 @@ export const test_equals_ObjectUnionImplicit = _test_equals(
             (1 === Object.keys(input).length ||
                 Object.keys(input).every((key: any) => {
                     if (
-                        ["centroid", "radius", "area"].some(
+                        ["radius", "centroid", "area"].some(
                             (prop: any) => key === prop,
                         )
                     )

--- a/test/generated/output/is/test_is_ObjectPartial.ts
+++ b/test/generated/output/is/test_is_ObjectPartial.ts
@@ -1,0 +1,48 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_is_ObjectPartial = _test_is("ObjectPartial")<ObjectPartial>(
+    ObjectPartial,
+)((input) =>
+    ((input: any): input is ObjectPartial => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input)
+        );
+    })(input),
+);

--- a/test/generated/output/is/test_is_ObjectPartialAndRequired.ts
+++ b/test/generated/output/is/test_is_ObjectPartialAndRequired.ts
@@ -1,0 +1,27 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_is_ObjectPartialAndRequired = _test_is(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): input is ObjectPartialAndRequired => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            );
+        return "object" === typeof input && null !== input && $io0(input);
+    })(input),
+);

--- a/test/generated/output/is/test_is_ObjectRequired.ts
+++ b/test/generated/output/is/test_is_ObjectRequired.ts
@@ -1,0 +1,45 @@
+import typia from "../../../../src";
+import { _test_is } from "../../../internal/_test_is";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_is_ObjectRequired = _test_is(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): input is ObjectRequired => {
+        const $io0 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        return "object" === typeof input && null !== input && $io0(input);
+    })(input),
+);

--- a/test/generated/output/is/test_is_ObjectUnionImplicit.ts
+++ b/test/generated/output/is/test_is_ObjectUnionImplicit.ts
@@ -104,12 +104,12 @@ export const test_is_ObjectUnionImplicit = _test_is(
                 ("number" === typeof input.area &&
                     Number.isFinite(input.area)));
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
+            Number.isFinite(input.radius) &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
-            Number.isFinite(input.radius) &&
             (null === input.area ||
                 undefined === input.area ||
                 ("number" === typeof input.area &&

--- a/test/generated/output/json.application/ajv/test_application_ajv_ObjectPartial.ts
+++ b/test/generated/output/json.application/ajv/test_application_ajv_ObjectPartial.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectPartial } from "../../../../structures/ObjectPartial";
+
+export const test_json_application_ajv_ObjectPartial = _test_json_application(
+    "ajv",
+)("ObjectPartial")(typia.json.application<[ObjectPartial], "ajv">());

--- a/test/generated/output/json.application/ajv/test_application_ajv_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.application/ajv/test_application_ajv_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectPartialAndRequired } from "../../../../structures/ObjectPartialAndRequired";
+
+export const test_json_application_ajv_ObjectPartialAndRequired =
+    _test_json_application("ajv")("ObjectPartialAndRequired")(
+        typia.json.application<[ObjectPartialAndRequired], "ajv">(),
+    );

--- a/test/generated/output/json.application/ajv/test_application_ajv_ObjectRequired.ts
+++ b/test/generated/output/json.application/ajv/test_application_ajv_ObjectRequired.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectRequired } from "../../../../structures/ObjectRequired";
+
+export const test_json_application_ajv_ObjectRequired = _test_json_application(
+    "ajv",
+)("ObjectRequired")(typia.json.application<[ObjectRequired], "ajv">());

--- a/test/generated/output/json.application/swagger/test_application_swagger_ObjectPartial.ts
+++ b/test/generated/output/json.application/swagger/test_application_swagger_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectPartial } from "../../../../structures/ObjectPartial";
+
+export const test_json_application_swagger_ObjectPartial =
+    _test_json_application("swagger")("ObjectPartial")(
+        typia.json.application<[ObjectPartial], "swagger">(),
+    );

--- a/test/generated/output/json.application/swagger/test_application_swagger_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.application/swagger/test_application_swagger_ObjectPartialAndRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectPartialAndRequired } from "../../../../structures/ObjectPartialAndRequired";
+
+export const test_json_application_swagger_ObjectPartialAndRequired =
+    _test_json_application("swagger")("ObjectPartialAndRequired")(
+        typia.json.application<[ObjectPartialAndRequired], "swagger">(),
+    );

--- a/test/generated/output/json.application/swagger/test_application_swagger_ObjectRequired.ts
+++ b/test/generated/output/json.application/swagger/test_application_swagger_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+import { _test_json_application } from "../../../../internal/_test_json_application";
+import { ObjectRequired } from "../../../../structures/ObjectRequired";
+
+export const test_json_application_swagger_ObjectRequired =
+    _test_json_application("swagger")("ObjectRequired")(
+        typia.json.application<[ObjectRequired], "swagger">(),
+    );

--- a/test/generated/output/json.assertParse/test_json_assertParse_ObjectPartial.ts
+++ b/test/generated/output/json.assertParse/test_json_assertParse_ObjectPartial.ts
@@ -1,0 +1,218 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_assertParse_ObjectPartial = _test_json_assertParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: string): typia.Primitive<ObjectPartial> => {
+        const assert = (input: any): ObjectPartial => {
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $guard = (typia.json.assertParse as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input) as any;
+    })(input),
+);

--- a/test/generated/output/json.assertParse/test_json_assertParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.assertParse/test_json_assertParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,137 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_assertParse_ObjectPartialAndRequired =
+    _test_json_assertParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: string): typia.Primitive<ObjectPartialAndRequired> => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.json.assertParse as any).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input) as any;
+        })(input),
+    );

--- a/test/generated/output/json.assertParse/test_json_assertParse_ObjectRequired.ts
+++ b/test/generated/output/json.assertParse/test_json_assertParse_ObjectRequired.ts
@@ -1,0 +1,217 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_assertParse_ObjectRequired = _test_json_assertParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: string): typia.Primitive<ObjectRequired> => {
+        const assert = (input: any): ObjectRequired => {
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $guard = (typia.json.assertParse as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input) as any;
+    })(input),
+);

--- a/test/generated/output/json.assertParse/test_json_assertParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.assertParse/test_json_assertParse_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_json_assertParse_ObjectUnionImplicit = _test_json_assertParse(
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_json_assertParse_ObjectUnionImplicit = _test_json_assertParse(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_json_assertParse_ObjectUnionImplicit = _test_json_assertParse(
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||

--- a/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectPartial.ts
+++ b/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectPartial.ts
@@ -1,0 +1,305 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_assertStringify_ObjectPartial =
+    _test_json_assertStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input) =>
+            ((input: any): string => {
+                const assert = (input: any): ObjectPartial => {
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $guard = (typia.json.assertStringify as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array.every(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }));
+                            const $ao1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                ("boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    })) &&
+                                (("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    })) &&
+                                ("string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const stringify = (input: ObjectPartial): string => {
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $number = (typia.json.assertStringify as any).number;
+                    const $string = (typia.json.assertStringify as any).string;
+                    const $tail = (typia.json.assertStringify as any).tail;
+                    const $so0 = (input: any): any =>
+                        `{${$tail(
+                            `${
+                                undefined === input.boolean
+                                    ? ""
+                                    : `"boolean":${
+                                          undefined !== input.boolean
+                                              ? input.boolean
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.number
+                                    ? ""
+                                    : `"number":${
+                                          undefined !== input.number
+                                              ? $number(input.number)
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.string
+                                    ? ""
+                                    : `"string":${
+                                          undefined !== input.string
+                                              ? $string(input.string)
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.array
+                                    ? ""
+                                    : `"array":${
+                                          undefined !== input.array
+                                              ? `[${input.array
+                                                    .map((elem: any) =>
+                                                        $number(elem),
+                                                    )
+                                                    .join(",")}]`
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.object
+                                    ? ""
+                                    : `"object":${
+                                          undefined !== input.object
+                                              ? null !== input.object
+                                                  ? $so1(input.object)
+                                                  : "null"
+                                              : undefined
+                                      }`
+                            }`,
+                        )}}`;
+                    const $so1 = (input: any): any =>
+                        `{"boolean":${input.boolean},"number":${$number(
+                            input.number,
+                        )},"string":${$string(
+                            input.string,
+                        )},"array":${`[${input.array
+                            .map((elem: any) => $number(elem))
+                            .join(",")}]`},"object":${
+                            null !== input.object ? $so1(input.object) : "null"
+                        }}`;
+                    return $so0(input);
+                };
+                return stringify(assert(input));
+            })(input),
+    );

--- a/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,185 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_assertStringify_ObjectPartialAndRequired =
+    _test_json_assertStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: any): string => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.json.assertStringify as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.assertStringify as any).string;
+                const $number = (typia.json.assertStringify as any).number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            return stringify(assert(input));
+        })(input),
+    );

--- a/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectRequired.ts
+++ b/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectRequired.ts
@@ -1,0 +1,310 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_assertStringify_ObjectRequired =
+    _test_json_assertStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input) =>
+        ((input: any): string => {
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (typia.json.assertStringify as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: ObjectRequired): string => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $number = (typia.json.assertStringify as any).number;
+                const $string = (typia.json.assertStringify as any).string;
+                const $tail = (typia.json.assertStringify as any).tail;
+                const $so0 = (input: any): any =>
+                    `{"boolean":${input.boolean},"number":${$number(
+                        input.number,
+                    )},"string":${$string(
+                        input.string,
+                    )},"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`},"object":${
+                        null !== input.object ? $so1(input.object) : "null"
+                    }}`;
+                const $so1 = (input: any): any =>
+                    `{${$tail(
+                        `${
+                            undefined === input.boolean
+                                ? ""
+                                : `"boolean":${
+                                      undefined !== input.boolean
+                                          ? input.boolean
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.number
+                                ? ""
+                                : `"number":${
+                                      undefined !== input.number
+                                          ? $number(input.number)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.string
+                                ? ""
+                                : `"string":${
+                                      undefined !== input.string
+                                          ? $string(input.string)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.array
+                                ? ""
+                                : `"array":${
+                                      undefined !== input.array
+                                          ? `[${input.array
+                                                .map((elem: any) =>
+                                                    $number(elem),
+                                                )
+                                                .join(",")}]`
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.object
+                                ? ""
+                                : `"object":${
+                                      undefined !== input.object
+                                          ? null !== input.object
+                                              ? $so1(input.object)
+                                              : "null"
+                                          : undefined
+                                  }`
+                        }`,
+                    )}}`;
+                return $so0(input);
+            };
+            return stringify(assert(input));
+        })(input),
+    );

--- a/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.assertStringify/test_json_assertStringify_ObjectUnionImplicit.ts
@@ -109,12 +109,12 @@ export const test_json_assertStringify_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -565,6 +565,13 @@ export const test_json_assertStringify_ObjectUnionImplicit =
                             _path: string,
                             _exceptionable: boolean = true,
                         ): boolean =>
+                            (("number" === typeof input.radius &&
+                                Number.isFinite(input.radius)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".radius",
+                                    expected: "number",
+                                    value: input.radius,
+                                })) &&
                             (undefined === input.centroid ||
                                 ((("object" === typeof input.centroid &&
                                     null !== input.centroid) ||
@@ -584,13 +591,6 @@ export const test_json_assertStringify_ObjectUnionImplicit =
                                     expected:
                                         "(ObjectUnionImplicit.IPoint | undefined)",
                                     value: input.centroid,
-                                })) &&
-                            (("number" === typeof input.radius &&
-                                Number.isFinite(input.radius)) ||
-                                $guard(_exceptionable, {
-                                    path: _path + ".radius",
-                                    expected: "number",
-                                    value: input.radius,
                                 })) &&
                             (null === input.area ||
                                 undefined === input.area ||
@@ -780,11 +780,11 @@ export const test_json_assertStringify_ObjectUnionImplicit =
                         undefined === input.area ||
                         "number" === typeof input.area);
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
                     (null === input.area ||
                         undefined === input.area ||
                         "number" === typeof input.area);

--- a/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectPartial.ts
+++ b/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectPartial.ts
@@ -1,0 +1,218 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createAssertParse_ObjectPartial = _test_json_assertParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: string): typia.Primitive<ObjectPartial> => {
+        const assert = (input: any): ObjectPartial => {
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $guard = (typia.json.createAssertParse as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        input = JSON.parse(input);
+        return assert(input) as any;
+    },
+);

--- a/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,138 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createAssertParse_ObjectPartialAndRequired =
+    _test_json_assertParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: string): typia.Primitive<ObjectPartialAndRequired> => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.json.createAssertParse as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input) as any;
+        },
+    );

--- a/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectRequired.ts
+++ b/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectRequired.ts
@@ -1,0 +1,225 @@
+import typia from "../../../../src";
+import { _test_json_assertParse } from "../../../internal/_test_json_assertParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createAssertParse_ObjectRequired =
+    _test_json_assertParse("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: string): typia.Primitive<ObjectRequired> => {
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (typia.json.createAssertParse as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            input = JSON.parse(input);
+            return assert(input) as any;
+        },
+    );

--- a/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_json_createAssertParse_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_json_createAssertParse_ObjectUnionImplicit =
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_json_createAssertParse_ObjectUnionImplicit =
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||

--- a/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectPartial.ts
+++ b/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectPartial.ts
@@ -1,0 +1,303 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createAssertStringify_ObjectPartial =
+    _test_json_assertStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input: any): string => {
+            const assert = (input: any): ObjectPartial => {
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $guard = (typia.json.createAssertStringify as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: ObjectPartial): string => {
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $number = (typia.json.createAssertStringify as any)
+                    .number;
+                const $string = (typia.json.createAssertStringify as any)
+                    .string;
+                const $tail = (typia.json.createAssertStringify as any).tail;
+                const $so0 = (input: any): any =>
+                    `{${$tail(
+                        `${
+                            undefined === input.boolean
+                                ? ""
+                                : `"boolean":${
+                                      undefined !== input.boolean
+                                          ? input.boolean
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.number
+                                ? ""
+                                : `"number":${
+                                      undefined !== input.number
+                                          ? $number(input.number)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.string
+                                ? ""
+                                : `"string":${
+                                      undefined !== input.string
+                                          ? $string(input.string)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.array
+                                ? ""
+                                : `"array":${
+                                      undefined !== input.array
+                                          ? `[${input.array
+                                                .map((elem: any) =>
+                                                    $number(elem),
+                                                )
+                                                .join(",")}]`
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.object
+                                ? ""
+                                : `"object":${
+                                      undefined !== input.object
+                                          ? null !== input.object
+                                              ? $so1(input.object)
+                                              : "null"
+                                          : undefined
+                                  }`
+                        }`,
+                    )}}`;
+                const $so1 = (input: any): any =>
+                    `{"boolean":${input.boolean},"number":${$number(
+                        input.number,
+                    )},"string":${$string(
+                        input.string,
+                    )},"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`},"object":${
+                        null !== input.object ? $so1(input.object) : "null"
+                    }}`;
+                return $so0(input);
+            };
+            return stringify(assert(input));
+        },
+    );

--- a/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,187 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createAssertStringify_ObjectPartialAndRequired =
+    _test_json_assertStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: any): string => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.json.createAssertStringify as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.createAssertStringify as any)
+                    .string;
+                const $number = (typia.json.createAssertStringify as any)
+                    .number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            return stringify(assert(input));
+        },
+    );

--- a/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectRequired.ts
+++ b/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectRequired.ts
@@ -1,0 +1,296 @@
+import typia from "../../../../src";
+import { _test_json_assertStringify } from "../../../internal/_test_json_assertStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createAssertStringify_ObjectRequired =
+    _test_json_assertStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input: any): string => {
+        const assert = (input: any): ObjectRequired => {
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $guard = (typia.json.createAssertStringify as any)
+                        .guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const stringify = (input: ObjectRequired): string => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $number = (typia.json.createAssertStringify as any).number;
+            const $string = (typia.json.createAssertStringify as any).string;
+            const $tail = (typia.json.createAssertStringify as any).tail;
+            const $so0 = (input: any): any =>
+                `{"boolean":${input.boolean},"number":${$number(
+                    input.number,
+                )},"string":${$string(input.string)},"array":${`[${input.array
+                    .map((elem: any) => $number(elem))
+                    .join(",")}]`},"object":${
+                    null !== input.object ? $so1(input.object) : "null"
+                }}`;
+            const $so1 = (input: any): any =>
+                `{${$tail(
+                    `${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.array
+                            ? ""
+                            : `"array":${
+                                  undefined !== input.array
+                                      ? `[${input.array
+                                            .map((elem: any) => $number(elem))
+                                            .join(",")}]`
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.object
+                            ? ""
+                            : `"object":${
+                                  undefined !== input.object
+                                      ? null !== input.object
+                                          ? $so1(input.object)
+                                          : "null"
+                                      : undefined
+                              }`
+                    }`,
+                )}}`;
+            return $so0(input);
+        };
+        return stringify(assert(input));
+    });

--- a/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_json_createAssertStringify_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -551,6 +551,13 @@ export const test_json_createAssertStringify_ObjectUnionImplicit =
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -570,13 +577,6 @@ export const test_json_createAssertStringify_ObjectUnionImplicit =
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||
@@ -763,11 +763,11 @@ export const test_json_createAssertStringify_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);

--- a/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectPartial.ts
+++ b/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectPartial.ts
@@ -1,0 +1,54 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createIsParse_ObjectPartial = _test_json_isParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: any): typia.Primitive<ObjectPartial> => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    },
+);

--- a/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,31 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createIsParse_ObjectPartialAndRequired =
+    _test_json_isParse("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: any): typia.Primitive<ObjectPartialAndRequired> => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    });

--- a/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectRequired.ts
+++ b/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectRequired.ts
@@ -1,0 +1,51 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createIsParse_ObjectRequired = _test_json_isParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: any): typia.Primitive<ObjectRequired> => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    },
+);

--- a/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_json_createIsParse_ObjectUnionImplicit = _test_json_isParse(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&

--- a/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectPartial.ts
+++ b/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectPartial.ts
@@ -1,0 +1,121 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createIsStringify_ObjectPartial = _test_json_isStringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: ObjectPartial): string | null => {
+    const is = (input: any): input is ObjectPartial => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input)
+        );
+    };
+    const stringify = (input: ObjectPartial): string => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $number = (typia.json.createIsStringify as any).number;
+        const $string = (typia.json.createIsStringify as any).string;
+        const $tail = (typia.json.createIsStringify as any).tail;
+        const $so0 = (input: any): any =>
+            `{${$tail(
+                `${
+                    undefined === input.boolean
+                        ? ""
+                        : `"boolean":${
+                              undefined !== input.boolean
+                                  ? input.boolean
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.number
+                        ? ""
+                        : `"number":${
+                              undefined !== input.number
+                                  ? $number(input.number)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.string
+                        ? ""
+                        : `"string":${
+                              undefined !== input.string
+                                  ? $string(input.string)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.array
+                        ? ""
+                        : `"array":${
+                              undefined !== input.array
+                                  ? `[${input.array
+                                        .map((elem: any) => $number(elem))
+                                        .join(",")}]`
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.object
+                        ? ""
+                        : `"object":${
+                              undefined !== input.object
+                                  ? null !== input.object
+                                      ? $so1(input.object)
+                                      : "null"
+                                  : undefined
+                          }`
+                }`,
+            )}}`;
+        const $so1 = (input: any): any =>
+            `{"boolean":${input.boolean},"number":${$number(
+                input.number,
+            )},"string":${$string(input.string)},"array":${`[${input.array
+                .map((elem: any) => $number(elem))
+                .join(",")}]`},"object":${
+                null !== input.object ? $so1(input.object) : "null"
+            }}`;
+        return $so0(input);
+    };
+    return is(input) ? stringify(input) : null;
+});

--- a/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,82 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createIsStringify_ObjectPartialAndRequired =
+    _test_json_isStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: ObjectPartialAndRequired): string | null => {
+            const is = (input: any): input is ObjectPartialAndRequired => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    );
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.createIsStringify as any).string;
+                const $number = (typia.json.createIsStringify as any).number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            return is(input) ? stringify(input) : null;
+        },
+    );

--- a/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectRequired.ts
+++ b/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectRequired.ts
@@ -1,0 +1,135 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createIsStringify_ObjectRequired =
+    _test_json_isStringify("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: ObjectRequired): string | null => {
+            const is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const stringify = (input: ObjectRequired): string => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $number = (typia.json.createIsStringify as any).number;
+                const $string = (typia.json.createIsStringify as any).string;
+                const $tail = (typia.json.createIsStringify as any).tail;
+                const $so0 = (input: any): any =>
+                    `{"boolean":${input.boolean},"number":${$number(
+                        input.number,
+                    )},"string":${$string(
+                        input.string,
+                    )},"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`},"object":${
+                        null !== input.object ? $so1(input.object) : "null"
+                    }}`;
+                const $so1 = (input: any): any =>
+                    `{${$tail(
+                        `${
+                            undefined === input.boolean
+                                ? ""
+                                : `"boolean":${
+                                      undefined !== input.boolean
+                                          ? input.boolean
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.number
+                                ? ""
+                                : `"number":${
+                                      undefined !== input.number
+                                          ? $number(input.number)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.string
+                                ? ""
+                                : `"string":${
+                                      undefined !== input.string
+                                          ? $string(input.string)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.array
+                                ? ""
+                                : `"array":${
+                                      undefined !== input.array
+                                          ? `[${input.array
+                                                .map((elem: any) =>
+                                                    $number(elem),
+                                                )
+                                                .join(",")}]`
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.object
+                                ? ""
+                                : `"object":${
+                                      undefined !== input.object
+                                          ? null !== input.object
+                                              ? $so1(input.object)
+                                              : "null"
+                                          : undefined
+                                  }`
+                        }`,
+                    )}}`;
+                return $so0(input);
+            };
+            return is(input) ? stringify(input) : null;
+        },
+    );

--- a/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_json_createIsStringify_ObjectUnionImplicit =
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,11 +222,11 @@ export const test_json_createIsStringify_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);

--- a/test/generated/output/json.createStringify/test_json_createStringify_ObjectPartial.ts
+++ b/test/generated/output/json.createStringify/test_json_createStringify_ObjectPartial.ts
@@ -1,0 +1,78 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createStringify_ObjectPartial = _test_json_stringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: ObjectPartial): string => {
+    const $io1 = (input: any): boolean =>
+        "boolean" === typeof input.boolean &&
+        "number" === typeof input.number &&
+        "string" === typeof input.string &&
+        Array.isArray(input.array) &&
+        input.array.every((elem: any) => "number" === typeof elem) &&
+        (null === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                $io1(input.object)));
+    const $number = (typia.json.createStringify as any).number;
+    const $string = (typia.json.createStringify as any).string;
+    const $tail = (typia.json.createStringify as any).tail;
+    const $so0 = (input: any): any =>
+        `{${$tail(
+            `${
+                undefined === input.boolean
+                    ? ""
+                    : `"boolean":${
+                          undefined !== input.boolean
+                              ? input.boolean
+                              : undefined
+                      },`
+            }${
+                undefined === input.number
+                    ? ""
+                    : `"number":${
+                          undefined !== input.number
+                              ? $number(input.number)
+                              : undefined
+                      },`
+            }${
+                undefined === input.string
+                    ? ""
+                    : `"string":${
+                          undefined !== input.string
+                              ? $string(input.string)
+                              : undefined
+                      },`
+            }${
+                undefined === input.array
+                    ? ""
+                    : `"array":${
+                          undefined !== input.array
+                              ? `[${input.array
+                                    .map((elem: any) => $number(elem))
+                                    .join(",")}]`
+                              : undefined
+                      },`
+            }${
+                undefined === input.object
+                    ? ""
+                    : `"object":${
+                          undefined !== input.object
+                              ? null !== input.object
+                                  ? $so1(input.object)
+                                  : "null"
+                              : undefined
+                      }`
+            }`,
+        )}}`;
+    const $so1 = (input: any): any =>
+        `{"boolean":${input.boolean},"number":${$number(
+            input.number,
+        )},"string":${$string(input.string)},"array":${`[${input.array
+            .map((elem: any) => $number(elem))
+            .join(",")}]`},"object":${
+            null !== input.object ? $so1(input.object) : "null"
+        }}`;
+    return $so0(input);
+});

--- a/test/generated/output/json.createStringify/test_json_createStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createStringify/test_json_createStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,53 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createStringify_ObjectPartialAndRequired =
+    _test_json_stringify("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: ObjectPartialAndRequired): string => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem);
+        const $string = (typia.json.createStringify as any).string;
+        const $number = (typia.json.createStringify as any).number;
+        const $so0 = (input: any): any =>
+            `{${
+                undefined === input.string
+                    ? ""
+                    : `"string":${
+                          undefined !== input.string
+                              ? $string(input.string)
+                              : undefined
+                      },`
+            }${
+                undefined === input.number
+                    ? ""
+                    : `"number":${
+                          undefined !== input.number
+                              ? $number(input.number)
+                              : undefined
+                      },`
+            }${
+                undefined === input.boolean
+                    ? ""
+                    : `"boolean":${
+                          undefined !== input.boolean
+                              ? input.boolean
+                              : undefined
+                      },`
+            }"object":${
+                null !== input.object ? $so0(input.object) : "null"
+            },"array":${`[${input.array
+                .map((elem: any) => $number(elem))
+                .join(",")}]`}}`;
+        return $so0(input);
+    });

--- a/test/generated/output/json.createStringify/test_json_createStringify_ObjectRequired.ts
+++ b/test/generated/output/json.createStringify/test_json_createStringify_ObjectRequired.ts
@@ -1,0 +1,81 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createStringify_ObjectRequired = _test_json_stringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: ObjectRequired): string => {
+    const $io1 = (input: any): boolean =>
+        (undefined === input.boolean || "boolean" === typeof input.boolean) &&
+        (undefined === input.number || "number" === typeof input.number) &&
+        (undefined === input.string || "string" === typeof input.string) &&
+        (undefined === input.array ||
+            (Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem))) &&
+        (null === input.object ||
+            undefined === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                false === Array.isArray(input.object) &&
+                $io1(input.object)));
+    const $number = (typia.json.createStringify as any).number;
+    const $string = (typia.json.createStringify as any).string;
+    const $tail = (typia.json.createStringify as any).tail;
+    const $so0 = (input: any): any =>
+        `{"boolean":${input.boolean},"number":${$number(
+            input.number,
+        )},"string":${$string(input.string)},"array":${`[${input.array
+            .map((elem: any) => $number(elem))
+            .join(",")}]`},"object":${
+            null !== input.object ? $so1(input.object) : "null"
+        }}`;
+    const $so1 = (input: any): any =>
+        `{${$tail(
+            `${
+                undefined === input.boolean
+                    ? ""
+                    : `"boolean":${
+                          undefined !== input.boolean
+                              ? input.boolean
+                              : undefined
+                      },`
+            }${
+                undefined === input.number
+                    ? ""
+                    : `"number":${
+                          undefined !== input.number
+                              ? $number(input.number)
+                              : undefined
+                      },`
+            }${
+                undefined === input.string
+                    ? ""
+                    : `"string":${
+                          undefined !== input.string
+                              ? $string(input.string)
+                              : undefined
+                      },`
+            }${
+                undefined === input.array
+                    ? ""
+                    : `"array":${
+                          undefined !== input.array
+                              ? `[${input.array
+                                    .map((elem: any) => $number(elem))
+                                    .join(",")}]`
+                              : undefined
+                      },`
+            }${
+                undefined === input.object
+                    ? ""
+                    : `"object":${
+                          undefined !== input.object
+                              ? null !== input.object
+                                  ? $so1(input.object)
+                                  : "null"
+                              : undefined
+                      }`
+            }`,
+        )}}`;
+    return $so0(input);
+});

--- a/test/generated/output/json.createStringify/test_json_createStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createStringify/test_json_createStringify_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_json_createStringify_ObjectUnionImplicit =
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);

--- a/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectPartial.ts
+++ b/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectPartial.ts
@@ -1,0 +1,244 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createValidateParse_ObjectPartial =
+    _test_json_validateParse("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input: string): typia.IValidation<typia.Primitive<ObjectPartial>> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.createValidateParse as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const output = JSON.parse(input);
+            return validate(output) as any;
+        },
+    );

--- a/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,154 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createValidateParse_ObjectPartialAndRequired =
+    _test_json_validateParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (
+            input: string,
+        ): typia.IValidation<typia.Primitive<ObjectPartialAndRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.createValidateParse as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const output = JSON.parse(input);
+            return validate(output) as any;
+        },
+    );

--- a/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectRequired.ts
+++ b/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectRequired.ts
@@ -1,0 +1,249 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createValidateParse_ObjectRequired =
+    _test_json_validateParse("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: string): typia.IValidation<typia.Primitive<ObjectRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.createValidateParse as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const output = JSON.parse(input);
+            return validate(output) as any;
+        },
+    );

--- a/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectUnionImplicit.ts
@@ -114,12 +114,12 @@ export const test_json_createValidateParse_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -595,6 +595,13 @@ export const test_json_createValidateParse_ObjectUnionImplicit =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                ("number" === typeof input.radius &&
+                                    Number.isFinite(input.radius)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".radius",
+                                        expected: "number",
+                                        value: input.radius,
+                                    }),
                                 undefined === input.centroid ||
                                     ((("object" === typeof input.centroid &&
                                         null !== input.centroid) ||
@@ -614,13 +621,6 @@ export const test_json_createValidateParse_ObjectUnionImplicit =
                                         expected:
                                             "(ObjectUnionImplicit.IPoint | undefined)",
                                         value: input.centroid,
-                                    }),
-                                ("number" === typeof input.radius &&
-                                    Number.isFinite(input.radius)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".radius",
-                                        expected: "number",
-                                        value: input.radius,
                                     }),
                                 null === input.area ||
                                     undefined === input.area ||

--- a/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectPartial.ts
+++ b/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectPartial.ts
@@ -1,0 +1,325 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_createValidateStringify_ObjectPartial =
+    _test_json_validateStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input: ObjectPartial): typia.IValidation<string> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.createValidateStringify as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: ObjectPartial): string => {
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $number = (typia.json.createValidateStringify as any)
+                    .number;
+                const $string = (typia.json.createValidateStringify as any)
+                    .string;
+                const $tail = (typia.json.createValidateStringify as any).tail;
+                const $so0 = (input: any): any =>
+                    `{${$tail(
+                        `${
+                            undefined === input.boolean
+                                ? ""
+                                : `"boolean":${
+                                      undefined !== input.boolean
+                                          ? input.boolean
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.number
+                                ? ""
+                                : `"number":${
+                                      undefined !== input.number
+                                          ? $number(input.number)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.string
+                                ? ""
+                                : `"string":${
+                                      undefined !== input.string
+                                          ? $string(input.string)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.array
+                                ? ""
+                                : `"array":${
+                                      undefined !== input.array
+                                          ? `[${input.array
+                                                .map((elem: any) =>
+                                                    $number(elem),
+                                                )
+                                                .join(",")}]`
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.object
+                                ? ""
+                                : `"object":${
+                                      undefined !== input.object
+                                          ? null !== input.object
+                                              ? $so1(input.object)
+                                              : "null"
+                                          : undefined
+                                  }`
+                        }`,
+                    )}}`;
+                const $so1 = (input: any): any =>
+                    `{"boolean":${input.boolean},"number":${$number(
+                        input.number,
+                    )},"string":${$string(
+                        input.string,
+                    )},"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`},"object":${
+                        null !== input.object ? $so1(input.object) : "null"
+                    }}`;
+                return $so0(input);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        },
+    );

--- a/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,203 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_createValidateStringify_ObjectPartialAndRequired =
+    _test_json_validateStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: ObjectPartialAndRequired): typia.IValidation<string> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.createValidateStringify as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.createValidateStringify as any)
+                    .string;
+                const $number = (typia.json.createValidateStringify as any)
+                    .number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        },
+    );

--- a/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectRequired.ts
+++ b/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectRequired.ts
@@ -1,0 +1,319 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_createValidateStringify_ObjectRequired =
+    _test_json_validateStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input: ObjectRequired): typia.IValidation<string> => {
+        const validate = (input: any): typia.IValidation<ObjectRequired> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (
+                    typia.json.createValidateStringify as any
+                ).report(errors);
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const stringify = (input: ObjectRequired): string => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $number = (typia.json.createValidateStringify as any).number;
+            const $string = (typia.json.createValidateStringify as any).string;
+            const $tail = (typia.json.createValidateStringify as any).tail;
+            const $so0 = (input: any): any =>
+                `{"boolean":${input.boolean},"number":${$number(
+                    input.number,
+                )},"string":${$string(input.string)},"array":${`[${input.array
+                    .map((elem: any) => $number(elem))
+                    .join(",")}]`},"object":${
+                    null !== input.object ? $so1(input.object) : "null"
+                }}`;
+            const $so1 = (input: any): any =>
+                `{${$tail(
+                    `${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.array
+                            ? ""
+                            : `"array":${
+                                  undefined !== input.array
+                                      ? `[${input.array
+                                            .map((elem: any) => $number(elem))
+                                            .join(",")}]`
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.object
+                            ? ""
+                            : `"object":${
+                                  undefined !== input.object
+                                      ? null !== input.object
+                                          ? $so1(input.object)
+                                          : "null"
+                                      : undefined
+                              }`
+                    }`,
+                )}}`;
+            return $so0(input);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = stringify(input);
+        return output;
+    });

--- a/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectUnionImplicit.ts
@@ -111,12 +111,12 @@ export const test_json_createValidateStringify_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -581,6 +581,13 @@ export const test_json_createValidateStringify_ObjectUnionImplicit =
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            ("number" === typeof input.radius &&
+                                Number.isFinite(input.radius)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".radius",
+                                    expected: "number",
+                                    value: input.radius,
+                                }),
                             undefined === input.centroid ||
                                 ((("object" === typeof input.centroid &&
                                     null !== input.centroid) ||
@@ -600,13 +607,6 @@ export const test_json_createValidateStringify_ObjectUnionImplicit =
                                     expected:
                                         "(ObjectUnionImplicit.IPoint | undefined)",
                                     value: input.centroid,
-                                }),
-                            ("number" === typeof input.radius &&
-                                Number.isFinite(input.radius)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".radius",
-                                    expected: "number",
-                                    value: input.radius,
                                 }),
                             null === input.area ||
                                 undefined === input.area ||
@@ -803,11 +803,11 @@ export const test_json_createValidateStringify_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);

--- a/test/generated/output/json.isParse/test_json_isParse_ObjectPartial.ts
+++ b/test/generated/output/json.isParse/test_json_isParse_ObjectPartial.ts
@@ -1,0 +1,54 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_isParse_ObjectPartial = _test_json_isParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.Primitive<ObjectPartial> => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    })(input),
+);

--- a/test/generated/output/json.isParse/test_json_isParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.isParse/test_json_isParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,32 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_isParse_ObjectPartialAndRequired = _test_json_isParse(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): typia.Primitive<ObjectPartialAndRequired> => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    })(input),
+);

--- a/test/generated/output/json.isParse/test_json_isParse_ObjectRequired.ts
+++ b/test/generated/output/json.isParse/test_json_isParse_ObjectRequired.ts
@@ -1,0 +1,51 @@
+import typia from "../../../../src";
+import { _test_json_isParse } from "../../../internal/_test_json_isParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_isParse_ObjectRequired = _test_json_isParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.Primitive<ObjectRequired> => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        input = JSON.parse(input);
+        return is(input) ? (input as any) : null;
+    })(input),
+);

--- a/test/generated/output/json.isParse/test_json_isParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.isParse/test_json_isParse_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_json_isParse_ObjectUnionImplicit = _test_json_isParse(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&

--- a/test/generated/output/json.isStringify/test_json_isStringify_ObjectPartial.ts
+++ b/test/generated/output/json.isStringify/test_json_isStringify_ObjectPartial.ts
@@ -1,0 +1,125 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_isStringify_ObjectPartial = _test_json_isStringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: ObjectPartial): string | null => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        const stringify = (input: ObjectPartial): string => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $number = (typia.json.isStringify as any).number;
+            const $string = (typia.json.isStringify as any).string;
+            const $tail = (typia.json.isStringify as any).tail;
+            const $so0 = (input: any): any =>
+                `{${$tail(
+                    `${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.array
+                            ? ""
+                            : `"array":${
+                                  undefined !== input.array
+                                      ? `[${input.array
+                                            .map((elem: any) => $number(elem))
+                                            .join(",")}]`
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.object
+                            ? ""
+                            : `"object":${
+                                  undefined !== input.object
+                                      ? null !== input.object
+                                          ? $so1(input.object)
+                                          : "null"
+                                      : undefined
+                              }`
+                    }`,
+                )}}`;
+            const $so1 = (input: any): any =>
+                `{"boolean":${input.boolean},"number":${$number(
+                    input.number,
+                )},"string":${$string(input.string)},"array":${`[${input.array
+                    .map((elem: any) => $number(elem))
+                    .join(",")}]`},"object":${
+                    null !== input.object ? $so1(input.object) : "null"
+                }}`;
+            return $so0(input);
+        };
+        return is(input) ? stringify(input) : null;
+    })(input),
+);

--- a/test/generated/output/json.isStringify/test_json_isStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.isStringify/test_json_isStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,82 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_isStringify_ObjectPartialAndRequired =
+    _test_json_isStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: ObjectPartialAndRequired): string | null => {
+            const is = (input: any): input is ObjectPartialAndRequired => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    );
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.isStringify as any).string;
+                const $number = (typia.json.isStringify as any).number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            return is(input) ? stringify(input) : null;
+        })(input),
+    );

--- a/test/generated/output/json.isStringify/test_json_isStringify_ObjectRequired.ts
+++ b/test/generated/output/json.isStringify/test_json_isStringify_ObjectRequired.ts
@@ -1,0 +1,130 @@
+import typia from "../../../../src";
+import { _test_json_isStringify } from "../../../internal/_test_json_isStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_isStringify_ObjectRequired = _test_json_isStringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: ObjectRequired): string | null => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const stringify = (input: ObjectRequired): string => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $number = (typia.json.isStringify as any).number;
+            const $string = (typia.json.isStringify as any).string;
+            const $tail = (typia.json.isStringify as any).tail;
+            const $so0 = (input: any): any =>
+                `{"boolean":${input.boolean},"number":${$number(
+                    input.number,
+                )},"string":${$string(input.string)},"array":${`[${input.array
+                    .map((elem: any) => $number(elem))
+                    .join(",")}]`},"object":${
+                    null !== input.object ? $so1(input.object) : "null"
+                }}`;
+            const $so1 = (input: any): any =>
+                `{${$tail(
+                    `${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.array
+                            ? ""
+                            : `"array":${
+                                  undefined !== input.array
+                                      ? `[${input.array
+                                            .map((elem: any) => $number(elem))
+                                            .join(",")}]`
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.object
+                            ? ""
+                            : `"object":${
+                                  undefined !== input.object
+                                      ? null !== input.object
+                                          ? $so1(input.object)
+                                          : "null"
+                                      : undefined
+                              }`
+                    }`,
+                )}}`;
+            return $so0(input);
+        };
+        return is(input) ? stringify(input) : null;
+    })(input),
+);

--- a/test/generated/output/json.isStringify/test_json_isStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.isStringify/test_json_isStringify_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_json_isStringify_ObjectUnionImplicit = _test_json_isStringify(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,11 +222,11 @@ export const test_json_isStringify_ObjectUnionImplicit = _test_json_isStringify(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);

--- a/test/generated/output/json.stringify/test_json_stringify_ObjectPartial.ts
+++ b/test/generated/output/json.stringify/test_json_stringify_ObjectPartial.ts
@@ -1,0 +1,80 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_stringify_ObjectPartial = _test_json_stringify(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: ObjectPartial): string => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $number = (typia.json.stringify as any).number;
+        const $string = (typia.json.stringify as any).string;
+        const $tail = (typia.json.stringify as any).tail;
+        const $so0 = (input: any): any =>
+            `{${$tail(
+                `${
+                    undefined === input.boolean
+                        ? ""
+                        : `"boolean":${
+                              undefined !== input.boolean
+                                  ? input.boolean
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.number
+                        ? ""
+                        : `"number":${
+                              undefined !== input.number
+                                  ? $number(input.number)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.string
+                        ? ""
+                        : `"string":${
+                              undefined !== input.string
+                                  ? $string(input.string)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.array
+                        ? ""
+                        : `"array":${
+                              undefined !== input.array
+                                  ? `[${input.array
+                                        .map((elem: any) => $number(elem))
+                                        .join(",")}]`
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.object
+                        ? ""
+                        : `"object":${
+                              undefined !== input.object
+                                  ? null !== input.object
+                                      ? $so1(input.object)
+                                      : "null"
+                                  : undefined
+                          }`
+                }`,
+            )}}`;
+        const $so1 = (input: any): any =>
+            `{"boolean":${input.boolean},"number":${$number(
+                input.number,
+            )},"string":${$string(input.string)},"array":${`[${input.array
+                .map((elem: any) => $number(elem))
+                .join(",")}]`},"object":${
+                null !== input.object ? $so1(input.object) : "null"
+            }}`;
+        return $so0(input);
+    })(input),
+);

--- a/test/generated/output/json.stringify/test_json_stringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.stringify/test_json_stringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,57 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_stringify_ObjectPartialAndRequired =
+    _test_json_stringify("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input) =>
+        ((input: ObjectPartialAndRequired): string => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem);
+            const $string = (typia.json.stringify as any).string;
+            const $number = (typia.json.stringify as any).number;
+            const $so0 = (input: any): any =>
+                `{${
+                    undefined === input.string
+                        ? ""
+                        : `"string":${
+                              undefined !== input.string
+                                  ? $string(input.string)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.number
+                        ? ""
+                        : `"number":${
+                              undefined !== input.number
+                                  ? $number(input.number)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.boolean
+                        ? ""
+                        : `"boolean":${
+                              undefined !== input.boolean
+                                  ? input.boolean
+                                  : undefined
+                          },`
+                }"object":${
+                    null !== input.object ? $so0(input.object) : "null"
+                },"array":${`[${input.array
+                    .map((elem: any) => $number(elem))
+                    .join(",")}]`}}`;
+            return $so0(input);
+        })(input),
+    );

--- a/test/generated/output/json.stringify/test_json_stringify_ObjectRequired.ts
+++ b/test/generated/output/json.stringify/test_json_stringify_ObjectRequired.ts
@@ -1,0 +1,86 @@
+import typia from "../../../../src";
+import { _test_json_stringify } from "../../../internal/_test_json_stringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_stringify_ObjectRequired = _test_json_stringify(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: ObjectRequired): string => {
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $number = (typia.json.stringify as any).number;
+        const $string = (typia.json.stringify as any).string;
+        const $tail = (typia.json.stringify as any).tail;
+        const $so0 = (input: any): any =>
+            `{"boolean":${input.boolean},"number":${$number(
+                input.number,
+            )},"string":${$string(input.string)},"array":${`[${input.array
+                .map((elem: any) => $number(elem))
+                .join(",")}]`},"object":${
+                null !== input.object ? $so1(input.object) : "null"
+            }}`;
+        const $so1 = (input: any): any =>
+            `{${$tail(
+                `${
+                    undefined === input.boolean
+                        ? ""
+                        : `"boolean":${
+                              undefined !== input.boolean
+                                  ? input.boolean
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.number
+                        ? ""
+                        : `"number":${
+                              undefined !== input.number
+                                  ? $number(input.number)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.string
+                        ? ""
+                        : `"string":${
+                              undefined !== input.string
+                                  ? $string(input.string)
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.array
+                        ? ""
+                        : `"array":${
+                              undefined !== input.array
+                                  ? `[${input.array
+                                        .map((elem: any) => $number(elem))
+                                        .join(",")}]`
+                                  : undefined
+                          },`
+                }${
+                    undefined === input.object
+                        ? ""
+                        : `"object":${
+                              undefined !== input.object
+                                  ? null !== input.object
+                                      ? $so1(input.object)
+                                      : "null"
+                                  : undefined
+                          }`
+                }`,
+            )}}`;
+        return $so0(input);
+    })(input),
+);

--- a/test/generated/output/json.stringify/test_json_stringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.stringify/test_json_stringify_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_json_stringify_ObjectUnionImplicit = _test_json_stringify(
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);

--- a/test/generated/output/json.validateParse/test_json_validateParse_ObjectPartial.ts
+++ b/test/generated/output/json.validateParse/test_json_validateParse_ObjectPartial.ts
@@ -1,0 +1,240 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_validateParse_ObjectPartial = _test_json_validateParse(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: string): typia.IValidation<typia.Primitive<ObjectPartial>> => {
+        const validate = (input: any): typia.IValidation<ObjectPartial> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.json.validateParse as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const output = JSON.parse(input);
+        return validate(output) as any;
+    })(input),
+);

--- a/test/generated/output/json.validateParse/test_json_validateParse_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.validateParse/test_json_validateParse_ObjectPartialAndRequired.ts
@@ -1,0 +1,154 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_validateParse_ObjectPartialAndRequired =
+    _test_json_validateParse(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((
+            input: string,
+        ): typia.IValidation<typia.Primitive<ObjectPartialAndRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (typia.json.validateParse as any).report(
+                        errors,
+                    );
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const output = JSON.parse(input);
+            return validate(output) as any;
+        })(input),
+    );

--- a/test/generated/output/json.validateParse/test_json_validateParse_ObjectRequired.ts
+++ b/test/generated/output/json.validateParse/test_json_validateParse_ObjectRequired.ts
@@ -1,0 +1,239 @@
+import typia from "../../../../src";
+import { _test_json_validateParse } from "../../../internal/_test_json_validateParse";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_validateParse_ObjectRequired = _test_json_validateParse(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: string): typia.IValidation<typia.Primitive<ObjectRequired>> => {
+        const validate = (input: any): typia.IValidation<ObjectRequired> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.json.validateParse as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const output = JSON.parse(input);
+        return validate(output) as any;
+    })(input),
+);

--- a/test/generated/output/json.validateParse/test_json_validateParse_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.validateParse/test_json_validateParse_ObjectUnionImplicit.ts
@@ -114,12 +114,12 @@ export const test_json_validateParse_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -595,6 +595,13 @@ export const test_json_validateParse_ObjectUnionImplicit =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                ("number" === typeof input.radius &&
+                                    Number.isFinite(input.radius)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".radius",
+                                        expected: "number",
+                                        value: input.radius,
+                                    }),
                                 undefined === input.centroid ||
                                     ((("object" === typeof input.centroid &&
                                         null !== input.centroid) ||
@@ -614,13 +621,6 @@ export const test_json_validateParse_ObjectUnionImplicit =
                                         expected:
                                             "(ObjectUnionImplicit.IPoint | undefined)",
                                         value: input.centroid,
-                                    }),
-                                ("number" === typeof input.radius &&
-                                    Number.isFinite(input.radius)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".radius",
-                                        expected: "number",
-                                        value: input.radius,
                                     }),
                                 null === input.area ||
                                     undefined === input.area ||

--- a/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectPartial.ts
+++ b/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectPartial.ts
@@ -1,0 +1,342 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_json_validateStringify_ObjectPartial =
+    _test_json_validateStringify("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input) =>
+            ((input: ObjectPartial): typia.IValidation<string> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectPartial> => {
+                    const errors = [] as any[];
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.json.validateStringify as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.array ||
+                                        ((Array.isArray(input.array) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".array",
+                                                expected:
+                                                    "(Array<number> | undefined)",
+                                                value: input.array,
+                                            })) &&
+                                            input.array
+                                                .map(
+                                                    (
+                                                        elem: any,
+                                                        _index1: number,
+                                                    ) =>
+                                                        ("number" ===
+                                                            typeof elem &&
+                                                            Number.isFinite(
+                                                                elem,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".array[" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number",
+                                                                value: elem,
+                                                            },
+                                                        ),
+                                                )
+                                                .every(
+                                                    (flag: boolean) => flag,
+                                                )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        undefined === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null | undefined)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            const $vo1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "boolean",
+                                            value: input.boolean,
+                                        }),
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "number",
+                                            value: input.number,
+                                        }),
+                                    "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "string",
+                                            value: input.string,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const stringify = (input: ObjectPartial): string => {
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $number = (typia.json.validateStringify as any)
+                        .number;
+                    const $string = (typia.json.validateStringify as any)
+                        .string;
+                    const $tail = (typia.json.validateStringify as any).tail;
+                    const $so0 = (input: any): any =>
+                        `{${$tail(
+                            `${
+                                undefined === input.boolean
+                                    ? ""
+                                    : `"boolean":${
+                                          undefined !== input.boolean
+                                              ? input.boolean
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.number
+                                    ? ""
+                                    : `"number":${
+                                          undefined !== input.number
+                                              ? $number(input.number)
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.string
+                                    ? ""
+                                    : `"string":${
+                                          undefined !== input.string
+                                              ? $string(input.string)
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.array
+                                    ? ""
+                                    : `"array":${
+                                          undefined !== input.array
+                                              ? `[${input.array
+                                                    .map((elem: any) =>
+                                                        $number(elem),
+                                                    )
+                                                    .join(",")}]`
+                                              : undefined
+                                      },`
+                            }${
+                                undefined === input.object
+                                    ? ""
+                                    : `"object":${
+                                          undefined !== input.object
+                                              ? null !== input.object
+                                                  ? $so1(input.object)
+                                                  : "null"
+                                              : undefined
+                                      }`
+                            }`,
+                        )}}`;
+                    const $so1 = (input: any): any =>
+                        `{"boolean":${input.boolean},"number":${$number(
+                            input.number,
+                        )},"string":${$string(
+                            input.string,
+                        )},"array":${`[${input.array
+                            .map((elem: any) => $number(elem))
+                            .join(",")}]`},"object":${
+                            null !== input.object ? $so1(input.object) : "null"
+                        }}`;
+                    return $so0(input);
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = stringify(input);
+                return output;
+            })(input),
+    );

--- a/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectPartialAndRequired.ts
+++ b/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectPartialAndRequired.ts
@@ -1,0 +1,201 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_json_validateStringify_ObjectPartialAndRequired =
+    _test_json_validateStringify(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: ObjectPartialAndRequired): typia.IValidation<string> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.validateStringify as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: ObjectPartialAndRequired): string => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $string = (typia.json.validateStringify as any).string;
+                const $number = (typia.json.validateStringify as any).number;
+                const $so0 = (input: any): any =>
+                    `{${
+                        undefined === input.string
+                            ? ""
+                            : `"string":${
+                                  undefined !== input.string
+                                      ? $string(input.string)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.number
+                            ? ""
+                            : `"number":${
+                                  undefined !== input.number
+                                      ? $number(input.number)
+                                      : undefined
+                              },`
+                    }${
+                        undefined === input.boolean
+                            ? ""
+                            : `"boolean":${
+                                  undefined !== input.boolean
+                                      ? input.boolean
+                                      : undefined
+                              },`
+                    }"object":${
+                        null !== input.object ? $so0(input.object) : "null"
+                    },"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`}}`;
+                return $so0(input);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        })(input),
+    );

--- a/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectRequired.ts
+++ b/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectRequired.ts
@@ -1,0 +1,336 @@
+import typia from "../../../../src";
+import { _test_json_validateStringify } from "../../../internal/_test_json_validateStringify";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_json_validateStringify_ObjectRequired =
+    _test_json_validateStringify("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )((input) =>
+        ((input: ObjectRequired): typia.IValidation<string> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.json.validateStringify as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const stringify = (input: ObjectRequired): string => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $number = (typia.json.validateStringify as any).number;
+                const $string = (typia.json.validateStringify as any).string;
+                const $tail = (typia.json.validateStringify as any).tail;
+                const $so0 = (input: any): any =>
+                    `{"boolean":${input.boolean},"number":${$number(
+                        input.number,
+                    )},"string":${$string(
+                        input.string,
+                    )},"array":${`[${input.array
+                        .map((elem: any) => $number(elem))
+                        .join(",")}]`},"object":${
+                        null !== input.object ? $so1(input.object) : "null"
+                    }}`;
+                const $so1 = (input: any): any =>
+                    `{${$tail(
+                        `${
+                            undefined === input.boolean
+                                ? ""
+                                : `"boolean":${
+                                      undefined !== input.boolean
+                                          ? input.boolean
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.number
+                                ? ""
+                                : `"number":${
+                                      undefined !== input.number
+                                          ? $number(input.number)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.string
+                                ? ""
+                                : `"string":${
+                                      undefined !== input.string
+                                          ? $string(input.string)
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.array
+                                ? ""
+                                : `"array":${
+                                      undefined !== input.array
+                                          ? `[${input.array
+                                                .map((elem: any) =>
+                                                    $number(elem),
+                                                )
+                                                .join(",")}]`
+                                          : undefined
+                                  },`
+                        }${
+                            undefined === input.object
+                                ? ""
+                                : `"object":${
+                                      undefined !== input.object
+                                          ? null !== input.object
+                                              ? $so1(input.object)
+                                              : "null"
+                                          : undefined
+                                  }`
+                        }`,
+                    )}}`;
+                return $so0(input);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = stringify(input);
+            return output;
+        })(input),
+    );

--- a/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectUnionImplicit.ts
+++ b/test/generated/output/json.validateStringify/test_json_validateStringify_ObjectUnionImplicit.ts
@@ -112,12 +112,12 @@ export const test_json_validateStringify_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -593,6 +593,13 @@ export const test_json_validateStringify_ObjectUnionImplicit =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                ("number" === typeof input.radius &&
+                                    Number.isFinite(input.radius)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".radius",
+                                        expected: "number",
+                                        value: input.radius,
+                                    }),
                                 undefined === input.centroid ||
                                     ((("object" === typeof input.centroid &&
                                         null !== input.centroid) ||
@@ -612,13 +619,6 @@ export const test_json_validateStringify_ObjectUnionImplicit =
                                         expected:
                                             "(ObjectUnionImplicit.IPoint | undefined)",
                                         value: input.centroid,
-                                    }),
-                                ("number" === typeof input.radius &&
-                                    Number.isFinite(input.radius)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".radius",
-                                        expected: "number",
-                                        value: input.radius,
                                     }),
                                 null === input.area ||
                                     undefined === input.area ||
@@ -821,11 +821,11 @@ export const test_json_validateStringify_ObjectUnionImplicit =
                         undefined === input.area ||
                         "number" === typeof input.area);
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
                     (null === input.area ||
                         undefined === input.area ||
                         "number" === typeof input.area);

--- a/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectPartial.ts
+++ b/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectPartial.ts
@@ -1,0 +1,259 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_assertClone_ObjectPartial = _test_misc_assertClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.Resolved<ObjectPartial> => {
+        const assert = (input: any): ObjectPartial => {
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $guard = (typia.misc.assertClone as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const clone = (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        assert(input);
+        const output = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,173 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_assertClone_ObjectPartialAndRequired =
+    _test_misc_assertClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: any): typia.Resolved<ObjectPartialAndRequired> => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.misc.assertClone as any).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const clone = (
+                input: ObjectPartialAndRequired,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    string: input.string as any,
+                    number: input.number as any,
+                    boolean: input.boolean as any,
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co0(input.object)
+                            : (input.object as any),
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        })(input),
+    );

--- a/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectRequired.ts
+++ b/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectRequired.ts
@@ -1,0 +1,268 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_assertClone_ObjectRequired = _test_misc_assertClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.Resolved<ObjectRequired> => {
+        const assert = (input: any): ObjectRequired => {
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $guard = (typia.misc.assertClone as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const clone = (
+            input: ObjectRequired,
+        ): typia.Resolved<ObjectRequired> => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        assert(input);
+        const output = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.assertClone/test_misc_assertClone_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_misc_assertClone_ObjectUnionImplicit = _test_misc_assertClone(
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_misc_assertClone_ObjectUnionImplicit = _test_misc_assertClone(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_misc_assertClone_ObjectUnionImplicit = _test_misc_assertClone(
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||
@@ -764,11 +764,11 @@ export const test_misc_assertClone_ObjectUnionImplicit = _test_misc_assertClone(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -862,12 +862,12 @@ export const test_misc_assertClone_ObjectUnionImplicit = _test_misc_assertClone(
                 area: input.area as any,
             });
             const $co6 = (input: any): any => ({
+                radius: input.radius as any,
                 centroid:
                     "object" === typeof input.centroid &&
                     null !== input.centroid
                         ? $co0(input.centroid)
                         : (input.centroid as any),
-                radius: input.radius as any,
                 area: input.area as any,
             });
             const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectPartial.ts
+++ b/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectPartial.ts
@@ -1,0 +1,262 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_assertPrune_ObjectPartial = _test_misc_assertPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): ObjectPartial => {
+        const assert = (input: any): ObjectPartial => {
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $guard = (typia.misc.assertPrune as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const prune = (input: ObjectPartial): void => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        assert(input);
+        prune(input);
+        return input;
+    })(input),
+);

--- a/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,172 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_assertPrune_ObjectPartialAndRequired =
+    _test_misc_assertPrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: any): ObjectPartialAndRequired => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.misc.assertPrune as any).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const prune = (input: ObjectPartialAndRequired): void => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po0(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "string" === key ||
+                            "number" === key ||
+                            "boolean" === key ||
+                            "object" === key ||
+                            "array" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            assert(input);
+            prune(input);
+            return input;
+        })(input),
+    );

--- a/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectRequired.ts
+++ b/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectRequired.ts
@@ -1,0 +1,269 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_assertPrune_ObjectRequired = _test_misc_assertPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): ObjectRequired => {
+        const assert = (input: any): ObjectRequired => {
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input))
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $guard = (typia.misc.assertPrune as any).guard;
+                    const $ao0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        ("boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            })) &&
+                        (("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            })) &&
+                        ("string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            })) &&
+                        (((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }));
+                    const $ao1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $guard(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            })) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            })) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $guard(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            })) &&
+                        (undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $ao1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }));
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $ao0(input, _path + "", true)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            return input;
+        };
+        const prune = (input: ObjectRequired): void => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        assert(input);
+        prune(input);
+        return input;
+    })(input),
+);

--- a/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_misc_assertPrune_ObjectUnionImplicit = _test_misc_assertPrune(
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_misc_assertPrune_ObjectUnionImplicit = _test_misc_assertPrune(
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_misc_assertPrune_ObjectUnionImplicit = _test_misc_assertPrune(
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||
@@ -762,11 +762,11 @@ export const test_misc_assertPrune_ObjectUnionImplicit = _test_misc_assertPrune(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -872,8 +872,8 @@ export const test_misc_assertPrune_ObjectUnionImplicit = _test_misc_assertPrune(
                     $po0(input.centroid);
                 for (const key of Object.keys(input)) {
                     if (
-                        "centroid" === key ||
                         "radius" === key ||
+                        "centroid" === key ||
                         "area" === key
                     )
                         continue;

--- a/test/generated/output/misc.clone/test_misc_clone_ObjectPartial.ts
+++ b/test/generated/output/misc.clone/test_misc_clone_ObjectPartial.ts
@@ -1,0 +1,48 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_clone_ObjectPartial = _test_misc_clone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        const $co1 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    })(input),
+);

--- a/test/generated/output/misc.clone/test_misc_clone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.clone/test_misc_clone_ObjectPartialAndRequired.ts
@@ -1,0 +1,39 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_clone_ObjectPartialAndRequired = _test_misc_clone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((
+        input: ObjectPartialAndRequired,
+    ): typia.Resolved<ObjectPartialAndRequired> => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem);
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            string: input.string as any,
+            number: input.number as any,
+            boolean: input.boolean as any,
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co0(input.object)
+                    : (input.object as any),
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    })(input),
+);

--- a/test/generated/output/misc.clone/test_misc_clone_ObjectRequired.ts
+++ b/test/generated/output/misc.clone/test_misc_clone_ObjectRequired.ts
@@ -1,0 +1,54 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_clone_ObjectRequired = _test_misc_clone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: ObjectRequired): typia.Resolved<ObjectRequired> => {
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        const $co1 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    })(input),
+);

--- a/test/generated/output/misc.clone/test_misc_clone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.clone/test_misc_clone_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_misc_clone_ObjectUnionImplicit = _test_misc_clone(
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);
@@ -189,11 +189,11 @@ export const test_misc_clone_ObjectUnionImplicit = _test_misc_clone(
             area: input.area as any,
         });
         const $co6 = (input: any): any => ({
+            radius: input.radius as any,
             centroid:
                 "object" === typeof input.centroid && null !== input.centroid
                     ? $co0(input.centroid)
                     : (input.centroid as any),
-            radius: input.radius as any,
             area: input.area as any,
         });
         const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectPartial.ts
+++ b/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectPartial.ts
@@ -1,0 +1,253 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createAssertClone_ObjectPartial = _test_misc_assertClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): typia.Resolved<ObjectPartial> => {
+    const assert = (input: any): ObjectPartial => {
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.misc.createAssertClone as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    };
+    const clone = (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        const $co1 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    };
+    assert(input);
+    const output = clone(input);
+    return output;
+});

--- a/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,174 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createAssertClone_ObjectPartialAndRequired =
+    _test_misc_assertClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: any): typia.Resolved<ObjectPartialAndRequired> => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.misc.createAssertClone as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const clone = (
+                input: ObjectPartialAndRequired,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    string: input.string as any,
+                    number: input.number as any,
+                    boolean: input.boolean as any,
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co0(input.object)
+                            : (input.object as any),
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectRequired.ts
+++ b/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectRequired.ts
@@ -1,0 +1,279 @@
+import typia from "../../../../src";
+import { _test_misc_assertClone } from "../../../internal/_test_misc_assertClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createAssertClone_ObjectRequired =
+    _test_misc_assertClone("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: any): typia.Resolved<ObjectRequired> => {
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (typia.misc.createAssertClone as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const clone = (
+                input: ObjectRequired,
+            ): typia.Resolved<ObjectRequired> => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                const $co1 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            assert(input);
+            const output = clone(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_misc_createAssertClone_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_misc_createAssertClone_ObjectUnionImplicit =
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_misc_createAssertClone_ObjectUnionImplicit =
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||
@@ -764,11 +764,11 @@ export const test_misc_createAssertClone_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -862,12 +862,12 @@ export const test_misc_createAssertClone_ObjectUnionImplicit =
                 area: input.area as any,
             });
             const $co6 = (input: any): any => ({
+                radius: input.radius as any,
                 centroid:
                     "object" === typeof input.centroid &&
                     null !== input.centroid
                         ? $co0(input.centroid)
                         : (input.centroid as any),
-                radius: input.radius as any,
                 area: input.area as any,
             });
             const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartial.ts
+++ b/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartial.ts
@@ -1,0 +1,256 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createAssertPrune_ObjectPartial = _test_misc_assertPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): ObjectPartial => {
+    const assert = (input: any): ObjectPartial => {
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.misc.createAssertPrune as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    };
+    const prune = (input: ObjectPartial): void => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        const $po1 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    };
+    assert(input);
+    prune(input);
+    return input;
+});

--- a/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,173 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createAssertPrune_ObjectPartialAndRequired =
+    _test_misc_assertPrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: any): ObjectPartialAndRequired => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (typia.misc.createAssertPrune as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const prune = (input: ObjectPartialAndRequired): void => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po0(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "string" === key ||
+                            "number" === key ||
+                            "boolean" === key ||
+                            "object" === key ||
+                            "array" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            assert(input);
+            prune(input);
+            return input;
+        },
+    );

--- a/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectRequired.ts
+++ b/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectRequired.ts
@@ -1,0 +1,283 @@
+import typia from "../../../../src";
+import { _test_misc_assertPrune } from "../../../internal/_test_misc_assertPrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createAssertPrune_ObjectRequired =
+    _test_misc_assertPrune("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: any): ObjectRequired => {
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (typia.misc.createAssertPrune as any)
+                            .guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const prune = (input: ObjectRequired): void => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                const $po1 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            assert(input);
+            prune(input);
+            return input;
+        },
+    );

--- a/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectUnionImplicit.ts
@@ -108,12 +108,12 @@ export const test_misc_createAssertPrune_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -550,6 +550,13 @@ export const test_misc_createAssertPrune_ObjectUnionImplicit =
                         _path: string,
                         _exceptionable: boolean = true,
                     ): boolean =>
+                        (("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            })) &&
                         (undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -569,13 +576,6 @@ export const test_misc_createAssertPrune_ObjectUnionImplicit =
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            })) &&
-                        (("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $guard(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             })) &&
                         (null === input.area ||
                             undefined === input.area ||
@@ -762,11 +762,11 @@ export const test_misc_createAssertPrune_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -872,8 +872,8 @@ export const test_misc_createAssertPrune_ObjectUnionImplicit =
                     $po0(input.centroid);
                 for (const key of Object.keys(input)) {
                     if (
-                        "centroid" === key ||
                         "radius" === key ||
+                        "centroid" === key ||
                         "area" === key
                     )
                         continue;

--- a/test/generated/output/misc.createClone/test_misc_createClone_ObjectPartial.ts
+++ b/test/generated/output/misc.createClone/test_misc_createClone_ObjectPartial.ts
@@ -1,0 +1,48 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createClone_ObjectPartial = _test_misc_clone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        const $co1 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    },
+);

--- a/test/generated/output/misc.createClone/test_misc_createClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createClone/test_misc_createClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,39 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createClone_ObjectPartialAndRequired = _test_misc_clone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (
+        input: ObjectPartialAndRequired,
+    ): typia.Resolved<ObjectPartialAndRequired> => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem);
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            string: input.string as any,
+            number: input.number as any,
+            boolean: input.boolean as any,
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co0(input.object)
+                    : (input.object as any),
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    },
+);

--- a/test/generated/output/misc.createClone/test_misc_createClone_ObjectRequired.ts
+++ b/test/generated/output/misc.createClone/test_misc_createClone_ObjectRequired.ts
@@ -1,0 +1,54 @@
+import typia from "../../../../src";
+import { _test_misc_clone } from "../../../internal/_test_misc_clone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createClone_ObjectRequired = _test_misc_clone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: ObjectRequired): typia.Resolved<ObjectRequired> => {
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+        const $co0 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        const $co1 = (input: any): any => ({
+            boolean: input.boolean as any,
+            number: input.number as any,
+            string: input.string as any,
+            array: Array.isArray(input.array)
+                ? $cp0(input.array)
+                : (input.array as any),
+            object:
+                "object" === typeof input.object && null !== input.object
+                    ? $co1(input.object)
+                    : (input.object as any),
+        });
+        return "object" === typeof input && null !== input
+            ? $co0(input)
+            : (input as any);
+    },
+);

--- a/test/generated/output/misc.createClone/test_misc_createClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createClone/test_misc_createClone_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_misc_createClone_ObjectUnionImplicit = _test_misc_clone(
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);
@@ -189,11 +189,11 @@ export const test_misc_createClone_ObjectUnionImplicit = _test_misc_clone(
             area: input.area as any,
         });
         const $co6 = (input: any): any => ({
+            radius: input.radius as any,
             centroid:
                 "object" === typeof input.centroid && null !== input.centroid
                     ? $co0(input.centroid)
                     : (input.centroid as any),
-            radius: input.radius as any,
             area: input.area as any,
         });
         const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectPartial.ts
+++ b/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectPartial.ts
@@ -1,0 +1,95 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createIsClone_ObjectPartial = _test_misc_isClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)(
+    (input: any): typia.Resolved<ObjectPartial> | null => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        const clone = (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    },
+);

--- a/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,65 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createIsClone_ObjectPartialAndRequired =
+    _test_misc_isClone("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: any): typia.Resolved<ObjectPartialAndRequired> | null => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const clone = (
+            input: ObjectPartialAndRequired,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem);
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                string: input.string as any,
+                number: input.number as any,
+                boolean: input.boolean as any,
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co0(input.object)
+                        : (input.object as any),
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    });

--- a/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectRequired.ts
+++ b/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectRequired.ts
@@ -1,0 +1,102 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createIsClone_ObjectRequired = _test_misc_isClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)(
+    (input: any): typia.Resolved<ObjectRequired> | null => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const clone = (
+            input: ObjectRequired,
+        ): typia.Resolved<ObjectRequired> => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    },
+);

--- a/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_misc_createIsClone_ObjectUnionImplicit = _test_misc_isClone(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -224,11 +224,11 @@ export const test_misc_createIsClone_ObjectUnionImplicit = _test_misc_isClone(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -322,12 +322,12 @@ export const test_misc_createIsClone_ObjectUnionImplicit = _test_misc_isClone(
                 area: input.area as any,
             });
             const $co6 = (input: any): any => ({
+                radius: input.radius as any,
                 centroid:
                     "object" === typeof input.centroid &&
                     null !== input.centroid
                         ? $co0(input.centroid)
                         : (input.centroid as any),
-                radius: input.radius as any,
                 area: input.area as any,
             });
             const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectPartial.ts
+++ b/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectPartial.ts
@@ -1,0 +1,94 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createIsPrune_ObjectPartial = _test_misc_isPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: any): input is ObjectPartial => {
+    const is = (input: any): input is ObjectPartial => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        return (
+            "object" === typeof input &&
+            null !== input &&
+            false === Array.isArray(input) &&
+            $io0(input)
+        );
+    };
+    const prune = (input: ObjectPartial): void => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        const $po1 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    };
+    if (!is(input)) return false;
+    prune(input);
+    return true;
+});

--- a/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,63 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createIsPrune_ObjectPartialAndRequired =
+    _test_misc_isPrune("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input: any): input is ObjectPartialAndRequired => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const prune = (input: ObjectPartialAndRequired): void => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem);
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po0(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "string" === key ||
+                        "number" === key ||
+                        "boolean" === key ||
+                        "object" === key ||
+                        "array" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    });

--- a/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectRequired.ts
+++ b/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectRequired.ts
@@ -1,0 +1,97 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createIsPrune_ObjectRequired = _test_misc_isPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: any): input is ObjectRequired => {
+    const is = (input: any): input is ObjectRequired => {
+        const $io0 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            Number.isFinite(input.number) &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every(
+                (elem: any) =>
+                    "number" === typeof elem && Number.isFinite(elem),
+            ) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number ||
+                ("number" === typeof input.number &&
+                    Number.isFinite(input.number))) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        return "object" === typeof input && null !== input && $io0(input);
+    };
+    const prune = (input: ObjectRequired): void => {
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        const $po1 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    };
+    if (!is(input)) return false;
+    prune(input);
+    return true;
+});

--- a/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_misc_createIsPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,11 +222,11 @@ export const test_misc_createIsPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -332,8 +332,8 @@ export const test_misc_createIsPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     $po0(input.centroid);
                 for (const key of Object.keys(input)) {
                     if (
-                        "centroid" === key ||
                         "radius" === key ||
+                        "centroid" === key ||
                         "area" === key
                     )
                         continue;

--- a/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectPartial.ts
+++ b/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectPartial.ts
@@ -1,0 +1,49 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createPrune_ObjectPartial = _test_misc_prune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input: ObjectPartial): void => {
+    const $io1 = (input: any): boolean =>
+        "boolean" === typeof input.boolean &&
+        "number" === typeof input.number &&
+        "string" === typeof input.string &&
+        Array.isArray(input.array) &&
+        input.array.every((elem: any) => "number" === typeof elem) &&
+        (null === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                $io1(input.object)));
+    const $po0 = (input: any): any => {
+        if ("object" === typeof input.object && null !== input.object)
+            $po1(input.object);
+        for (const key of Object.keys(input)) {
+            if (
+                "boolean" === key ||
+                "number" === key ||
+                "string" === key ||
+                "array" === key ||
+                "object" === key
+            )
+                continue;
+            delete input[key];
+        }
+    };
+    const $po1 = (input: any): any => {
+        if ("object" === typeof input.object && null !== input.object)
+            $po1(input.object);
+        for (const key of Object.keys(input)) {
+            if (
+                "boolean" === key ||
+                "number" === key ||
+                "string" === key ||
+                "array" === key ||
+                "object" === key
+            )
+                continue;
+            delete input[key];
+        }
+    };
+    if ("object" === typeof input && null !== input) $po0(input);
+});

--- a/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,37 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createPrune_ObjectPartialAndRequired = _test_misc_prune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+    (input: ObjectPartialAndRequired): void => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem);
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po0(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "string" === key ||
+                    "number" === key ||
+                    "boolean" === key ||
+                    "object" === key ||
+                    "array" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    },
+);

--- a/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectRequired.ts
+++ b/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectRequired.ts
@@ -1,0 +1,52 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createPrune_ObjectRequired = _test_misc_prune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input: ObjectRequired): void => {
+    const $io1 = (input: any): boolean =>
+        (undefined === input.boolean || "boolean" === typeof input.boolean) &&
+        (undefined === input.number || "number" === typeof input.number) &&
+        (undefined === input.string || "string" === typeof input.string) &&
+        (undefined === input.array ||
+            (Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem))) &&
+        (null === input.object ||
+            undefined === input.object ||
+            ("object" === typeof input.object &&
+                null !== input.object &&
+                false === Array.isArray(input.object) &&
+                $io1(input.object)));
+    const $po0 = (input: any): any => {
+        if ("object" === typeof input.object && null !== input.object)
+            $po1(input.object);
+        for (const key of Object.keys(input)) {
+            if (
+                "boolean" === key ||
+                "number" === key ||
+                "string" === key ||
+                "array" === key ||
+                "object" === key
+            )
+                continue;
+            delete input[key];
+        }
+    };
+    const $po1 = (input: any): any => {
+        if ("object" === typeof input.object && null !== input.object)
+            $po1(input.object);
+        for (const key of Object.keys(input)) {
+            if (
+                "boolean" === key ||
+                "number" === key ||
+                "string" === key ||
+                "array" === key ||
+                "object" === key
+            )
+                continue;
+            delete input[key];
+        }
+    };
+    if ("object" === typeof input && null !== input) $po0(input);
+});

--- a/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_misc_createPrune_ObjectUnionImplicit = _test_misc_prune(
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);
@@ -197,7 +197,7 @@ export const test_misc_createPrune_ObjectUnionImplicit = _test_misc_prune(
             if ("object" === typeof input.centroid && null !== input.centroid)
                 $po0(input.centroid);
             for (const key of Object.keys(input)) {
-                if ("centroid" === key || "radius" === key || "area" === key)
+                if ("radius" === key || "centroid" === key || "area" === key)
                     continue;
                 delete input[key];
             }

--- a/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectPartial.ts
+++ b/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectPartial.ts
@@ -1,0 +1,292 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createValidateClone_ObjectPartial =
+    _test_misc_validateClone("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input: any): typia.IValidation<typia.Resolved<ObjectPartial>> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidateClone as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: ObjectPartial,
+            ): typia.Resolved<ObjectPartial> => {
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                const $co1 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,190 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createValidateClone_ObjectPartialAndRequired =
+    _test_misc_validateClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (
+            input: any,
+        ): typia.IValidation<typia.Resolved<ObjectPartialAndRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidateClone as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: ObjectPartialAndRequired,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    string: input.string as any,
+                    number: input.number as any,
+                    boolean: input.boolean as any,
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co0(input.object)
+                            : (input.object as any),
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectRequired.ts
+++ b/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectRequired.ts
@@ -1,0 +1,303 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createValidateClone_ObjectRequired =
+    _test_misc_validateClone("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: any): typia.IValidation<typia.Resolved<ObjectRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidateClone as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: ObjectRequired,
+            ): typia.Resolved<ObjectRequired> => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                const $co1 = (input: any): any => ({
+                    boolean: input.boolean as any,
+                    number: input.number as any,
+                    string: input.string as any,
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co1(input.object)
+                            : (input.object as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectUnionImplicit.ts
@@ -111,12 +111,12 @@ export const test_misc_createValidateClone_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -581,6 +581,13 @@ export const test_misc_createValidateClone_ObjectUnionImplicit =
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            ("number" === typeof input.radius &&
+                                Number.isFinite(input.radius)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".radius",
+                                    expected: "number",
+                                    value: input.radius,
+                                }),
                             undefined === input.centroid ||
                                 ((("object" === typeof input.centroid &&
                                     null !== input.centroid) ||
@@ -600,13 +607,6 @@ export const test_misc_createValidateClone_ObjectUnionImplicit =
                                     expected:
                                         "(ObjectUnionImplicit.IPoint | undefined)",
                                     value: input.centroid,
-                                }),
-                            ("number" === typeof input.radius &&
-                                Number.isFinite(input.radius)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".radius",
-                                    expected: "number",
-                                    value: input.radius,
                                 }),
                             null === input.area ||
                                 undefined === input.area ||
@@ -805,11 +805,11 @@ export const test_misc_createValidateClone_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -903,12 +903,12 @@ export const test_misc_createValidateClone_ObjectUnionImplicit =
                 area: input.area as any,
             });
             const $co6 = (input: any): any => ({
+                radius: input.radius as any,
                 centroid:
                     "object" === typeof input.centroid &&
                     null !== input.centroid
                         ? $co0(input.centroid)
                         : (input.centroid as any),
-                radius: input.radius as any,
                 area: input.area as any,
             });
             const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartial.ts
+++ b/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartial.ts
@@ -1,0 +1,296 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_createValidatePrune_ObjectPartial =
+    _test_misc_validatePrune("ObjectPartial")<ObjectPartial>(ObjectPartial)(
+        (input: any): typia.IValidation<ObjectPartial> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidatePrune as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: ObjectPartial): void => {
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                const $po1 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,187 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_createValidatePrune_ObjectPartialAndRequired =
+    _test_misc_validatePrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)(
+        (input: any): typia.IValidation<ObjectPartialAndRequired> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidatePrune as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: ObjectPartialAndRequired): void => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po0(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "string" === key ||
+                            "number" === key ||
+                            "boolean" === key ||
+                            "object" === key ||
+                            "array" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectRequired.ts
+++ b/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectRequired.ts
@@ -1,0 +1,307 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_createValidatePrune_ObjectRequired =
+    _test_misc_validatePrune("ObjectRequired")<ObjectRequired>(ObjectRequired)(
+        (input: any): typia.IValidation<ObjectRequired> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.misc.createValidatePrune as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: ObjectRequired): void => {
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                const $po1 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po1(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "boolean" === key ||
+                            "number" === key ||
+                            "string" === key ||
+                            "array" === key ||
+                            "object" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        },
+    );

--- a/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectUnionImplicit.ts
@@ -111,12 +111,12 @@ export const test_misc_createValidatePrune_ObjectUnionImplicit =
                         ("number" === typeof input.area &&
                             Number.isFinite(input.area)));
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
+                    Number.isFinite(input.radius) &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
-                    Number.isFinite(input.radius) &&
                     (null === input.area ||
                         undefined === input.area ||
                         ("number" === typeof input.area &&
@@ -581,6 +581,13 @@ export const test_misc_createValidatePrune_ObjectUnionImplicit =
                         _exceptionable: boolean = true,
                     ): boolean =>
                         [
+                            ("number" === typeof input.radius &&
+                                Number.isFinite(input.radius)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".radius",
+                                    expected: "number",
+                                    value: input.radius,
+                                }),
                             undefined === input.centroid ||
                                 ((("object" === typeof input.centroid &&
                                     null !== input.centroid) ||
@@ -600,13 +607,6 @@ export const test_misc_createValidatePrune_ObjectUnionImplicit =
                                     expected:
                                         "(ObjectUnionImplicit.IPoint | undefined)",
                                     value: input.centroid,
-                                }),
-                            ("number" === typeof input.radius &&
-                                Number.isFinite(input.radius)) ||
-                                $report(_exceptionable, {
-                                    path: _path + ".radius",
-                                    expected: "number",
-                                    value: input.radius,
                                 }),
                             null === input.area ||
                                 undefined === input.area ||
@@ -803,11 +803,11 @@ export const test_misc_createValidatePrune_ObjectUnionImplicit =
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -913,8 +913,8 @@ export const test_misc_createValidatePrune_ObjectUnionImplicit =
                     $po0(input.centroid);
                 for (const key of Object.keys(input)) {
                     if (
-                        "centroid" === key ||
                         "radius" === key ||
+                        "centroid" === key ||
                         "area" === key
                     )
                         continue;

--- a/test/generated/output/misc.isClone/test_misc_isClone_ObjectPartial.ts
+++ b/test/generated/output/misc.isClone/test_misc_isClone_ObjectPartial.ts
@@ -1,0 +1,95 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_isClone_ObjectPartial = _test_misc_isClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.Resolved<ObjectPartial> | null => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        const clone = (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.isClone/test_misc_isClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.isClone/test_misc_isClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,66 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_isClone_ObjectPartialAndRequired = _test_misc_isClone(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): typia.Resolved<ObjectPartialAndRequired> | null => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const clone = (
+            input: ObjectPartialAndRequired,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem);
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                string: input.string as any,
+                number: input.number as any,
+                boolean: input.boolean as any,
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co0(input.object)
+                        : (input.object as any),
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.isClone/test_misc_isClone_ObjectRequired.ts
+++ b/test/generated/output/misc.isClone/test_misc_isClone_ObjectRequired.ts
@@ -1,0 +1,102 @@
+import typia from "../../../../src";
+import { _test_misc_isClone } from "../../../internal/_test_misc_isClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_isClone_ObjectRequired = _test_misc_isClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.Resolved<ObjectRequired> | null => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const clone = (
+            input: ObjectRequired,
+        ): typia.Resolved<ObjectRequired> => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        if (!is(input)) return null;
+        const output = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.isClone/test_misc_isClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.isClone/test_misc_isClone_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_misc_isClone_ObjectUnionImplicit = _test_misc_isClone(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -224,11 +224,11 @@ export const test_misc_isClone_ObjectUnionImplicit = _test_misc_isClone(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -322,12 +322,12 @@ export const test_misc_isClone_ObjectUnionImplicit = _test_misc_isClone(
                 area: input.area as any,
             });
             const $co6 = (input: any): any => ({
+                radius: input.radius as any,
                 centroid:
                     "object" === typeof input.centroid &&
                     null !== input.centroid
                         ? $co0(input.centroid)
                         : (input.centroid as any),
-                radius: input.radius as any,
                 area: input.area as any,
             });
             const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectPartial.ts
+++ b/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectPartial.ts
@@ -1,0 +1,98 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_isPrune_ObjectPartial = _test_misc_isPrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): input is ObjectPartial => {
+        const is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        const prune = (input: ObjectPartial): void => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    })(input),
+);

--- a/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,64 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_isPrune_ObjectPartialAndRequired = _test_misc_isPrune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): input is ObjectPartialAndRequired => {
+        const is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const prune = (input: ObjectPartialAndRequired): void => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem);
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po0(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "string" === key ||
+                        "number" === key ||
+                        "boolean" === key ||
+                        "object" === key ||
+                        "array" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    })(input),
+);

--- a/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectRequired.ts
+++ b/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectRequired.ts
@@ -1,0 +1,103 @@
+import typia from "../../../../src";
+import { _test_misc_isPrune } from "../../../internal/_test_misc_isPrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_isPrune_ObjectRequired = _test_misc_isPrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): input is ObjectRequired => {
+        const is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        const prune = (input: ObjectRequired): void => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        if (!is(input)) return false;
+        prune(input);
+        return true;
+    })(input),
+);

--- a/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionImplicit.ts
@@ -105,12 +105,12 @@ export const test_misc_isPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -222,11 +222,11 @@ export const test_misc_isPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     undefined === input.area ||
                     "number" === typeof input.area);
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
                 (null === input.area ||
                     undefined === input.area ||
                     "number" === typeof input.area);
@@ -332,8 +332,8 @@ export const test_misc_isPrune_ObjectUnionImplicit = _test_misc_isPrune(
                     $po0(input.centroid);
                 for (const key of Object.keys(input)) {
                     if (
-                        "centroid" === key ||
                         "radius" === key ||
+                        "centroid" === key ||
                         "area" === key
                     )
                         continue;

--- a/test/generated/output/misc.prune/test_misc_prune_ObjectPartial.ts
+++ b/test/generated/output/misc.prune/test_misc_prune_ObjectPartial.ts
@@ -1,0 +1,51 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_prune_ObjectPartial = _test_misc_prune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: ObjectPartial): void => {
+        const $io1 = (input: any): boolean =>
+            "boolean" === typeof input.boolean &&
+            "number" === typeof input.number &&
+            "string" === typeof input.string &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io1(input.object)));
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        const $po1 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    })(input),
+);

--- a/test/generated/output/misc.prune/test_misc_prune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.prune/test_misc_prune_ObjectPartialAndRequired.ts
@@ -1,0 +1,37 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_prune_ObjectPartialAndRequired = _test_misc_prune(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: ObjectPartialAndRequired): void => {
+        const $io0 = (input: any): boolean =>
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (null === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    $io0(input.object))) &&
+            Array.isArray(input.array) &&
+            input.array.every((elem: any) => "number" === typeof elem);
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po0(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "string" === key ||
+                    "number" === key ||
+                    "boolean" === key ||
+                    "object" === key ||
+                    "array" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    })(input),
+);

--- a/test/generated/output/misc.prune/test_misc_prune_ObjectRequired.ts
+++ b/test/generated/output/misc.prune/test_misc_prune_ObjectRequired.ts
@@ -1,0 +1,57 @@
+import typia from "../../../../src";
+import { _test_misc_prune } from "../../../internal/_test_misc_prune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_prune_ObjectRequired = _test_misc_prune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: ObjectRequired): void => {
+        const $io1 = (input: any): boolean =>
+            (undefined === input.boolean ||
+                "boolean" === typeof input.boolean) &&
+            (undefined === input.number || "number" === typeof input.number) &&
+            (undefined === input.string || "string" === typeof input.string) &&
+            (undefined === input.array ||
+                (Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ))) &&
+            (null === input.object ||
+                undefined === input.object ||
+                ("object" === typeof input.object &&
+                    null !== input.object &&
+                    false === Array.isArray(input.object) &&
+                    $io1(input.object)));
+        const $po0 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        const $po1 = (input: any): any => {
+            if ("object" === typeof input.object && null !== input.object)
+                $po1(input.object);
+            for (const key of Object.keys(input)) {
+                if (
+                    "boolean" === key ||
+                    "number" === key ||
+                    "string" === key ||
+                    "array" === key ||
+                    "object" === key
+                )
+                    continue;
+                delete input[key];
+            }
+        };
+        if ("object" === typeof input && null !== input) $po0(input);
+    })(input),
+);

--- a/test/generated/output/misc.prune/test_misc_prune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.prune/test_misc_prune_ObjectUnionImplicit.ts
@@ -91,11 +91,11 @@ export const test_misc_prune_ObjectUnionImplicit = _test_misc_prune(
                 undefined === input.area ||
                 "number" === typeof input.area);
         const $io6 = (input: any): boolean =>
+            "number" === typeof input.radius &&
             (undefined === input.centroid ||
                 ("object" === typeof input.centroid &&
                     null !== input.centroid &&
                     $io0(input.centroid))) &&
-            "number" === typeof input.radius &&
             (null === input.area ||
                 undefined === input.area ||
                 "number" === typeof input.area);
@@ -197,7 +197,7 @@ export const test_misc_prune_ObjectUnionImplicit = _test_misc_prune(
             if ("object" === typeof input.centroid && null !== input.centroid)
                 $po0(input.centroid);
             for (const key of Object.keys(input)) {
-                if ("centroid" === key || "radius" === key || "area" === key)
+                if ("radius" === key || "centroid" === key || "area" === key)
                     continue;
                 delete input[key];
             }

--- a/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectPartial.ts
+++ b/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectPartial.ts
@@ -1,0 +1,281 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_validateClone_ObjectPartial = _test_misc_validateClone(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.IValidation<typia.Resolved<ObjectPartial>> => {
+        const validate = (input: any): typia.IValidation<ObjectPartial> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.misc.validateClone as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const clone = (input: ObjectPartial): typia.Resolved<ObjectPartial> => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectPartialAndRequired.ts
@@ -1,0 +1,190 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_validateClone_ObjectPartialAndRequired =
+    _test_misc_validateClone(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((
+            input: any,
+        ): typia.IValidation<typia.Resolved<ObjectPartialAndRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (typia.misc.validateClone as any).report(
+                        errors,
+                    );
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const clone = (
+                input: ObjectPartialAndRequired,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $cp0 = (input: any) =>
+                    input.map((elem: any) => elem as any);
+                const $co0 = (input: any): any => ({
+                    string: input.string as any,
+                    number: input.number as any,
+                    boolean: input.boolean as any,
+                    object:
+                        "object" === typeof input.object &&
+                        null !== input.object
+                            ? $co0(input.object)
+                            : (input.object as any),
+                    array: Array.isArray(input.array)
+                        ? $cp0(input.array)
+                        : (input.array as any),
+                });
+                return "object" === typeof input && null !== input
+                    ? $co0(input)
+                    : (input as any);
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = clone(input);
+            return output;
+        })(input),
+    );

--- a/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectRequired.ts
+++ b/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectRequired.ts
@@ -1,0 +1,290 @@
+import typia from "../../../../src";
+import { _test_misc_validateClone } from "../../../internal/_test_misc_validateClone";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_validateClone_ObjectRequired = _test_misc_validateClone(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.IValidation<typia.Resolved<ObjectRequired>> => {
+        const validate = (input: any): typia.IValidation<ObjectRequired> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.misc.validateClone as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const clone = (
+            input: ObjectRequired,
+        ): typia.Resolved<ObjectRequired> => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $cp0 = (input: any) => input.map((elem: any) => elem as any);
+            const $co0 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            const $co1 = (input: any): any => ({
+                boolean: input.boolean as any,
+                number: input.number as any,
+                string: input.string as any,
+                array: Array.isArray(input.array)
+                    ? $cp0(input.array)
+                    : (input.array as any),
+                object:
+                    "object" === typeof input.object && null !== input.object
+                        ? $co1(input.object)
+                        : (input.object as any),
+            });
+            return "object" === typeof input && null !== input
+                ? $co0(input)
+                : (input as any);
+        };
+        const output = validate(input) as any;
+        if (output.success) output.data = clone(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.validateClone/test_misc_validateClone_ObjectUnionImplicit.ts
@@ -114,12 +114,12 @@ export const test_misc_validateClone_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -595,6 +595,13 @@ export const test_misc_validateClone_ObjectUnionImplicit =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                ("number" === typeof input.radius &&
+                                    Number.isFinite(input.radius)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".radius",
+                                        expected: "number",
+                                        value: input.radius,
+                                    }),
                                 undefined === input.centroid ||
                                     ((("object" === typeof input.centroid &&
                                         null !== input.centroid) ||
@@ -614,13 +621,6 @@ export const test_misc_validateClone_ObjectUnionImplicit =
                                         expected:
                                             "(ObjectUnionImplicit.IPoint | undefined)",
                                         value: input.centroid,
-                                    }),
-                                ("number" === typeof input.radius &&
-                                    Number.isFinite(input.radius)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".radius",
-                                        expected: "number",
-                                        value: input.radius,
                                     }),
                                 null === input.area ||
                                     undefined === input.area ||
@@ -825,11 +825,11 @@ export const test_misc_validateClone_ObjectUnionImplicit =
                         undefined === input.area ||
                         "number" === typeof input.area);
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
                     (null === input.area ||
                         undefined === input.area ||
                         "number" === typeof input.area);
@@ -923,12 +923,12 @@ export const test_misc_validateClone_ObjectUnionImplicit =
                     area: input.area as any,
                 });
                 const $co6 = (input: any): any => ({
+                    radius: input.radius as any,
                     centroid:
                         "object" === typeof input.centroid &&
                         null !== input.centroid
                             ? $co0(input.centroid)
                             : (input.centroid as any),
-                    radius: input.radius as any,
                     area: input.area as any,
                 });
                 const $cu0 = (input: any): any =>

--- a/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectPartial.ts
+++ b/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectPartial.ts
@@ -1,0 +1,284 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_misc_validatePrune_ObjectPartial = _test_misc_validatePrune(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.IValidation<ObjectPartial> => {
+        const validate = (input: any): typia.IValidation<ObjectPartial> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.misc.validatePrune as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartial => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const prune = (input: ObjectPartial): void => {
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        const output = validate(input);
+        if (output.success) prune(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectPartialAndRequired.ts
+++ b/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectPartialAndRequired.ts
@@ -1,0 +1,187 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_misc_validatePrune_ObjectPartialAndRequired =
+    _test_misc_validatePrune(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+        ((input: any): typia.IValidation<ObjectPartialAndRequired> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (typia.misc.validatePrune as any).report(
+                        errors,
+                    );
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const prune = (input: ObjectPartialAndRequired): void => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                const $po0 = (input: any): any => {
+                    if (
+                        "object" === typeof input.object &&
+                        null !== input.object
+                    )
+                        $po0(input.object);
+                    for (const key of Object.keys(input)) {
+                        if (
+                            "string" === key ||
+                            "number" === key ||
+                            "boolean" === key ||
+                            "object" === key ||
+                            "array" === key
+                        )
+                            continue;
+                        delete input[key];
+                    }
+                };
+                if ("object" === typeof input && null !== input) $po0(input);
+            };
+            const output = validate(input);
+            if (output.success) prune(input);
+            return output;
+        })(input),
+    );

--- a/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectRequired.ts
+++ b/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectRequired.ts
@@ -1,0 +1,291 @@
+import typia from "../../../../src";
+import { _test_misc_validatePrune } from "../../../internal/_test_misc_validatePrune";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_misc_validatePrune_ObjectRequired = _test_misc_validatePrune(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.IValidation<ObjectRequired> => {
+        const validate = (input: any): typia.IValidation<ObjectRequired> => {
+            const errors = [] as any[];
+            const __is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.misc.validatePrune as any).report(
+                    errors,
+                );
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectRequired => {
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                }),
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                }),
+                            "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    const $vo1 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                }),
+                            null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        };
+        const prune = (input: ObjectRequired): void => {
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $po0 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            const $po1 = (input: any): any => {
+                if ("object" === typeof input.object && null !== input.object)
+                    $po1(input.object);
+                for (const key of Object.keys(input)) {
+                    if (
+                        "boolean" === key ||
+                        "number" === key ||
+                        "string" === key ||
+                        "array" === key ||
+                        "object" === key
+                    )
+                        continue;
+                    delete input[key];
+                }
+            };
+            if ("object" === typeof input && null !== input) $po0(input);
+        };
+        const output = validate(input);
+        if (output.success) prune(input);
+        return output;
+    })(input),
+);

--- a/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectUnionImplicit.ts
+++ b/test/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectUnionImplicit.ts
@@ -112,12 +112,12 @@ export const test_misc_validatePrune_ObjectUnionImplicit =
                             ("number" === typeof input.area &&
                                 Number.isFinite(input.area)));
                     const $io6 = (input: any): boolean =>
+                        "number" === typeof input.radius &&
+                        Number.isFinite(input.radius) &&
                         (undefined === input.centroid ||
                             ("object" === typeof input.centroid &&
                                 null !== input.centroid &&
                                 $io0(input.centroid))) &&
-                        "number" === typeof input.radius &&
-                        Number.isFinite(input.radius) &&
                         (null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -593,6 +593,13 @@ export const test_misc_validatePrune_ObjectUnionImplicit =
                             _exceptionable: boolean = true,
                         ): boolean =>
                             [
+                                ("number" === typeof input.radius &&
+                                    Number.isFinite(input.radius)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".radius",
+                                        expected: "number",
+                                        value: input.radius,
+                                    }),
                                 undefined === input.centroid ||
                                     ((("object" === typeof input.centroid &&
                                         null !== input.centroid) ||
@@ -612,13 +619,6 @@ export const test_misc_validatePrune_ObjectUnionImplicit =
                                         expected:
                                             "(ObjectUnionImplicit.IPoint | undefined)",
                                         value: input.centroid,
-                                    }),
-                                ("number" === typeof input.radius &&
-                                    Number.isFinite(input.radius)) ||
-                                    $report(_exceptionable, {
-                                        path: _path + ".radius",
-                                        expected: "number",
-                                        value: input.radius,
                                     }),
                                 null === input.area ||
                                     undefined === input.area ||
@@ -821,11 +821,11 @@ export const test_misc_validatePrune_ObjectUnionImplicit =
                         undefined === input.area ||
                         "number" === typeof input.area);
                 const $io6 = (input: any): boolean =>
+                    "number" === typeof input.radius &&
                     (undefined === input.centroid ||
                         ("object" === typeof input.centroid &&
                             null !== input.centroid &&
                             $io0(input.centroid))) &&
-                    "number" === typeof input.radius &&
                     (null === input.area ||
                         undefined === input.area ||
                         "number" === typeof input.area);
@@ -939,8 +939,8 @@ export const test_misc_validatePrune_ObjectUnionImplicit =
                         $po0(input.centroid);
                     for (const key of Object.keys(input)) {
                         if (
-                            "centroid" === key ||
                             "radius" === key ||
+                            "centroid" === key ||
                             "area" === key
                         )
                             continue;

--- a/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartial.ts
@@ -1,0 +1,424 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_assertDecode_ObjectPartial =
+    _test_protobuf_assertDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertDecode: (input) =>
+            ((input: Uint8Array): typia.Resolved<ObjectPartial> => {
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectPartial> => {
+                    const $Reader = (typia.protobuf.assertDecode as any).Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: undefined as any,
+                            array: undefined as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    output.array ??= [] as any[];
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectPartial.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const $pdo1 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: "" as any,
+                            array: [] as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectPartial.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const assert = (input: any): ObjectPartial => {
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $guard = (typia.protobuf.assertDecode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array.every(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }));
+                            const $ao1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                ("boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    })) &&
+                                (("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    })) &&
+                                ("string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const output = decode(input);
+                return assert(output) as any;
+            })(input),
+        encode: (input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,256 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_assertDecode_ObjectPartialAndRequired =
+    _test_protobuf_assertDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertDecode: (input) =>
+            ((input: Uint8Array): typia.Resolved<ObjectPartialAndRequired> => {
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectPartialAndRequired> => {
+                    const $Reader = (typia.protobuf.assertDecode as any).Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            string: undefined as any,
+                            number: undefined as any,
+                            boolean: undefined as any,
+                            object: null as any,
+                            array: [] as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 4:
+                                    // ObjectPartialAndRequired;
+                                    output.object = $pdo0(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                case 5:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const assert = (input: any): ObjectPartialAndRequired => {
+                    const __is = (
+                        input: any,
+                    ): input is ObjectPartialAndRequired => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            );
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartialAndRequired => {
+                            const $guard = (typia.protobuf.assertDecode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "ObjectPartialAndRequired",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const output = decode(input);
+                return assert(output) as any;
+            })(input),
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectRequired.ts
@@ -1,0 +1,436 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_assertDecode_ObjectRequired =
+    _test_protobuf_assertDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertDecode: (input) =>
+            ((input: Uint8Array): typia.Resolved<ObjectRequired> => {
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectRequired> => {
+                    const $Reader = (typia.protobuf.assertDecode as any).Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: "" as any,
+                            array: [] as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectRequired.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const $pdo1 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: undefined as any,
+                            array: undefined as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    output.array ??= [] as any[];
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectRequired.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const assert = (input: any): ObjectRequired => {
+                    const __is = (input: any): input is ObjectRequired => {
+                        const $io0 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectRequired => {
+                            const $guard = (typia.protobuf.assertDecode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                ("boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    })) &&
+                                (("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    })) &&
+                                ("string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }));
+                            const $ao1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array.every(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Required<ObjectRequired.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const output = decode(input);
+                return assert(output) as any;
+            })(input),
+        encode: (input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartial.ts
@@ -1,0 +1,412 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_assertEncode_ObjectPartial =
+    _test_protobuf_assertEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertEncode: (input) =>
+            ((input: any): Uint8Array => {
+                const assert = (input: any): ObjectPartial => {
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $guard = (typia.protobuf.assertEncode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array.every(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }));
+                            const $ao1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                ("boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    })) &&
+                                (("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    })) &&
+                                ("string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const encode = (input: ObjectPartial): Uint8Array => {
+                    const $Sizer = (typia.protobuf.assertEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.assertEncode as any).Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(8);
+                                writer.bool(input.boolean);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(26);
+                                writer.string(input.string);
+                            }
+                            // property "array";
+                            if (undefined !== input.array) {
+                                if (0 !== input.array.length) {
+                                    writer.uint32(34);
+                                    writer.fork();
+                                    for (const elem of input.array) {
+                                        writer.double(elem);
+                                    }
+                                    writer.ldelim();
+                                }
+                            }
+                            // property "object";
+                            if (
+                                undefined !== input.object &&
+                                null !== input.object
+                            ) {
+                                // 5 -> ObjectPartial.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $peo1 = (input: any): any => {
+                            // property "boolean";
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                            // property "number";
+                            writer.uint32(17);
+                            writer.double(input.number);
+                            // property "string";
+                            writer.uint32(26);
+                            writer.string(input.string);
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 5 -> ObjectPartial.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        //Partial<ObjectPartial.IBase>;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                return encode(assert(input));
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,254 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_assertEncode_ObjectPartialAndRequired =
+    _test_protobuf_assertEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertEncode: (input) =>
+            ((input: any): Uint8Array => {
+                const assert = (input: any): ObjectPartialAndRequired => {
+                    const __is = (
+                        input: any,
+                    ): input is ObjectPartialAndRequired => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            );
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartialAndRequired => {
+                            const $guard = (typia.protobuf.assertEncode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected: "ObjectPartialAndRequired",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const encode = (
+                    input: ObjectPartialAndRequired,
+                ): Uint8Array => {
+                    const $Sizer = (typia.protobuf.assertEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.assertEncode as any).Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(10);
+                                writer.string(input.string);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(24);
+                                writer.bool(input.boolean);
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 4 -> ObjectPartialAndRequired;
+                                writer.uint32(34);
+                                writer.fork();
+                                $peo0(input.object);
+                                writer.ldelim();
+                            }
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(42);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        };
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                "number" === typeof input.number) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            );
+                        //ObjectPartialAndRequired;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                return encode(assert(input));
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectRequired.ts
@@ -1,0 +1,424 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_assertEncode_ObjectRequired =
+    _test_protobuf_assertEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertEncode: (input) =>
+            ((input: any): Uint8Array => {
+                const assert = (input: any): ObjectRequired => {
+                    const __is = (input: any): input is ObjectRequired => {
+                        const $io0 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input))
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectRequired => {
+                            const $guard = (typia.protobuf.assertEncode as any)
+                                .guard;
+                            const $ao0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                ("boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    })) &&
+                                (("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    })) &&
+                                ("string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    })) &&
+                                (((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }));
+                            const $ao1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                (undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    })) &&
+                                (undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    })) &&
+                                (undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    })) &&
+                                (undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array.every(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $guard(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                (null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $guard(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $ao1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }));
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $guard(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Required<ObjectRequired.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $ao0(input, _path + "", true)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    return input;
+                };
+                const encode = (input: ObjectRequired): Uint8Array => {
+                    const $Sizer = (typia.protobuf.assertEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.assertEncode as any).Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "boolean";
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                            // property "number";
+                            writer.uint32(17);
+                            writer.double(input.number);
+                            // property "string";
+                            writer.uint32(26);
+                            writer.string(input.string);
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 5 -> ObjectRequired.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $peo1 = (input: any): any => {
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(8);
+                                writer.bool(input.boolean);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(26);
+                                writer.string(input.string);
+                            }
+                            // property "array";
+                            if (undefined !== input.array) {
+                                if (0 !== input.array.length) {
+                                    writer.uint32(34);
+                                    writer.fork();
+                                    for (const elem of input.array) {
+                                        writer.double(elem);
+                                    }
+                                    writer.ldelim();
+                                }
+                            }
+                            // property "object";
+                            if (
+                                undefined !== input.object &&
+                                null !== input.object
+                            ) {
+                                // 5 -> ObjectRequired.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                "number" === typeof input.number) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) => "number" === typeof elem,
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        //Required<ObjectRequired.IBase>;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                return encode(assert(input));
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartial.ts
@@ -1,0 +1,412 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createAssertDecode_ObjectPartial =
+    _test_protobuf_assertDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertDecode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartial> => {
+                const $Reader = (typia.protobuf.createAssertDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const assert = (input: any): ObjectPartial => {
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $guard = (
+                            typia.protobuf.createAssertDecode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const output = decode(input);
+            return assert(output) as any;
+        },
+        encode: (input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,253 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createAssertDecode_ObjectPartialAndRequired =
+    _test_protobuf_assertDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertDecode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $Reader = (typia.protobuf.createAssertDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        string: undefined as any,
+                        number: undefined as any,
+                        boolean: undefined as any,
+                        object: null as any,
+                        array: [] as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 4:
+                                // ObjectPartialAndRequired;
+                                output.object = $pdo0(reader, reader.uint32());
+                                break;
+                            case 5:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (
+                            typia.protobuf.createAssertDecode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const output = decode(input);
+            return assert(output) as any;
+        },
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectRequired.ts
@@ -1,0 +1,421 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertDecode } from "../../../internal/_test_protobuf_assertDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createAssertDecode_ObjectRequired =
+    _test_protobuf_assertDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertDecode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectRequired> => {
+                const $Reader = (typia.protobuf.createAssertDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (
+                            typia.protobuf.createAssertDecode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const output = decode(input);
+            return assert(output) as any;
+        },
+        encode: (input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartial.ts
@@ -1,0 +1,410 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createAssertEncode_ObjectPartial =
+    _test_protobuf_assertEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        assertEncode: (input: any): Uint8Array => {
+            const assert = (input: any): ObjectPartial => {
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $guard = (
+                            typia.protobuf.createAssertEncode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const encode = (input: ObjectPartial): Uint8Array => {
+                const $Sizer = (typia.protobuf.createAssertEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createAssertEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    //Partial<ObjectPartial.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return encode(assert(input));
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,252 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createAssertEncode_ObjectPartialAndRequired =
+    _test_protobuf_assertEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        assertEncode: (input: any): Uint8Array => {
+            const assert = (input: any): ObjectPartialAndRequired => {
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $guard = (
+                            typia.protobuf.createAssertEncode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const encode = (input: ObjectPartialAndRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createAssertEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createAssertEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(10);
+                            writer.string(input.string);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(24);
+                            writer.bool(input.boolean);
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 4 -> ObjectPartialAndRequired;
+                            writer.uint32(34);
+                            writer.fork();
+                            $peo0(input.object);
+                            writer.ldelim();
+                        }
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(42);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    };
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        );
+                    //ObjectPartialAndRequired;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return encode(assert(input));
+        },
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectRequired.ts
@@ -1,0 +1,419 @@
+import typia from "../../../../src";
+import { _test_protobuf_assertEncode } from "../../../internal/_test_protobuf_assertEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createAssertEncode_ObjectRequired =
+    _test_protobuf_assertEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        assertEncode: (input: any): Uint8Array => {
+            const assert = (input: any): ObjectRequired => {
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input))
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $guard = (
+                            typia.protobuf.createAssertEncode as any
+                        ).guard;
+                        const $ao0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            ("boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "boolean",
+                                    value: input.boolean,
+                                })) &&
+                            (("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "number",
+                                    value: input.number,
+                                })) &&
+                            ("string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "string",
+                                    value: input.string,
+                                })) &&
+                            (((Array.isArray(input.array) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array.every(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $guard(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                }));
+                        const $ao1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                })) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                })) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                })) &&
+                            (undefined === input.array ||
+                                ((Array.isArray(input.array) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    })) &&
+                                    input.array.every(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $guard(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    })) &&
+                                    $ao1(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                }));
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $guard(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $ao0(input, _path + "", true)) ||
+                            $guard(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                return input;
+            };
+            const encode = (input: ObjectRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createAssertEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createAssertEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) => "number" === typeof elem,
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    //Required<ObjectRequired.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return encode(assert(input));
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectPartial.ts
@@ -1,0 +1,186 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createDecode_ObjectPartial = _test_protobuf_decode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+    encode: (input: ObjectPartial): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            //Partial<ObjectPartial.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,118 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createDecode_ObjectPartialAndRequired =
+    _test_protobuf_decode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectRequired.ts
@@ -1,0 +1,194 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createDecode_ObjectRequired = _test_protobuf_decode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+    encode: (input: ObjectRequired): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            //Required<ObjectRequired.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectPartial.ts
@@ -1,0 +1,188 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createEncode_ObjectPartial = _test_protobuf_encode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    encode: (input: ObjectPartial): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            //Partial<ObjectPartial.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+    message:
+        'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,120 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createEncode_ObjectPartialAndRequired =
+    _test_protobuf_encode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectRequired.ts
@@ -1,0 +1,196 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createEncode_ObjectRequired = _test_protobuf_encode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    encode: (input: ObjectRequired): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            //Required<ObjectRequired.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+    message:
+        'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartial.ts
@@ -1,0 +1,240 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createIsDecode_ObjectPartial =
+    _test_protobuf_isDecode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        isDecode: (input: Uint8Array): typia.Resolved<ObjectPartial> | null => {
+            const is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartial> => {
+                const $Reader = (typia.protobuf.createIsDecode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            if (!is(output)) return null;
+            return output;
+        },
+        encode: (input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,149 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createIsDecode_ObjectPartialAndRequired =
+    _test_protobuf_isDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isDecode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> | null => {
+            const is = (input: any): input is ObjectPartialAndRequired => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    );
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $Reader = (typia.protobuf.createIsDecode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        string: undefined as any,
+                        number: undefined as any,
+                        boolean: undefined as any,
+                        object: null as any,
+                        array: [] as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 4:
+                                // ObjectPartialAndRequired;
+                                output.object = $pdo0(reader, reader.uint32());
+                                break;
+                            case 5:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            if (!is(output)) return null;
+            return output;
+        },
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectRequired.ts
@@ -1,0 +1,247 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createIsDecode_ObjectRequired =
+    _test_protobuf_isDecode("ObjectRequired")<ObjectRequired>(ObjectRequired)({
+        isDecode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectRequired> | null => {
+            const is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectRequired> => {
+                const $Reader = (typia.protobuf.createIsDecode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            if (!is(output)) return null;
+            return output;
+        },
+        encode: (input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartial.ts
@@ -1,0 +1,237 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createIsEncode_ObjectPartial =
+    _test_protobuf_isEncode("ObjectPartial")<ObjectPartial>(ObjectPartial)({
+        isEncode: (input: ObjectPartial): Uint8Array | null => {
+            const is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            const encode = (input: ObjectPartial): Uint8Array => {
+                const $Sizer = (typia.protobuf.createIsEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createIsEncode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    //Partial<ObjectPartial.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return is(input) ? encode(input) : null;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,147 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createIsEncode_ObjectPartialAndRequired =
+    _test_protobuf_isEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isEncode: (input: ObjectPartialAndRequired): Uint8Array | null => {
+            const is = (input: any): input is ObjectPartialAndRequired => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    );
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const encode = (input: ObjectPartialAndRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createIsEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createIsEncode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(10);
+                            writer.string(input.string);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(24);
+                            writer.bool(input.boolean);
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 4 -> ObjectPartialAndRequired;
+                            writer.uint32(34);
+                            writer.fork();
+                            $peo0(input.object);
+                            writer.ldelim();
+                        }
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(42);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    };
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        );
+                    //ObjectPartialAndRequired;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return is(input) ? encode(input) : null;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectRequired.ts
@@ -1,0 +1,242 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createIsEncode_ObjectRequired =
+    _test_protobuf_isEncode("ObjectRequired")<ObjectRequired>(ObjectRequired)({
+        isEncode: (input: ObjectRequired): Uint8Array | null => {
+            const is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const encode = (input: ObjectRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createIsEncode as any).Sizer;
+                const $Writer = (typia.protobuf.createIsEncode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) => "number" === typeof elem,
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    //Required<ObjectRequired.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return is(input) ? encode(input) : null;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartial.ts
@@ -1,0 +1,435 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createValidateDecode_ObjectPartial =
+    _test_protobuf_validateDecode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateDecode: (
+            input: Uint8Array,
+        ): typia.IValidation<typia.Resolved<ObjectPartial>> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateDecode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartial> => {
+                const $Reader = (typia.protobuf.createValidateDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            return validate(output) as any;
+        },
+        encode: (input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,266 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createValidateDecode_ObjectPartialAndRequired =
+    _test_protobuf_validateDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateDecode: (
+            input: Uint8Array,
+        ): typia.IValidation<typia.Resolved<ObjectPartialAndRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateDecode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartialAndRequired> => {
+                const $Reader = (typia.protobuf.createValidateDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        string: undefined as any,
+                        number: undefined as any,
+                        boolean: undefined as any,
+                        object: null as any,
+                        array: [] as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 4:
+                                // ObjectPartialAndRequired;
+                                output.object = $pdo0(reader, reader.uint32());
+                                break;
+                            case 5:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            return validate(output) as any;
+        },
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectRequired.ts
@@ -1,0 +1,446 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createValidateDecode_ObjectRequired =
+    _test_protobuf_validateDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateDecode: (
+            input: Uint8Array,
+        ): typia.IValidation<typia.Resolved<ObjectRequired>> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateDecode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectRequired> => {
+                const $Reader = (typia.protobuf.createValidateDecode as any)
+                    .Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            return validate(output) as any;
+        },
+        encode: (input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartial.ts
@@ -1,0 +1,436 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_createValidateEncode_ObjectPartial =
+    _test_protobuf_validateEncode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateEncode: (
+            input: ObjectPartial,
+        ): typia.IValidation<Uint8Array> => {
+            const validate = (input: any): typia.IValidation<ObjectPartial> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectPartial => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input) &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateEncode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartial => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index2: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index2 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartial.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input &&
+                                null !== input &&
+                                false === Array.isArray(input)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Partial<ObjectPartial.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const encode = (input: ObjectPartial): Uint8Array => {
+                const $Sizer = (typia.protobuf.createValidateEncode as any)
+                    .Sizer;
+                const $Writer = (typia.protobuf.createValidateEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    //Partial<ObjectPartial.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = encode(input);
+            return output;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,270 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_createValidateEncode_ObjectPartialAndRequired =
+    _test_protobuf_validateEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateEncode: (
+            input: ObjectPartialAndRequired,
+        ): typia.IValidation<Uint8Array> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectPartialAndRequired> => {
+                const errors = [] as any[];
+                const __is = (
+                    input: any,
+                ): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateEncode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectPartialAndRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo0(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const encode = (input: ObjectPartialAndRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createValidateEncode as any)
+                    .Sizer;
+                const $Writer = (typia.protobuf.createValidateEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(10);
+                            writer.string(input.string);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(24);
+                            writer.bool(input.boolean);
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 4 -> ObjectPartialAndRequired;
+                            writer.uint32(34);
+                            writer.fork();
+                            $peo0(input.object);
+                            writer.ldelim();
+                        }
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(42);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    };
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        );
+                    //ObjectPartialAndRequired;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = encode(input);
+            return output;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectRequired.ts
@@ -1,0 +1,447 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_createValidateEncode_ObjectRequired =
+    _test_protobuf_validateEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateEncode: (
+            input: ObjectRequired,
+        ): typia.IValidation<Uint8Array> => {
+            const validate = (
+                input: any,
+            ): typia.IValidation<ObjectRequired> => {
+                const errors = [] as any[];
+                const __is = (input: any): input is ObjectRequired => {
+                    const $io0 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        Number.isFinite(input.number) &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) =>
+                                        "number" === typeof elem &&
+                                        Number.isFinite(elem),
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                if (false === __is(input)) {
+                    const $report = (
+                        typia.protobuf.createValidateEncode as any
+                    ).report(errors);
+                    ((
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): input is ObjectRequired => {
+                        const $vo0 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "boolean",
+                                        value: input.boolean,
+                                    }),
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "number",
+                                        value: input.number,
+                                    }),
+                                "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "string",
+                                        value: input.string,
+                                    }),
+                                ((Array.isArray(input.array) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    })) &&
+                                    input.array
+                                        .map(
+                                            (elem: any, _index1: number) =>
+                                                ("number" === typeof elem &&
+                                                    Number.isFinite(elem)) ||
+                                                $report(_exceptionable, {
+                                                    path:
+                                                        _path +
+                                                        ".array[" +
+                                                        _index1 +
+                                                        "]",
+                                                    expected: "number",
+                                                    value: elem,
+                                                }),
+                                        )
+                                        .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "Array<number>",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        const $vo1 = (
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): boolean =>
+                            [
+                                undefined === input.boolean ||
+                                    "boolean" === typeof input.boolean ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".boolean",
+                                        expected: "(boolean | undefined)",
+                                        value: input.boolean,
+                                    }),
+                                undefined === input.number ||
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".number",
+                                        expected: "(number | undefined)",
+                                        value: input.number,
+                                    }),
+                                undefined === input.string ||
+                                    "string" === typeof input.string ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".string",
+                                        expected: "(string | undefined)",
+                                        value: input.string,
+                                    }),
+                                undefined === input.array ||
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".array",
+                                        expected: "(Array<number> | undefined)",
+                                        value: input.array,
+                                    }),
+                                null === input.object ||
+                                    undefined === input.object ||
+                                    ((("object" === typeof input.object &&
+                                        null !== input.object &&
+                                        false ===
+                                            Array.isArray(input.object)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        })) &&
+                                        $vo1(
+                                            input.object,
+                                            _path + ".object",
+                                            true && _exceptionable,
+                                        )) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectRequired.IBase | null | undefined)",
+                                        value: input.object,
+                                    }),
+                            ].every((flag: boolean) => flag);
+                        return (
+                            ((("object" === typeof input && null !== input) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })) &&
+                                $vo0(input, _path + "", true)) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "Required<ObjectRequired.IBase>",
+                                value: input,
+                            })
+                        );
+                    })(input, "$input", true);
+                }
+                const success = 0 === errors.length;
+                return {
+                    success,
+                    errors,
+                    data: success ? input : undefined,
+                } as any;
+            };
+            const encode = (input: ObjectRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.createValidateEncode as any)
+                    .Sizer;
+                const $Writer = (typia.protobuf.createValidateEncode as any)
+                    .Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) => "number" === typeof elem,
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    //Required<ObjectRequired.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            const output = validate(input) as any;
+            if (output.success) output.data = encode(input);
+            return output;
+        },
+        message:
+            'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectPartial.ts
@@ -1,0 +1,187 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_decode_ObjectPartial = _test_protobuf_decode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    decode: (input) =>
+        ((input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.decode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        })(input),
+    encode: (input: ObjectPartial): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            //Partial<ObjectPartial.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectPartialAndRequired.ts
@@ -1,0 +1,119 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_decode_ObjectPartialAndRequired =
+    _test_protobuf_decode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        decode: (input) =>
+            ((input: Uint8Array): typia.Resolved<ObjectPartialAndRequired> => {
+                const $Reader = (typia.protobuf.decode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        string: undefined as any,
+                        number: undefined as any,
+                        boolean: undefined as any,
+                        object: null as any,
+                        array: [] as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 4:
+                                // ObjectPartialAndRequired;
+                                output.object = $pdo0(reader, reader.uint32());
+                                break;
+                            case 5:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            })(input),
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.decode/test_protobuf_decode_ObjectRequired.ts
@@ -1,0 +1,195 @@
+import typia from "../../../../src";
+import { _test_protobuf_decode } from "../../../internal/_test_protobuf_decode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_decode_ObjectRequired = _test_protobuf_decode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    decode: (input) =>
+        ((input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.decode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        })(input),
+    encode: (input: ObjectRequired): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            //Required<ObjectRequired.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectPartial.ts
@@ -1,0 +1,191 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_encode_ObjectPartial = _test_protobuf_encode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    encode: (input) =>
+        ((input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.encode as any).Sizer;
+            const $Writer = (typia.protobuf.encode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        })(input),
+    message:
+        'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectPartialAndRequired.ts
@@ -1,0 +1,123 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_encode_ObjectPartialAndRequired =
+    _test_protobuf_encode("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )({
+        encode: (input) =>
+            ((input: ObjectPartialAndRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.encode as any).Sizer;
+                const $Writer = (typia.protobuf.encode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(10);
+                            writer.string(input.string);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(24);
+                            writer.bool(input.boolean);
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 4 -> ObjectPartialAndRequired;
+                            writer.uint32(34);
+                            writer.fork();
+                            $peo0(input.object);
+                            writer.ldelim();
+                        }
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(42);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    };
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        );
+                    //ObjectPartialAndRequired;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.encode/test_protobuf_encode_ObjectRequired.ts
@@ -1,0 +1,197 @@
+import typia from "../../../../src";
+import { _test_protobuf_encode } from "../../../internal/_test_protobuf_encode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_encode_ObjectRequired = _test_protobuf_encode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    encode: (input) =>
+        ((input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.encode as any).Sizer;
+            const $Writer = (typia.protobuf.encode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        })(input),
+    message:
+        'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectPartial.ts
@@ -1,0 +1,240 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_isDecode_ObjectPartial = _test_protobuf_isDecode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    isDecode: (input) =>
+        ((input: Uint8Array): typia.Resolved<ObjectPartial> | null => {
+            const is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartial> => {
+                const $Reader = (typia.protobuf.isDecode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectPartial.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            if (!is(output)) return null;
+            return output;
+        })(input),
+    encode: (input: ObjectPartial): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectPartial.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every((elem: any) => "number" === typeof elem) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            //Partial<ObjectPartial.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,158 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_isDecode_ObjectPartialAndRequired =
+    _test_protobuf_isDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isDecode: (input) =>
+            ((
+                input: Uint8Array,
+            ): typia.Resolved<ObjectPartialAndRequired> | null => {
+                const is = (input: any): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectPartialAndRequired> => {
+                    const $Reader = (typia.protobuf.isDecode as any).Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            string: undefined as any,
+                            number: undefined as any,
+                            boolean: undefined as any,
+                            object: null as any,
+                            array: [] as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 4:
+                                    // ObjectPartialAndRequired;
+                                    output.object = $pdo0(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                case 5:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const output = decode(input);
+                if (!is(output)) return null;
+                return output;
+            })(input),
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectRequired.ts
@@ -1,0 +1,247 @@
+import typia from "../../../../src";
+import { _test_protobuf_isDecode } from "../../../internal/_test_protobuf_isDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_isDecode_ObjectRequired = _test_protobuf_isDecode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    isDecode: (input) =>
+        ((input: Uint8Array): typia.Resolved<ObjectRequired> | null => {
+            const is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const decode = (
+                input: Uint8Array,
+            ): typia.Resolved<ObjectRequired> => {
+                const $Reader = (typia.protobuf.isDecode as any).Reader;
+                const $pdo0 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: "" as any,
+                        array: [] as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const $pdo1 = (reader: any, length: number = -1): any => {
+                    length =
+                        length < 0 ? reader.size() : reader.index() + length;
+                    const output = {
+                        boolean: undefined as any,
+                        number: undefined as any,
+                        string: undefined as any,
+                        array: undefined as any,
+                        object: null as any,
+                    };
+                    while (reader.index() < length) {
+                        const tag = reader.uint32();
+                        switch (tag >>> 3) {
+                            case 1:
+                                // bool;
+                                output.boolean = reader.bool();
+                                break;
+                            case 2:
+                                // double;
+                                output.number = reader.double();
+                                break;
+                            case 3:
+                                // string;
+                                output.string = reader.string();
+                                break;
+                            case 4:
+                                // type: Array<number>;
+                                output.array ??= [] as any[];
+                                if (2 === (tag & 7)) {
+                                    const piece =
+                                        reader.uint32() + reader.index();
+                                    while (reader.index() < piece)
+                                        output.array.push(reader.double());
+                                } else output.array.push(reader.double());
+                                break;
+                            case 5:
+                                // ObjectRequired.IBase;
+                                output.object = $pdo1(reader, reader.uint32());
+                                break;
+                            default:
+                                reader.skipType(tag & 7);
+                                break;
+                        }
+                    }
+                    return output;
+                };
+                const reader = new $Reader(input);
+                return $pdo0(reader);
+            };
+            const output = decode(input);
+            if (!is(output)) return null;
+            return output;
+        })(input),
+    encode: (input: ObjectRequired): Uint8Array => {
+        const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+        const $Writer = (typia.protobuf.createEncode as any).Writer;
+        const encoder = (writer: any): any => {
+            const $peo0 = (input: any): any => {
+                // property "boolean";
+                writer.uint32(8);
+                writer.bool(input.boolean);
+                // property "number";
+                writer.uint32(17);
+                writer.double(input.number);
+                // property "string";
+                writer.uint32(26);
+                writer.string(input.string);
+                // property "array";
+                if (0 !== input.array.length) {
+                    writer.uint32(34);
+                    writer.fork();
+                    for (const elem of input.array) {
+                        writer.double(elem);
+                    }
+                    writer.ldelim();
+                }
+                // property "object";
+                if (null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $peo1 = (input: any): any => {
+                // property "boolean";
+                if (undefined !== input.boolean) {
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                }
+                // property "number";
+                if (undefined !== input.number) {
+                    writer.uint32(17);
+                    writer.double(input.number);
+                }
+                // property "string";
+                if (undefined !== input.string) {
+                    writer.uint32(26);
+                    writer.string(input.string);
+                }
+                // property "array";
+                if (undefined !== input.array) {
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                }
+                // property "object";
+                if (undefined !== input.object && null !== input.object) {
+                    // 5 -> ObjectRequired.IBase;
+                    writer.uint32(42);
+                    writer.fork();
+                    $peo1(input.object);
+                    writer.ldelim();
+                }
+            };
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    "number" === typeof input.number) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            //Required<ObjectRequired.IBase>;
+            $peo0(input);
+            return writer;
+        };
+        const sizer = encoder(new $Sizer());
+        const writer = encoder(new $Writer(sizer));
+        return writer.buffer();
+    },
+});

--- a/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectPartial.ts
@@ -1,0 +1,239 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_isEncode_ObjectPartial = _test_protobuf_isEncode(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    isEncode: (input) =>
+        ((input: ObjectPartial): Uint8Array | null => {
+            const is = (input: any): input is ObjectPartial => {
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    false === Array.isArray(input) &&
+                    $io0(input)
+                );
+            };
+            const encode = (input: ObjectPartial): Uint8Array => {
+                const $Sizer = (typia.protobuf.isEncode as any).Sizer;
+                const $Writer = (typia.protobuf.isEncode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectPartial.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        "boolean" === typeof input.boolean &&
+                        "number" === typeof input.number &&
+                        "string" === typeof input.string &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) => "number" === typeof elem,
+                        ) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io1(input.object)));
+                    //Partial<ObjectPartial.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return is(input) ? encode(input) : null;
+        })(input),
+    message:
+        'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectPartial.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,153 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_isEncode_ObjectPartialAndRequired =
+    _test_protobuf_isEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        isEncode: (input) =>
+            ((input: ObjectPartialAndRequired): Uint8Array | null => {
+                const is = (input: any): input is ObjectPartialAndRequired => {
+                    const $io0 = (input: any): boolean =>
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number))) &&
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (null === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                $io0(input.object))) &&
+                        Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        );
+                    return (
+                        "object" === typeof input &&
+                        null !== input &&
+                        $io0(input)
+                    );
+                };
+                const encode = (
+                    input: ObjectPartialAndRequired,
+                ): Uint8Array => {
+                    const $Sizer = (typia.protobuf.isEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.isEncode as any).Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(10);
+                                writer.string(input.string);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(24);
+                                writer.bool(input.boolean);
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 4 -> ObjectPartialAndRequired;
+                                writer.uint32(34);
+                                writer.fork();
+                                $peo0(input.object);
+                                writer.ldelim();
+                            }
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(42);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        };
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                "number" === typeof input.number) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            );
+                        //ObjectPartialAndRequired;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                return is(input) ? encode(input) : null;
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectRequired.ts
@@ -1,0 +1,244 @@
+import typia from "../../../../src";
+import { _test_protobuf_isEncode } from "../../../internal/_test_protobuf_isEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_isEncode_ObjectRequired = _test_protobuf_isEncode(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    isEncode: (input) =>
+        ((input: ObjectRequired): Uint8Array | null => {
+            const is = (input: any): input is ObjectRequired => {
+                const $io0 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    Number.isFinite(input.number) &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                return (
+                    "object" === typeof input && null !== input && $io0(input)
+                );
+            };
+            const encode = (input: ObjectRequired): Uint8Array => {
+                const $Sizer = (typia.protobuf.isEncode as any).Sizer;
+                const $Writer = (typia.protobuf.isEncode as any).Writer;
+                const encoder = (writer: any): any => {
+                    const $peo0 = (input: any): any => {
+                        // property "boolean";
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                        // property "number";
+                        writer.uint32(17);
+                        writer.double(input.number);
+                        // property "string";
+                        writer.uint32(26);
+                        writer.string(input.string);
+                        // property "array";
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                        // property "object";
+                        if (null !== input.object) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $peo1 = (input: any): any => {
+                        // property "boolean";
+                        if (undefined !== input.boolean) {
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                        }
+                        // property "number";
+                        if (undefined !== input.number) {
+                            writer.uint32(17);
+                            writer.double(input.number);
+                        }
+                        // property "string";
+                        if (undefined !== input.string) {
+                            writer.uint32(26);
+                            writer.string(input.string);
+                        }
+                        // property "array";
+                        if (undefined !== input.array) {
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        }
+                        // property "object";
+                        if (
+                            undefined !== input.object &&
+                            null !== input.object
+                        ) {
+                            // 5 -> ObjectRequired.IBase;
+                            writer.uint32(42);
+                            writer.fork();
+                            $peo1(input.object);
+                            writer.ldelim();
+                        }
+                    };
+                    const $io1 = (input: any): boolean =>
+                        (undefined === input.boolean ||
+                            "boolean" === typeof input.boolean) &&
+                        (undefined === input.number ||
+                            "number" === typeof input.number) &&
+                        (undefined === input.string ||
+                            "string" === typeof input.string) &&
+                        (undefined === input.array ||
+                            (Array.isArray(input.array) &&
+                                input.array.every(
+                                    (elem: any) => "number" === typeof elem,
+                                ))) &&
+                        (null === input.object ||
+                            undefined === input.object ||
+                            ("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object) &&
+                                $io1(input.object)));
+                    //Required<ObjectRequired.IBase>;
+                    $peo0(input);
+                    return writer;
+                };
+                const sizer = encoder(new $Sizer());
+                const writer = encoder(new $Writer(sizer));
+                return writer.buffer();
+            };
+            return is(input) ? encode(input) : null;
+        })(input),
+    message:
+        'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+    decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+        const $Reader = (typia.protobuf.createDecode as any).Reader;
+        const $pdo0 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: "" as any,
+                array: [] as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const $pdo1 = (reader: any, length: number = -1): any => {
+            length = length < 0 ? reader.size() : reader.index() + length;
+            const output = {
+                boolean: undefined as any,
+                number: undefined as any,
+                string: undefined as any,
+                array: undefined as any,
+                object: null as any,
+            };
+            while (reader.index() < length) {
+                const tag = reader.uint32();
+                switch (tag >>> 3) {
+                    case 1:
+                        // bool;
+                        output.boolean = reader.bool();
+                        break;
+                    case 2:
+                        // double;
+                        output.number = reader.double();
+                        break;
+                    case 3:
+                        // string;
+                        output.string = reader.string();
+                        break;
+                    case 4:
+                        // type: Array<number>;
+                        output.array ??= [] as any[];
+                        if (2 === (tag & 7)) {
+                            const piece = reader.uint32() + reader.index();
+                            while (reader.index() < piece)
+                                output.array.push(reader.double());
+                        } else output.array.push(reader.double());
+                        break;
+                    case 5:
+                        // ObjectRequired.IBase;
+                        output.object = $pdo1(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                }
+            }
+            return output;
+        };
+        const reader = new $Reader(input);
+        return $pdo0(reader);
+    },
+});

--- a/test/generated/output/protobuf.message/test_protobuf_message_ObjectPartial.ts
+++ b/test/generated/output/protobuf.message/test_protobuf_message_ObjectPartial.ts
@@ -1,0 +1,9 @@
+import typia from "../../../../src";
+import { _test_protobuf_message } from "../../../internal/_test_protobuf_message";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_message_ObjectPartial = _test_protobuf_message(
+    "ObjectPartial",
+)(
+    'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+);

--- a/test/generated/output/protobuf.message/test_protobuf_message_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.message/test_protobuf_message_ObjectPartialAndRequired.ts
@@ -1,0 +1,8 @@
+import typia from "../../../../src";
+import { _test_protobuf_message } from "../../../internal/_test_protobuf_message";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_message_ObjectPartialAndRequired =
+    _test_protobuf_message("ObjectPartialAndRequired")(
+        'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+    );

--- a/test/generated/output/protobuf.message/test_protobuf_message_ObjectRequired.ts
+++ b/test/generated/output/protobuf.message/test_protobuf_message_ObjectRequired.ts
@@ -1,0 +1,9 @@
+import typia from "../../../../src";
+import { _test_protobuf_message } from "../../../internal/_test_protobuf_message";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_message_ObjectRequired = _test_protobuf_message(
+    "ObjectRequired",
+)(
+    'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+);

--- a/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartial.ts
@@ -1,0 +1,462 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_validateDecode_ObjectPartial =
+    _test_protobuf_validateDecode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateDecode: (input) =>
+            ((
+                input: Uint8Array,
+            ): typia.IValidation<typia.Resolved<ObjectPartial>> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectPartial> => {
+                    const errors = [] as any[];
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateDecode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.array ||
+                                        ((Array.isArray(input.array) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".array",
+                                                expected:
+                                                    "(Array<number> | undefined)",
+                                                value: input.array,
+                                            })) &&
+                                            input.array
+                                                .map(
+                                                    (
+                                                        elem: any,
+                                                        _index1: number,
+                                                    ) =>
+                                                        ("number" ===
+                                                            typeof elem &&
+                                                            Number.isFinite(
+                                                                elem,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".array[" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number",
+                                                                value: elem,
+                                                            },
+                                                        ),
+                                                )
+                                                .every(
+                                                    (flag: boolean) => flag,
+                                                )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        undefined === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null | undefined)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            const $vo1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "boolean",
+                                            value: input.boolean,
+                                        }),
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "number",
+                                            value: input.number,
+                                        }),
+                                    "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "string",
+                                            value: input.string,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectPartial> => {
+                    const $Reader = (typia.protobuf.validateDecode as any)
+                        .Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: undefined as any,
+                            array: undefined as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    output.array ??= [] as any[];
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectPartial.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const $pdo1 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: "" as any,
+                            array: [] as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectPartial.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const output = decode(input);
+                return validate(output) as any;
+            })(input),
+        encode: (input: ObjectPartial): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectPartial.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    "boolean" === typeof input.boolean &&
+                    "number" === typeof input.number &&
+                    "string" === typeof input.string &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any) => "number" === typeof elem,
+                    ) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io1(input.object)));
+                //Partial<ObjectPartial.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectPartialAndRequired.ts
@@ -1,0 +1,275 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_validateDecode_ObjectPartialAndRequired =
+    _test_protobuf_validateDecode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateDecode: (input) =>
+            ((
+                input: Uint8Array,
+            ): typia.IValidation<typia.Resolved<ObjectPartialAndRequired>> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectPartialAndRequired> => {
+                    const errors = [] as any[];
+                    const __is = (
+                        input: any,
+                    ): input is ObjectPartialAndRequired => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            );
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateDecode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartialAndRequired => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartialAndRequired | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo0(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "ObjectPartialAndRequired",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectPartialAndRequired> => {
+                    const $Reader = (typia.protobuf.validateDecode as any)
+                        .Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            string: undefined as any,
+                            number: undefined as any,
+                            boolean: undefined as any,
+                            object: null as any,
+                            array: [] as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 4:
+                                    // ObjectPartialAndRequired;
+                                    output.object = $pdo0(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                case 5:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const output = decode(input);
+                return validate(output) as any;
+            })(input),
+        encode: (input: ObjectPartialAndRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(10);
+                        writer.string(input.string);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(24);
+                        writer.bool(input.boolean);
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 4 -> ObjectPartialAndRequired;
+                        writer.uint32(34);
+                        writer.fork();
+                        $peo0(input.object);
+                        writer.ldelim();
+                    }
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(42);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                };
+                const $io0 = (input: any): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every((elem: any) => "number" === typeof elem);
+                //ObjectPartialAndRequired;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectRequired.ts
@@ -1,0 +1,472 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateDecode } from "../../../internal/_test_protobuf_validateDecode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_validateDecode_ObjectRequired =
+    _test_protobuf_validateDecode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateDecode: (input) =>
+            ((
+                input: Uint8Array,
+            ): typia.IValidation<typia.Resolved<ObjectRequired>> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectRequired> => {
+                    const errors = [] as any[];
+                    const __is = (input: any): input is ObjectRequired => {
+                        const $io0 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateDecode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectRequired => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "boolean",
+                                            value: input.boolean,
+                                        }),
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "number",
+                                            value: input.number,
+                                        }),
+                                    "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "string",
+                                            value: input.string,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object &&
+                                            false ===
+                                                Array.isArray(input.object)) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectRequired.IBase | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            const $vo1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.array ||
+                                        ((Array.isArray(input.array) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".array",
+                                                expected:
+                                                    "(Array<number> | undefined)",
+                                                value: input.array,
+                                            })) &&
+                                            input.array
+                                                .map(
+                                                    (
+                                                        elem: any,
+                                                        _index2: number,
+                                                    ) =>
+                                                        ("number" ===
+                                                            typeof elem &&
+                                                            Number.isFinite(
+                                                                elem,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".array[" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number",
+                                                                value: elem,
+                                                            },
+                                                        ),
+                                                )
+                                                .every(
+                                                    (flag: boolean) => flag,
+                                                )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        undefined === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object &&
+                                            false ===
+                                                Array.isArray(input.object)) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectRequired.IBase | null | undefined)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Required<ObjectRequired.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const decode = (
+                    input: Uint8Array,
+                ): typia.Resolved<ObjectRequired> => {
+                    const $Reader = (typia.protobuf.validateDecode as any)
+                        .Reader;
+                    const $pdo0 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: "" as any,
+                            array: [] as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectRequired.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const $pdo1 = (reader: any, length: number = -1): any => {
+                        length =
+                            length < 0
+                                ? reader.size()
+                                : reader.index() + length;
+                        const output = {
+                            boolean: undefined as any,
+                            number: undefined as any,
+                            string: undefined as any,
+                            array: undefined as any,
+                            object: null as any,
+                        };
+                        while (reader.index() < length) {
+                            const tag = reader.uint32();
+                            switch (tag >>> 3) {
+                                case 1:
+                                    // bool;
+                                    output.boolean = reader.bool();
+                                    break;
+                                case 2:
+                                    // double;
+                                    output.number = reader.double();
+                                    break;
+                                case 3:
+                                    // string;
+                                    output.string = reader.string();
+                                    break;
+                                case 4:
+                                    // type: Array<number>;
+                                    output.array ??= [] as any[];
+                                    if (2 === (tag & 7)) {
+                                        const piece =
+                                            reader.uint32() + reader.index();
+                                        while (reader.index() < piece)
+                                            output.array.push(reader.double());
+                                    } else output.array.push(reader.double());
+                                    break;
+                                case 5:
+                                    // ObjectRequired.IBase;
+                                    output.object = $pdo1(
+                                        reader,
+                                        reader.uint32(),
+                                    );
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                            }
+                        }
+                        return output;
+                    };
+                    const reader = new $Reader(input);
+                    return $pdo0(reader);
+                };
+                const output = decode(input);
+                return validate(output) as any;
+            })(input),
+        encode: (input: ObjectRequired): Uint8Array => {
+            const $Sizer = (typia.protobuf.createEncode as any).Sizer;
+            const $Writer = (typia.protobuf.createEncode as any).Writer;
+            const encoder = (writer: any): any => {
+                const $peo0 = (input: any): any => {
+                    // property "boolean";
+                    writer.uint32(8);
+                    writer.bool(input.boolean);
+                    // property "number";
+                    writer.uint32(17);
+                    writer.double(input.number);
+                    // property "string";
+                    writer.uint32(26);
+                    writer.string(input.string);
+                    // property "array";
+                    if (0 !== input.array.length) {
+                        writer.uint32(34);
+                        writer.fork();
+                        for (const elem of input.array) {
+                            writer.double(elem);
+                        }
+                        writer.ldelim();
+                    }
+                    // property "object";
+                    if (null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $peo1 = (input: any): any => {
+                    // property "boolean";
+                    if (undefined !== input.boolean) {
+                        writer.uint32(8);
+                        writer.bool(input.boolean);
+                    }
+                    // property "number";
+                    if (undefined !== input.number) {
+                        writer.uint32(17);
+                        writer.double(input.number);
+                    }
+                    // property "string";
+                    if (undefined !== input.string) {
+                        writer.uint32(26);
+                        writer.string(input.string);
+                    }
+                    // property "array";
+                    if (undefined !== input.array) {
+                        if (0 !== input.array.length) {
+                            writer.uint32(34);
+                            writer.fork();
+                            for (const elem of input.array) {
+                                writer.double(elem);
+                            }
+                            writer.ldelim();
+                        }
+                    }
+                    // property "object";
+                    if (undefined !== input.object && null !== input.object) {
+                        // 5 -> ObjectRequired.IBase;
+                        writer.uint32(42);
+                        writer.fork();
+                        $peo1(input.object);
+                        writer.ldelim();
+                    }
+                };
+                const $io1 = (input: any): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (undefined === input.number ||
+                        "number" === typeof input.number) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.array ||
+                        (Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ))) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object) &&
+                            $io1(input.object)));
+                //Required<ObjectRequired.IBase>;
+                $peo0(input);
+                return writer;
+            };
+            const sizer = encoder(new $Sizer());
+            const writer = encoder(new $Writer(sizer));
+            return writer.buffer();
+        },
+    });

--- a/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartial.ts
+++ b/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartial.ts
@@ -1,0 +1,450 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_protobuf_validateEncode_ObjectPartial =
+    _test_protobuf_validateEncode("ObjectPartial")<ObjectPartial>(
+        ObjectPartial,
+    )({
+        validateEncode: (input) =>
+            ((input: ObjectPartial): typia.IValidation<Uint8Array> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectPartial> => {
+                    const errors = [] as any[];
+                    const __is = (input: any): input is ObjectPartial => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            false === Array.isArray(input) &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateEncode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartial => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.array ||
+                                        ((Array.isArray(input.array) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".array",
+                                                expected:
+                                                    "(Array<number> | undefined)",
+                                                value: input.array,
+                                            })) &&
+                                            input.array
+                                                .map(
+                                                    (
+                                                        elem: any,
+                                                        _index1: number,
+                                                    ) =>
+                                                        ("number" ===
+                                                            typeof elem &&
+                                                            Number.isFinite(
+                                                                elem,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".array[" +
+                                                                    _index1 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number",
+                                                                value: elem,
+                                                            },
+                                                        ),
+                                                )
+                                                .every(
+                                                    (flag: boolean) => flag,
+                                                )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        undefined === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null | undefined)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null | undefined)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            const $vo1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "boolean",
+                                            value: input.boolean,
+                                        }),
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "number",
+                                            value: input.number,
+                                        }),
+                                    "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "string",
+                                            value: input.string,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index2: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index2 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartial.IBase | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartial.IBase | null)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input &&
+                                    false === Array.isArray(input)) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Partial<ObjectPartial.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Partial<ObjectPartial.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const encode = (input: ObjectPartial): Uint8Array => {
+                    const $Sizer = (typia.protobuf.validateEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.validateEncode as any)
+                        .Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(8);
+                                writer.bool(input.boolean);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(26);
+                                writer.string(input.string);
+                            }
+                            // property "array";
+                            if (undefined !== input.array) {
+                                if (0 !== input.array.length) {
+                                    writer.uint32(34);
+                                    writer.fork();
+                                    for (const elem of input.array) {
+                                        writer.double(elem);
+                                    }
+                                    writer.ldelim();
+                                }
+                            }
+                            // property "object";
+                            if (
+                                undefined !== input.object &&
+                                null !== input.object
+                            ) {
+                                // 5 -> ObjectPartial.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $peo1 = (input: any): any => {
+                            // property "boolean";
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                            // property "number";
+                            writer.uint32(17);
+                            writer.double(input.number);
+                            // property "string";
+                            writer.uint32(26);
+                            writer.string(input.string);
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 5 -> ObjectPartial.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $io1 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io1(input.object)));
+                        //Partial<ObjectPartial.IBase>;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = encode(input);
+                return output;
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage Partial_lt_ObjectPartial {\n    message IBase_gt_ {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}\n\nmessage ObjectPartial {\n    message IBase {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectPartial.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectPartial> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectPartial.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartialAndRequired.ts
+++ b/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectPartialAndRequired.ts
@@ -1,0 +1,275 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_protobuf_validateEncode_ObjectPartialAndRequired =
+    _test_protobuf_validateEncode(
+        "ObjectPartialAndRequired",
+    )<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+        validateEncode: (input) =>
+            ((
+                input: ObjectPartialAndRequired,
+            ): typia.IValidation<Uint8Array> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectPartialAndRequired> => {
+                    const errors = [] as any[];
+                    const __is = (
+                        input: any,
+                    ): input is ObjectPartialAndRequired => {
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            );
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateEncode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectPartialAndRequired => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectPartialAndRequired | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo0(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectPartialAndRequired | null)",
+                                            value: input.object,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected: "ObjectPartialAndRequired",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "ObjectPartialAndRequired",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const encode = (
+                    input: ObjectPartialAndRequired,
+                ): Uint8Array => {
+                    const $Sizer = (typia.protobuf.validateEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.validateEncode as any)
+                        .Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(10);
+                                writer.string(input.string);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(24);
+                                writer.bool(input.boolean);
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 4 -> ObjectPartialAndRequired;
+                                writer.uint32(34);
+                                writer.fork();
+                                $peo0(input.object);
+                                writer.ldelim();
+                            }
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(42);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                        };
+                        const $io0 = (input: any): boolean =>
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.number ||
+                                "number" === typeof input.number) &&
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    $io0(input.object))) &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) => "number" === typeof elem,
+                            );
+                        //ObjectPartialAndRequired;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = encode(input);
+                return output;
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage ObjectPartialAndRequired {\n    optional string string = 1;\n    optional double number = 2;\n    optional bool boolean = 3;\n    optional ObjectPartialAndRequired object = 4;\n    repeated double array = 5;\n}',
+        decode: (
+            input: Uint8Array,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    string: undefined as any,
+                    number: undefined as any,
+                    boolean: undefined as any,
+                    object: null as any,
+                    array: [] as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 4:
+                            // ObjectPartialAndRequired;
+                            output.object = $pdo0(reader, reader.uint32());
+                            break;
+                        case 5:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectRequired.ts
+++ b/test/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectRequired.ts
@@ -1,0 +1,460 @@
+import typia from "../../../../src";
+import { _test_protobuf_validateEncode } from "../../../internal/_test_protobuf_validateEncode";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_protobuf_validateEncode_ObjectRequired =
+    _test_protobuf_validateEncode("ObjectRequired")<ObjectRequired>(
+        ObjectRequired,
+    )({
+        validateEncode: (input) =>
+            ((input: ObjectRequired): typia.IValidation<Uint8Array> => {
+                const validate = (
+                    input: any,
+                ): typia.IValidation<ObjectRequired> => {
+                    const errors = [] as any[];
+                    const __is = (input: any): input is ObjectRequired => {
+                        const $io0 = (input: any): boolean =>
+                            "boolean" === typeof input.boolean &&
+                            "number" === typeof input.number &&
+                            Number.isFinite(input.number) &&
+                            "string" === typeof input.string &&
+                            Array.isArray(input.array) &&
+                            input.array.every(
+                                (elem: any) =>
+                                    "number" === typeof elem &&
+                                    Number.isFinite(elem),
+                            ) &&
+                            (null === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number))) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) =>
+                                            "number" === typeof elem &&
+                                            Number.isFinite(elem),
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        return (
+                            "object" === typeof input &&
+                            null !== input &&
+                            $io0(input)
+                        );
+                    };
+                    if (false === __is(input)) {
+                        const $report = (
+                            typia.protobuf.validateEncode as any
+                        ).report(errors);
+                        ((
+                            input: any,
+                            _path: string,
+                            _exceptionable: boolean = true,
+                        ): input is ObjectRequired => {
+                            const $vo0 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "boolean",
+                                            value: input.boolean,
+                                        }),
+                                    ("number" === typeof input.number &&
+                                        Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "number",
+                                            value: input.number,
+                                        }),
+                                    "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "string",
+                                            value: input.string,
+                                        }),
+                                    ((Array.isArray(input.array) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        })) &&
+                                        input.array
+                                            .map(
+                                                (elem: any, _index1: number) =>
+                                                    ("number" === typeof elem &&
+                                                        Number.isFinite(
+                                                            elem,
+                                                        )) ||
+                                                    $report(_exceptionable, {
+                                                        path:
+                                                            _path +
+                                                            ".array[" +
+                                                            _index1 +
+                                                            "]",
+                                                        expected: "number",
+                                                        value: elem,
+                                                    }),
+                                            )
+                                            .every((flag: boolean) => flag)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected: "Array<number>",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object &&
+                                            false ===
+                                                Array.isArray(input.object)) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectRequired.IBase | null)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            const $vo1 = (
+                                input: any,
+                                _path: string,
+                                _exceptionable: boolean = true,
+                            ): boolean =>
+                                [
+                                    undefined === input.boolean ||
+                                        "boolean" === typeof input.boolean ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".boolean",
+                                            expected: "(boolean | undefined)",
+                                            value: input.boolean,
+                                        }),
+                                    undefined === input.number ||
+                                        ("number" === typeof input.number &&
+                                            Number.isFinite(input.number)) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".number",
+                                            expected: "(number | undefined)",
+                                            value: input.number,
+                                        }),
+                                    undefined === input.string ||
+                                        "string" === typeof input.string ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".string",
+                                            expected: "(string | undefined)",
+                                            value: input.string,
+                                        }),
+                                    undefined === input.array ||
+                                        ((Array.isArray(input.array) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".array",
+                                                expected:
+                                                    "(Array<number> | undefined)",
+                                                value: input.array,
+                                            })) &&
+                                            input.array
+                                                .map(
+                                                    (
+                                                        elem: any,
+                                                        _index2: number,
+                                                    ) =>
+                                                        ("number" ===
+                                                            typeof elem &&
+                                                            Number.isFinite(
+                                                                elem,
+                                                            )) ||
+                                                        $report(
+                                                            _exceptionable,
+                                                            {
+                                                                path:
+                                                                    _path +
+                                                                    ".array[" +
+                                                                    _index2 +
+                                                                    "]",
+                                                                expected:
+                                                                    "number",
+                                                                value: elem,
+                                                            },
+                                                        ),
+                                                )
+                                                .every(
+                                                    (flag: boolean) => flag,
+                                                )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".array",
+                                            expected:
+                                                "(Array<number> | undefined)",
+                                            value: input.array,
+                                        }),
+                                    null === input.object ||
+                                        undefined === input.object ||
+                                        ((("object" === typeof input.object &&
+                                            null !== input.object &&
+                                            false ===
+                                                Array.isArray(input.object)) ||
+                                            $report(_exceptionable, {
+                                                path: _path + ".object",
+                                                expected:
+                                                    "(ObjectRequired.IBase | null | undefined)",
+                                                value: input.object,
+                                            })) &&
+                                            $vo1(
+                                                input.object,
+                                                _path + ".object",
+                                                true && _exceptionable,
+                                            )) ||
+                                        $report(_exceptionable, {
+                                            path: _path + ".object",
+                                            expected:
+                                                "(ObjectRequired.IBase | null | undefined)",
+                                            value: input.object,
+                                        }),
+                                ].every((flag: boolean) => flag);
+                            return (
+                                ((("object" === typeof input &&
+                                    null !== input) ||
+                                    $report(true, {
+                                        path: _path + "",
+                                        expected:
+                                            "Required<ObjectRequired.IBase>",
+                                        value: input,
+                                    })) &&
+                                    $vo0(input, _path + "", true)) ||
+                                $report(true, {
+                                    path: _path + "",
+                                    expected: "Required<ObjectRequired.IBase>",
+                                    value: input,
+                                })
+                            );
+                        })(input, "$input", true);
+                    }
+                    const success = 0 === errors.length;
+                    return {
+                        success,
+                        errors,
+                        data: success ? input : undefined,
+                    } as any;
+                };
+                const encode = (input: ObjectRequired): Uint8Array => {
+                    const $Sizer = (typia.protobuf.validateEncode as any).Sizer;
+                    const $Writer = (typia.protobuf.validateEncode as any)
+                        .Writer;
+                    const encoder = (writer: any): any => {
+                        const $peo0 = (input: any): any => {
+                            // property "boolean";
+                            writer.uint32(8);
+                            writer.bool(input.boolean);
+                            // property "number";
+                            writer.uint32(17);
+                            writer.double(input.number);
+                            // property "string";
+                            writer.uint32(26);
+                            writer.string(input.string);
+                            // property "array";
+                            if (0 !== input.array.length) {
+                                writer.uint32(34);
+                                writer.fork();
+                                for (const elem of input.array) {
+                                    writer.double(elem);
+                                }
+                                writer.ldelim();
+                            }
+                            // property "object";
+                            if (null !== input.object) {
+                                // 5 -> ObjectRequired.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $peo1 = (input: any): any => {
+                            // property "boolean";
+                            if (undefined !== input.boolean) {
+                                writer.uint32(8);
+                                writer.bool(input.boolean);
+                            }
+                            // property "number";
+                            if (undefined !== input.number) {
+                                writer.uint32(17);
+                                writer.double(input.number);
+                            }
+                            // property "string";
+                            if (undefined !== input.string) {
+                                writer.uint32(26);
+                                writer.string(input.string);
+                            }
+                            // property "array";
+                            if (undefined !== input.array) {
+                                if (0 !== input.array.length) {
+                                    writer.uint32(34);
+                                    writer.fork();
+                                    for (const elem of input.array) {
+                                        writer.double(elem);
+                                    }
+                                    writer.ldelim();
+                                }
+                            }
+                            // property "object";
+                            if (
+                                undefined !== input.object &&
+                                null !== input.object
+                            ) {
+                                // 5 -> ObjectRequired.IBase;
+                                writer.uint32(42);
+                                writer.fork();
+                                $peo1(input.object);
+                                writer.ldelim();
+                            }
+                        };
+                        const $io1 = (input: any): boolean =>
+                            (undefined === input.boolean ||
+                                "boolean" === typeof input.boolean) &&
+                            (undefined === input.number ||
+                                "number" === typeof input.number) &&
+                            (undefined === input.string ||
+                                "string" === typeof input.string) &&
+                            (undefined === input.array ||
+                                (Array.isArray(input.array) &&
+                                    input.array.every(
+                                        (elem: any) => "number" === typeof elem,
+                                    ))) &&
+                            (null === input.object ||
+                                undefined === input.object ||
+                                ("object" === typeof input.object &&
+                                    null !== input.object &&
+                                    false === Array.isArray(input.object) &&
+                                    $io1(input.object)));
+                        //Required<ObjectRequired.IBase>;
+                        $peo0(input);
+                        return writer;
+                    };
+                    const sizer = encoder(new $Sizer());
+                    const writer = encoder(new $Writer(sizer));
+                    return writer.buffer();
+                };
+                const output = validate(input) as any;
+                if (output.success) output.data = encode(input);
+                return output;
+            })(input),
+        message:
+            'syntax = "proto3";\n\nmessage Required_lt_ObjectRequired {\n    message IBase_gt_ {\n        required bool boolean = 1;\n        required double number = 2;\n        required string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}\n\nmessage ObjectRequired {\n    message IBase {\n        optional bool boolean = 1;\n        optional double number = 2;\n        optional string string = 3;\n        repeated double array = 4;\n        optional ObjectRequired.IBase object = 5;\n    }\n}',
+        decode: (input: Uint8Array): typia.Resolved<ObjectRequired> => {
+            const $Reader = (typia.protobuf.createDecode as any).Reader;
+            const $pdo0 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: "" as any,
+                    array: [] as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const $pdo1 = (reader: any, length: number = -1): any => {
+                length = length < 0 ? reader.size() : reader.index() + length;
+                const output = {
+                    boolean: undefined as any,
+                    number: undefined as any,
+                    string: undefined as any,
+                    array: undefined as any,
+                    object: null as any,
+                };
+                while (reader.index() < length) {
+                    const tag = reader.uint32();
+                    switch (tag >>> 3) {
+                        case 1:
+                            // bool;
+                            output.boolean = reader.bool();
+                            break;
+                        case 2:
+                            // double;
+                            output.number = reader.double();
+                            break;
+                        case 3:
+                            // string;
+                            output.string = reader.string();
+                            break;
+                        case 4:
+                            // type: Array<number>;
+                            output.array ??= [] as any[];
+                            if (2 === (tag & 7)) {
+                                const piece = reader.uint32() + reader.index();
+                                while (reader.index() < piece)
+                                    output.array.push(reader.double());
+                            } else output.array.push(reader.double());
+                            break;
+                        case 5:
+                            // ObjectRequired.IBase;
+                            output.object = $pdo1(reader, reader.uint32());
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                    }
+                }
+                return output;
+            };
+            const reader = new $Reader(input);
+            return $pdo0(reader);
+        },
+    });

--- a/test/generated/output/random/test_random_ObjectPartial.ts
+++ b/test/generated/output/random/test_random_ObjectPartial.ts
@@ -1,0 +1,291 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_random_ObjectPartial = _test_random(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)({
+    random: () =>
+        ((
+            generator?: Partial<typia.IRandomGenerator>,
+        ): typia.Resolved<ObjectPartial> => {
+            const $generator = (typia.random as any).generator;
+            const $pick = (typia.random as any).pick;
+            const $ro0 = (
+                _recursive: boolean = false,
+                _depth: number = 0,
+            ): any => ({
+                boolean: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
+                number: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.(
+                            [],
+                        ) ?? (generator?.number ?? $generator.number)(0, 100),
+                ])(),
+                string: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.string?.(
+                            [],
+                        ) ?? (generator?.string ?? $generator.string)(),
+                ])(),
+                array: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.array ?? $generator.array)(
+                            () =>
+                                (
+                                    generator?.customs ?? $generator.customs
+                                )?.number?.([]) ??
+                                (generator?.number ?? $generator.number)(
+                                    0,
+                                    100,
+                                ),
+                        ),
+                ])(),
+                object: $pick([
+                    () => undefined,
+                    () => null,
+                    () => $ro1(_recursive, _recursive ? 1 + _depth : _depth),
+                ])(),
+            });
+            const $ro1 = (
+                _recursive: boolean = true,
+                _depth: number = 0,
+            ): any => ({
+                boolean: (generator?.boolean ?? $generator.boolean)(),
+                number:
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+                string:
+                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+                array:
+                    _recursive && 5 < _depth
+                        ? []
+                        : 5 >= _depth
+                        ? (generator?.array ?? $generator.array)(
+                              () =>
+                                  (
+                                      generator?.customs ?? $generator.customs
+                                  )?.number?.([]) ??
+                                  (generator?.number ?? $generator.number)(
+                                      0,
+                                      100,
+                                  ),
+                          )
+                        : [],
+                object: $pick([
+                    () => null,
+                    () => $ro1(true, _recursive ? 1 + _depth : _depth),
+                ])(),
+            });
+            return $ro0();
+        })(),
+    assert: (input: any): ObjectPartial => {
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index1: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index1 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectPartial.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index2 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartial.IBase | null)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/random/test_random_ObjectPartialAndRequired.ts
+++ b/test/generated/output/random/test_random_ObjectPartialAndRequired.ts
@@ -1,0 +1,169 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_random_ObjectPartialAndRequired = _test_random(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)({
+    random: () =>
+        ((
+            generator?: Partial<typia.IRandomGenerator>,
+        ): typia.Resolved<ObjectPartialAndRequired> => {
+            const $generator = (typia.random as any).generator;
+            const $pick = (typia.random as any).pick;
+            const $ro0 = (
+                _recursive: boolean = true,
+                _depth: number = 0,
+            ): any => ({
+                string: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.string?.(
+                            [],
+                        ) ?? (generator?.string ?? $generator.string)(),
+                ])(),
+                number: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.(
+                            [],
+                        ) ?? (generator?.number ?? $generator.number)(0, 100),
+                ])(),
+                boolean: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
+                object: $pick([
+                    () => null,
+                    () => $ro0(true, _recursive ? 1 + _depth : _depth),
+                ])(),
+                array:
+                    _recursive && 5 < _depth
+                        ? []
+                        : 5 >= _depth
+                        ? (generator?.array ?? $generator.array)(
+                              () =>
+                                  (
+                                      generator?.customs ?? $generator.customs
+                                  )?.number?.([]) ??
+                                  (generator?.number ?? $generator.number)(
+                                      0,
+                                      100,
+                                  ),
+                          )
+                        : [],
+            });
+            return $ro0();
+        })(),
+    assert: (input: any): ObjectPartialAndRequired => {
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            })) &&
+                            $ao0(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectPartialAndRequired | null)",
+                            value: input.object,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/random/test_random_ObjectRequired.ts
+++ b/test/generated/output/random/test_random_ObjectRequired.ts
@@ -1,0 +1,284 @@
+import typia from "../../../../src";
+import { _test_random } from "../../../internal/_test_random";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_random_ObjectRequired = _test_random(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)({
+    random: () =>
+        ((
+            generator?: Partial<typia.IRandomGenerator>,
+        ): typia.Resolved<ObjectRequired> => {
+            const $generator = (typia.random as any).generator;
+            const $pick = (typia.random as any).pick;
+            const $ro0 = (
+                _recursive: boolean = false,
+                _depth: number = 0,
+            ): any => ({
+                boolean: (generator?.boolean ?? $generator.boolean)(),
+                number:
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
+                string:
+                    (generator?.customs ?? $generator.customs)?.string?.([]) ??
+                    (generator?.string ?? $generator.string)(),
+                array: (generator?.array ?? $generator.array)(
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.(
+                            [],
+                        ) ?? (generator?.number ?? $generator.number)(0, 100),
+                ),
+                object: $pick([
+                    () => null,
+                    () => $ro1(_recursive, _recursive ? 1 + _depth : _depth),
+                ])(),
+            });
+            const $ro1 = (
+                _recursive: boolean = true,
+                _depth: number = 0,
+            ): any => ({
+                boolean: $pick([
+                    () => undefined,
+                    () => (generator?.boolean ?? $generator.boolean)(),
+                ])(),
+                number: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.number?.(
+                            [],
+                        ) ?? (generator?.number ?? $generator.number)(0, 100),
+                ])(),
+                string: $pick([
+                    () => undefined,
+                    () =>
+                        (generator?.customs ?? $generator.customs)?.string?.(
+                            [],
+                        ) ?? (generator?.string ?? $generator.string)(),
+                ])(),
+                array: $pick([
+                    () => undefined,
+                    () =>
+                        _recursive && 5 < _depth
+                            ? []
+                            : 5 >= _depth
+                            ? (generator?.array ?? $generator.array)(
+                                  () =>
+                                      (
+                                          generator?.customs ??
+                                          $generator.customs
+                                      )?.number?.([]) ??
+                                      (generator?.number ?? $generator.number)(
+                                          0,
+                                          100,
+                                      ),
+                              )
+                            : [],
+                ])(),
+                object: $pick([
+                    () => undefined,
+                    () => null,
+                    () => $ro1(true, _recursive ? 1 + _depth : _depth),
+                ])(),
+            });
+            return $ro0();
+        })(),
+    assert: (input: any): ObjectRequired => {
+        const __is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input))
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $guard = (typia.createAssert as any).guard;
+                const $ao0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    ("boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "boolean",
+                            value: input.boolean,
+                        })) &&
+                    (("number" === typeof input.number &&
+                        Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "number",
+                            value: input.number,
+                        })) &&
+                    ("string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "string",
+                            value: input.string,
+                        })) &&
+                    (((Array.isArray(input.array) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                ("number" === typeof elem &&
+                                    Number.isFinite(elem)) ||
+                                $guard(_exceptionable, {
+                                    path: _path + ".array[" + _index1 + "]",
+                                    expected: "number",
+                                    value: elem,
+                                }),
+                        )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "Array<number>",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected: "(ObjectRequired.IBase | null)",
+                            value: input.object,
+                        }));
+                const $ao1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean ||
+                        $guard(_exceptionable, {
+                            path: _path + ".boolean",
+                            expected: "(boolean | undefined)",
+                            value: input.boolean,
+                        })) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".number",
+                            expected: "(number | undefined)",
+                            value: input.number,
+                        })) &&
+                    (undefined === input.string ||
+                        "string" === typeof input.string ||
+                        $guard(_exceptionable, {
+                            path: _path + ".string",
+                            expected: "(string | undefined)",
+                            value: input.string,
+                        })) &&
+                    (undefined === input.array ||
+                        ((Array.isArray(input.array) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            })) &&
+                            input.array.every(
+                                (elem: any, _index2: number) =>
+                                    ("number" === typeof elem &&
+                                        Number.isFinite(elem)) ||
+                                    $guard(_exceptionable, {
+                                        path: _path + ".array[" + _index2 + "]",
+                                        expected: "number",
+                                        value: elem,
+                                    }),
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".array",
+                            expected: "(Array<number> | undefined)",
+                            value: input.array,
+                        })) &&
+                    (null === input.object ||
+                        undefined === input.object ||
+                        ((("object" === typeof input.object &&
+                            null !== input.object &&
+                            false === Array.isArray(input.object)) ||
+                            $guard(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            })) &&
+                            $ao1(
+                                input.object,
+                                _path + ".object",
+                                true && _exceptionable,
+                            )) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".object",
+                            expected:
+                                "(ObjectRequired.IBase | null | undefined)",
+                            value: input.object,
+                        }));
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $guard(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $ao0(input, _path + "", true)) ||
+                    $guard(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        return input;
+    },
+});

--- a/test/generated/output/random/test_random_ObjectUnionImplicit.ts
+++ b/test/generated/output/random/test_random_ObjectUnionImplicit.ts
@@ -159,13 +159,13 @@ export const test_random_ObjectUnionImplicit = _test_random(
                 _recursive: boolean = false,
                 _depth: number = 0,
             ): any => ({
+                radius:
+                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
+                    (generator?.number ?? $generator.number)(0, 100),
                 centroid: $pick([
                     () => undefined,
                     () => $ro0(_recursive, _recursive ? 1 + _depth : _depth),
                 ])(),
-                radius:
-                    (generator?.customs ?? $generator.customs)?.number?.([]) ??
-                    (generator?.number ?? $generator.number)(0, 100),
                 area: $pick([
                     () => undefined,
                     () => null,
@@ -287,12 +287,12 @@ export const test_random_ObjectUnionImplicit = _test_random(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -705,6 +705,13 @@ export const test_random_ObjectUnionImplicit = _test_random(
                     _path: string,
                     _exceptionable: boolean = true,
                 ): boolean =>
+                    (("number" === typeof input.radius &&
+                        Number.isFinite(input.radius)) ||
+                        $guard(_exceptionable, {
+                            path: _path + ".radius",
+                            expected: "number",
+                            value: input.radius,
+                        })) &&
                     (undefined === input.centroid ||
                         ((("object" === typeof input.centroid &&
                             null !== input.centroid) ||
@@ -724,13 +731,6 @@ export const test_random_ObjectUnionImplicit = _test_random(
                             expected:
                                 "(ObjectUnionImplicit.IPoint | undefined)",
                             value: input.centroid,
-                        })) &&
-                    (("number" === typeof input.radius &&
-                        Number.isFinite(input.radius)) ||
-                        $guard(_exceptionable, {
-                            path: _path + ".radius",
-                            expected: "number",
-                            value: input.radius,
                         })) &&
                     (null === input.area ||
                         undefined === input.area ||

--- a/test/generated/output/validate/test_validate_ObjectPartial.ts
+++ b/test/generated/output/validate/test_validate_ObjectPartial.ts
@@ -1,0 +1,233 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_validate_ObjectPartial = _test_validate(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.IValidation<ObjectPartial> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectPartial => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object)));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.validate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    })(input),
+);

--- a/test/generated/output/validate/test_validate_ObjectPartialAndRequired.ts
+++ b/test/generated/output/validate/test_validate_ObjectPartialAndRequired.ts
@@ -1,0 +1,135 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_validate_ObjectPartialAndRequired = _test_validate(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(ObjectPartialAndRequired)((input) =>
+    ((input: any): typia.IValidation<ObjectPartialAndRequired> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectPartialAndRequired => {
+            const $io0 = (input: any): boolean =>
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io0(input.object))) &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                );
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input)) {
+            const $report = (typia.validate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo0(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartialAndRequired | null)",
+                                value: input.object,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "ObjectPartialAndRequired",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    })(input),
+);

--- a/test/generated/output/validate/test_validate_ObjectRequired.ts
+++ b/test/generated/output/validate/test_validate_ObjectRequired.ts
@@ -1,0 +1,230 @@
+import typia from "../../../../src";
+import { _test_validate } from "../../../internal/_test_validate";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_validate_ObjectRequired = _test_validate(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.IValidation<ObjectRequired> => {
+        const errors = [] as any[];
+        const __is = (input: any): input is ObjectRequired => {
+            const $io0 = (input: any): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            const $io1 = (input: any): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object)));
+            return "object" === typeof input && null !== input && $io0(input);
+        };
+        if (false === __is(input)) {
+            const $report = (typia.validate as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    })(input),
+);

--- a/test/generated/output/validate/test_validate_ObjectUnionImplicit.ts
+++ b/test/generated/output/validate/test_validate_ObjectUnionImplicit.ts
@@ -106,12 +106,12 @@ export const test_validate_ObjectUnionImplicit = _test_validate(
                     ("number" === typeof input.area &&
                         Number.isFinite(input.area)));
             const $io6 = (input: any): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -561,6 +561,13 @@ export const test_validate_ObjectUnionImplicit = _test_validate(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
+                        ("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            }),
                         undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -580,13 +587,6 @@ export const test_validate_ObjectUnionImplicit = _test_validate(
                                 expected:
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
-                            }),
-                        ("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
                             }),
                         null === input.area ||
                             undefined === input.area ||

--- a/test/generated/output/validateEquals/test_validateEquals_ObjectPartial.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_ObjectPartial.ts
@@ -1,0 +1,321 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectPartial } from "../../../structures/ObjectPartial";
+
+export const test_validateEquals_ObjectPartial = _test_validateEquals(
+    "ObjectPartial",
+)<ObjectPartial>(ObjectPartial)((input) =>
+    ((input: any): typia.IValidation<ObjectPartial> => {
+        const errors = [] as any[];
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectPartial => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index1: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index2: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input &&
+                null !== input &&
+                false === Array.isArray(input) &&
+                $io0(input, true)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.validateEquals as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartial => {
+                const $join = (typia.validateEquals as any).join;
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartial.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectPartial.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                        0 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index2: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index2 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectPartial.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectPartial.IBase | null)",
+                                value: input.object,
+                            }),
+                        5 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input &&
+                        null !== input &&
+                        false === Array.isArray(input)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Partial<ObjectPartial.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Partial<ObjectPartial.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    })(input),
+);

--- a/test/generated/output/validateEquals/test_validateEquals_ObjectPartialAndRequired.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_ObjectPartialAndRequired.ts
@@ -1,0 +1,187 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+
+export const test_validateEquals_ObjectPartialAndRequired =
+    _test_validateEquals("ObjectPartialAndRequired")<ObjectPartialAndRequired>(
+        ObjectPartialAndRequired,
+    )((input) =>
+        ((input: any): typia.IValidation<ObjectPartialAndRequired> => {
+            const errors = [] as any[];
+            const __is = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): input is ObjectPartialAndRequired => {
+                const $io0 = (
+                    input: any,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    (undefined === input.string ||
+                        "string" === typeof input.string) &&
+                    (undefined === input.number ||
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number))) &&
+                    (undefined === input.boolean ||
+                        "boolean" === typeof input.boolean) &&
+                    (null === input.object ||
+                        ("object" === typeof input.object &&
+                            null !== input.object &&
+                            $io0(input.object, true && _exceptionable))) &&
+                    Array.isArray(input.array) &&
+                    input.array.every(
+                        (elem: any, _index1: number) =>
+                            "number" === typeof elem && Number.isFinite(elem),
+                    ) &&
+                    (2 === Object.keys(input).length ||
+                        Object.keys(input).every((key: any) => {
+                            if (
+                                [
+                                    "string",
+                                    "number",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                ].some((prop: any) => key === prop)
+                            )
+                                return true;
+                            const value = input[key];
+                            if (undefined === value) return true;
+                            return false;
+                        }));
+                return (
+                    "object" === typeof input &&
+                    null !== input &&
+                    $io0(input, true)
+                );
+            };
+            if (false === __is(input)) {
+                const $report = (typia.validateEquals as any).report(errors);
+                ((
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): input is ObjectPartialAndRequired => {
+                    const $join = (typia.validateEquals as any).join;
+                    const $vo0 = (
+                        input: any,
+                        _path: string,
+                        _exceptionable: boolean = true,
+                    ): boolean =>
+                        [
+                            undefined === input.string ||
+                                "string" === typeof input.string ||
+                                $report(_exceptionable, {
+                                    path: _path + ".string",
+                                    expected: "(string | undefined)",
+                                    value: input.string,
+                                }),
+                            undefined === input.number ||
+                                ("number" === typeof input.number &&
+                                    Number.isFinite(input.number)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".number",
+                                    expected: "(number | undefined)",
+                                    value: input.number,
+                                }),
+                            undefined === input.boolean ||
+                                "boolean" === typeof input.boolean ||
+                                $report(_exceptionable, {
+                                    path: _path + ".boolean",
+                                    expected: "(boolean | undefined)",
+                                    value: input.boolean,
+                                }),
+                            null === input.object ||
+                                ((("object" === typeof input.object &&
+                                    null !== input.object) ||
+                                    $report(_exceptionable, {
+                                        path: _path + ".object",
+                                        expected:
+                                            "(ObjectPartialAndRequired | null)",
+                                        value: input.object,
+                                    })) &&
+                                    $vo0(
+                                        input.object,
+                                        _path + ".object",
+                                        true && _exceptionable,
+                                    )) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectPartialAndRequired | null)",
+                                    value: input.object,
+                                }),
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index1: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index1 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "Array<number>",
+                                    value: input.array,
+                                }),
+                            2 === Object.keys(input).length ||
+                                false === _exceptionable ||
+                                Object.keys(input)
+                                    .map((key: any) => {
+                                        if (
+                                            [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "object",
+                                                "array",
+                                            ].some((prop: any) => key === prop)
+                                        )
+                                            return true;
+                                        const value = input[key];
+                                        if (undefined === value) return true;
+                                        return $report(_exceptionable, {
+                                            path: _path + $join(key),
+                                            expected: "undefined",
+                                            value: value,
+                                        });
+                                    })
+                                    .every((flag: boolean) => flag),
+                        ].every((flag: boolean) => flag);
+                    return (
+                        ((("object" === typeof input && null !== input) ||
+                            $report(true, {
+                                path: _path + "",
+                                expected: "ObjectPartialAndRequired",
+                                value: input,
+                            })) &&
+                            $vo0(input, _path + "", true)) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "ObjectPartialAndRequired",
+                            value: input,
+                        })
+                    );
+                })(input, "$input", true);
+            }
+            const success = 0 === errors.length;
+            return {
+                success,
+                errors,
+                data: success ? input : undefined,
+            } as any;
+        })(input),
+    );

--- a/test/generated/output/validateEquals/test_validateEquals_ObjectRequired.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_ObjectRequired.ts
@@ -1,0 +1,320 @@
+import typia from "../../../../src";
+import { _test_validateEquals } from "../../../internal/_test_validateEquals";
+import { ObjectRequired } from "../../../structures/ObjectRequired";
+
+export const test_validateEquals_ObjectRequired = _test_validateEquals(
+    "ObjectRequired",
+)<ObjectRequired>(ObjectRequired)((input) =>
+    ((input: any): typia.IValidation<ObjectRequired> => {
+        const errors = [] as any[];
+        const __is = (
+            input: any,
+            _exceptionable: boolean = true,
+        ): input is ObjectRequired => {
+            const $io0 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                "boolean" === typeof input.boolean &&
+                "number" === typeof input.number &&
+                Number.isFinite(input.number) &&
+                "string" === typeof input.string &&
+                Array.isArray(input.array) &&
+                input.array.every(
+                    (elem: any, _index1: number) =>
+                        "number" === typeof elem && Number.isFinite(elem),
+                ) &&
+                (null === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (5 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            const $io1 = (
+                input: any,
+                _exceptionable: boolean = true,
+            ): boolean =>
+                (undefined === input.boolean ||
+                    "boolean" === typeof input.boolean) &&
+                (undefined === input.number ||
+                    ("number" === typeof input.number &&
+                        Number.isFinite(input.number))) &&
+                (undefined === input.string ||
+                    "string" === typeof input.string) &&
+                (undefined === input.array ||
+                    (Array.isArray(input.array) &&
+                        input.array.every(
+                            (elem: any, _index2: number) =>
+                                "number" === typeof elem &&
+                                Number.isFinite(elem),
+                        ))) &&
+                (null === input.object ||
+                    undefined === input.object ||
+                    ("object" === typeof input.object &&
+                        null !== input.object &&
+                        false === Array.isArray(input.object) &&
+                        $io1(input.object, true && _exceptionable))) &&
+                (0 === Object.keys(input).length ||
+                    Object.keys(input).every((key: any) => {
+                        if (
+                            [
+                                "boolean",
+                                "number",
+                                "string",
+                                "array",
+                                "object",
+                            ].some((prop: any) => key === prop)
+                        )
+                            return true;
+                        const value = input[key];
+                        if (undefined === value) return true;
+                        return false;
+                    }));
+            return (
+                "object" === typeof input && null !== input && $io0(input, true)
+            );
+        };
+        if (false === __is(input)) {
+            const $report = (typia.validateEquals as any).report(errors);
+            ((
+                input: any,
+                _path: string,
+                _exceptionable: boolean = true,
+            ): input is ObjectRequired => {
+                const $join = (typia.validateEquals as any).join;
+                const $vo0 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "boolean",
+                                value: input.boolean,
+                            }),
+                        ("number" === typeof input.number &&
+                            Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "number",
+                                value: input.number,
+                            }),
+                        "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "string",
+                                value: input.string,
+                            }),
+                        ((Array.isArray(input.array) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            })) &&
+                            input.array
+                                .map(
+                                    (elem: any, _index1: number) =>
+                                        ("number" === typeof elem &&
+                                            Number.isFinite(elem)) ||
+                                        $report(_exceptionable, {
+                                            path:
+                                                _path +
+                                                ".array[" +
+                                                _index1 +
+                                                "]",
+                                            expected: "number",
+                                            value: elem,
+                                        }),
+                                )
+                                .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "Array<number>",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected: "(ObjectRequired.IBase | null)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected: "(ObjectRequired.IBase | null)",
+                                value: input.object,
+                            }),
+                        5 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                const $vo1 = (
+                    input: any,
+                    _path: string,
+                    _exceptionable: boolean = true,
+                ): boolean =>
+                    [
+                        undefined === input.boolean ||
+                            "boolean" === typeof input.boolean ||
+                            $report(_exceptionable, {
+                                path: _path + ".boolean",
+                                expected: "(boolean | undefined)",
+                                value: input.boolean,
+                            }),
+                        undefined === input.number ||
+                            ("number" === typeof input.number &&
+                                Number.isFinite(input.number)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".number",
+                                expected: "(number | undefined)",
+                                value: input.number,
+                            }),
+                        undefined === input.string ||
+                            "string" === typeof input.string ||
+                            $report(_exceptionable, {
+                                path: _path + ".string",
+                                expected: "(string | undefined)",
+                                value: input.string,
+                            }),
+                        undefined === input.array ||
+                            ((Array.isArray(input.array) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".array",
+                                    expected: "(Array<number> | undefined)",
+                                    value: input.array,
+                                })) &&
+                                input.array
+                                    .map(
+                                        (elem: any, _index2: number) =>
+                                            ("number" === typeof elem &&
+                                                Number.isFinite(elem)) ||
+                                            $report(_exceptionable, {
+                                                path:
+                                                    _path +
+                                                    ".array[" +
+                                                    _index2 +
+                                                    "]",
+                                                expected: "number",
+                                                value: elem,
+                                            }),
+                                    )
+                                    .every((flag: boolean) => flag)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".array",
+                                expected: "(Array<number> | undefined)",
+                                value: input.array,
+                            }),
+                        null === input.object ||
+                            undefined === input.object ||
+                            ((("object" === typeof input.object &&
+                                null !== input.object &&
+                                false === Array.isArray(input.object)) ||
+                                $report(_exceptionable, {
+                                    path: _path + ".object",
+                                    expected:
+                                        "(ObjectRequired.IBase | null | undefined)",
+                                    value: input.object,
+                                })) &&
+                                $vo1(
+                                    input.object,
+                                    _path + ".object",
+                                    true && _exceptionable,
+                                )) ||
+                            $report(_exceptionable, {
+                                path: _path + ".object",
+                                expected:
+                                    "(ObjectRequired.IBase | null | undefined)",
+                                value: input.object,
+                            }),
+                        0 === Object.keys(input).length ||
+                            false === _exceptionable ||
+                            Object.keys(input)
+                                .map((key: any) => {
+                                    if (
+                                        [
+                                            "boolean",
+                                            "number",
+                                            "string",
+                                            "array",
+                                            "object",
+                                        ].some((prop: any) => key === prop)
+                                    )
+                                        return true;
+                                    const value = input[key];
+                                    if (undefined === value) return true;
+                                    return $report(_exceptionable, {
+                                        path: _path + $join(key),
+                                        expected: "undefined",
+                                        value: value,
+                                    });
+                                })
+                                .every((flag: boolean) => flag),
+                    ].every((flag: boolean) => flag);
+                return (
+                    ((("object" === typeof input && null !== input) ||
+                        $report(true, {
+                            path: _path + "",
+                            expected: "Required<ObjectRequired.IBase>",
+                            value: input,
+                        })) &&
+                        $vo0(input, _path + "", true)) ||
+                    $report(true, {
+                        path: _path + "",
+                        expected: "Required<ObjectRequired.IBase>",
+                        value: input,
+                    })
+                );
+            })(input, "$input", true);
+        }
+        const success = 0 === errors.length;
+        return {
+            success,
+            errors,
+            data: success ? input : undefined,
+        } as any;
+    })(input),
+);

--- a/test/generated/output/validateEquals/test_validateEquals_ObjectUnionImplicit.ts
+++ b/test/generated/output/validateEquals/test_validateEquals_ObjectUnionImplicit.ts
@@ -210,12 +210,12 @@ export const test_validateEquals_ObjectUnionImplicit = _test_validateEquals(
                 input: any,
                 _exceptionable: boolean = true,
             ): boolean =>
+                "number" === typeof input.radius &&
+                Number.isFinite(input.radius) &&
                 (undefined === input.centroid ||
                     ("object" === typeof input.centroid &&
                         null !== input.centroid &&
                         $io0(input.centroid, true && _exceptionable))) &&
-                "number" === typeof input.radius &&
-                Number.isFinite(input.radius) &&
                 (null === input.area ||
                     undefined === input.area ||
                     ("number" === typeof input.area &&
@@ -223,7 +223,7 @@ export const test_validateEquals_ObjectUnionImplicit = _test_validateEquals(
                 (1 === Object.keys(input).length ||
                     Object.keys(input).every((key: any) => {
                         if (
-                            ["centroid", "radius", "area"].some(
+                            ["radius", "centroid", "area"].some(
                                 (prop: any) => key === prop,
                             )
                         )
@@ -811,6 +811,13 @@ export const test_validateEquals_ObjectUnionImplicit = _test_validateEquals(
                     _exceptionable: boolean = true,
                 ): boolean =>
                     [
+                        ("number" === typeof input.radius &&
+                            Number.isFinite(input.radius)) ||
+                            $report(_exceptionable, {
+                                path: _path + ".radius",
+                                expected: "number",
+                                value: input.radius,
+                            }),
                         undefined === input.centroid ||
                             ((("object" === typeof input.centroid &&
                                 null !== input.centroid) ||
@@ -831,13 +838,6 @@ export const test_validateEquals_ObjectUnionImplicit = _test_validateEquals(
                                     "(ObjectUnionImplicit.IPoint | undefined)",
                                 value: input.centroid,
                             }),
-                        ("number" === typeof input.radius &&
-                            Number.isFinite(input.radius)) ||
-                            $report(_exceptionable, {
-                                path: _path + ".radius",
-                                expected: "number",
-                                value: input.radius,
-                            }),
                         null === input.area ||
                             undefined === input.area ||
                             ("number" === typeof input.area &&
@@ -852,7 +852,7 @@ export const test_validateEquals_ObjectUnionImplicit = _test_validateEquals(
                             Object.keys(input)
                                 .map((key: any) => {
                                     if (
-                                        ["centroid", "radius", "area"].some(
+                                        ["radius", "centroid", "area"].some(
                                             (prop: any) => key === prop,
                                         )
                                     )

--- a/test/issues/ajv.ts
+++ b/test/issues/ajv.ts
@@ -9,7 +9,7 @@ const app = typia.json.application<[IPointer<ObjectSimple>], "ajv">();
 fs.writeFileSync(__dirname + "/ajv.json", JSON.stringify(app, null, 4), "utf8");
 
 const program = new Ajv({
-    schemas: Object.values(app.components.schemas ?? {}),
+    schemas: Object.values(app.components.schemas ?? {}) as any,
     keywords: [
         "x-typia-tuple",
         "x-typia-typeTags",

--- a/test/issues/json-schema.ts
+++ b/test/issues/json-schema.ts
@@ -15,7 +15,7 @@ const app = typia.json.application<[ObjectArray], "swagger">();
 const stringify = fast({
     ...app.schemas[0]!,
     ...app,
-});
+} as any);
 console.log(stringify(data));
 
 console.log(

--- a/test/schemas/json/ajv/ObjectOptional.json
+++ b/test/schemas/json/ajv/ObjectOptional.json
@@ -11,22 +11,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "name": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "email": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "sequence": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "number"
           }

--- a/test/schemas/json/ajv/ObjectPartial.json
+++ b/test/schemas/json/ajv/ObjectPartial.json
@@ -1,0 +1,111 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/PartialObjectPartial.IBase"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "PartialObjectPartial.IBase": {
+        "$id": "#/components/schemas/PartialObjectPartial.IBase",
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": true,
+              "type": "number"
+            }
+          },
+          "object": {
+            "oneOf": [
+              {
+                "x-typia-required": true,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectPartial.IBase"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": true
+          }
+        },
+        "x-typia-jsDocTags": []
+      },
+      "ObjectPartial.IBase": {
+        "$id": "#/components/schemas/ObjectPartial.IBase",
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          },
+          "object": {
+            "oneOf": [
+              {
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectPartial.IBase"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false
+          }
+        },
+        "required": [
+          "boolean",
+          "number",
+          "string",
+          "array",
+          "object"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "ajv"
+}

--- a/test/schemas/json/ajv/ObjectPartialAndRequired.json
+++ b/test/schemas/json/ajv/ObjectPartialAndRequired.json
@@ -1,0 +1,62 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/ObjectPartialAndRequired"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ObjectPartialAndRequired": {
+        "$id": "#/components/schemas/ObjectPartialAndRequired",
+        "type": "object",
+        "properties": {
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "object": {
+            "oneOf": [
+              {
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectPartialAndRequired"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "object",
+          "array"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "ajv"
+}

--- a/test/schemas/json/ajv/ObjectRequired.json
+++ b/test/schemas/json/ajv/ObjectRequired.json
@@ -1,0 +1,111 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/RequiredObjectRequired.IBase"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "RequiredObjectRequired.IBase": {
+        "$id": "#/components/schemas/RequiredObjectRequired.IBase",
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          },
+          "object": {
+            "oneOf": [
+              {
+                "x-typia-required": true,
+                "x-typia-optional": false,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRequired.IBase"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false
+          }
+        },
+        "required": [
+          "boolean",
+          "number",
+          "string",
+          "array",
+          "object"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "ObjectRequired.IBase": {
+        "$id": "#/components/schemas/ObjectRequired.IBase",
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": true,
+              "type": "number"
+            }
+          },
+          "object": {
+            "oneOf": [
+              {
+                "x-typia-required": true,
+                "x-typia-optional": true,
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRequired.IBase"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": true
+          }
+        },
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "ajv"
+}

--- a/test/schemas/json/ajv/ObjectUnionImplicit.json
+++ b/test/schemas/json/ajv/ObjectUnionImplicit.json
@@ -338,13 +338,13 @@
         "$id": "#/components/schemas/ObjectUnionImplicit.ICircle",
         "type": "object",
         "properties": {
-          "centroid": {
-            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint"
-          },
           "radius": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
+          },
+          "centroid": {
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint"
           },
           "area": {
             "oneOf": [

--- a/test/schemas/json/ajv/UltimateUnion.json
+++ b/test/schemas/json/ajv/UltimateUnion.json
@@ -177,7 +177,7 @@
             "type": "string"
           },
           "text": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "array",
             "items": {

--- a/test/schemas/json/swagger/ObjectOptional.json
+++ b/test/schemas/json/swagger/ObjectOptional.json
@@ -10,22 +10,22 @@
         "type": "object",
         "properties": {
           "id": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "name": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "email": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "string"
           },
           "sequence": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "number"
           }

--- a/test/schemas/json/swagger/ObjectPartial.json
+++ b/test/schemas/json/swagger/ObjectPartial.json
@@ -1,0 +1,89 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/PartialObjectPartial.IBase"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "PartialObjectPartial.IBase": {
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": true,
+              "type": "number"
+            }
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectPartial.IBase.Nullable"
+          }
+        },
+        "nullable": false,
+        "x-typia-jsDocTags": []
+      },
+      "ObjectPartial.IBase.Nullable": {
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectPartial.IBase.Nullable"
+          }
+        },
+        "nullable": true,
+        "required": [
+          "boolean",
+          "number",
+          "string",
+          "array",
+          "object"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "swagger"
+}

--- a/test/schemas/json/swagger/ObjectPartialAndRequired.json
+++ b/test/schemas/json/swagger/ObjectPartialAndRequired.json
@@ -1,0 +1,90 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/ObjectPartialAndRequired"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ObjectPartialAndRequired": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectPartialAndRequired.Nullable"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          }
+        },
+        "nullable": false,
+        "required": [
+          "object",
+          "array"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "ObjectPartialAndRequired.Nullable": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectPartialAndRequired.Nullable"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          }
+        },
+        "nullable": true,
+        "required": [
+          "object",
+          "array"
+        ],
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "swagger"
+}

--- a/test/schemas/json/swagger/ObjectRequired.json
+++ b/test/schemas/json/swagger/ObjectRequired.json
@@ -1,0 +1,89 @@
+{
+  "schemas": [
+    {
+      "$ref": "#/components/schemas/RequiredObjectRequired.IBase"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "RequiredObjectRequired.IBase": {
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "number"
+            }
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectRequired.IBase.Nullable"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "boolean",
+          "number",
+          "string",
+          "array",
+          "object"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "ObjectRequired.IBase.Nullable": {
+        "type": "object",
+        "properties": {
+          "boolean": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "boolean"
+          },
+          "number": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "number"
+          },
+          "string": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "string"
+          },
+          "array": {
+            "x-typia-required": true,
+            "x-typia-optional": true,
+            "type": "array",
+            "items": {
+              "x-typia-required": true,
+              "x-typia-optional": true,
+              "type": "number"
+            }
+          },
+          "object": {
+            "$ref": "#/components/schemas/ObjectRequired.IBase.Nullable"
+          }
+        },
+        "nullable": true,
+        "x-typia-jsDocTags": []
+      }
+    }
+  },
+  "purpose": "swagger"
+}

--- a/test/schemas/json/swagger/ObjectUnionImplicit.json
+++ b/test/schemas/json/swagger/ObjectUnionImplicit.json
@@ -226,13 +226,13 @@
       "ObjectUnionImplicit.ICircle": {
         "type": "object",
         "properties": {
-          "centroid": {
-            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint"
-          },
           "radius": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
+          },
+          "centroid": {
+            "$ref": "#/components/schemas/ObjectUnionImplicit.IPoint"
           },
           "area": {
             "x-typia-required": false,

--- a/test/schemas/json/swagger/UltimateUnion.json
+++ b/test/schemas/json/swagger/UltimateUnion.json
@@ -174,7 +174,7 @@
             "type": "string"
           },
           "text": {
-            "x-typia-required": false,
+            "x-typia-required": true,
             "x-typia-optional": true,
             "type": "array",
             "items": {

--- a/test/schemas/protobuf/ObjectPartial.proto
+++ b/test/schemas/protobuf/ObjectPartial.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+message Partial_lt_ObjectPartial {
+    message IBase_gt_ {
+        optional bool boolean = 1;
+        optional double number = 2;
+        optional string string = 3;
+        repeated double array = 4;
+        optional ObjectPartial.IBase object = 5;
+    }
+}
+
+message ObjectPartial {
+    message IBase {
+        required bool boolean = 1;
+        required double number = 2;
+        required string string = 3;
+        repeated double array = 4;
+        optional ObjectPartial.IBase object = 5;
+    }
+}

--- a/test/schemas/protobuf/ObjectPartialAndRequired.proto
+++ b/test/schemas/protobuf/ObjectPartialAndRequired.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message ObjectPartialAndRequired {
+    optional string string = 1;
+    optional double number = 2;
+    optional bool boolean = 3;
+    optional ObjectPartialAndRequired object = 4;
+    repeated double array = 5;
+}

--- a/test/schemas/protobuf/ObjectRequired.proto
+++ b/test/schemas/protobuf/ObjectRequired.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+message Required_lt_ObjectRequired {
+    message IBase_gt_ {
+        required bool boolean = 1;
+        required double number = 2;
+        required string string = 3;
+        repeated double array = 4;
+        optional ObjectRequired.IBase object = 5;
+    }
+}
+
+message ObjectRequired {
+    message IBase {
+        optional bool boolean = 1;
+        optional double number = 2;
+        optional string string = 3;
+        repeated double array = 4;
+        optional ObjectRequired.IBase object = 5;
+    }
+}

--- a/test/structures/ObjectPartial.ts
+++ b/test/structures/ObjectPartial.ts
@@ -1,0 +1,39 @@
+import { Spoiler } from "../helpers/Spoiler";
+
+export type ObjectPartial = Partial<ObjectPartial.IBase>;
+export namespace ObjectPartial {
+    export interface IBase {
+        boolean: boolean;
+        number: number;
+        string: string;
+        array: number[];
+        object: IBase | null;
+    }
+
+    export function generate(): ObjectPartial {
+        return {};
+    }
+
+    export const SPOILERS: Spoiler<ObjectPartial>[] = [
+        (input) => {
+            input.boolean = null!;
+            return ["$input.boolean"];
+        },
+        (input) => {
+            input.number = true as any;
+            return ["$input.number"];
+        },
+        (input) => {
+            input.string = 2 as any;
+            return ["$input.string"];
+        },
+        (input) => {
+            input.array = [0, 1, undefined!];
+            return ["$input.array[2]"];
+        },
+        (input) => {
+            input.object = "something" as any;
+            return ["$input.object"];
+        },
+    ];
+}

--- a/test/structures/ObjectPartialAndRequired.ts
+++ b/test/structures/ObjectPartialAndRequired.ts
@@ -1,0 +1,46 @@
+import { Spoiler } from "../helpers/Spoiler";
+
+export type ObjectPartialAndRequired = Pick<
+    Partial<ObjectPartialAndRequired.IBase>,
+    "boolean" | "number" | "string"
+> &
+    Required<Pick<ObjectPartialAndRequired.IBase, "array" | "object">>;
+export namespace ObjectPartialAndRequired {
+    export interface IBase {
+        boolean: boolean;
+        number: number;
+        string: string;
+        array?: number[];
+        object?: ObjectPartialAndRequired | null;
+    }
+
+    export function generate(level: number = 0): ObjectPartialAndRequired {
+        return {
+            array: [1, 2, 3],
+            object: level < 2 ? generate(level + 1) : null,
+        };
+    }
+
+    export const SPOILERS: Spoiler<ObjectPartialAndRequired>[] = [
+        (input) => {
+            input.boolean = null!;
+            return ["$input.boolean"];
+        },
+        (input) => {
+            input.number = true as any;
+            return ["$input.number"];
+        },
+        (input) => {
+            input.string = 2 as any;
+            return ["$input.string"];
+        },
+        (input) => {
+            input.array = undefined!;
+            return ["$input.array"];
+        },
+        (input) => {
+            input.object = undefined!;
+            return ["$input.object"];
+        },
+    ];
+}

--- a/test/structures/ObjectPropertyNullable.ts
+++ b/test/structures/ObjectPropertyNullable.ts
@@ -13,8 +13,8 @@ export namespace ObjectPropertyNullable {
     export interface IMember {
         id: string;
         name: string | null;
-        grade?: number;
-        serial?: number | null;
+        grade?: undefined | number;
+        serial?: undefined | number | null;
         activated: boolean | null;
     }
 

--- a/test/structures/ObjectRequired.ts
+++ b/test/structures/ObjectRequired.ts
@@ -1,0 +1,45 @@
+import { Spoiler } from "../helpers/Spoiler";
+
+export type ObjectRequired = Required<ObjectRequired.IBase>;
+export namespace ObjectRequired {
+    export interface IBase {
+        boolean?: boolean;
+        number?: number;
+        string?: string;
+        array?: number[];
+        object?: IBase | null;
+    }
+
+    export function generate(level: number = 0): ObjectRequired {
+        return {
+            boolean: false,
+            number: 2,
+            string: "three",
+            array: [0, 1, 2],
+            object: level < 2 ? generate(level + 1) : null,
+        };
+    }
+
+    export const SPOILERS: Spoiler<ObjectRequired>[] = [
+        (input) => {
+            input.boolean = undefined!;
+            return ["$input.boolean"];
+        },
+        (input) => {
+            input.number = undefined!;
+            return ["$input.number"];
+        },
+        (input) => {
+            input.string = undefined!;
+            return ["$input.string"];
+        },
+        (input) => {
+            input.array = undefined!;
+            return ["$input.array"];
+        },
+        (input) => {
+            input.object = undefined!;
+            return ["$input.object"];
+        },
+    ];
+}

--- a/test/structures/ObjectUndefined.ts
+++ b/test/structures/ObjectUndefined.ts
@@ -6,8 +6,8 @@ export namespace ObjectUndefined {
 
     export interface ILecture {
         name: string;
-        professor?: string | number;
-        classroom?: IClassroom;
+        professor?: undefined | string | number;
+        classroom?: undefined | IClassroom;
         grade: number | undefined;
         nothing: undefined;
         unknown: unknown;

--- a/test/structures/ObjectUnionImplicit.ts
+++ b/test/structures/ObjectUnionImplicit.ts
@@ -14,44 +14,44 @@ export namespace ObjectUnionImplicit {
     export interface IPoint {
         x: number;
         y: number;
-        slope?: number | null;
+        slope?: undefined | number | null;
     }
     export interface ILine {
         p1: IPoint;
         p2: IPoint;
-        width?: number | null;
-        distance?: number | null;
+        width?: undefined | number | null;
+        distance?: undefined | number | null;
     }
     export interface ITriangle {
         p1: IPoint;
         p2: IPoint;
         p3: IPoint;
-        width?: number | null;
-        height?: number | null;
-        area?: number | null;
+        width?: undefined | number | null;
+        height?: undefined | number | null;
+        area?: undefined | number | null;
     }
     export interface IRectangle {
         p1: IPoint;
         p2: IPoint;
         p3: IPoint;
         p4: IPoint;
-        width?: number | null;
-        height?: number | null;
-        area?: number | null;
+        width?: undefined | number | null;
+        height?: undefined | number | null;
+        area?: undefined | number | null;
     }
     export interface IPolyline {
         points: IPoint[];
-        length?: number | null;
+        length?: undefined | number | null;
     }
     export interface IPolygon {
         outer: IPolyline;
-        inner?: IPolyline[];
-        area?: number | null;
+        inner?: undefined | IPolyline[];
+        area?: undefined | number | null;
     }
     export interface ICircle {
-        centroid?: IPoint;
         radius: number;
-        area?: number | null;
+        centroid?: undefined | IPoint;
+        area?: undefined | number | null;
     }
 
     export function generate(): ObjectUnionImplicit {

--- a/test/tsconfig.actions.json
+++ b/test/tsconfig.actions.json
@@ -91,7 +91,7 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -91,7 +91,7 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,7 +88,7 @@
     "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */


### PR DESCRIPTION
If user configured `tsconfig.json` to turn on `exactOptionalPropertyTypes` option, and use `Partial<T>` or `Required<T>` type, `typia` could not identify whether each property is optional or not.

This PR fixes such bug, by enhancing analyzer of TypeScript types. Also, turned on the `exactOptionalPropertyTypes` option tor enhancing type safety for this case.
