### PR TITLE
Fix #884 - wrong union predication about constant type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.3.0",
+  "version": "5.3.1-dev.20231127-4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.0.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.1-dev.20231127-4.tgz"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.0.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.1-dev.20231127-4.tgz"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -46,6 +46,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.0.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.1-dev.20231127-4.tgz"
   }
 }

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.3.0",
+  "version": "5.3.1-dev.20231127-4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -56,7 +56,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.3.0"
+    "typia": "5.3.1-dev.20231127-4"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.4.0"

--- a/src/schemas/metadata/Metadata.ts
+++ b/src/schemas/metadata/Metadata.ts
@@ -322,11 +322,18 @@ export namespace Metadata {
     // VALUES
     //----
     // ATOMICS
-    for (const atomic of x.atomics)
+    for (const atomic of x.atomics) {
       if (y.atomics.some((ya) => atomic.type === ya.type)) return true;
+      if (y.constants.some((yc) => atomic.type === yc.type)) return true;
+    }
 
     // CONSTANTS
     for (const constant of x.constants) {
+      const atomic: MetadataAtomic | undefined = y.atomics.find(
+        (elem) => elem.type === constant.type,
+      );
+      if (atomic !== undefined) return true;
+
       const opposite: MetadataConstant | undefined = y.constants.find(
         (elem) => elem.type === constant.type,
       );
@@ -339,6 +346,15 @@ export namespace Metadata {
       if (values.size !== constant.values.length + opposite.values.length)
         return true;
     }
+
+    // TEMPLATES
+    if (!!x.templates.length && y.atomics.some((ya) => ya.type === "string"))
+      return true;
+    else if (
+      !!y.templates.length &&
+      x.atomics.some((xa) => xa.type === "string")
+    )
+      return true;
     return false;
   };
 


### PR DESCRIPTION
When there's same type exists in both `atomics` and `constants` and try to predicate union type about that case, `typia` mis-computes whether each types are intersected or not.

This PR fixes the bug, just by adding the special logic about the same typed `atomics` and `constants` are compatible.
md)