### PR TITLE
Ban `yarn berry` on setup wizard.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.2.0",
+  "version": "5.2.1-dev.20231011",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.2.0"
+    "typia": "5.2.1-dev.20231011"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -35,27 +35,29 @@ export namespace TypiaSetupWizard {
         await pack.save((data) => {
             // COMPOSE POSTINSTALL COMMAND
             data.scripts ??= {};
-            if (
-                typeof data.scripts.postinstall === "string" &&
-                data.scripts.postinstall.trim().length
-            ) {
-                if (data.scripts.postinstall.indexOf("ts-patch install") === -1)
-                    data.scripts.postinstall =
-                        "ts-patch install && " + data.scripts.postinstall;
-            } else data.scripts.postinstall = "ts-patch install";
 
             // FOR OLDER VERSIONS
-            if (typeof data.scripts.prepare === "string") {
-                data.scripts.prepare = data.scripts.prepare
+            if (typeof data.scripts.postinstall === "string") {
+                data.scripts.postinstall = data.scripts.postinstall
                     .split("&&")
                     .map((str) => str.trim())
                     .filter((str) => str.indexOf("ts-patch install") === -1)
                     .join(" && ");
-                if (data.scripts.prepare.length === 0)
-                    delete data.scripts.prepare;
+                if (data.scripts.postinstall.length === 0)
+                    delete data.scripts.postinstall;
             }
+
+            // THE PREPARE SCRIPT
+            if (
+                typeof data.scripts.prepare === "string" &&
+                data.scripts.prepare.trim().length
+            ) {
+                if (data.scripts.prepare.indexOf("ts-patch install") === -1)
+                    data.scripts.prepare =
+                        "ts-patch install && " + data.scripts.prepare;
+            } else data.scripts.prepare = "ts-patch install";
         });
-        CommandExecutor.run(`${pack.manager} run postinstall`);
+        CommandExecutor.run(`${pack.manager} run prepare`);
 
         // CONFIGURE TYPIA
         await PluginConfigurator.configure(args);


### PR DESCRIPTION
To support `yarn berry` which had banned `npm prepare` script, I'd changed setup wizard of `typia` to define `npm postinstall` script instead.

By the way, unlike the `npm prepare` script which works on only in the local drive and does not work when be installed from remote `npm`, `npm postinstall` script is working even when installing from the remote `npm`. Therefore, when publishing an `npm` module which has installed `tyipa` through setup wizard, it enforces users of derived libraries to run the `npm postinstall` command that requires `ts-patch` module.

To fix this crazy bug, I've decided to ban `yarn berry` on the setup wizard. From now on, when you run the `npx typia setup` command, it will print a text that "yarn berry is not supported". If you still want to utilize the `yarn berry`, configure it manually by yourself please.
