### PR TITLE
fix: add `@sinclair/typebox` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "devDependencies": {
     "@fastify/type-provider-typebox": "^3.5.0",
+    "@sinclair/typebox": "^0.31.17",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@typegoose/typegoose": "^10.1.1",
     "@types/autocannon": "^7.9.0",


### PR DESCRIPTION
When I'm trying to initialise project by using `pnpm` `typebox` dependency is missing due to [strictness](https://pnpm.io/blog/2020/05/27/flat-node-modules-is-not-the-only-way) in `pnpm`.

This PR adds `@sinclair/typebox` to `devDependencies`



Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)