### PR TITLE
Add `binary` value on the `IJsonSchema.IString.format`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.4.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.5.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.4.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.5.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.4.4"
+    "typia": "5.4.5"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/schemas/json/IJsonSchema.ts
+++ b/src/schemas/json/IJsonSchema.ts
@@ -44,6 +44,7 @@ export namespace IJsonSchema {
     pattern?: undefined | string;
     format?:
       | undefined
+      | "binary"
       | "byte"
       | "password"
       | "regex"

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.4.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.5.tgz"
   }
 }

--- a/test/src/structures/ObjectHttpFormData.ts
+++ b/test/src/structures/ObjectHttpFormData.ts
@@ -1,4 +1,4 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
 import { v4 } from "uuid";
 
 import { Spoiler } from "../helpers/Spoiler";


### PR DESCRIPTION
As OpenAPI utilizes `binary` format value in the `multipart/form-data` with file data, this PR addes the `binary` literal type on the `IJsonSchema` following the OpenAPI spec.
