### PR TITLE
Fix invalid decorator-use in tags.mdx

### DIFF
--- a/website/pages/docs/validators/tags.mdx
+++ b/website/pages/docs/validators/tags.mdx
@@ -383,7 +383,7 @@ interface CustomTag {
     string: string;
 
     /**
-     * @format /^[a-z]+$/
+     * @Pattern /^[a-z]+$/
      */
     pattern: string;
 


### PR DESCRIPTION
Regular expressions are used through a decorator called Pattern rather than Format.

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)