### PR TITLE
Remove deprecated @types/commander package

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@types/autocannon": "^7.9.0",
     "@types/benchmark": "^2.1.2",
     "@types/cli": "^0.11.20",
-    "@types/commander": "^2.12.2",
     "@types/d3": "^7.4.0",
     "@types/express": "^4.17.14",
     "@types/inquirer": "^8.2.5",


### PR DESCRIPTION
During packages installation
```
 WARN  deprecated @types/commander@2.12.2: This is a stub types definition for commander (https://github.com/tj/commander.js). commander provides its own type definitions, so you don't need @types/commander installed!
```

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)