### PR TITLE
Support Parcel and npm link

### DIFF
--- a/src/transform-program.ts
+++ b/src/transform-program.ts
@@ -1,0 +1,64 @@
+import type * as ts from 'typescript';
+import {
+  CancellationToken,
+  createCompilerHostWorker,
+  CreateSourceFileOptions,
+  CustomTransformers,
+  ScriptTarget,
+  SourceFile, WriteFileCallback,
+} from "typescript";
+import {ITransformOptions} from "./transformers/ITransformOptions";
+
+// Copied from ts-patch to prevent needing a new dependency
+type ProgramTransformerExtras = {
+  /**
+   * Originating TypeScript instance
+   */
+  ts: typeof ts;
+}
+
+export default function (
+  program: ts.Program,
+  host: ts.CompilerHost | undefined,
+  _options: ITransformOptions | undefined,
+  { ts: tsInstance }: ProgramTransformerExtras
+) {
+  const newOptions = {
+    ...program.getCompilerOptions(),
+    noLib: false,
+    noResolve: false,
+    isolatedModules: false,
+  }
+
+  if(!host) {
+    host = createCompilerHostWorker(newOptions, undefined, tsInstance.sys);
+  }
+
+  const standardCompilerHost = createCompilerHostWorker(newOptions, undefined, tsInstance.sys);
+
+  const customHost = {
+    ...standardCompilerHost,
+    getSourceFile: (filename: string, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions) => host?.getSourceFile?.(filename, languageVersionOrOptions) ?? standardCompilerHost.getSourceFile(filename, languageVersionOrOptions),
+    writeFile: host?.writeFile ?? standardCompilerHost.writeFile,
+    fileExists: (filename: string) => (host?.fileExists(filename) ?? false) ? true : standardCompilerHost.fileExists(filename),
+  }
+
+  const newProgram = tsInstance.createProgram(
+    /* rootNames */ program.getRootFileNames(),
+    newOptions,
+    customHost,
+    /* oldProgram */ program
+  );
+  if(program.getRootFileNames().length === 1) {
+    const fileToEmit = program.getSourceFiles()[0];
+    if(!fileToEmit) {
+      return newProgram;
+    }
+    const oldEmit = newProgram.emit;
+    newProgram.emit = (_targetSourceFile?: SourceFile | undefined, writeFile?: WriteFileCallback | undefined, cancellationToken?: CancellationToken | undefined, emitOnlyDtsFiles?: boolean | undefined, customTransformers?: CustomTransformers | undefined) => {
+      return oldEmit(fileToEmit, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
+    }
+  }
+
+  return newProgram;
+}

--- a/src/transformers/CallExpressionTransformer.ts
+++ b/src/transformers/CallExpressionTransformer.ts
@@ -128,7 +128,7 @@ export namespace CallExpressionTransformer {
   const isTarget = (location: string): boolean => {
     const files: string[] = Object.keys(FUNCTORS);
     return files.some((f) =>
-      location.includes(path.join("node_modules", "typia", "lib", `${f}.d.ts`)),
+      location.includes(path.join("typia", "lib", `${f}.d.ts`)),
     );
   };
 }


### PR DESCRIPTION
Hi,

This adds a ProgramTransformer to enable Parcel to use `tsc` and typia. This also removes `node_modules` from the location check to enable `npm link` to test in projects while working on the project. 

I am not sure where to put a check to make sure this works with Parcel. Would appreciate some advise on where to put it.

============== TEST TBA ==================

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)