### PR TITLE
Print CLI output when running `npx typia setup`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.2.2"
+    "typia": "5.2.3"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.0"

--- a/src/executable/setup/CommandExecutor.ts
+++ b/src/executable/setup/CommandExecutor.ts
@@ -2,7 +2,7 @@ import cp from "child_process";
 
 export namespace CommandExecutor {
     export const run = (str: string): void => {
-        console.log(str);
-        cp.execSync(str, { stdio: "ignore" });
+        console.log(`\n$ ${str}`);
+        cp.execSync(str, { stdio: "inherit" });
     };
 }


### PR DESCRIPTION
When installing dependencies of `typia` through the `npx typia setup` command, the setup process can be failed by another libraries' `peerDependencies` restriction. By the way, as current typia setup wizard does not print the console output during the dependencies' setup, user can't know the reason why of the setup failure.

Therefore, changed the setup wizard to print the console output during the dependencies' setup process.
