### PR TITLE
Adjust nonara/ts-patch#138

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "typia",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "bin": {
     "typia": "./lib/executable/typia.js"
+  },
+  "tsp": {
+    "tscOptions": {
+      "parseAllJsDoc": true
+    }
   },
   "scripts": {
     "test": "npm run package:tgz",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rimraf bin && tsc",
     "build:actions": "rimraf bin && tsc -p tsconfig.actions.json",
-    "prepare": "ts-patch install && typia patch",
+    "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "start": "node bin",
     "template": "ts-node src/template && npm run prettier && npm run build"
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.4.tgz"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf bin && tsc",
-    "prepare": "ts-patch install && typia patch",
+    "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",
     "start": "node index"
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.4.tgz"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,10 +4,15 @@
   "version": "0.1.0",
   "description": "Test program for typia",
   "main": "bin/index.js",
+  "tsp": {
+    "tscOptions": {
+      "parseAllJsDoc": true
+    }
+  },
   "scripts": {
     "build": "rimraf bin && tsc",
     "build:actions": "rimraf bin && tsc -p tsconfig.actions.json",
-    "prepare": "ts-patch install && typia patch",
+    "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",
     "start": "node bin",
@@ -35,7 +40,7 @@
     "prettier": "^2.6.2",
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.2",
+    "ts-patch": "^3.1.0",
     "typescript": "^5.3.2"
   },
   "dependencies": {
@@ -46,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.3.3.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.3.4.tgz"
   }
 }

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,9 +1,14 @@
 {
   "name": "typescript-json",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "tsp": {
+    "tscOptions": {
+      "parseAllJsDoc": true
+    }
+  },
   "scripts": {
     "test": "npm run package:tgz",
     "-------------------------------------------------": "",
@@ -56,7 +61,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.3.3"
+    "typia": "5.3.4"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.4.0"


### PR DESCRIPTION
Since TypeScript v5.3 update, `tsc` no more parses `JSDocComment`s. Therefore, `typia` also cannot utilize those `JSDocComment` related features too, especially "Comment Tags" and "JSON schema generator".

To reflect such TypeScript v5.3 update, `typia` has newly added a  temporary CLI command `npx typia patch` that is hacking the TypeScript module to turning on the `JSDocComment` parsing.

  - samchon/typia#883

In today, `ts-patch` has started supporting the TypeScript v5.3 update by reading `package.json` of transformer libraries. Therefore, the temporary CLI command no more required. Following the `ts-patch` guide, this PR has configured the `package.json` file for `ts-patch`, and `JSDocComment` parsing would be turned on by the `ts-patch`.

For reference, the temporary CLI command `npx typia patch` would be kept for a while, due to there can be some users using previous version of `ts-patch`. It would be deprecated after the next major update.
