### PR TITLE
Fix #893 - erase `@internal` tag from `IMetadataDictionary`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.2.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.2.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -46,6 +46,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.2.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
   }
 }

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -56,7 +56,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.3.2"
+    "typia": "5.3.3"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.4.0"

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,7 @@ export * as protobuf from "./protobuf";
 export * as reflect from "./reflect";
 export * as tags from "./tags";
 
+export * from "./schemas/metadata/IJsDocTagInfo";
 export * from "./schemas/json/IJsonApplication";
 export * from "./schemas/json/IJsonComponents";
 export * from "./schemas/json/IJsonSchema";

--- a/src/schemas/metadata/IMetadataDictionary.ts
+++ b/src/schemas/metadata/IMetadataDictionary.ts
@@ -3,9 +3,6 @@ import { MetadataArrayType } from "./MetadataArrayType";
 import { MetadataObject } from "./MetadataObject";
 import { MetadataTupleType } from "./MetadataTupleType";
 
-/**
- * @internal
- */
 export interface IMetadataDictionary {
   objects: Map<string, MetadataObject>;
   aliases: Map<string, MetadataAlias>;


### PR DESCRIPTION
Making `typia.reflect.metadata<Types>()` function, I'd taken a mistake that adding vulnerable `@internal` tag on the `IMetadataDictionary` type, so that makes compilation error when using that function.

This PR solves that problem.
