### PR TITLE
Docs: Enhance Yarn Berry Comment

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -20,7 +20,7 @@ pnpm typia setup --manager pnpm
     </Tab>
     <Tab>
 ```bash filename="Terminal" showLineNumbers copy
-# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED (yarn typia setup ...)
 # YOU MUST SETUP MANUALLY
 # @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
@@ -153,7 +153,7 @@ pnpm typia setup --manager pnpm
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED (yarn typia setup ...)
 # YOU MUST SETUP MANUALLY
 # @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
@@ -182,7 +182,7 @@ pnpm install --save-dev typescript ts-patch ts-node
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED (yarn typia setup ...)
 # YOU MUST SETUP MANUALLY
 # @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
@@ -240,7 +240,7 @@ pnpm prepare
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED (yarn typia setup ...)
 # YOU MUST SETUP MANUALLY
 # @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn prepare
@@ -409,7 +409,7 @@ pnpm install --save-dev webpack webpack-cli
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 ##############################
-# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED (yarn typia setup ...)
 # YOU MUST SETUP MANUALLY
 # @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 ##############################

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -20,7 +20,9 @@ pnpm typia setup --manager pnpm
     </Tab>
     <Tab>
 ```bash filename="Terminal" showLineNumbers copy
-# YARN BERRY IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YOU MUST SETUP MANUALLY
+# @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
 yarn typia setup --manager yarn
 ```
@@ -151,7 +153,9 @@ pnpm typia setup --manager pnpm
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YOU MUST SETUP MANUALLY
+# @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
 yarn typia setup --manager yarn
 ```
@@ -178,7 +182,9 @@ pnpm install --save-dev typescript ts-patch ts-node
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YOU MUST SETUP MANUALLY
+# @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn add typia
 yarn add -D typescript ts-patch ts-node
 ```
@@ -234,7 +240,9 @@ pnpm prepare
     </Tab>
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
-# YARN BERRY IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YOU MUST SETUP MANUALLY
+# @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 yarn prepare
 ```
     </Tab>
@@ -401,7 +409,9 @@ pnpm install --save-dev webpack webpack-cli
     <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 ##############################
-# YARN BERRY IS NOT SUPPORTED
+# YARN BERRY AUTO SETUP IS NOT SUPPORTED
+# YOU MUST SETUP MANUALLY
+# @see [Github Issue: 840](https://github.com/samchon/typia/pull/840)
 ##############################
 # TYPIA
 yarn add typia


### PR DESCRIPTION
This comment is misleading and may lead to users assuming it is not possible to use yarn berry at all.  

Instead, link to the github and indicate it can stll be used manually - at the moment this is not linked in docs that i could find and i almost left the site!

Potentially could add the comment below the `yarn add --dev typia` to make it even more clear but honestly did a find and replace - happy to do that as well if agreed

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)