### PR TITLE
Fix #951 - unreachable code being generated.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7-dev.20240207.tgz"
+    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7-dev.20240207.tgz"
+    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.4.7-dev.20240207",
+  "version": "5.4.7",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.4.7-dev.20240207",
+  "version": "5.4.7",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.4.7-dev.20240207"
+    "typia": "5.4.7"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/programmers/internal/check_dynamic_key.ts
+++ b/src/programmers/internal/check_dynamic_key.ts
@@ -157,8 +157,8 @@ export const check_dynamic_key =
       : conditions.reduce(ts.factory.createLogicalOr);
   };
 
-const atomist = (entry: ICheckEntry) => {
-  return [
+const atomist = (entry: ICheckEntry) =>
+  [
     ...(entry.expression ? [entry.expression] : []),
     ...(entry.conditions.length === 0
       ? []
@@ -172,4 +172,3 @@ const atomist = (entry: ICheckEntry) => {
             .reduce((a, b) => ts.factory.createLogicalOr(a, b)),
         ]),
   ].reduce((x, y) => ts.factory.createLogicalAnd(x, y));
-};

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7-dev.20240207.tgz"
+    "typia": "D:\\github\\samchon\\typia@master\\typia-5.4.7.tgz"
   }
 }

--- a/test/src/features/issues/test_issue_951_dynamic_key_check_true.ts
+++ b/test/src/features/issues/test_issue_951_dynamic_key_check_true.ts
@@ -1,0 +1,15 @@
+import typia from "typia";
+
+export const test_issue_951_dynamic_key_check_true = () => {
+  typia.createIs<MyInterface>();
+};
+
+interface MyInterface {
+  name: string;
+  volumes: {
+    system?: number;
+    messages?: {
+      [messageId: string]: number;
+    };
+  };
+}

--- a/test/src/generated/output/assert/test_assert_DynamicJsonValue.ts
+++ b/test/src/generated/output/assert/test_assert_DynamicJsonValue.ts
@@ -12,20 +12,18 @@ export const test_assert_DynamicJsonValue = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -71,38 +69,36 @@ export const test_assert_DynamicJsonValue = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                null === value ||
-                undefined === value ||
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                (Array.isArray(value) &&
-                  ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicJsonValue.JsonArray",
-                      value: value,
-                    }))) ||
-                ("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                }) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              null === value ||
+              undefined === value ||
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              (Array.isArray(value) &&
+                ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicJsonValue.JsonArray",
+                    value: value,
+                  }))) ||
+              ("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              }) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              })
+            );
           });
         const $aa0 = (
           input: any,

--- a/test/src/generated/output/assert/test_assert_DynamicNever.ts
+++ b/test/src/generated/output/assert/test_assert_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_assert_DynamicNever = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_assert_DynamicNever = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assert/test_assert_DynamicTree.ts
+++ b/test/src/generated/output/assert/test_assert_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_assert_DynamicTree = _test_assert("DynamicTree")<DynamicTree>(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -79,22 +77,20 @@ export const test_assert_DynamicTree = _test_assert("DynamicTree")<DynamicTree>(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/assert/test_assert_DynamicUndefined.ts
+++ b/test/src/generated/output/assert/test_assert_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_assert_DynamicUndefined = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_assert_DynamicUndefined = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assert/test_assert_ObjectDynamic.ts
+++ b/test/src/generated/output/assert/test_assert_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_assert_ObjectDynamic = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -44,18 +42,16 @@ export const test_assert_ObjectDynamic = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assert/test_assert_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/assert/test_assert_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_assert_ObjectUnionNonPredictable = _test_assert(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/assert/test_assert_ToJsonUnion.ts
+++ b/test/src/generated/output/assert/test_assert_ToJsonUnion.ts
@@ -22,9 +22,9 @@ export const test_assert_ToJsonUnion = _test_assert("ToJsonUnion")<ToJsonUnion>(
           else
             return (() => {
               if ($io3(input)) return $io3(input);
-              else if ($io2(input)) return $io2(input);
-              else if ($io1(input)) return $io1(input);
-              else return false;
+              if ($io2(input)) return $io2(input);
+              if ($io1(input)) return $io1(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/assert/test_assert_UltimateUnion.ts
+++ b/test/src/generated/output/assert/test_assert_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_assert_UltimateUnion = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_assert_UltimateUnion = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_assert_UltimateUnion = _test_assert(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_assert_UltimateUnion = _test_assert(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2873,26 +2869,24 @@ export const test_assert_UltimateUnion = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -3293,26 +3287,24 @@ export const test_assert_UltimateUnion = _test_assert(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,

--- a/test/src/generated/output/assertEquals/test_assertEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/assertEquals/test_assertEquals_ObjectUnionNonPredictable.ts
@@ -113,11 +113,11 @@ export const test_assertEquals_ObjectUnionNonPredictable = _test_assertEquals(
         (() => {
           if ($io7(input, false && _exceptionable))
             return $io7(input, true && _exceptionable);
-          else if ($io5(input, false && _exceptionable))
+          if ($io5(input, false && _exceptionable))
             return $io5(input, true && _exceptionable);
-          else if ($io3(input, false && _exceptionable))
+          if ($io3(input, false && _exceptionable))
             return $io3(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input, true);
     };
@@ -404,17 +404,16 @@ export const test_assertEquals_ObjectUnionNonPredictable = _test_assertEquals(
           (() => {
             if ($ao7(input, _path, false && _exceptionable))
               return $ao7(input, _path, true && _exceptionable);
-            else if ($ao5(input, _path, false && _exceptionable))
+            if ($ao5(input, _path, false && _exceptionable))
               return $ao5(input, _path, true && _exceptionable);
-            else if ($ao3(input, _path, false && _exceptionable))
+            if ($ao3(input, _path, false && _exceptionable))
               return $ao3(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/assertEquals/test_assertEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/assertEquals/test_assertEquals_ToJsonUnion.ts
@@ -59,11 +59,11 @@ export const test_assertEquals_ToJsonUnion = _test_assertEquals(
             return (() => {
               if ($io3(input, false && _exceptionable))
                 return $io3(input, true && _exceptionable);
-              else if ($io2(input, false && _exceptionable))
+              if ($io2(input, false && _exceptionable))
                 return $io2(input, true && _exceptionable);
-              else if ($io1(input, false && _exceptionable))
+              if ($io1(input, false && _exceptionable))
                 return $io1(input, true && _exceptionable);
-              else return false;
+              return false;
             })();
         })();
       return (
@@ -203,17 +203,16 @@ export const test_assertEquals_ToJsonUnion = _test_assertEquals(
               return (() => {
                 if ($ao3(input, _path, false && _exceptionable))
                   return $ao3(input, _path, true && _exceptionable);
-                else if ($ao2(input, _path, false && _exceptionable))
+                if ($ao2(input, _path, false && _exceptionable))
                   return $ao2(input, _path, true && _exceptionable);
-                else if ($ao1(input, _path, false && _exceptionable))
+                if ($ao1(input, _path, false && _exceptionable))
                   return $ao1(input, _path, true && _exceptionable);
-                else
-                  return $guard(_exceptionable, {
-                    path: _path,
-                    expected:
-                      "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                    value: input,
-                  });
+                return $guard(_exceptionable, {
+                  path: _path,
+                  expected:
+                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                  value: input,
+                });
               })();
           })();
         return (

--- a/test/src/generated/output/assertGuard/test_assertGuard_DynamicJsonValue.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_DynamicJsonValue.ts
@@ -12,20 +12,18 @@ export const test_assertGuard_DynamicJsonValue = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -71,38 +69,36 @@ export const test_assertGuard_DynamicJsonValue = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                null === value ||
-                undefined === value ||
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                (Array.isArray(value) &&
-                  ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicJsonValue.JsonArray",
-                      value: value,
-                    }))) ||
-                ("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                }) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              null === value ||
+              undefined === value ||
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              (Array.isArray(value) &&
+                ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicJsonValue.JsonArray",
+                    value: value,
+                  }))) ||
+              ("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              }) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              })
+            );
           });
         const $aa0 = (
           input: any,

--- a/test/src/generated/output/assertGuard/test_assertGuard_DynamicNever.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_assertGuard_DynamicNever = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_assertGuard_DynamicNever = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assertGuard/test_assertGuard_DynamicTree.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_assertGuard_DynamicTree = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -79,22 +77,20 @@ export const test_assertGuard_DynamicTree = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/assertGuard/test_assertGuard_DynamicUndefined.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_assertGuard_DynamicUndefined = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_assertGuard_DynamicUndefined = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assertGuard/test_assertGuard_ObjectDynamic.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_assertGuard_ObjectDynamic = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -44,18 +42,16 @@ export const test_assertGuard_ObjectDynamic = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/assertGuard/test_assertGuard_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_assertGuard_ObjectUnionNonPredictable = _test_assertGuard(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/assertGuard/test_assertGuard_ToJsonUnion.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_ToJsonUnion.ts
@@ -22,9 +22,9 @@ export const test_assertGuard_ToJsonUnion = _test_assertGuard(
           else
             return (() => {
               if ($io3(input)) return $io3(input);
-              else if ($io2(input)) return $io2(input);
-              else if ($io1(input)) return $io1(input);
-              else return false;
+              if ($io2(input)) return $io2(input);
+              if ($io1(input)) return $io1(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/assertGuard/test_assertGuard_UltimateUnion.ts
+++ b/test/src/generated/output/assertGuard/test_assertGuard_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2873,26 +2869,24 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -3293,26 +3287,24 @@ export const test_assertGuard_UltimateUnion = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,

--- a/test/src/generated/output/assertGuardEquals/test_assertGuardEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/assertGuardEquals/test_assertGuardEquals_ObjectUnionNonPredictable.ts
@@ -114,11 +114,11 @@ export const test_assertGuardEquals_ObjectUnionNonPredictable =
           (() => {
             if ($io7(input, false && _exceptionable))
               return $io7(input, true && _exceptionable);
-            else if ($io5(input, false && _exceptionable))
+            if ($io5(input, false && _exceptionable))
               return $io5(input, true && _exceptionable);
-            else if ($io3(input, false && _exceptionable))
+            if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input, true);
       };
@@ -406,17 +406,16 @@ export const test_assertGuardEquals_ObjectUnionNonPredictable =
             (() => {
               if ($ao7(input, _path, false && _exceptionable))
                 return $ao7(input, _path, true && _exceptionable);
-              else if ($ao5(input, _path, false && _exceptionable))
+              if ($ao5(input, _path, false && _exceptionable))
                 return $ao5(input, _path, true && _exceptionable);
-              else if ($ao3(input, _path, false && _exceptionable))
+              if ($ao3(input, _path, false && _exceptionable))
                 return $ao3(input, _path, true && _exceptionable);
-              else
-                return $guard(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $guard(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input,
+              });
             })();
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/assertGuardEquals/test_assertGuardEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/assertGuardEquals/test_assertGuardEquals_ToJsonUnion.ts
@@ -59,11 +59,11 @@ export const test_assertGuardEquals_ToJsonUnion = _test_assertGuardEquals(
             return (() => {
               if ($io3(input, false && _exceptionable))
                 return $io3(input, true && _exceptionable);
-              else if ($io2(input, false && _exceptionable))
+              if ($io2(input, false && _exceptionable))
                 return $io2(input, true && _exceptionable);
-              else if ($io1(input, false && _exceptionable))
+              if ($io1(input, false && _exceptionable))
                 return $io1(input, true && _exceptionable);
-              else return false;
+              return false;
             })();
         })();
       return (
@@ -203,17 +203,16 @@ export const test_assertGuardEquals_ToJsonUnion = _test_assertGuardEquals(
               return (() => {
                 if ($ao3(input, _path, false && _exceptionable))
                   return $ao3(input, _path, true && _exceptionable);
-                else if ($ao2(input, _path, false && _exceptionable))
+                if ($ao2(input, _path, false && _exceptionable))
                   return $ao2(input, _path, true && _exceptionable);
-                else if ($ao1(input, _path, false && _exceptionable))
+                if ($ao1(input, _path, false && _exceptionable))
                   return $ao1(input, _path, true && _exceptionable);
-                else
-                  return $guard(_exceptionable, {
-                    path: _path,
-                    expected:
-                      "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                    value: input,
-                  });
+                return $guard(_exceptionable, {
+                  path: _path,
+                  expected:
+                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                  value: input,
+                });
               })();
           })();
         return (

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicArray.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicArray.ts
@@ -16,12 +16,10 @@ export const test_createAssert_DynamicArray = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -61,30 +59,28 @@ export const test_createAssert_DynamicArray = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((Array.isArray(value) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "Array<string>",
-                  value: value,
-                })) &&
-                value.every(
-                  (elem: any, _index1: number) =>
-                    "string" === typeof elem ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key) + "[" + _index1 + "]",
-                      expected: "string",
-                      value: elem,
-                    }),
-                )) ||
+          return (
+            ((Array.isArray(value) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected: "Array<string>",
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              value.every(
+                (elem: any, _index1: number) =>
+                  "string" === typeof elem ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key) + "[" + _index1 + "]",
+                    expected: "string",
+                    value: elem,
+                  }),
+              )) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "Array<string>",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicJsonValue.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicJsonValue.ts
@@ -11,20 +11,18 @@ export const test_createAssert_DynamicJsonValue = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            null === value ||
-            undefined === value ||
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value ||
-            (Array.isArray(value) && ($ia0(value) || false)) ||
-            ("object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $io0(value))
-          );
-        return true;
+        return (
+          null === value ||
+          undefined === value ||
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value ||
+          (Array.isArray(value) && ($ia0(value) || false)) ||
+          ("object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $io0(value))
+        );
       });
     const $ia0 = (input: any): any =>
       input.every(
@@ -70,38 +68,36 @@ export const test_createAssert_DynamicJsonValue = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) &&
-                ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicJsonValue.JsonArray",
-                    value: value,
-                  }))) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $ao0(value, _path + $join(key), true && _exceptionable)) ||
-              $guard(_exceptionable, {
-                path: _path + $join(key),
-                expected:
-                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                value: value,
-              }) ||
-              $guard(_exceptionable, {
-                path: _path + $join(key),
-                expected:
-                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                value: value,
-              })
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) &&
+              ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicJsonValue.JsonArray",
+                  value: value,
+                }))) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected:
+                "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+              value: value,
+            }) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected:
+                "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+              value: value,
+            })
+          );
         });
       const $aa0 = (
         input: any,

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicNever.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicNever.ts
@@ -11,8 +11,7 @@ export const test_createAssert_DynamicNever = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&
@@ -38,22 +37,20 @@ export const test_createAssert_DynamicNever = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              (null !== value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                })) &&
-              (undefined === value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                }))
-            );
-          return true;
+          return (
+            (null !== value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              })) &&
+            (undefined === value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              }))
+          );
         });
       return (
         ((("object" === typeof input &&

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicSimple.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicSimple.ts
@@ -16,8 +16,7 @@ export const test_createAssert_DynamicSimple = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value && Number.isFinite(value);
-        return true;
+        return "number" === typeof value && Number.isFinite(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -57,16 +56,14 @@ export const test_createAssert_DynamicSimple = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ("number" === typeof value && Number.isFinite(value)) ||
-              $guard(_exceptionable, {
-                path: _path + $join(key),
-                expected: "number",
-                value: value,
-              })
-            );
-          return true;
+          return (
+            ("number" === typeof value && Number.isFinite(value)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "number",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicTree.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicTree.ts
@@ -19,9 +19,7 @@ export const test_createAssert_DynamicTree = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -74,22 +72,20 @@ export const test_createAssert_DynamicTree = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((("object" === typeof value && null !== value) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "DynamicTree",
-                  value: value,
-                })) &&
-                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+          return (
+            ((("object" === typeof value && null !== value) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected: "DynamicTree",
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "DynamicTree",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssert/test_createAssert_DynamicUndefined.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_DynamicUndefined.ts
@@ -11,8 +11,7 @@ export const test_createAssert_DynamicUndefined = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&
@@ -38,22 +37,20 @@ export const test_createAssert_DynamicUndefined = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              (null !== value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                })) &&
-              (undefined === value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                }))
-            );
-          return true;
+          return (
+            (null !== value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              })) &&
+            (undefined === value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              }))
+          );
         });
       return (
         ((("object" === typeof input &&

--- a/test/src/generated/output/createAssert/test_createAssert_ObjectDynamic.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_ObjectDynamic.ts
@@ -11,13 +11,11 @@ export const test_createAssert_ObjectDynamic = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value
-          );
-        return true;
+        return (
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value
+        );
       });
     return (
       "object" === typeof input &&
@@ -43,18 +41,16 @@ export const test_createAssert_ObjectDynamic = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              $guard(_exceptionable, {
-                path: _path + $join(key),
-                expected: "(boolean | number | string)",
-                value: value,
-              })
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "(boolean | number | string)",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input &&

--- a/test/src/generated/output/createAssert/test_createAssert_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_ObjectGenericUnion.ts
@@ -75,8 +75,8 @@ export const test_createAssert_ObjectGenericUnion = _test_assert(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io5(input)) return $io5(input);
-        else if ($io1(input)) return $io1(input);
-        else return false;
+        if ($io1(input)) return $io1(input);
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input);
   };

--- a/test/src/generated/output/createAssert/test_createAssert_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_ObjectUnionDouble.ts
@@ -47,20 +47,20 @@ export const test_createAssert_ObjectUnionDouble = _test_assert(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $io6(input);
-        else if ($io0(input)) return $io0(input);
-        else return false;
+        if ($io0(input)) return $io0(input);
+        return false;
       })();
     const $iu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $io4(input);
-        else if ($io2(input)) return $io2(input);
-        else return false;
+        if ($io2(input)) return $io2(input);
+        return false;
       })();
     const $iu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $io10(input);
-        else if ($io8(input)) return $io8(input);
-        else return false;
+        if ($io8(input)) return $io8(input);
+        return false;
       })();
     return (
       Array.isArray(input) &&

--- a/test/src/generated/output/createAssert/test_createAssert_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_createAssert_ObjectUnionNonPredictable = _test_assert(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createAssert/test_createAssert_ToJsonUnion.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_ToJsonUnion.ts
@@ -21,9 +21,9 @@ export const test_createAssert_ToJsonUnion = _test_assert(
         else
           return (() => {
             if ($io3(input)) return $io3(input);
-            else if ($io2(input)) return $io2(input);
-            else if ($io1(input)) return $io1(input);
-            else return false;
+            if ($io2(input)) return $io2(input);
+            if ($io1(input)) return $io1(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/createAssert/test_createAssert_UltimateUnion.ts
+++ b/test/src/generated/output/createAssert/test_createAssert_UltimateUnion.ts
@@ -412,14 +412,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -515,14 +513,12 @@ export const test_createAssert_UltimateUnion = _test_assert(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -1039,13 +1035,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
         else
           return (() => {
             if ($io5(input)) return $io5(input);
-            else if ($io4(input)) return $io4(input);
-            else if ($io1(input)) return $io1(input);
-            else if ($io6(input)) return $io6(input);
-            else if ($io9(input)) return $io9(input);
-            else if ($io10(input)) return $io10(input);
-            else if ($io18(input)) return $io18(input);
-            else return false;
+            if ($io4(input)) return $io4(input);
+            if ($io1(input)) return $io1(input);
+            if ($io6(input)) return $io6(input);
+            if ($io9(input)) return $io9(input);
+            if ($io10(input)) return $io10(input);
+            if ($io18(input)) return $io18(input);
+            return false;
           })();
       })();
     const $iu1 = (input: any): any =>
@@ -1076,13 +1072,13 @@ export const test_createAssert_UltimateUnion = _test_assert(
         else
           return (() => {
             if ($io23(input)) return $io23(input);
-            else if ($io22(input)) return $io22(input);
-            else if ($io21(input)) return $io21(input);
-            else if ($io24(input)) return $io24(input);
-            else if ($io26(input)) return $io26(input);
-            else if ($io27(input)) return $io27(input);
-            else if ($io34(input)) return $io34(input);
-            else return false;
+            if ($io22(input)) return $io22(input);
+            if ($io21(input)) return $io21(input);
+            if ($io24(input)) return $io24(input);
+            if ($io26(input)) return $io26(input);
+            if ($io27(input)) return $io27(input);
+            if ($io34(input)) return $io34(input);
+            return false;
           })();
       })();
     return (
@@ -2870,26 +2866,24 @@ export const test_createAssert_UltimateUnion = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                  value: value,
-                })) &&
-                $au0(value, _path + $join(key), true && _exceptionable)) ||
+          return (
+            ((("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value)) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected:
                   '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              $au0(value, _path + $join(key), true && _exceptionable)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected:
+                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+              value: value,
+            })
+          );
         });
       const $ao15 = (
         input: any,
@@ -3290,26 +3284,24 @@ export const test_createAssert_UltimateUnion = _test_assert(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                  value: value,
-                })) &&
-                $au1(value, _path + $join(key), true && _exceptionable)) ||
+          return (
+            ((("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value)) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected:
                   '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              $au1(value, _path + $join(key), true && _exceptionable)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected:
+                '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+              value: value,
+            })
+          );
         });
       const $ao21 = (
         input: any,

--- a/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectGenericUnion.ts
@@ -169,9 +169,9 @@ export const test_createAssertEquals_ObjectGenericUnion = _test_assertEquals(
       (() => {
         if ($io5(input, false && _exceptionable))
           return $io5(input, true && _exceptionable);
-        else if ($io1(input, false && _exceptionable))
+        if ($io1(input, false && _exceptionable))
           return $io1(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input, true);
   };
@@ -665,15 +665,14 @@ export const test_createAssertEquals_ObjectGenericUnion = _test_assertEquals(
         (() => {
           if ($ao5(input, _path, false && _exceptionable))
             return $ao5(input, _path, true && _exceptionable);
-          else if ($ao1(input, _path, false && _exceptionable))
+          if ($ao1(input, _path, false && _exceptionable))
             return $ao1(input, _path, true && _exceptionable);
-          else
-            return $guard(_exceptionable, {
-              path: _path,
-              expected:
-                "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
-              value: input,
-            });
+          return $guard(_exceptionable, {
+            path: _path,
+            expected:
+              "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
+            value: input,
+          });
         })();
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionDouble.ts
@@ -146,25 +146,25 @@ export const test_createAssertEquals_ObjectUnionDouble = _test_assertEquals(
       (() => {
         if ($io6(input, false && _exceptionable))
           return $io6(input, true && _exceptionable);
-        else if ($io0(input, false && _exceptionable))
+        if ($io0(input, false && _exceptionable))
           return $io0(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu1 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io4(input, false && _exceptionable))
           return $io4(input, true && _exceptionable);
-        else if ($io2(input, false && _exceptionable))
+        if ($io2(input, false && _exceptionable))
           return $io2(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu2 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io10(input, false && _exceptionable))
           return $io10(input, true && _exceptionable);
-        else if ($io8(input, false && _exceptionable))
+        if ($io8(input, false && _exceptionable))
           return $io8(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return (
       Array.isArray(input) &&
@@ -542,14 +542,13 @@ export const test_createAssertEquals_ObjectUnionDouble = _test_assertEquals(
         (() => {
           if ($ao6(input, _path, false && _exceptionable))
             return $ao6(input, _path, true && _exceptionable);
-          else if ($ao0(input, _path, false && _exceptionable))
+          if ($ao0(input, _path, false && _exceptionable))
             return $ao0(input, _path, true && _exceptionable);
-          else
-            return $guard(_exceptionable, {
-              path: _path,
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          return $guard(_exceptionable, {
+            path: _path,
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $au1 = (
         input: any,
@@ -559,14 +558,13 @@ export const test_createAssertEquals_ObjectUnionDouble = _test_assertEquals(
         (() => {
           if ($ao4(input, _path, false && _exceptionable))
             return $ao4(input, _path, true && _exceptionable);
-          else if ($ao2(input, _path, false && _exceptionable))
+          if ($ao2(input, _path, false && _exceptionable))
             return $ao2(input, _path, true && _exceptionable);
-          else
-            return $guard(_exceptionable, {
-              path: _path,
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          return $guard(_exceptionable, {
+            path: _path,
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $au2 = (
         input: any,
@@ -576,14 +574,13 @@ export const test_createAssertEquals_ObjectUnionDouble = _test_assertEquals(
         (() => {
           if ($ao10(input, _path, false && _exceptionable))
             return $ao10(input, _path, true && _exceptionable);
-          else if ($ao8(input, _path, false && _exceptionable))
+          if ($ao8(input, _path, false && _exceptionable))
             return $ao8(input, _path, true && _exceptionable);
-          else
-            return $guard(_exceptionable, {
-              path: _path,
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          return $guard(_exceptionable, {
+            path: _path,
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       return (
         ((Array.isArray(input) ||

--- a/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createAssertEquals/test_createAssertEquals_ObjectUnionNonPredictable.ts
@@ -113,11 +113,11 @@ export const test_createAssertEquals_ObjectUnionNonPredictable =
         (() => {
           if ($io7(input, false && _exceptionable))
             return $io7(input, true && _exceptionable);
-          else if ($io5(input, false && _exceptionable))
+          if ($io5(input, false && _exceptionable))
             return $io5(input, true && _exceptionable);
-          else if ($io3(input, false && _exceptionable))
+          if ($io3(input, false && _exceptionable))
             return $io3(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input, true);
     };
@@ -404,17 +404,16 @@ export const test_createAssertEquals_ObjectUnionNonPredictable =
           (() => {
             if ($ao7(input, _path, false && _exceptionable))
               return $ao7(input, _path, true && _exceptionable);
-            else if ($ao5(input, _path, false && _exceptionable))
+            if ($ao5(input, _path, false && _exceptionable))
               return $ao5(input, _path, true && _exceptionable);
-            else if ($ao3(input, _path, false && _exceptionable))
+            if ($ao3(input, _path, false && _exceptionable))
               return $ao3(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertEquals/test_createAssertEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/createAssertEquals/test_createAssertEquals_ToJsonUnion.ts
@@ -57,11 +57,11 @@ export const test_createAssertEquals_ToJsonUnion = _test_assertEquals(
           return (() => {
             if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else if ($io2(input, false && _exceptionable))
+            if ($io2(input, false && _exceptionable))
               return $io2(input, true && _exceptionable);
-            else if ($io1(input, false && _exceptionable))
+            if ($io1(input, false && _exceptionable))
               return $io1(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
       })();
     return (
@@ -201,17 +201,16 @@ export const test_createAssertEquals_ToJsonUnion = _test_assertEquals(
             return (() => {
               if ($ao3(input, _path, false && _exceptionable))
                 return $ao3(input, _path, true && _exceptionable);
-              else if ($ao2(input, _path, false && _exceptionable))
+              if ($ao2(input, _path, false && _exceptionable))
                 return $ao2(input, _path, true && _exceptionable);
-              else if ($ao1(input, _path, false && _exceptionable))
+              if ($ao1(input, _path, false && _exceptionable))
                 return $ao1(input, _path, true && _exceptionable);
-              else
-                return $guard(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $guard(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                value: input,
+              });
             })();
         })();
       return (

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicArray.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicArray.ts
@@ -16,12 +16,10 @@ export const test_createAssertGuard_DynamicArray = _test_assertGuard(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -61,30 +59,28 @@ export const test_createAssertGuard_DynamicArray = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((Array.isArray(value) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "Array<string>",
-                  value: value,
-                })) &&
-                value.every(
-                  (elem: any, _index1: number) =>
-                    "string" === typeof elem ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key) + "[" + _index1 + "]",
-                      expected: "string",
-                      value: elem,
-                    }),
-                )) ||
+          return (
+            ((Array.isArray(value) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected: "Array<string>",
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              value.every(
+                (elem: any, _index1: number) =>
+                  "string" === typeof elem ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key) + "[" + _index1 + "]",
+                    expected: "string",
+                    value: elem,
+                  }),
+              )) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "Array<string>",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicJsonValue.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicJsonValue.ts
@@ -12,20 +12,18 @@ export const test_createAssertGuard_DynamicJsonValue = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -71,38 +69,36 @@ export const test_createAssertGuard_DynamicJsonValue = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                null === value ||
-                undefined === value ||
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                (Array.isArray(value) &&
-                  ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicJsonValue.JsonArray",
-                      value: value,
-                    }))) ||
-                ("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                }) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              null === value ||
+              undefined === value ||
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              (Array.isArray(value) &&
+                ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicJsonValue.JsonArray",
+                    value: value,
+                  }))) ||
+              ("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              }) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              })
+            );
           });
         const $aa0 = (
           input: any,

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicNever.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicNever.ts
@@ -11,8 +11,7 @@ export const test_createAssertGuard_DynamicNever = _test_assertGuard(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&
@@ -38,22 +37,20 @@ export const test_createAssertGuard_DynamicNever = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              (null !== value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                })) &&
-              (undefined === value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "undefined",
-                  value: value,
-                }))
-            );
-          return true;
+          return (
+            (null !== value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              })) &&
+            (undefined === value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "undefined",
+                value: value,
+              }))
+          );
         });
       return (
         ((("object" === typeof input &&

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicSimple.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_createAssertGuard_DynamicSimple = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -58,16 +57,14 @@ export const test_createAssertGuard_DynamicSimple = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ("number" === typeof value && Number.isFinite(value)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "number",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              ("number" === typeof value && Number.isFinite(value)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "number",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicTree.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicTree.ts
@@ -19,9 +19,7 @@ export const test_createAssertGuard_DynamicTree = _test_assertGuard(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -74,22 +72,20 @@ export const test_createAssertGuard_DynamicTree = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              ((("object" === typeof value && null !== value) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "DynamicTree",
-                  value: value,
-                })) &&
-                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+          return (
+            ((("object" === typeof value && null !== value) ||
               $guard(_exceptionable, {
                 path: _path + $join(key),
                 expected: "DynamicTree",
                 value: value,
-              })
-            );
-          return true;
+              })) &&
+              $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            $guard(_exceptionable, {
+              path: _path + $join(key),
+              expected: "DynamicTree",
+              value: value,
+            })
+          );
         });
       return (
         ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicUndefined.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_createAssertGuard_DynamicUndefined = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_createAssertGuard_DynamicUndefined = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectDynamic.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_createAssertGuard_ObjectDynamic = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -44,18 +42,16 @@ export const test_createAssertGuard_ObjectDynamic = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectGenericUnion.ts
@@ -81,8 +81,8 @@ export const test_createAssertGuard_ObjectGenericUnion = _test_assertGuard(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io5(input)) return $io5(input);
-          else if ($io1(input)) return $io1(input);
-          else return false;
+          if ($io1(input)) return $io1(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_createAssertGuard_ObjectUnionDouble = _test_assertGuard(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_createAssertGuard_ObjectUnionNonPredictable =
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_ToJsonUnion.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_ToJsonUnion.ts
@@ -21,9 +21,9 @@ export const test_createAssertGuard_ToJsonUnion = _test_assertGuard(
         else
           return (() => {
             if ($io3(input)) return $io3(input);
-            else if ($io2(input)) return $io2(input);
-            else if ($io1(input)) return $io1(input);
-            else return false;
+            if ($io2(input)) return $io2(input);
+            if ($io1(input)) return $io1(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/createAssertGuard/test_createAssertGuard_UltimateUnion.ts
+++ b/test/src/generated/output/createAssertGuard/test_createAssertGuard_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2873,26 +2869,24 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -3293,26 +3287,24 @@ export const test_createAssertGuard_UltimateUnion = _test_assertGuard(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,

--- a/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectGenericUnion.ts
@@ -170,9 +170,9 @@ export const test_createAssertGuardEquals_ObjectGenericUnion =
         (() => {
           if ($io5(input, false && _exceptionable))
             return $io5(input, true && _exceptionable);
-          else if ($io1(input, false && _exceptionable))
+          if ($io1(input, false && _exceptionable))
             return $io1(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input, true);
     };
@@ -678,15 +678,14 @@ export const test_createAssertGuardEquals_ObjectGenericUnion =
           (() => {
             if ($ao5(input, _path, false && _exceptionable))
               return $ao5(input, _path, true && _exceptionable);
-            else if ($ao1(input, _path, false && _exceptionable))
+            if ($ao1(input, _path, false && _exceptionable))
               return $ao1(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected:
-                  "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected:
+                "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
+              value: input,
+            });
           })();
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectUnionDouble.ts
@@ -149,25 +149,25 @@ export const test_createAssertGuardEquals_ObjectUnionDouble =
         (() => {
           if ($io6(input, false && _exceptionable))
             return $io6(input, true && _exceptionable);
-          else if ($io0(input, false && _exceptionable))
+          if ($io0(input, false && _exceptionable))
             return $io0(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       const $iu1 = (input: any, _exceptionable: boolean = true): any =>
         (() => {
           if ($io4(input, false && _exceptionable))
             return $io4(input, true && _exceptionable);
-          else if ($io2(input, false && _exceptionable))
+          if ($io2(input, false && _exceptionable))
             return $io2(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       const $iu2 = (input: any, _exceptionable: boolean = true): any =>
         (() => {
           if ($io10(input, false && _exceptionable))
             return $io10(input, true && _exceptionable);
-          else if ($io8(input, false && _exceptionable))
+          if ($io8(input, false && _exceptionable))
             return $io8(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -545,14 +545,13 @@ export const test_createAssertGuardEquals_ObjectUnionDouble =
           (() => {
             if ($ao6(input, _path, false && _exceptionable))
               return $ao6(input, _path, true && _exceptionable);
-            else if ($ao0(input, _path, false && _exceptionable))
+            if ($ao0(input, _path, false && _exceptionable))
               return $ao0(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+              value: input,
+            });
           })();
         const $au1 = (
           input: any,
@@ -562,14 +561,13 @@ export const test_createAssertGuardEquals_ObjectUnionDouble =
           (() => {
             if ($ao4(input, _path, false && _exceptionable))
               return $ao4(input, _path, true && _exceptionable);
-            else if ($ao2(input, _path, false && _exceptionable))
+            if ($ao2(input, _path, false && _exceptionable))
               return $ao2(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+              value: input,
+            });
           })();
         const $au2 = (
           input: any,
@@ -579,14 +577,13 @@ export const test_createAssertGuardEquals_ObjectUnionDouble =
           (() => {
             if ($ao10(input, _path, false && _exceptionable))
               return $ao10(input, _path, true && _exceptionable);
-            else if ($ao8(input, _path, false && _exceptionable))
+            if ($ao8(input, _path, false && _exceptionable))
               return $ao8(input, _path, true && _exceptionable);
-            else
-              return $guard(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-                value: input,
-              });
+            return $guard(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+              value: input,
+            });
           })();
         return (
           ((Array.isArray(input) ||

--- a/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ObjectUnionNonPredictable.ts
@@ -114,11 +114,11 @@ export const test_createAssertGuardEquals_ObjectUnionNonPredictable =
           (() => {
             if ($io7(input, false && _exceptionable))
               return $io7(input, true && _exceptionable);
-            else if ($io5(input, false && _exceptionable))
+            if ($io5(input, false && _exceptionable))
               return $io5(input, true && _exceptionable);
-            else if ($io3(input, false && _exceptionable))
+            if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input, true);
       };
@@ -406,17 +406,16 @@ export const test_createAssertGuardEquals_ObjectUnionNonPredictable =
             (() => {
               if ($ao7(input, _path, false && _exceptionable))
                 return $ao7(input, _path, true && _exceptionable);
-              else if ($ao5(input, _path, false && _exceptionable))
+              if ($ao5(input, _path, false && _exceptionable))
                 return $ao5(input, _path, true && _exceptionable);
-              else if ($ao3(input, _path, false && _exceptionable))
+              if ($ao3(input, _path, false && _exceptionable))
                 return $ao3(input, _path, true && _exceptionable);
-              else
-                return $guard(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $guard(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input,
+              });
             })();
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/createAssertGuardEquals/test_createAssertGuardEquals_ToJsonUnion.ts
@@ -57,11 +57,11 @@ export const test_createAssertGuardEquals_ToJsonUnion = _test_assertGuardEquals(
           return (() => {
             if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else if ($io2(input, false && _exceptionable))
+            if ($io2(input, false && _exceptionable))
               return $io2(input, true && _exceptionable);
-            else if ($io1(input, false && _exceptionable))
+            if ($io1(input, false && _exceptionable))
               return $io1(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
       })();
     return (
@@ -201,17 +201,16 @@ export const test_createAssertGuardEquals_ToJsonUnion = _test_assertGuardEquals(
             return (() => {
               if ($ao3(input, _path, false && _exceptionable))
                 return $ao3(input, _path, true && _exceptionable);
-              else if ($ao2(input, _path, false && _exceptionable))
+              if ($ao2(input, _path, false && _exceptionable))
                 return $ao2(input, _path, true && _exceptionable);
-              else if ($ao1(input, _path, false && _exceptionable))
+              if ($ao1(input, _path, false && _exceptionable))
                 return $ao1(input, _path, true && _exceptionable);
-              else
-                return $guard(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $guard(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                value: input,
+              });
             })();
         })();
       return (

--- a/test/src/generated/output/createEquals/test_createEquals_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createEquals/test_createEquals_ObjectGenericUnion.ts
@@ -166,9 +166,9 @@ export const test_createEquals_ObjectGenericUnion = _test_equals(
       (() => {
         if ($io5(input, false && _exceptionable))
           return $io5(input, true && _exceptionable);
-        else if ($io1(input, false && _exceptionable))
+        if ($io1(input, false && _exceptionable))
           return $io1(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input, true);
   },

--- a/test/src/generated/output/createEquals/test_createEquals_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createEquals/test_createEquals_ObjectUnionDouble.ts
@@ -143,25 +143,25 @@ export const test_createEquals_ObjectUnionDouble = _test_equals(
       (() => {
         if ($io6(input, false && _exceptionable))
           return $io6(input, true && _exceptionable);
-        else if ($io0(input, false && _exceptionable))
+        if ($io0(input, false && _exceptionable))
           return $io0(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu1 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io4(input, false && _exceptionable))
           return $io4(input, true && _exceptionable);
-        else if ($io2(input, false && _exceptionable))
+        if ($io2(input, false && _exceptionable))
           return $io2(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu2 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io10(input, false && _exceptionable))
           return $io10(input, true && _exceptionable);
-        else if ($io8(input, false && _exceptionable))
+        if ($io8(input, false && _exceptionable))
           return $io8(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return (
       Array.isArray(input) &&

--- a/test/src/generated/output/createEquals/test_createEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createEquals/test_createEquals_ObjectUnionNonPredictable.ts
@@ -112,11 +112,11 @@ export const test_createEquals_ObjectUnionNonPredictable = _test_equals(
       (() => {
         if ($io7(input, false && _exceptionable))
           return $io7(input, true && _exceptionable);
-        else if ($io5(input, false && _exceptionable))
+        if ($io5(input, false && _exceptionable))
           return $io5(input, true && _exceptionable);
-        else if ($io3(input, false && _exceptionable))
+        if ($io3(input, false && _exceptionable))
           return $io3(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input, true);
   },

--- a/test/src/generated/output/createEquals/test_createEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/createEquals/test_createEquals_ToJsonUnion.ts
@@ -54,11 +54,11 @@ export const test_createEquals_ToJsonUnion = _test_equals(
           return (() => {
             if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else if ($io2(input, false && _exceptionable))
+            if ($io2(input, false && _exceptionable))
               return $io2(input, true && _exceptionable);
-            else if ($io1(input, false && _exceptionable))
+            if ($io1(input, false && _exceptionable))
               return $io1(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/createIs/test_createIs_DynamicArray.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicArray.ts
@@ -15,12 +15,10 @@ export const test_createIs_DynamicArray = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          Array.isArray(value) &&
-          value.every((elem: any) => "string" === typeof elem)
-        );
-      return true;
+      return (
+        Array.isArray(value) &&
+        value.every((elem: any) => "string" === typeof elem)
+      );
     });
   return "object" === typeof input && null !== input && $io0(input);
 });

--- a/test/src/generated/output/createIs/test_createIs_DynamicJsonValue.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicJsonValue.ts
@@ -11,20 +11,18 @@ export const test_createIs_DynamicJsonValue = _test_is(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            null === value ||
-            undefined === value ||
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value ||
-            (Array.isArray(value) && ($ia0(value) || false)) ||
-            ("object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $io0(value))
-          );
-        return true;
+        return (
+          null === value ||
+          undefined === value ||
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value ||
+          (Array.isArray(value) && ($ia0(value) || false)) ||
+          ("object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $io0(value))
+        );
       });
     const $ia0 = (input: any): any =>
       input.every(

--- a/test/src/generated/output/createIs/test_createIs_DynamicNever.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicNever.ts
@@ -10,8 +10,7 @@ export const test_createIs_DynamicNever = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true) return null !== value && undefined === value;
-      return true;
+      return null !== value && undefined === value;
     });
   return (
     "object" === typeof input &&

--- a/test/src/generated/output/createIs/test_createIs_DynamicSimple.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicSimple.ts
@@ -15,8 +15,7 @@ export const test_createIs_DynamicSimple = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true) return "number" === typeof value && Number.isFinite(value);
-      return true;
+      return "number" === typeof value && Number.isFinite(value);
     });
   return "object" === typeof input && null !== input && $io0(input);
 });

--- a/test/src/generated/output/createIs/test_createIs_DynamicTree.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicTree.ts
@@ -18,9 +18,7 @@ export const test_createIs_DynamicTree = _test_is("DynamicTree")<DynamicTree>(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return "object" === typeof value && null !== value && $io0(value);
-      return true;
+      return "object" === typeof value && null !== value && $io0(value);
     });
   return "object" === typeof input && null !== input && $io0(input);
 });

--- a/test/src/generated/output/createIs/test_createIs_DynamicUndefined.ts
+++ b/test/src/generated/output/createIs/test_createIs_DynamicUndefined.ts
@@ -11,8 +11,7 @@ export const test_createIs_DynamicUndefined = _test_is(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/createIs/test_createIs_ObjectDynamic.ts
+++ b/test/src/generated/output/createIs/test_createIs_ObjectDynamic.ts
@@ -10,13 +10,11 @@ export const test_createIs_ObjectDynamic = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          "string" === typeof value ||
-          ("number" === typeof value && Number.isFinite(value)) ||
-          "boolean" === typeof value
-        );
-      return true;
+      return (
+        "string" === typeof value ||
+        ("number" === typeof value && Number.isFinite(value)) ||
+        "boolean" === typeof value
+      );
     });
   return (
     "object" === typeof input &&

--- a/test/src/generated/output/createIs/test_createIs_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createIs/test_createIs_ObjectGenericUnion.ts
@@ -75,8 +75,8 @@ export const test_createIs_ObjectGenericUnion = _test_is(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io5(input)) return $io5(input);
-        else if ($io1(input)) return $io1(input);
-        else return false;
+        if ($io1(input)) return $io1(input);
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input);
   },

--- a/test/src/generated/output/createIs/test_createIs_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createIs/test_createIs_ObjectUnionDouble.ts
@@ -47,20 +47,20 @@ export const test_createIs_ObjectUnionDouble = _test_is(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $io6(input);
-        else if ($io0(input)) return $io0(input);
-        else return false;
+        if ($io0(input)) return $io0(input);
+        return false;
       })();
     const $iu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $io4(input);
-        else if ($io2(input)) return $io2(input);
-        else return false;
+        if ($io2(input)) return $io2(input);
+        return false;
       })();
     const $iu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $io10(input);
-        else if ($io8(input)) return $io8(input);
-        else return false;
+        if ($io8(input)) return $io8(input);
+        return false;
       })();
     return (
       Array.isArray(input) &&

--- a/test/src/generated/output/createIs/test_createIs_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createIs/test_createIs_ObjectUnionNonPredictable.ts
@@ -36,9 +36,9 @@ export const test_createIs_ObjectUnionNonPredictable = _test_is(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $io7(input);
-        else if ($io5(input)) return $io5(input);
-        else if ($io3(input)) return $io3(input);
-        else return false;
+        if ($io5(input)) return $io5(input);
+        if ($io3(input)) return $io3(input);
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input);
   },

--- a/test/src/generated/output/createIs/test_createIs_ToJsonUnion.ts
+++ b/test/src/generated/output/createIs/test_createIs_ToJsonUnion.ts
@@ -20,9 +20,9 @@ export const test_createIs_ToJsonUnion = _test_is("ToJsonUnion")<ToJsonUnion>(
       else
         return (() => {
           if ($io3(input)) return $io3(input);
-          else if ($io2(input)) return $io2(input);
-          else if ($io1(input)) return $io1(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          if ($io1(input)) return $io1(input);
+          return false;
         })();
     })();
   return (

--- a/test/src/generated/output/createIs/test_createIs_UltimateUnion.ts
+++ b/test/src/generated/output/createIs/test_createIs_UltimateUnion.ts
@@ -395,14 +395,12 @@ export const test_createIs_UltimateUnion = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          "object" === typeof value &&
-          null !== value &&
-          false === Array.isArray(value) &&
-          $iu0(value)
-        );
-      return true;
+      return (
+        "object" === typeof value &&
+        null !== value &&
+        false === Array.isArray(value) &&
+        $iu0(value)
+      );
     });
   const $io15 = (input: any): boolean =>
     "string" === typeof input.$ref &&
@@ -494,14 +492,12 @@ export const test_createIs_UltimateUnion = _test_is(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          "object" === typeof value &&
-          null !== value &&
-          false === Array.isArray(value) &&
-          $iu1(value)
-        );
-      return true;
+      return (
+        "object" === typeof value &&
+        null !== value &&
+        false === Array.isArray(value) &&
+        $iu1(value)
+      );
     });
   const $io21 = (input: any): boolean =>
     Array.isArray(input["enum"]) &&
@@ -998,13 +994,13 @@ export const test_createIs_UltimateUnion = _test_is(
       else
         return (() => {
           if ($io5(input)) return $io5(input);
-          else if ($io4(input)) return $io4(input);
-          else if ($io1(input)) return $io1(input);
-          else if ($io6(input)) return $io6(input);
-          else if ($io9(input)) return $io9(input);
-          else if ($io10(input)) return $io10(input);
-          else if ($io18(input)) return $io18(input);
-          else return false;
+          if ($io4(input)) return $io4(input);
+          if ($io1(input)) return $io1(input);
+          if ($io6(input)) return $io6(input);
+          if ($io9(input)) return $io9(input);
+          if ($io10(input)) return $io10(input);
+          if ($io18(input)) return $io18(input);
+          return false;
         })();
     })();
   const $iu1 = (input: any): any =>
@@ -1035,13 +1031,13 @@ export const test_createIs_UltimateUnion = _test_is(
       else
         return (() => {
           if ($io23(input)) return $io23(input);
-          else if ($io22(input)) return $io22(input);
-          else if ($io21(input)) return $io21(input);
-          else if ($io24(input)) return $io24(input);
-          else if ($io26(input)) return $io26(input);
-          else if ($io27(input)) return $io27(input);
-          else if ($io34(input)) return $io34(input);
-          else return false;
+          if ($io22(input)) return $io22(input);
+          if ($io21(input)) return $io21(input);
+          if ($io24(input)) return $io24(input);
+          if ($io26(input)) return $io26(input);
+          if ($io27(input)) return $io27(input);
+          if ($io34(input)) return $io34(input);
+          return false;
         })();
     })();
   return (

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicArray.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicArray.ts
@@ -42,12 +42,10 @@ export const test_createRandom_DynamicArray = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -87,30 +85,28 @@ export const test_createRandom_DynamicArray = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((Array.isArray(value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "Array<string>",
-                    value: value,
-                  })) &&
-                  value.every(
-                    (elem: any, _index1: number) =>
-                      "string" === typeof elem ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key) + "[" + _index1 + "]",
-                        expected: "string",
-                        value: elem,
-                      }),
-                  )) ||
+            return (
+              ((Array.isArray(value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "Array<string>",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                value.every(
+                  (elem: any, _index1: number) =>
+                    "string" === typeof elem ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key) + "[" + _index1 + "]",
+                      expected: "string",
+                      value: elem,
+                    }),
+                )) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "Array<string>",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicJsonValue.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicJsonValue.ts
@@ -86,20 +86,18 @@ export const test_createRandom_DynamicJsonValue = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -145,38 +143,36 @@ export const test_createRandom_DynamicJsonValue = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                null === value ||
-                undefined === value ||
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                (Array.isArray(value) &&
-                  ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicJsonValue.JsonArray",
-                      value: value,
-                    }))) ||
-                ("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                }) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              null === value ||
+              undefined === value ||
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              (Array.isArray(value) &&
+                ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicJsonValue.JsonArray",
+                    value: value,
+                  }))) ||
+              ("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              }) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              })
+            );
           });
         const $aa0 = (
           input: any,

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicNever.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicNever.ts
@@ -30,8 +30,7 @@ export const test_createRandom_DynamicNever = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -57,22 +56,20 @@ export const test_createRandom_DynamicNever = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicSimple.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicSimple.ts
@@ -40,8 +40,7 @@ export const test_createRandom_DynamicSimple = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -81,16 +80,14 @@ export const test_createRandom_DynamicSimple = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ("number" === typeof value && Number.isFinite(value)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "number",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              ("number" === typeof value && Number.isFinite(value)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "number",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicTree.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicTree.ts
@@ -49,9 +49,7 @@ export const test_createRandom_DynamicTree = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -108,22 +106,20 @@ export const test_createRandom_DynamicTree = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createRandom/test_createRandom_DynamicUndefined.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_DynamicUndefined.ts
@@ -31,8 +31,7 @@ export const test_createRandom_DynamicUndefined = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -58,22 +57,20 @@ export const test_createRandom_DynamicUndefined = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/createRandom/test_createRandom_ObjectDynamic.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_ObjectDynamic.ts
@@ -39,13 +39,11 @@ export const test_createRandom_ObjectDynamic = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -71,18 +69,16 @@ export const test_createRandom_ObjectDynamic = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/createRandom/test_createRandom_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_ObjectGenericUnion.ts
@@ -202,8 +202,8 @@ export const test_createRandom_ObjectGenericUnion = _test_random(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io5(input)) return $io5(input);
-          else if ($io1(input)) return $io1(input);
-          else return false;
+          if ($io1(input)) return $io1(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createRandom/test_createRandom_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_ObjectUnionDouble.ts
@@ -114,20 +114,20 @@ export const test_createRandom_ObjectUnionDouble = _test_random(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&

--- a/test/src/generated/output/createRandom/test_createRandom_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_ObjectUnionNonPredictable.ts
@@ -84,9 +84,9 @@ export const test_createRandom_ObjectUnionNonPredictable = _test_random(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createRandom/test_createRandom_UltimateUnion.ts
+++ b/test/src/generated/output/createRandom/test_createRandom_UltimateUnion.ts
@@ -2548,14 +2548,12 @@ export const test_createRandom_UltimateUnion = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -2651,14 +2649,12 @@ export const test_createRandom_UltimateUnion = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -3175,13 +3171,13 @@ export const test_createRandom_UltimateUnion = _test_random(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -3212,13 +3208,13 @@ export const test_createRandom_UltimateUnion = _test_random(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -5008,26 +5004,24 @@ export const test_createRandom_UltimateUnion = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -5428,26 +5422,24 @@ export const test_createRandom_UltimateUnion = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicArray.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicArray.ts
@@ -17,12 +17,10 @@ export const test_createValidate_DynamicArray = _test_validate(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -66,32 +64,30 @@ export const test_createValidate_DynamicArray = _test_validate(
               .map((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((Array.isArray(value) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "Array<string>",
-                        value: value,
-                      })) &&
-                      value
-                        .map(
-                          (elem: any, _index1: number) =>
-                            "string" === typeof elem ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key) + "[" + _index1 + "]",
-                              expected: "string",
-                              value: elem,
-                            }),
-                        )
-                        .every((flag: boolean) => flag)) ||
+                return (
+                  ((Array.isArray(value) ||
                     $report(_exceptionable, {
                       path: _path + $join(key),
                       expected: "Array<string>",
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    value
+                      .map(
+                        (elem: any, _index1: number) =>
+                          "string" === typeof elem ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key) + "[" + _index1 + "]",
+                            expected: "string",
+                            value: elem,
+                          }),
+                      )
+                      .every((flag: boolean) => flag)) ||
+                  $report(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "Array<string>",
+                    value: value,
+                  })
+                );
               })
               .every((flag: boolean) => flag),
         ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicJsonValue.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicJsonValue.ts
@@ -13,20 +13,18 @@ export const test_createValidate_DynamicJsonValue = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -74,46 +72,44 @@ export const test_createValidate_DynamicJsonValue = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      null === value ||
-                      undefined === value ||
-                      "string" === typeof value ||
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      "boolean" === typeof value ||
-                      (Array.isArray(value) &&
-                        ($va0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        ) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "DynamicJsonValue.JsonArray",
-                            value: value,
-                          }))) ||
-                      ("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value) &&
-                        $vo0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                        value: value,
-                      }) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    null === value ||
+                    undefined === value ||
+                    "string" === typeof value ||
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    "boolean" === typeof value ||
+                    (Array.isArray(value) &&
+                      ($va0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      ) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicJsonValue.JsonArray",
+                          value: value,
+                        }))) ||
+                    ("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value) &&
+                      $vo0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                      value: value,
+                    }) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicNever.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_createValidate_DynamicNever = _test_validate(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&
@@ -41,22 +40,20 @@ export const test_createValidate_DynamicNever = _test_validate(
               .map((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    (null !== value ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      })) &&
-                    (undefined === value ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      }))
-                  );
-                return true;
+                return (
+                  (null !== value ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    })) &&
+                  (undefined === value ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    }))
+                );
               })
               .every((flag: boolean) => flag),
         ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicSimple.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicSimple.ts
@@ -18,8 +18,7 @@ export const test_createValidate_DynamicSimple = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -63,16 +62,14 @@ export const test_createValidate_DynamicSimple = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "number",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "number",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicTree.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_createValidate_DynamicTree = _test_validate(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -83,26 +81,20 @@ export const test_createValidate_DynamicTree = _test_validate(
               .map((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value && null !== value) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "DynamicTree",
-                        value: value,
-                      })) &&
-                      $vo0(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value && null !== value) ||
                     $report(_exceptionable, {
                       path: _path + $join(key),
                       expected: "DynamicTree",
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $vo0(value, _path + $join(key), true && _exceptionable)) ||
+                  $report(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicTree",
+                    value: value,
+                  })
+                );
               })
               .every((flag: boolean) => flag),
         ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_DynamicUndefined.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_createValidate_DynamicUndefined = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -42,22 +41,20 @@ export const test_createValidate_DynamicUndefined = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      (null !== value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        })) &&
-                      (undefined === value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        }))
-                    );
-                  return true;
+                  return (
+                    (null !== value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      })) &&
+                    (undefined === value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      }))
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_ObjectDynamic.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_createValidate_ObjectDynamic = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -47,18 +45,16 @@ export const test_createValidate_ObjectDynamic = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      "string" === typeof value ||
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      "boolean" === typeof value ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "(boolean | number | string)",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    "string" === typeof value ||
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    "boolean" === typeof value ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "(boolean | number | string)",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidate/test_createValidate_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_ObjectGenericUnion.ts
@@ -82,8 +82,8 @@ export const test_createValidate_ObjectGenericUnion = _test_validate(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io5(input)) return $io5(input);
-          else if ($io1(input)) return $io1(input);
-          else return false;
+          if ($io1(input)) return $io1(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createValidate/test_createValidate_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_ObjectUnionDouble.ts
@@ -49,20 +49,20 @@ export const test_createValidate_ObjectUnionDouble = _test_validate(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&

--- a/test/src/generated/output/createValidate/test_createValidate_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_ObjectUnionNonPredictable.ts
@@ -39,9 +39,9 @@ export const test_createValidate_ObjectUnionNonPredictable = _test_validate(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/createValidate/test_createValidate_ToJsonUnion.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_ToJsonUnion.ts
@@ -22,9 +22,9 @@ export const test_createValidate_ToJsonUnion = _test_validate(
         else
           return (() => {
             if ($io3(input)) return $io3(input);
-            else if ($io2(input)) return $io2(input);
-            else if ($io1(input)) return $io1(input);
-            else return false;
+            if ($io2(input)) return $io2(input);
+            if ($io1(input)) return $io1(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/createValidate/test_createValidate_UltimateUnion.ts
+++ b/test/src/generated/output/createValidate/test_createValidate_UltimateUnion.ts
@@ -414,14 +414,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -517,14 +515,12 @@ export const test_createValidate_UltimateUnion = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1041,13 +1037,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1078,13 +1074,13 @@ export const test_createValidate_UltimateUnion = _test_validate(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2966,30 +2962,28 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                          value: value,
-                        })) &&
-                        $vu0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $report(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $vu0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);
@@ -3424,30 +3418,28 @@ export const test_createValidate_UltimateUnion = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                          value: value,
-                        })) &&
-                        $vu1(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $report(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $vu1(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectGenericUnion.ts
+++ b/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectGenericUnion.ts
@@ -171,9 +171,9 @@ export const test_createValidateEquals_ObjectGenericUnion =
         (() => {
           if ($io5(input, false && _exceptionable))
             return $io5(input, true && _exceptionable);
-          else if ($io1(input, false && _exceptionable))
+          if ($io1(input, false && _exceptionable))
             return $io1(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input, true);
     };
@@ -732,15 +732,14 @@ export const test_createValidateEquals_ObjectGenericUnion =
           (() => {
             if ($vo5(input, _path, false && _exceptionable))
               return $vo5(input, _path, true && _exceptionable);
-            else if ($vo1(input, _path, false && _exceptionable))
+            if ($vo1(input, _path, false && _exceptionable))
               return $vo1(input, _path, true && _exceptionable);
-            else
-              return $report(_exceptionable, {
-                path: _path,
-                expected:
-                  "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
-                value: input,
-              });
+            return $report(_exceptionable, {
+              path: _path,
+              expected:
+                "(ObjectGenericUnion.ISaleReview | ObjectGenericUnion.ISaleQuestion)",
+              value: input,
+            });
           })();
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionDouble.ts
+++ b/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionDouble.ts
@@ -150,25 +150,25 @@ export const test_createValidateEquals_ObjectUnionDouble = _test_validateEquals(
         (() => {
           if ($io6(input, false && _exceptionable))
             return $io6(input, true && _exceptionable);
-          else if ($io0(input, false && _exceptionable))
+          if ($io0(input, false && _exceptionable))
             return $io0(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       const $iu1 = (input: any, _exceptionable: boolean = true): any =>
         (() => {
           if ($io4(input, false && _exceptionable))
             return $io4(input, true && _exceptionable);
-          else if ($io2(input, false && _exceptionable))
+          if ($io2(input, false && _exceptionable))
             return $io2(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       const $iu2 = (input: any, _exceptionable: boolean = true): any =>
         (() => {
           if ($io10(input, false && _exceptionable))
             return $io10(input, true && _exceptionable);
-          else if ($io8(input, false && _exceptionable))
+          if ($io8(input, false && _exceptionable))
             return $io8(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -596,14 +596,13 @@ export const test_createValidateEquals_ObjectUnionDouble = _test_validateEquals(
           (() => {
             if ($vo6(input, _path, false && _exceptionable))
               return $vo6(input, _path, true && _exceptionable);
-            else if ($vo0(input, _path, false && _exceptionable))
+            if ($vo0(input, _path, false && _exceptionable))
               return $vo0(input, _path, true && _exceptionable);
-            else
-              return $report(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-                value: input,
-              });
+            return $report(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+              value: input,
+            });
           })();
         const $vu1 = (
           input: any,
@@ -613,14 +612,13 @@ export const test_createValidateEquals_ObjectUnionDouble = _test_validateEquals(
           (() => {
             if ($vo4(input, _path, false && _exceptionable))
               return $vo4(input, _path, true && _exceptionable);
-            else if ($vo2(input, _path, false && _exceptionable))
+            if ($vo2(input, _path, false && _exceptionable))
               return $vo2(input, _path, true && _exceptionable);
-            else
-              return $report(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-                value: input,
-              });
+            return $report(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+              value: input,
+            });
           })();
         const $vu2 = (
           input: any,
@@ -630,14 +628,13 @@ export const test_createValidateEquals_ObjectUnionDouble = _test_validateEquals(
           (() => {
             if ($vo10(input, _path, false && _exceptionable))
               return $vo10(input, _path, true && _exceptionable);
-            else if ($vo8(input, _path, false && _exceptionable))
+            if ($vo8(input, _path, false && _exceptionable))
               return $vo8(input, _path, true && _exceptionable);
-            else
-              return $report(_exceptionable, {
-                path: _path,
-                expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-                value: input,
-              });
+            return $report(_exceptionable, {
+              path: _path,
+              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+              value: input,
+            });
           })();
         return (
           ((Array.isArray(input) ||

--- a/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/createValidateEquals/test_createValidateEquals_ObjectUnionNonPredictable.ts
@@ -114,11 +114,11 @@ export const test_createValidateEquals_ObjectUnionNonPredictable =
         (() => {
           if ($io7(input, false && _exceptionable))
             return $io7(input, true && _exceptionable);
-          else if ($io5(input, false && _exceptionable))
+          if ($io5(input, false && _exceptionable))
             return $io5(input, true && _exceptionable);
-          else if ($io3(input, false && _exceptionable))
+          if ($io3(input, false && _exceptionable))
             return $io3(input, true && _exceptionable);
-          else return false;
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input, true);
     };
@@ -443,17 +443,16 @@ export const test_createValidateEquals_ObjectUnionNonPredictable =
           (() => {
             if ($vo7(input, _path, false && _exceptionable))
               return $vo7(input, _path, true && _exceptionable);
-            else if ($vo5(input, _path, false && _exceptionable))
+            if ($vo5(input, _path, false && _exceptionable))
               return $vo5(input, _path, true && _exceptionable);
-            else if ($vo3(input, _path, false && _exceptionable))
+            if ($vo3(input, _path, false && _exceptionable))
               return $vo3(input, _path, true && _exceptionable);
-            else
-              return $report(_exceptionable, {
-                path: _path,
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            return $report(_exceptionable, {
+              path: _path,
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/createValidateEquals/test_createValidateEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/createValidateEquals/test_createValidateEquals_ToJsonUnion.ts
@@ -58,11 +58,11 @@ export const test_createValidateEquals_ToJsonUnion = _test_validateEquals(
           return (() => {
             if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else if ($io2(input, false && _exceptionable))
+            if ($io2(input, false && _exceptionable))
               return $io2(input, true && _exceptionable);
-            else if ($io1(input, false && _exceptionable))
+            if ($io1(input, false && _exceptionable))
               return $io1(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
       })();
     return (
@@ -218,17 +218,16 @@ export const test_createValidateEquals_ToJsonUnion = _test_validateEquals(
             return (() => {
               if ($vo3(input, _path, false && _exceptionable))
                 return $vo3(input, _path, true && _exceptionable);
-              else if ($vo2(input, _path, false && _exceptionable))
+              if ($vo2(input, _path, false && _exceptionable))
                 return $vo2(input, _path, true && _exceptionable);
-              else if ($vo1(input, _path, false && _exceptionable))
+              if ($vo1(input, _path, false && _exceptionable))
                 return $vo1(input, _path, true && _exceptionable);
-              else
-                return $report(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $report(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                value: input,
+              });
             })();
         })();
       return (

--- a/test/src/generated/output/equals/test_equals_ObjectUnionDouble.ts
+++ b/test/src/generated/output/equals/test_equals_ObjectUnionDouble.ts
@@ -143,25 +143,25 @@ export const test_equals_ObjectUnionDouble = _test_equals(
       (() => {
         if ($io6(input, false && _exceptionable))
           return $io6(input, true && _exceptionable);
-        else if ($io0(input, false && _exceptionable))
+        if ($io0(input, false && _exceptionable))
           return $io0(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu1 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io4(input, false && _exceptionable))
           return $io4(input, true && _exceptionable);
-        else if ($io2(input, false && _exceptionable))
+        if ($io2(input, false && _exceptionable))
           return $io2(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     const $iu2 = (input: any, _exceptionable: boolean = true): any =>
       (() => {
         if ($io10(input, false && _exceptionable))
           return $io10(input, true && _exceptionable);
-        else if ($io8(input, false && _exceptionable))
+        if ($io8(input, false && _exceptionable))
           return $io8(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return (
       Array.isArray(input) &&

--- a/test/src/generated/output/equals/test_equals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/equals/test_equals_ObjectUnionNonPredictable.ts
@@ -112,11 +112,11 @@ export const test_equals_ObjectUnionNonPredictable = _test_equals(
       (() => {
         if ($io7(input, false && _exceptionable))
           return $io7(input, true && _exceptionable);
-        else if ($io5(input, false && _exceptionable))
+        if ($io5(input, false && _exceptionable))
           return $io5(input, true && _exceptionable);
-        else if ($io3(input, false && _exceptionable))
+        if ($io3(input, false && _exceptionable))
           return $io3(input, true && _exceptionable);
-        else return false;
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input, true);
   })(input),

--- a/test/src/generated/output/equals/test_equals_ToJsonUnion.ts
+++ b/test/src/generated/output/equals/test_equals_ToJsonUnion.ts
@@ -54,11 +54,11 @@ export const test_equals_ToJsonUnion = _test_equals("ToJsonUnion")<ToJsonUnion>(
           return (() => {
             if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else if ($io2(input, false && _exceptionable))
+            if ($io2(input, false && _exceptionable))
               return $io2(input, true && _exceptionable);
-            else if ($io1(input, false && _exceptionable))
+            if ($io1(input, false && _exceptionable))
               return $io1(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/is/test_is_DynamicArray.ts
+++ b/test/src/generated/output/is/test_is_DynamicArray.ts
@@ -16,12 +16,10 @@ export const test_is_DynamicArray = _test_is("DynamicArray")<DynamicArray>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   })(input),

--- a/test/src/generated/output/is/test_is_DynamicJsonValue.ts
+++ b/test/src/generated/output/is/test_is_DynamicJsonValue.ts
@@ -11,20 +11,18 @@ export const test_is_DynamicJsonValue = _test_is(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            null === value ||
-            undefined === value ||
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value ||
-            (Array.isArray(value) && ($ia0(value) || false)) ||
-            ("object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $io0(value))
-          );
-        return true;
+        return (
+          null === value ||
+          undefined === value ||
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value ||
+          (Array.isArray(value) && ($ia0(value) || false)) ||
+          ("object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $io0(value))
+        );
       });
     const $ia0 = (input: any): any =>
       input.every(

--- a/test/src/generated/output/is/test_is_DynamicNever.ts
+++ b/test/src/generated/output/is/test_is_DynamicNever.ts
@@ -11,8 +11,7 @@ export const test_is_DynamicNever = _test_is("DynamicNever")<DynamicNever>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/is/test_is_DynamicSimple.ts
+++ b/test/src/generated/output/is/test_is_DynamicSimple.ts
@@ -16,8 +16,7 @@ export const test_is_DynamicSimple = _test_is("DynamicSimple")<DynamicSimple>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value && Number.isFinite(value);
-        return true;
+        return "number" === typeof value && Number.isFinite(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   })(input),

--- a/test/src/generated/output/is/test_is_DynamicTree.ts
+++ b/test/src/generated/output/is/test_is_DynamicTree.ts
@@ -19,9 +19,7 @@ export const test_is_DynamicTree = _test_is("DynamicTree")<DynamicTree>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   })(input),

--- a/test/src/generated/output/is/test_is_DynamicUndefined.ts
+++ b/test/src/generated/output/is/test_is_DynamicUndefined.ts
@@ -11,8 +11,7 @@ export const test_is_DynamicUndefined = _test_is(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/is/test_is_ObjectDynamic.ts
+++ b/test/src/generated/output/is/test_is_ObjectDynamic.ts
@@ -11,13 +11,11 @@ export const test_is_ObjectDynamic = _test_is("ObjectDynamic")<ObjectDynamic>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value
-          );
-        return true;
+        return (
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value
+        );
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/is/test_is_ObjectUnionDouble.ts
+++ b/test/src/generated/output/is/test_is_ObjectUnionDouble.ts
@@ -47,20 +47,20 @@ export const test_is_ObjectUnionDouble = _test_is(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $io6(input);
-        else if ($io0(input)) return $io0(input);
-        else return false;
+        if ($io0(input)) return $io0(input);
+        return false;
       })();
     const $iu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $io4(input);
-        else if ($io2(input)) return $io2(input);
-        else return false;
+        if ($io2(input)) return $io2(input);
+        return false;
       })();
     const $iu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $io10(input);
-        else if ($io8(input)) return $io8(input);
-        else return false;
+        if ($io8(input)) return $io8(input);
+        return false;
       })();
     return (
       Array.isArray(input) &&

--- a/test/src/generated/output/is/test_is_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/is/test_is_ObjectUnionNonPredictable.ts
@@ -36,9 +36,9 @@ export const test_is_ObjectUnionNonPredictable = _test_is(
     const $iu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $io7(input);
-        else if ($io5(input)) return $io5(input);
-        else if ($io3(input)) return $io3(input);
-        else return false;
+        if ($io5(input)) return $io5(input);
+        if ($io3(input)) return $io3(input);
+        return false;
       })();
     return "object" === typeof input && null !== input && $io0(input);
   })(input),

--- a/test/src/generated/output/is/test_is_ToJsonUnion.ts
+++ b/test/src/generated/output/is/test_is_ToJsonUnion.ts
@@ -21,9 +21,9 @@ export const test_is_ToJsonUnion = _test_is("ToJsonUnion")<ToJsonUnion>(
         else
           return (() => {
             if ($io3(input)) return $io3(input);
-            else if ($io2(input)) return $io2(input);
-            else if ($io1(input)) return $io1(input);
-            else return false;
+            if ($io2(input)) return $io2(input);
+            if ($io1(input)) return $io1(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/is/test_is_UltimateUnion.ts
+++ b/test/src/generated/output/is/test_is_UltimateUnion.ts
@@ -412,14 +412,12 @@ export const test_is_UltimateUnion = _test_is("UltimateUnion")<UltimateUnion>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -515,14 +513,12 @@ export const test_is_UltimateUnion = _test_is("UltimateUnion")<UltimateUnion>(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -1039,13 +1035,13 @@ export const test_is_UltimateUnion = _test_is("UltimateUnion")<UltimateUnion>(
         else
           return (() => {
             if ($io5(input)) return $io5(input);
-            else if ($io4(input)) return $io4(input);
-            else if ($io1(input)) return $io1(input);
-            else if ($io6(input)) return $io6(input);
-            else if ($io9(input)) return $io9(input);
-            else if ($io10(input)) return $io10(input);
-            else if ($io18(input)) return $io18(input);
-            else return false;
+            if ($io4(input)) return $io4(input);
+            if ($io1(input)) return $io1(input);
+            if ($io6(input)) return $io6(input);
+            if ($io9(input)) return $io9(input);
+            if ($io10(input)) return $io10(input);
+            if ($io18(input)) return $io18(input);
+            return false;
           })();
       })();
     const $iu1 = (input: any): any =>
@@ -1076,13 +1072,13 @@ export const test_is_UltimateUnion = _test_is("UltimateUnion")<UltimateUnion>(
         else
           return (() => {
             if ($io23(input)) return $io23(input);
-            else if ($io22(input)) return $io22(input);
-            else if ($io21(input)) return $io21(input);
-            else if ($io24(input)) return $io24(input);
-            else if ($io26(input)) return $io26(input);
-            else if ($io27(input)) return $io27(input);
-            else if ($io34(input)) return $io34(input);
-            else return false;
+            if ($io22(input)) return $io22(input);
+            if ($io21(input)) return $io21(input);
+            if ($io24(input)) return $io24(input);
+            if ($io26(input)) return $io26(input);
+            if ($io27(input)) return $io27(input);
+            if ($io34(input)) return $io34(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/issues/test_issue_951_dynamic_key_check_true.ts
+++ b/test/src/generated/output/issues/test_issue_951_dynamic_key_check_true.ts
@@ -1,0 +1,36 @@
+import typia from "typia";
+
+export const test_issue_951_dynamic_key_check_true = () => {
+  (input: any): input is MyInterface => {
+    const $io0 = (input: any): boolean =>
+      "string" === typeof input.name &&
+      "object" === typeof input.volumes &&
+      null !== input.volumes &&
+      false === Array.isArray(input.volumes) &&
+      $io1(input.volumes);
+    const $io1 = (input: any): boolean =>
+      (undefined === input.system ||
+        ("number" === typeof input.system && Number.isFinite(input.system))) &&
+      (undefined === input.messages ||
+        ("object" === typeof input.messages &&
+          null !== input.messages &&
+          false === Array.isArray(input.messages) &&
+          $io2(input.messages)));
+    const $io2 = (input: any): boolean =>
+      Object.keys(input).every((key: any) => {
+        const value = input[key];
+        if (undefined === value) return true;
+        return "number" === typeof value && Number.isFinite(value);
+      });
+    return "object" === typeof input && null !== input && $io0(input);
+  };
+};
+interface MyInterface {
+  name: string;
+  volumes: {
+    system?: number;
+    messages?: {
+      [messageId: string]: number;
+    };
+  };
+}

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicNever.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_json_assertParse_DynamicNever = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_assertParse_DynamicNever = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicTree.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_json_assertParse_DynamicTree = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -80,22 +78,20 @@ export const test_json_assertParse_DynamicTree = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_json_assertParse_DynamicUndefined = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_assertParse_DynamicUndefined = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_json_assertParse_ObjectDynamic = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -45,18 +43,16 @@ export const test_json_assertParse_ObjectDynamic = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_json_assertParse_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };

--- a/test/src/generated/output/json.assertParse/test_json_assertParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.assertParse/test_json_assertParse_UltimateUnion.ts
@@ -426,14 +426,12 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -529,14 +527,12 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -1063,13 +1059,13 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -1100,13 +1096,13 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -2897,26 +2893,24 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                      value: value,
-                    })) &&
-                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                  value: value,
+                })
+              );
             });
           const $ao15 = (
             input: any,
@@ -3322,26 +3316,24 @@ export const test_json_assertParse_UltimateUnion = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                      value: value,
-                    })) &&
-                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                  value: value,
+                })
+              );
             });
           const $ao21 = (
             input: any,

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_json_assertStringify_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_assertStringify_DynamicNever =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      (null !== value ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        })) &&
-                      (undefined === value ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        }))
-                    );
-                  return true;
+                  return (
+                    (null !== value ||
+                      $guard(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      })) &&
+                    (undefined === value ||
+                      $guard(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      }))
+                  );
                 });
               return (
                 ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_json_assertStringify_DynamicTree = _test_json_assertStringify(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -80,22 +78,20 @@ export const test_json_assertStringify_DynamicTree = _test_json_assertStringify(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||
@@ -126,9 +122,7 @@ export const test_json_assertStringify_DynamicTree = _test_json_assertStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $string = (typia.json.assertStringify as any).string;
       const $number = (typia.json.assertStringify as any).number;

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_DynamicUndefined.ts
@@ -14,8 +14,7 @@ export const test_json_assertStringify_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -41,22 +40,20 @@ export const test_json_assertStringify_DynamicUndefined =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    (null !== value ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      })) &&
-                    (undefined === value ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      }))
-                  );
-                return true;
+                return (
+                  (null !== value ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    })) &&
+                  (undefined === value ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    }))
+                );
               });
             return (
               ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_json_assertStringify_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value
+                );
               });
             return (
               "object" === typeof input &&
@@ -45,18 +43,16 @@ export const test_json_assertStringify_ObjectDynamic =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      "string" === typeof value ||
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      "boolean" === typeof value ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "(boolean | number | string)",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    "string" === typeof value ||
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    "boolean" === typeof value ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "(boolean | number | string)",
+                      value: value,
+                    })
+                  );
                 });
               return (
                 ((("object" === typeof input &&

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_json_assertStringify_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -288,14 +288,13 @@ export const test_json_assertStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_ToJsonUnion.ts
@@ -23,9 +23,9 @@ export const test_json_assertStringify_ToJsonUnion = _test_json_assertStringify(
             else
               return (() => {
                 if ($io3(input)) return $io3(input);
-                else if ($io2(input)) return $io2(input);
-                else if ($io1(input)) return $io1(input);
-                else return false;
+                if ($io2(input)) return $io2(input);
+                if ($io1(input)) return $io1(input);
+                return false;
               })();
           })();
         return (

--- a/test/src/generated/output/json.assertStringify/test_json_assertStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.assertStringify/test_json_assertStringify_UltimateUnion.ts
@@ -433,14 +433,12 @@ export const test_json_assertStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu0(value)
+                );
               });
             const $io15 = (input: any): boolean =>
               "string" === typeof input.$ref &&
@@ -536,14 +534,12 @@ export const test_json_assertStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu1(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu1(value)
+                );
               });
             const $io21 = (input: any): boolean =>
               Array.isArray(input["enum"]) &&
@@ -1076,13 +1072,13 @@ export const test_json_assertStringify_UltimateUnion =
                 else
                   return (() => {
                     if ($io5(input)) return $io5(input);
-                    else if ($io4(input)) return $io4(input);
-                    else if ($io1(input)) return $io1(input);
-                    else if ($io6(input)) return $io6(input);
-                    else if ($io9(input)) return $io9(input);
-                    else if ($io10(input)) return $io10(input);
-                    else if ($io18(input)) return $io18(input);
-                    else return false;
+                    if ($io4(input)) return $io4(input);
+                    if ($io1(input)) return $io1(input);
+                    if ($io6(input)) return $io6(input);
+                    if ($io9(input)) return $io9(input);
+                    if ($io10(input)) return $io10(input);
+                    if ($io18(input)) return $io18(input);
+                    return false;
                   })();
               })();
             const $iu1 = (input: any): any =>
@@ -1113,13 +1109,13 @@ export const test_json_assertStringify_UltimateUnion =
                 else
                   return (() => {
                     if ($io23(input)) return $io23(input);
-                    else if ($io22(input)) return $io22(input);
-                    else if ($io21(input)) return $io21(input);
-                    else if ($io24(input)) return $io24(input);
-                    else if ($io26(input)) return $io26(input);
-                    else if ($io27(input)) return $io27(input);
-                    else if ($io34(input)) return $io34(input);
-                    else return false;
+                    if ($io22(input)) return $io22(input);
+                    if ($io21(input)) return $io21(input);
+                    if ($io24(input)) return $io24(input);
+                    if ($io26(input)) return $io26(input);
+                    if ($io27(input)) return $io27(input);
+                    if ($io34(input)) return $io34(input);
+                    return false;
                   })();
               })();
             return (
@@ -2946,30 +2942,28 @@ export const test_json_assertStringify_UltimateUnion =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                          value: value,
-                        })) &&
-                        $au0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $guard(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $au0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                      value: value,
+                    })
+                  );
                 });
               const $ao15 = (
                 input: any,
@@ -3384,30 +3378,28 @@ export const test_json_assertStringify_UltimateUnion =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                          value: value,
-                        })) &&
-                        $au1(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $guard(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $au1(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                      value: value,
+                    })
+                  );
                 });
               const $ao21 = (
                 input: any,
@@ -6125,14 +6117,12 @@ export const test_json_assertStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -6228,14 +6218,12 @@ export const test_json_assertStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -9644,18 +9632,17 @@ export const test_json_assertStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $so5(input);
-                  else if ($io4(input)) return $so4(input);
-                  else if ($io1(input)) return $so1(input);
-                  else if ($io6(input)) return $so6(input);
-                  else if ($io9(input)) return $so9(input);
-                  else if ($io10(input)) return $so10(input);
-                  else if ($io18(input)) return $so18(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                      value: input,
-                    });
+                  if ($io4(input)) return $so4(input);
+                  if ($io1(input)) return $so1(input);
+                  if ($io6(input)) return $so6(input);
+                  if ($io9(input)) return $so9(input);
+                  if ($io10(input)) return $so10(input);
+                  if ($io18(input)) return $so18(input);
+                  $throws({
+                    expected:
+                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                    value: input,
+                  });
                 })();
             })();
           const $su1 = (input: any): any =>
@@ -9686,18 +9673,17 @@ export const test_json_assertStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $so23(input);
-                  else if ($io22(input)) return $so22(input);
-                  else if ($io21(input)) return $so21(input);
-                  else if ($io24(input)) return $so24(input);
-                  else if ($io26(input)) return $so26(input);
-                  else if ($io27(input)) return $so27(input);
-                  else if ($io34(input)) return $so34(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                      value: input,
-                    });
+                  if ($io22(input)) return $so22(input);
+                  if ($io21(input)) return $so21(input);
+                  if ($io24(input)) return $so24(input);
+                  if ($io26(input)) return $so26(input);
+                  if ($io27(input)) return $so27(input);
+                  if ($io34(input)) return $so34(input);
+                  $throws({
+                    expected:
+                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                    value: input,
+                  });
                 })();
             })();
           return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicNever.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_json_createAssertParse_DynamicNever = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_createAssertParse_DynamicNever = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicTree.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_json_createAssertParse_DynamicTree = _test_json_assertParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -79,22 +77,20 @@ export const test_json_createAssertParse_DynamicTree = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_json_createAssertParse_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_createAssertParse_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_json_createAssertParse_ObjectDynamic = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -45,18 +43,16 @@ export const test_json_createAssertParse_ObjectDynamic = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_json_createAssertParse_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };

--- a/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.createAssertParse/test_json_createAssertParse_UltimateUnion.ts
@@ -426,14 +426,12 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -529,14 +527,12 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -1063,13 +1059,13 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -1100,13 +1096,13 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -2897,26 +2893,24 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                      value: value,
-                    })) &&
-                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                  value: value,
+                })
+              );
             });
           const $ao15 = (
             input: any,
@@ -3322,26 +3316,24 @@ export const test_json_createAssertParse_UltimateUnion = _test_json_assertParse(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                      value: value,
-                    })) &&
-                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                  value: value,
+                })
+              );
             });
           const $ao21 = (
             input: any,

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_json_createAssertStringify_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_json_createAssertStringify_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    (null !== value ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      })) &&
-                    (undefined === value ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "undefined",
-                        value: value,
-                      }))
-                  );
-                return true;
+                return (
+                  (null !== value ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    })) &&
+                  (undefined === value ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "undefined",
+                      value: value,
+                    }))
+                );
               });
             return (
               ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicTree.ts
@@ -20,11 +20,7 @@ export const test_json_createAssertStringify_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -81,26 +77,20 @@ export const test_json_createAssertStringify_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value && null !== value) ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "DynamicTree",
-                        value: value,
-                      })) &&
-                      $ao0(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value && null !== value) ||
                     $guard(_exceptionable, {
                       path: _path + $join(key),
                       expected: "DynamicTree",
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicTree",
+                    value: value,
+                  })
+                );
               });
             return (
               ((("object" === typeof input && null !== input) ||
@@ -131,9 +121,7 @@ export const test_json_createAssertStringify_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         const $string = (typia.json.createAssertStringify as any).string;
         const $number = (typia.json.createAssertStringify as any).number;

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_json_createAssertStringify_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_json_createAssertStringify_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_json_createAssertStringify_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -44,18 +42,16 @@ export const test_json_createAssertStringify_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "(boolean | number | string)",
-                      value: value,
-                    })
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "(boolean | number | string)",
+                    value: value,
+                  })
+                );
               });
             return (
               ((("object" === typeof input &&

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_json_createAssertStringify_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -288,14 +288,13 @@ export const test_json_createAssertStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_ToJsonUnion.ts
@@ -22,9 +22,9 @@ export const test_json_createAssertStringify_ToJsonUnion =
               else
                 return (() => {
                   if ($io3(input)) return $io3(input);
-                  else if ($io2(input)) return $io2(input);
-                  else if ($io1(input)) return $io1(input);
-                  else return false;
+                  if ($io2(input)) return $io2(input);
+                  if ($io1(input)) return $io1(input);
+                  return false;
                 })();
             })();
           return (

--- a/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.createAssertStringify/test_json_createAssertStringify_UltimateUnion.ts
@@ -430,14 +430,12 @@ export const test_json_createAssertStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -533,14 +531,12 @@ export const test_json_createAssertStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -1071,13 +1067,13 @@ export const test_json_createAssertStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $io5(input);
-                  else if ($io4(input)) return $io4(input);
-                  else if ($io1(input)) return $io1(input);
-                  else if ($io6(input)) return $io6(input);
-                  else if ($io9(input)) return $io9(input);
-                  else if ($io10(input)) return $io10(input);
-                  else if ($io18(input)) return $io18(input);
-                  else return false;
+                  if ($io4(input)) return $io4(input);
+                  if ($io1(input)) return $io1(input);
+                  if ($io6(input)) return $io6(input);
+                  if ($io9(input)) return $io9(input);
+                  if ($io10(input)) return $io10(input);
+                  if ($io18(input)) return $io18(input);
+                  return false;
                 })();
             })();
           const $iu1 = (input: any): any =>
@@ -1108,13 +1104,13 @@ export const test_json_createAssertStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $io23(input);
-                  else if ($io22(input)) return $io22(input);
-                  else if ($io21(input)) return $io21(input);
-                  else if ($io24(input)) return $io24(input);
-                  else if ($io26(input)) return $io26(input);
-                  else if ($io27(input)) return $io27(input);
-                  else if ($io34(input)) return $io34(input);
-                  else return false;
+                  if ($io22(input)) return $io22(input);
+                  if ($io21(input)) return $io21(input);
+                  if ($io24(input)) return $io24(input);
+                  if ($io26(input)) return $io26(input);
+                  if ($io27(input)) return $io27(input);
+                  if ($io34(input)) return $io34(input);
+                  return false;
                 })();
             })();
           return (
@@ -2921,30 +2917,24 @@ export const test_json_createAssertStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value &&
-                      null !== value &&
-                      false === Array.isArray(value)) ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                        value: value,
-                      })) &&
-                      $au0(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value &&
+                    null !== value &&
+                    false === Array.isArray(value)) ||
                     $guard(_exceptionable, {
                       path: _path + $join(key),
                       expected:
                         '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected:
+                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                    value: value,
+                  })
+                );
               });
             const $ao15 = (
               input: any,
@@ -3355,30 +3345,24 @@ export const test_json_createAssertStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value &&
-                      null !== value &&
-                      false === Array.isArray(value)) ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                        value: value,
-                      })) &&
-                      $au1(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value &&
+                    null !== value &&
+                    false === Array.isArray(value)) ||
                     $guard(_exceptionable, {
                       path: _path + $join(key),
                       expected:
                         '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected:
+                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                    value: value,
+                  })
+                );
               });
             const $ao21 = (
               input: any,
@@ -6065,14 +6049,12 @@ export const test_json_createAssertStringify_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -6168,14 +6150,12 @@ export const test_json_createAssertStringify_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -9509,18 +9489,17 @@ export const test_json_createAssertStringify_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $so5(input);
-                else if ($io4(input)) return $so4(input);
-                else if ($io1(input)) return $so1(input);
-                else if ($io6(input)) return $so6(input);
-                else if ($io9(input)) return $so9(input);
-                else if ($io10(input)) return $so10(input);
-                else if ($io18(input)) return $so18(input);
-                else
-                  $throws({
-                    expected:
-                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                    value: input,
-                  });
+                if ($io4(input)) return $so4(input);
+                if ($io1(input)) return $so1(input);
+                if ($io6(input)) return $so6(input);
+                if ($io9(input)) return $so9(input);
+                if ($io10(input)) return $so10(input);
+                if ($io18(input)) return $so18(input);
+                $throws({
+                  expected:
+                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                  value: input,
+                });
               })();
           })();
         const $su1 = (input: any): any =>
@@ -9551,18 +9530,17 @@ export const test_json_createAssertStringify_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $so23(input);
-                else if ($io22(input)) return $so22(input);
-                else if ($io21(input)) return $so21(input);
-                else if ($io24(input)) return $so24(input);
-                else if ($io26(input)) return $so26(input);
-                else if ($io27(input)) return $so27(input);
-                else if ($io34(input)) return $so34(input);
-                else
-                  $throws({
-                    expected:
-                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                    value: input,
-                  });
+                if ($io22(input)) return $so22(input);
+                if ($io21(input)) return $so21(input);
+                if ($io24(input)) return $so24(input);
+                if ($io26(input)) return $so26(input);
+                if ($io27(input)) return $so27(input);
+                if ($io34(input)) return $so34(input);
+                $throws({
+                  expected:
+                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                  value: input,
+                });
               })();
           })();
         return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicArray.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicArray.ts
@@ -16,12 +16,10 @@ export const test_json_createIsParse_DynamicArray = _test_json_isParse(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   };

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicNever.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicNever.ts
@@ -11,8 +11,7 @@ export const test_json_createIsParse_DynamicNever = _test_json_isParse(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicSimple.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_json_createIsParse_DynamicSimple = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicTree.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicTree.ts
@@ -19,9 +19,7 @@ export const test_json_createIsParse_DynamicTree = _test_json_isParse(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_json_createIsParse_DynamicUndefined = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_json_createIsParse_ObjectDynamic = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_json_createIsParse_ObjectUnionDouble = _test_json_isParse(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_json_createIsParse_ObjectUnionNonPredictable =
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.createIsParse/test_json_createIsParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.createIsParse/test_json_createIsParse_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_json_createIsParse_UltimateUnion = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_json_createIsParse_UltimateUnion = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_json_createIsParse_UltimateUnion = _test_json_isParse(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_json_createIsParse_UltimateUnion = _test_json_isParse(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicArray.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicArray.ts
@@ -16,12 +16,10 @@ export const test_json_createIsStringify_DynamicArray = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -30,12 +28,10 @@ export const test_json_createIsStringify_DynamicArray = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     const $string = (typia.json.createIsStringify as any).string;
     const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicNever.ts
@@ -11,8 +11,7 @@ export const test_json_createIsStringify_DynamicNever = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return null !== value && undefined === value;
-        return true;
+        return null !== value && undefined === value;
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicSimple.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicSimple.ts
@@ -16,8 +16,7 @@ export const test_json_createIsStringify_DynamicSimple = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value && Number.isFinite(value);
-        return true;
+        return "number" === typeof value && Number.isFinite(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -26,8 +25,7 @@ export const test_json_createIsStringify_DynamicSimple = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value;
-        return true;
+        return "number" === typeof value;
       });
     const $number = (typia.json.createIsStringify as any).number;
     const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicTree.ts
@@ -19,9 +19,7 @@ export const test_json_createIsStringify_DynamicTree = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     return "object" === typeof input && null !== input && $io0(input);
   };
@@ -37,9 +35,7 @@ export const test_json_createIsStringify_DynamicTree = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     const $string = (typia.json.createIsStringify as any).string;
     const $number = (typia.json.createIsStringify as any).number;

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_json_createIsStringify_DynamicUndefined =
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectDynamic.ts
@@ -11,13 +11,11 @@ export const test_json_createIsStringify_ObjectDynamic = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "string" === typeof value ||
-            ("number" === typeof value && Number.isFinite(value)) ||
-            "boolean" === typeof value
-          );
-        return true;
+        return (
+          "string" === typeof value ||
+          ("number" === typeof value && Number.isFinite(value)) ||
+          "boolean" === typeof value
+        );
       });
     return (
       "object" === typeof input &&

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_json_createIsStringify_ObjectUnionDouble =
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -135,32 +135,29 @@ export const test_json_createIsStringify_ObjectUnionDouble =
       const $su0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $so6(input);
-          else if ($io0(input)) return $so0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $so0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $su1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $so4(input);
-          else if ($io2(input)) return $so2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $so2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $su2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $so10(input);
-          else if ($io8(input)) return $so8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $so8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       return `[${input.map((elem: any) => $su0(elem)).join(",")}]`;
     };

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ObjectUnionNonPredictable.ts
@@ -39,9 +39,9 @@ export const test_json_createIsStringify_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -89,14 +89,13 @@ export const test_json_createIsStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_ToJsonUnion.ts
@@ -21,9 +21,9 @@ export const test_json_createIsStringify_ToJsonUnion = _test_json_isStringify(
         else
           return (() => {
             if ($io3(input)) return $io3(input);
-            else if ($io2(input)) return $io2(input);
-            else if ($io1(input)) return $io1(input);
-            else return false;
+            if ($io2(input)) return $io2(input);
+            if ($io1(input)) return $io1(input);
+            return false;
           })();
       })();
     return (

--- a/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.createIsStringify/test_json_createIsStringify_UltimateUnion.ts
@@ -412,14 +412,12 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -515,14 +513,12 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -1039,13 +1035,13 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
         else
           return (() => {
             if ($io5(input)) return $io5(input);
-            else if ($io4(input)) return $io4(input);
-            else if ($io1(input)) return $io1(input);
-            else if ($io6(input)) return $io6(input);
-            else if ($io9(input)) return $io9(input);
-            else if ($io10(input)) return $io10(input);
-            else if ($io18(input)) return $io18(input);
-            else return false;
+            if ($io4(input)) return $io4(input);
+            if ($io1(input)) return $io1(input);
+            if ($io6(input)) return $io6(input);
+            if ($io9(input)) return $io9(input);
+            if ($io10(input)) return $io10(input);
+            if ($io18(input)) return $io18(input);
+            return false;
           })();
       })();
     const $iu1 = (input: any): any =>
@@ -1076,13 +1072,13 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
         else
           return (() => {
             if ($io23(input)) return $io23(input);
-            else if ($io22(input)) return $io22(input);
-            else if ($io21(input)) return $io21(input);
-            else if ($io24(input)) return $io24(input);
-            else if ($io26(input)) return $io26(input);
-            else if ($io27(input)) return $io27(input);
-            else if ($io34(input)) return $io34(input);
-            else return false;
+            if ($io22(input)) return $io22(input);
+            if ($io21(input)) return $io21(input);
+            if ($io24(input)) return $io24(input);
+            if ($io26(input)) return $io26(input);
+            if ($io27(input)) return $io27(input);
+            if ($io34(input)) return $io34(input);
+            return false;
           })();
       })();
     return (
@@ -1473,14 +1469,12 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -1576,14 +1570,12 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -4829,18 +4821,17 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
         else
           return (() => {
             if ($io5(input)) return $so5(input);
-            else if ($io4(input)) return $so4(input);
-            else if ($io1(input)) return $so1(input);
-            else if ($io6(input)) return $so6(input);
-            else if ($io9(input)) return $so9(input);
-            else if ($io10(input)) return $so10(input);
-            else if ($io18(input)) return $so18(input);
-            else
-              $throws({
-                expected:
-                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                value: input,
-              });
+            if ($io4(input)) return $so4(input);
+            if ($io1(input)) return $so1(input);
+            if ($io6(input)) return $so6(input);
+            if ($io9(input)) return $so9(input);
+            if ($io10(input)) return $so10(input);
+            if ($io18(input)) return $so18(input);
+            $throws({
+              expected:
+                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+              value: input,
+            });
           })();
       })();
     const $su1 = (input: any): any =>
@@ -4871,18 +4862,17 @@ export const test_json_createIsStringify_UltimateUnion = _test_json_isStringify(
         else
           return (() => {
             if ($io23(input)) return $so23(input);
-            else if ($io22(input)) return $so22(input);
-            else if ($io21(input)) return $so21(input);
-            else if ($io24(input)) return $so24(input);
-            else if ($io26(input)) return $so26(input);
-            else if ($io27(input)) return $so27(input);
-            else if ($io34(input)) return $so34(input);
-            else
-              $throws({
-                expected:
-                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                value: input,
-              });
+            if ($io22(input)) return $so22(input);
+            if ($io21(input)) return $so21(input);
+            if ($io24(input)) return $so24(input);
+            if ($io26(input)) return $so26(input);
+            if ($io27(input)) return $so27(input);
+            if ($io34(input)) return $so34(input);
+            $throws({
+              expected:
+                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+              value: input,
+            });
           })();
       })();
     return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicArray.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicArray.ts
@@ -10,12 +10,10 @@ export const test_json_createStringify_DynamicArray = _test_json_stringify(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          Array.isArray(value) &&
-          value.every((elem: any) => "string" === typeof elem)
-        );
-      return true;
+      return (
+        Array.isArray(value) &&
+        value.every((elem: any) => "string" === typeof elem)
+      );
     });
   const $string = (typia.json.createStringify as any).string;
   const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicSimple.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicSimple.ts
@@ -10,8 +10,7 @@ export const test_json_createStringify_DynamicSimple = _test_json_stringify(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true) return "number" === typeof value;
-      return true;
+      return "number" === typeof value;
     });
   const $number = (typia.json.createStringify as any).number;
   const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_DynamicTree.ts
@@ -17,9 +17,7 @@ export const test_json_createStringify_DynamicTree = _test_json_stringify(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return "object" === typeof value && null !== value && $io0(value);
-      return true;
+      return "object" === typeof value && null !== value && $io0(value);
     });
   const $string = (typia.json.createStringify as any).string;
   const $number = (typia.json.createStringify as any).number;

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_ObjectUnionDouble.ts
@@ -69,32 +69,29 @@ export const test_json_createStringify_ObjectUnionDouble = _test_json_stringify(
   const $su0 = (input: any): any =>
     (() => {
       if ($io6(input)) return $so6(input);
-      else if ($io0(input)) return $so0(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-          value: input,
-        });
+      if ($io0(input)) return $so0(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+        value: input,
+      });
     })();
   const $su1 = (input: any): any =>
     (() => {
       if ($io4(input)) return $so4(input);
-      else if ($io2(input)) return $so2(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-          value: input,
-        });
+      if ($io2(input)) return $so2(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+        value: input,
+      });
     })();
   const $su2 = (input: any): any =>
     (() => {
       if ($io10(input)) return $so10(input);
-      else if ($io8(input)) return $so8(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-          value: input,
-        });
+      if ($io8(input)) return $so8(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+        value: input,
+      });
     })();
   return `[${input.map((elem: any) => $su0(elem)).join(",")}]`;
 });

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_ObjectUnionNonPredictable.ts
@@ -49,14 +49,13 @@ export const test_json_createStringify_ObjectUnionNonPredictable =
     const $su0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $so7(input);
-        else if ($io5(input)) return $so5(input);
-        else if ($io3(input)) return $so3(input);
-        else
-          $throws({
-            expected:
-              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-            value: input,
-          });
+        if ($io5(input)) return $so5(input);
+        if ($io3(input)) return $so3(input);
+        $throws({
+          expected:
+            "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+          value: input,
+        });
       })();
     return $so0(input);
   });

--- a/test/src/generated/output/json.createStringify/test_json_createStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.createStringify/test_json_createStringify_UltimateUnion.ts
@@ -368,14 +368,12 @@ export const test_json_createStringify_UltimateUnion = _test_json_stringify(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          "object" === typeof value &&
-          null !== value &&
-          false === Array.isArray(value) &&
-          $iu0(value)
-        );
-      return true;
+      return (
+        "object" === typeof value &&
+        null !== value &&
+        false === Array.isArray(value) &&
+        $iu0(value)
+      );
     });
   const $io15 = (input: any): boolean =>
     "string" === typeof input.$ref &&
@@ -467,14 +465,12 @@ export const test_json_createStringify_UltimateUnion = _test_json_stringify(
     Object.keys(input).every((key: any) => {
       const value = input[key];
       if (undefined === value) return true;
-      if (true)
-        return (
-          "object" === typeof value &&
-          null !== value &&
-          false === Array.isArray(value) &&
-          $iu1(value)
-        );
-      return true;
+      return (
+        "object" === typeof value &&
+        null !== value &&
+        false === Array.isArray(value) &&
+        $iu1(value)
+      );
     });
   const $io21 = (input: any): boolean =>
     Array.isArray(input["enum"]) &&
@@ -3686,18 +3682,17 @@ export const test_json_createStringify_UltimateUnion = _test_json_stringify(
       else
         return (() => {
           if ($io5(input)) return $so5(input);
-          else if ($io4(input)) return $so4(input);
-          else if ($io1(input)) return $so1(input);
-          else if ($io6(input)) return $so6(input);
-          else if ($io9(input)) return $so9(input);
-          else if ($io10(input)) return $so10(input);
-          else if ($io18(input)) return $so18(input);
-          else
-            $throws({
-              expected:
-                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-              value: input,
-            });
+          if ($io4(input)) return $so4(input);
+          if ($io1(input)) return $so1(input);
+          if ($io6(input)) return $so6(input);
+          if ($io9(input)) return $so9(input);
+          if ($io10(input)) return $so10(input);
+          if ($io18(input)) return $so18(input);
+          $throws({
+            expected:
+              '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+            value: input,
+          });
         })();
     })();
   const $su1 = (input: any): any =>
@@ -3728,18 +3723,17 @@ export const test_json_createStringify_UltimateUnion = _test_json_stringify(
       else
         return (() => {
           if ($io23(input)) return $so23(input);
-          else if ($io22(input)) return $so22(input);
-          else if ($io21(input)) return $so21(input);
-          else if ($io24(input)) return $so24(input);
-          else if ($io26(input)) return $so26(input);
-          else if ($io27(input)) return $so27(input);
-          else if ($io34(input)) return $so34(input);
-          else
-            $throws({
-              expected:
-                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-              value: input,
-            });
+          if ($io22(input)) return $so22(input);
+          if ($io21(input)) return $so21(input);
+          if ($io24(input)) return $so24(input);
+          if ($io26(input)) return $so26(input);
+          if ($io27(input)) return $so27(input);
+          if ($io34(input)) return $so34(input);
+          $throws({
+            expected:
+              '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+            value: input,
+          });
         })();
     })();
   return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicNever.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_json_createValidateParse_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_json_createValidateParse_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicTree.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicTree.ts
@@ -21,11 +21,7 @@ export const test_json_createValidateParse_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -88,26 +84,24 @@ export const test_json_createValidateParse_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_DynamicUndefined.ts
@@ -14,8 +14,7 @@ export const test_json_createValidateParse_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -43,22 +42,20 @@ export const test_json_createValidateParse_DynamicUndefined =
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        (null !== value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          })) &&
-                        (undefined === value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          }))
-                      );
-                    return true;
+                    return (
+                      (null !== value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        })) &&
+                      (undefined === value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        }))
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_json_createValidateParse_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -49,19 +47,16 @@ export const test_json_createValidateParse_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_json_createValidateParse_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };

--- a/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.createValidateParse/test_json_createValidateParse_UltimateUnion.ts
@@ -431,14 +431,12 @@ export const test_json_createValidateParse_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -534,14 +532,12 @@ export const test_json_createValidateParse_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -1072,13 +1068,13 @@ export const test_json_createValidateParse_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $io5(input);
-                  else if ($io4(input)) return $io4(input);
-                  else if ($io1(input)) return $io1(input);
-                  else if ($io6(input)) return $io6(input);
-                  else if ($io9(input)) return $io9(input);
-                  else if ($io10(input)) return $io10(input);
-                  else if ($io18(input)) return $io18(input);
-                  else return false;
+                  if ($io4(input)) return $io4(input);
+                  if ($io1(input)) return $io1(input);
+                  if ($io6(input)) return $io6(input);
+                  if ($io9(input)) return $io9(input);
+                  if ($io10(input)) return $io10(input);
+                  if ($io18(input)) return $io18(input);
+                  return false;
                 })();
             })();
           const $iu1 = (input: any): any =>
@@ -1109,13 +1105,13 @@ export const test_json_createValidateParse_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $io23(input);
-                  else if ($io22(input)) return $io22(input);
-                  else if ($io21(input)) return $io21(input);
-                  else if ($io24(input)) return $io24(input);
-                  else if ($io26(input)) return $io26(input);
-                  else if ($io27(input)) return $io27(input);
-                  else if ($io34(input)) return $io34(input);
-                  else return false;
+                  if ($io22(input)) return $io22(input);
+                  if ($io21(input)) return $io21(input);
+                  if ($io24(input)) return $io24(input);
+                  if ($io26(input)) return $io26(input);
+                  if ($io27(input)) return $io27(input);
+                  if ($io34(input)) return $io34(input);
+                  return false;
                 })();
             })();
           return (
@@ -3065,30 +3061,28 @@ export const test_json_createValidateParse_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                              value: value,
-                            })) &&
-                            $vu0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -3539,30 +3533,28 @@ export const test_json_createValidateParse_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                              value: value,
-                            })) &&
-                            $vu1(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu1(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_json_createValidateStringify_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_json_createValidateStringify_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicTree.ts
@@ -21,11 +21,7 @@ export const test_json_createValidateStringify_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -88,26 +84,24 @@ export const test_json_createValidateStringify_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -146,9 +140,7 @@ export const test_json_createValidateStringify_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         const $string = (typia.json.createValidateStringify as any).string;
         const $number = (typia.json.createValidateStringify as any).number;

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_DynamicUndefined.ts
@@ -14,8 +14,7 @@ export const test_json_createValidateStringify_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -45,22 +44,20 @@ export const test_json_createValidateStringify_DynamicUndefined =
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        (null !== value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          })) &&
-                        (undefined === value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          }))
-                      );
-                    return true;
+                    return (
+                      (null !== value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        })) &&
+                      (undefined === value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        }))
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_json_createValidateStringify_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -49,19 +47,16 @@ export const test_json_createValidateStringify_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ObjectUnionNonPredictable.ts
@@ -43,9 +43,9 @@ export const test_json_createValidateStringify_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -333,14 +333,13 @@ export const test_json_createValidateStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_ToJsonUnion.ts
@@ -23,9 +23,9 @@ export const test_json_createValidateStringify_ToJsonUnion =
               else
                 return (() => {
                   if ($io3(input)) return $io3(input);
-                  else if ($io2(input)) return $io2(input);
-                  else if ($io1(input)) return $io1(input);
-                  else return false;
+                  if ($io2(input)) return $io2(input);
+                  if ($io1(input)) return $io1(input);
+                  return false;
                 })();
             })();
           return (

--- a/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.createValidateStringify/test_json_createValidateStringify_UltimateUnion.ts
@@ -431,14 +431,12 @@ export const test_json_createValidateStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -534,14 +532,12 @@ export const test_json_createValidateStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -1072,13 +1068,13 @@ export const test_json_createValidateStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $io5(input);
-                  else if ($io4(input)) return $io4(input);
-                  else if ($io1(input)) return $io1(input);
-                  else if ($io6(input)) return $io6(input);
-                  else if ($io9(input)) return $io9(input);
-                  else if ($io10(input)) return $io10(input);
-                  else if ($io18(input)) return $io18(input);
-                  else return false;
+                  if ($io4(input)) return $io4(input);
+                  if ($io1(input)) return $io1(input);
+                  if ($io6(input)) return $io6(input);
+                  if ($io9(input)) return $io9(input);
+                  if ($io10(input)) return $io10(input);
+                  if ($io18(input)) return $io18(input);
+                  return false;
                 })();
             })();
           const $iu1 = (input: any): any =>
@@ -1109,13 +1105,13 @@ export const test_json_createValidateStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $io23(input);
-                  else if ($io22(input)) return $io22(input);
-                  else if ($io21(input)) return $io21(input);
-                  else if ($io24(input)) return $io24(input);
-                  else if ($io26(input)) return $io26(input);
-                  else if ($io27(input)) return $io27(input);
-                  else if ($io34(input)) return $io34(input);
-                  else return false;
+                  if ($io22(input)) return $io22(input);
+                  if ($io21(input)) return $io21(input);
+                  if ($io24(input)) return $io24(input);
+                  if ($io26(input)) return $io26(input);
+                  if ($io27(input)) return $io27(input);
+                  if ($io34(input)) return $io34(input);
+                  return false;
                 })();
             })();
           return (
@@ -3065,30 +3061,28 @@ export const test_json_createValidateStringify_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                              value: value,
-                            })) &&
-                            $vu0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -3539,30 +3533,28 @@ export const test_json_createValidateStringify_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                              value: value,
-                            })) &&
-                            $vu1(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu1(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -6410,14 +6402,12 @@ export const test_json_createValidateStringify_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -6513,14 +6503,12 @@ export const test_json_createValidateStringify_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -9854,18 +9842,17 @@ export const test_json_createValidateStringify_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $so5(input);
-                else if ($io4(input)) return $so4(input);
-                else if ($io1(input)) return $so1(input);
-                else if ($io6(input)) return $so6(input);
-                else if ($io9(input)) return $so9(input);
-                else if ($io10(input)) return $so10(input);
-                else if ($io18(input)) return $so18(input);
-                else
-                  $throws({
-                    expected:
-                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                    value: input,
-                  });
+                if ($io4(input)) return $so4(input);
+                if ($io1(input)) return $so1(input);
+                if ($io6(input)) return $so6(input);
+                if ($io9(input)) return $so9(input);
+                if ($io10(input)) return $so10(input);
+                if ($io18(input)) return $so18(input);
+                $throws({
+                  expected:
+                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                  value: input,
+                });
               })();
           })();
         const $su1 = (input: any): any =>
@@ -9896,18 +9883,17 @@ export const test_json_createValidateStringify_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $so23(input);
-                else if ($io22(input)) return $so22(input);
-                else if ($io21(input)) return $so21(input);
-                else if ($io24(input)) return $so24(input);
-                else if ($io26(input)) return $so26(input);
-                else if ($io27(input)) return $so27(input);
-                else if ($io34(input)) return $so34(input);
-                else
-                  $throws({
-                    expected:
-                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                    value: input,
-                  });
+                if ($io22(input)) return $so22(input);
+                if ($io21(input)) return $so21(input);
+                if ($io24(input)) return $so24(input);
+                if ($io26(input)) return $so26(input);
+                if ($io27(input)) return $so27(input);
+                if ($io34(input)) return $so34(input);
+                $throws({
+                  expected:
+                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                  value: input,
+                });
               })();
           })();
         return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.isParse/test_json_isParse_DynamicArray.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_DynamicArray.ts
@@ -17,12 +17,10 @@ export const test_json_isParse_DynamicArray = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.isParse/test_json_isParse_DynamicNever.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_json_isParse_DynamicNever = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isParse/test_json_isParse_DynamicSimple.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_json_isParse_DynamicSimple = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.isParse/test_json_isParse_DynamicTree.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_json_isParse_DynamicTree = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.isParse/test_json_isParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_json_isParse_DynamicUndefined = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isParse/test_json_isParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_json_isParse_ObjectDynamic = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isParse/test_json_isParse_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_json_isParse_ObjectUnionDouble = _test_json_isParse(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&

--- a/test/src/generated/output/json.isParse/test_json_isParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_json_isParse_ObjectUnionNonPredictable = _test_json_isParse(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/json.isParse/test_json_isParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.isParse/test_json_isParse_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_json_isParse_UltimateUnion = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_json_isParse_UltimateUnion = _test_json_isParse(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_json_isParse_UltimateUnion = _test_json_isParse(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_json_isParse_UltimateUnion = _test_json_isParse(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicArray.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicArray.ts
@@ -17,12 +17,10 @@ export const test_json_isStringify_DynamicArray = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -31,12 +29,10 @@ export const test_json_isStringify_DynamicArray = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       const $string = (typia.json.isStringify as any).string;
       const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_json_isStringify_DynamicNever = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicSimple.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_json_isStringify_DynamicSimple = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -27,8 +26,7 @@ export const test_json_isStringify_DynamicSimple = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value;
-          return true;
+          return "number" === typeof value;
         });
       const $number = (typia.json.isStringify as any).number;
       const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_json_isStringify_DynamicTree = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -38,9 +36,7 @@ export const test_json_isStringify_DynamicTree = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $string = (typia.json.isStringify as any).string;
       const $number = (typia.json.isStringify as any).number;

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_json_isStringify_DynamicUndefined = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_json_isStringify_ObjectDynamic = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_json_isStringify_ObjectUnionDouble = _test_json_isStringify(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -135,32 +135,29 @@ export const test_json_isStringify_ObjectUnionDouble = _test_json_isStringify(
       const $su0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $so6(input);
-          else if ($io0(input)) return $so0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $so0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $su1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $so4(input);
-          else if ($io2(input)) return $so2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $so2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $su2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $so10(input);
-          else if ($io8(input)) return $so8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $so8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       return `[${input.map((elem: any) => $su0(elem)).join(",")}]`;
     };

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_ObjectUnionNonPredictable.ts
@@ -39,9 +39,9 @@ export const test_json_isStringify_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -89,14 +89,13 @@ export const test_json_isStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_ToJsonUnion.ts
@@ -22,9 +22,9 @@ export const test_json_isStringify_ToJsonUnion = _test_json_isStringify(
           else
             return (() => {
               if ($io3(input)) return $io3(input);
-              else if ($io2(input)) return $io2(input);
-              else if ($io1(input)) return $io1(input);
-              else return false;
+              if ($io2(input)) return $io2(input);
+              if ($io1(input)) return $io1(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/json.isStringify/test_json_isStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.isStringify/test_json_isStringify_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -1475,14 +1471,12 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -1578,14 +1572,12 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -4876,18 +4868,17 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
           else
             return (() => {
               if ($io5(input)) return $so5(input);
-              else if ($io4(input)) return $so4(input);
-              else if ($io1(input)) return $so1(input);
-              else if ($io6(input)) return $so6(input);
-              else if ($io9(input)) return $so9(input);
-              else if ($io10(input)) return $so10(input);
-              else if ($io18(input)) return $so18(input);
-              else
-                $throws({
-                  expected:
-                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                  value: input,
-                });
+              if ($io4(input)) return $so4(input);
+              if ($io1(input)) return $so1(input);
+              if ($io6(input)) return $so6(input);
+              if ($io9(input)) return $so9(input);
+              if ($io10(input)) return $so10(input);
+              if ($io18(input)) return $so18(input);
+              $throws({
+                expected:
+                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                value: input,
+              });
             })();
         })();
       const $su1 = (input: any): any =>
@@ -4918,18 +4909,17 @@ export const test_json_isStringify_UltimateUnion = _test_json_isStringify(
           else
             return (() => {
               if ($io23(input)) return $so23(input);
-              else if ($io22(input)) return $so22(input);
-              else if ($io21(input)) return $so21(input);
-              else if ($io24(input)) return $so24(input);
-              else if ($io26(input)) return $so26(input);
-              else if ($io27(input)) return $so27(input);
-              else if ($io34(input)) return $so34(input);
-              else
-                $throws({
-                  expected:
-                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                  value: input,
-                });
+              if ($io22(input)) return $so22(input);
+              if ($io21(input)) return $so21(input);
+              if ($io24(input)) return $so24(input);
+              if ($io26(input)) return $so26(input);
+              if ($io27(input)) return $so27(input);
+              if ($io34(input)) return $so34(input);
+              $throws({
+                expected:
+                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                value: input,
+              });
             })();
         })();
       return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.stringify/test_json_stringify_DynamicArray.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_DynamicArray.ts
@@ -11,12 +11,10 @@ export const test_json_stringify_DynamicArray = _test_json_stringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     const $string = (typia.json.stringify as any).string;
     const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.stringify/test_json_stringify_DynamicSimple.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_DynamicSimple.ts
@@ -11,8 +11,7 @@ export const test_json_stringify_DynamicSimple = _test_json_stringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value;
-        return true;
+        return "number" === typeof value;
       });
     const $number = (typia.json.stringify as any).number;
     const $so0 = (input: any): any => `{"value":${$so1(input.value)}}`;

--- a/test/src/generated/output/json.stringify/test_json_stringify_DynamicTree.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_DynamicTree.ts
@@ -18,9 +18,7 @@ export const test_json_stringify_DynamicTree = _test_json_stringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     const $string = (typia.json.stringify as any).string;
     const $number = (typia.json.stringify as any).number;

--- a/test/src/generated/output/json.stringify/test_json_stringify_ObjectUnionDouble.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_ObjectUnionDouble.ts
@@ -70,32 +70,29 @@ export const test_json_stringify_ObjectUnionDouble = _test_json_stringify(
     const $su0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $so6(input);
-        else if ($io0(input)) return $so0(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-            value: input,
-          });
+        if ($io0(input)) return $so0(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+          value: input,
+        });
       })();
     const $su1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $so4(input);
-        else if ($io2(input)) return $so2(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-            value: input,
-          });
+        if ($io2(input)) return $so2(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+          value: input,
+        });
       })();
     const $su2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $so10(input);
-        else if ($io8(input)) return $so8(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-            value: input,
-          });
+        if ($io8(input)) return $so8(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+          value: input,
+        });
       })();
     return `[${input.map((elem: any) => $su0(elem)).join(",")}]`;
   })(input),

--- a/test/src/generated/output/json.stringify/test_json_stringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_ObjectUnionNonPredictable.ts
@@ -51,14 +51,13 @@ export const test_json_stringify_ObjectUnionNonPredictable =
       const $su0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $so7(input);
-          else if ($io5(input)) return $so5(input);
-          else if ($io3(input)) return $so3(input);
-          else
-            $throws({
-              expected:
-                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-              value: input,
-            });
+          if ($io5(input)) return $so5(input);
+          if ($io3(input)) return $so3(input);
+          $throws({
+            expected:
+              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+            value: input,
+          });
         })();
       return $so0(input);
     })(input),

--- a/test/src/generated/output/json.stringify/test_json_stringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.stringify/test_json_stringify_UltimateUnion.ts
@@ -387,14 +387,12 @@ export const test_json_stringify_UltimateUnion = _test_json_stringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -490,14 +488,12 @@ export const test_json_stringify_UltimateUnion = _test_json_stringify(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -3743,18 +3739,17 @@ export const test_json_stringify_UltimateUnion = _test_json_stringify(
         else
           return (() => {
             if ($io5(input)) return $so5(input);
-            else if ($io4(input)) return $so4(input);
-            else if ($io1(input)) return $so1(input);
-            else if ($io6(input)) return $so6(input);
-            else if ($io9(input)) return $so9(input);
-            else if ($io10(input)) return $so10(input);
-            else if ($io18(input)) return $so18(input);
-            else
-              $throws({
-                expected:
-                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                value: input,
-              });
+            if ($io4(input)) return $so4(input);
+            if ($io1(input)) return $so1(input);
+            if ($io6(input)) return $so6(input);
+            if ($io9(input)) return $so9(input);
+            if ($io10(input)) return $so10(input);
+            if ($io18(input)) return $so18(input);
+            $throws({
+              expected:
+                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+              value: input,
+            });
           })();
       })();
     const $su1 = (input: any): any =>
@@ -3785,18 +3780,17 @@ export const test_json_stringify_UltimateUnion = _test_json_stringify(
         else
           return (() => {
             if ($io23(input)) return $so23(input);
-            else if ($io22(input)) return $so22(input);
-            else if ($io21(input)) return $so21(input);
-            else if ($io24(input)) return $so24(input);
-            else if ($io26(input)) return $so26(input);
-            else if ($io27(input)) return $so27(input);
-            else if ($io34(input)) return $so34(input);
-            else
-              $throws({
-                expected:
-                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                value: input,
-              });
+            if ($io22(input)) return $so22(input);
+            if ($io21(input)) return $so21(input);
+            if ($io24(input)) return $so24(input);
+            if ($io26(input)) return $so26(input);
+            if ($io27(input)) return $so27(input);
+            if ($io34(input)) return $so34(input);
+            $throws({
+              expected:
+                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+              value: input,
+            });
           })();
       })();
     return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicNever.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicNever.ts
@@ -14,8 +14,7 @@ export const test_json_validateParse_DynamicNever = _test_json_validateParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -43,22 +42,20 @@ export const test_json_validateParse_DynamicNever = _test_json_validateParse(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        (null !== value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          })) &&
-                        (undefined === value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          }))
-                      );
-                    return true;
+                    return (
+                      (null !== value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        })) &&
+                      (undefined === value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        }))
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicTree.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicTree.ts
@@ -22,9 +22,7 @@ export const test_json_validateParse_DynamicTree = _test_json_validateParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -85,26 +83,24 @@ export const test_json_validateParse_DynamicTree = _test_json_validateParse(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value && null !== value) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "DynamicTree",
-                            value: value,
-                          })) &&
-                          $vo0(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value && null !== value) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected: "DynamicTree",
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vo0(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "DynamicTree",
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicUndefined.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_DynamicUndefined.ts
@@ -15,8 +15,7 @@ export const test_json_validateParse_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_json_validateParse_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_ObjectDynamic.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_ObjectDynamic.ts
@@ -14,13 +14,11 @@ export const test_json_validateParse_ObjectDynamic = _test_json_validateParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -48,18 +46,16 @@ export const test_json_validateParse_ObjectDynamic = _test_json_validateParse(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        "string" === typeof value ||
-                        ("number" === typeof value && Number.isFinite(value)) ||
-                        "boolean" === typeof value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "(boolean | number | string)",
-                          value: value,
-                        })
-                      );
-                    return true;
+                    return (
+                      "string" === typeof value ||
+                      ("number" === typeof value && Number.isFinite(value)) ||
+                      "boolean" === typeof value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "(boolean | number | string)",
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_json_validateParse_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };

--- a/test/src/generated/output/json.validateParse/test_json_validateParse_UltimateUnion.ts
+++ b/test/src/generated/output/json.validateParse/test_json_validateParse_UltimateUnion.ts
@@ -427,14 +427,12 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -530,14 +528,12 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -1064,13 +1060,13 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -1101,13 +1097,13 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -3005,30 +3001,28 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value &&
-                          null !== value &&
-                          false === Array.isArray(value)) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected:
-                              '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                            value: value,
-                          })) &&
-                          $vu0(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value &&
+                        null !== value &&
+                        false === Array.isArray(value)) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected:
                             '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vu0(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected:
+                          '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);
@@ -3467,30 +3461,28 @@ export const test_json_validateParse_UltimateUnion = _test_json_validateParse(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value &&
-                          null !== value &&
-                          false === Array.isArray(value)) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected:
-                              '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                            value: value,
-                          })) &&
-                          $vu1(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value &&
+                        null !== value &&
+                        false === Array.isArray(value)) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected:
                             '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vu1(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected:
+                          '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicNever.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicNever.ts
@@ -14,8 +14,7 @@ export const test_json_validateStringify_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -45,22 +44,20 @@ export const test_json_validateStringify_DynamicNever =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicTree.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicTree.ts
@@ -22,11 +22,9 @@ export const test_json_validateStringify_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -89,26 +87,24 @@ export const test_json_validateStringify_DynamicTree =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value && null !== value) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "DynamicTree",
-                                value: value,
-                              })) &&
-                              $vo0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value && null !== value) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected: "DynamicTree",
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vo0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "DynamicTree",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -147,11 +143,7 @@ export const test_json_validateStringify_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           const $string = (typia.json.validateStringify as any).string;
           const $number = (typia.json.validateStringify as any).number;

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicUndefined.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_DynamicUndefined.ts
@@ -15,8 +15,7 @@ export const test_json_validateStringify_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_json_validateStringify_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_ObjectDynamic.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_ObjectDynamic.ts
@@ -14,13 +14,11 @@ export const test_json_validateStringify_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value
+                );
               });
             return (
               "object" === typeof input &&
@@ -50,19 +48,17 @@ export const test_json_validateStringify_ObjectDynamic =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            "string" === typeof value ||
-                            ("number" === typeof value &&
-                              Number.isFinite(value)) ||
-                            "boolean" === typeof value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "(boolean | number | string)",
-                              value: value,
-                            })
-                          );
-                        return true;
+                        return (
+                          "string" === typeof value ||
+                          ("number" === typeof value &&
+                            Number.isFinite(value)) ||
+                          "boolean" === typeof value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "(boolean | number | string)",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_ObjectUnionNonPredictable.ts
@@ -43,9 +43,9 @@ export const test_json_validateStringify_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -331,14 +331,13 @@ export const test_json_validateStringify_ObjectUnionNonPredictable =
         const $su0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $so7(input);
-            else if ($io5(input)) return $so5(input);
-            else if ($io3(input)) return $so3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $so5(input);
+            if ($io3(input)) return $so3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return $so0(input);
       };

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_ToJsonUnion.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_ToJsonUnion.ts
@@ -24,9 +24,9 @@ export const test_json_validateStringify_ToJsonUnion =
                 else
                   return (() => {
                     if ($io3(input)) return $io3(input);
-                    else if ($io2(input)) return $io2(input);
-                    else if ($io1(input)) return $io1(input);
-                    else return false;
+                    if ($io2(input)) return $io2(input);
+                    if ($io1(input)) return $io1(input);
+                    return false;
                   })();
               })();
             return (

--- a/test/src/generated/output/json.validateStringify/test_json_validateStringify_UltimateUnion.ts
+++ b/test/src/generated/output/json.validateStringify/test_json_validateStringify_UltimateUnion.ts
@@ -434,14 +434,12 @@ export const test_json_validateStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu0(value)
+                );
               });
             const $io15 = (input: any): boolean =>
               "string" === typeof input.$ref &&
@@ -537,14 +535,12 @@ export const test_json_validateStringify_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu1(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu1(value)
+                );
               });
             const $io21 = (input: any): boolean =>
               Array.isArray(input["enum"]) &&
@@ -1077,13 +1073,13 @@ export const test_json_validateStringify_UltimateUnion =
                 else
                   return (() => {
                     if ($io5(input)) return $io5(input);
-                    else if ($io4(input)) return $io4(input);
-                    else if ($io1(input)) return $io1(input);
-                    else if ($io6(input)) return $io6(input);
-                    else if ($io9(input)) return $io9(input);
-                    else if ($io10(input)) return $io10(input);
-                    else if ($io18(input)) return $io18(input);
-                    else return false;
+                    if ($io4(input)) return $io4(input);
+                    if ($io1(input)) return $io1(input);
+                    if ($io6(input)) return $io6(input);
+                    if ($io9(input)) return $io9(input);
+                    if ($io10(input)) return $io10(input);
+                    if ($io18(input)) return $io18(input);
+                    return false;
                   })();
               })();
             const $iu1 = (input: any): any =>
@@ -1114,13 +1110,13 @@ export const test_json_validateStringify_UltimateUnion =
                 else
                   return (() => {
                     if ($io23(input)) return $io23(input);
-                    else if ($io22(input)) return $io22(input);
-                    else if ($io21(input)) return $io21(input);
-                    else if ($io24(input)) return $io24(input);
-                    else if ($io26(input)) return $io26(input);
-                    else if ($io27(input)) return $io27(input);
-                    else if ($io34(input)) return $io34(input);
-                    else return false;
+                    if ($io22(input)) return $io22(input);
+                    if ($io21(input)) return $io21(input);
+                    if ($io24(input)) return $io24(input);
+                    if ($io26(input)) return $io26(input);
+                    if ($io27(input)) return $io27(input);
+                    if ($io34(input)) return $io34(input);
+                    return false;
                   })();
               })();
             return (
@@ -3160,30 +3156,28 @@ export const test_json_validateStringify_UltimateUnion =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value &&
-                              null !== value &&
-                              false === Array.isArray(value)) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected:
-                                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                value: value,
-                              })) &&
-                              $vu0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value &&
+                            null !== value &&
+                            false === Array.isArray(value)) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected:
                                 '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vu0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected:
+                              '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -3658,30 +3652,28 @@ export const test_json_validateStringify_UltimateUnion =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value &&
-                              null !== value &&
-                              false === Array.isArray(value)) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected:
-                                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                                value: value,
-                              })) &&
-                              $vu1(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value &&
+                            null !== value &&
+                            false === Array.isArray(value)) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected:
                                 '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vu1(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected:
+                              '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -6650,14 +6642,12 @@ export const test_json_validateStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -6753,14 +6743,12 @@ export const test_json_validateStringify_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -10169,18 +10157,17 @@ export const test_json_validateStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $so5(input);
-                  else if ($io4(input)) return $so4(input);
-                  else if ($io1(input)) return $so1(input);
-                  else if ($io6(input)) return $so6(input);
-                  else if ($io9(input)) return $so9(input);
-                  else if ($io10(input)) return $so10(input);
-                  else if ($io18(input)) return $so18(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                      value: input,
-                    });
+                  if ($io4(input)) return $so4(input);
+                  if ($io1(input)) return $so1(input);
+                  if ($io6(input)) return $so6(input);
+                  if ($io9(input)) return $so9(input);
+                  if ($io10(input)) return $so10(input);
+                  if ($io18(input)) return $so18(input);
+                  $throws({
+                    expected:
+                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                    value: input,
+                  });
                 })();
             })();
           const $su1 = (input: any): any =>
@@ -10211,18 +10198,17 @@ export const test_json_validateStringify_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $so23(input);
-                  else if ($io22(input)) return $so22(input);
-                  else if ($io21(input)) return $so21(input);
-                  else if ($io24(input)) return $so24(input);
-                  else if ($io26(input)) return $so26(input);
-                  else if ($io27(input)) return $so27(input);
-                  else if ($io34(input)) return $so34(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                      value: input,
-                    });
+                  if ($io22(input)) return $so22(input);
+                  if ($io21(input)) return $so21(input);
+                  if ($io24(input)) return $so24(input);
+                  if ($io26(input)) return $so26(input);
+                  if ($io27(input)) return $so27(input);
+                  if ($io34(input)) return $so34(input);
+                  $throws({
+                    expected:
+                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                    value: input,
+                  });
                 })();
             })();
           return `[${input.map((elem: any) => $so0(elem)).join(",")}]`;

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_misc_assertClone_DynamicNever = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_misc_assertClone_DynamicNever = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_misc_assertClone_DynamicTree = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -80,22 +78,20 @@ export const test_misc_assertClone_DynamicTree = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||
@@ -126,9 +122,7 @@ export const test_misc_assertClone_DynamicTree = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $co0 = (input: any): any => ({
         id: input.id as any,

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_misc_assertClone_DynamicUndefined = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_misc_assertClone_DynamicUndefined = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_misc_assertClone_ObjectDynamic = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -45,18 +43,16 @@ export const test_misc_assertClone_ObjectDynamic = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_misc_assertClone_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -326,14 +326,13 @@ export const test_misc_assertClone_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)

--- a/test/src/generated/output/misc.assertClone/test_misc_assertClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.assertClone/test_misc_assertClone_UltimateUnion.ts
@@ -426,14 +426,12 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -529,14 +527,12 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -1063,13 +1059,13 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -1100,13 +1096,13 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -2897,26 +2893,24 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                      value: value,
-                    })) &&
-                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                  value: value,
+                })
+              );
             });
           const $ao15 = (
             input: any,
@@ -3322,26 +3316,24 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                      value: value,
-                    })) &&
-                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                  value: value,
+                })
+              );
             });
           const $ao21 = (
             input: any,
@@ -5996,14 +5988,12 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -6099,14 +6089,12 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -7347,18 +7335,17 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
           else
             return (() => {
               if ($io5(input)) return $co5(input);
-              else if ($io4(input)) return $co4(input);
-              else if ($io1(input)) return $co1(input);
-              else if ($io6(input)) return $co6(input);
-              else if ($io9(input)) return $co9(input);
-              else if ($io10(input)) return $co10(input);
-              else if ($io18(input)) return $co18(input);
-              else
-                $throws({
-                  expected:
-                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                  value: input,
-                });
+              if ($io4(input)) return $co4(input);
+              if ($io1(input)) return $co1(input);
+              if ($io6(input)) return $co6(input);
+              if ($io9(input)) return $co9(input);
+              if ($io10(input)) return $co10(input);
+              if ($io18(input)) return $co18(input);
+              $throws({
+                expected:
+                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                value: input,
+              });
             })();
         })();
       const $cu1 = (input: any): any =>
@@ -7389,18 +7376,17 @@ export const test_misc_assertClone_UltimateUnion = _test_misc_assertClone(
           else
             return (() => {
               if ($io23(input)) return $co23(input);
-              else if ($io22(input)) return $co22(input);
-              else if ($io21(input)) return $co21(input);
-              else if ($io24(input)) return $co24(input);
-              else if ($io26(input)) return $co26(input);
-              else if ($io27(input)) return $co27(input);
-              else if ($io34(input)) return $co34(input);
-              else
-                $throws({
-                  expected:
-                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                  value: input,
-                });
+              if ($io22(input)) return $co22(input);
+              if ($io21(input)) return $co21(input);
+              if ($io24(input)) return $co24(input);
+              if ($io26(input)) return $co26(input);
+              if ($io27(input)) return $co27(input);
+              if ($io34(input)) return $co34(input);
+              $throws({
+                expected:
+                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                value: input,
+              });
             })();
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.assertPrune/test_misc_assertPrune_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_misc_assertPrune_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -343,14 +343,13 @@ export const test_misc_assertPrune_ObjectUnionNonPredictable =
         const $pu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $po7(input);
-            else if ($io5(input)) return $po5(input);
-            else if ($io3(input)) return $po3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $po5(input);
+            if ($io3(input)) return $po3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         if ("object" === typeof input && null !== input) $po0(input);
       };

--- a/test/src/generated/output/misc.clone/test_misc_clone_DynamicArray.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_DynamicArray.ts
@@ -11,12 +11,10 @@ export const test_misc_clone_DynamicArray = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     const $cp0 = (input: any) => input.map((elem: any) => elem as any);
     const $co0 = (input: any): any => ({

--- a/test/src/generated/output/misc.clone/test_misc_clone_DynamicSimple.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_DynamicSimple.ts
@@ -11,8 +11,7 @@ export const test_misc_clone_DynamicSimple = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value;
-        return true;
+        return "number" === typeof value;
       });
     const $co0 = (input: any): any => ({
       value:

--- a/test/src/generated/output/misc.clone/test_misc_clone_DynamicTree.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_DynamicTree.ts
@@ -18,9 +18,7 @@ export const test_misc_clone_DynamicTree = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     const $co0 = (input: any): any => ({
       id: input.id as any,

--- a/test/src/generated/output/misc.clone/test_misc_clone_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_ObjectUnionDouble.ts
@@ -118,32 +118,29 @@ export const test_misc_clone_ObjectUnionDouble = _test_misc_clone(
     const $cu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $co6(input);
-        else if ($io0(input)) return $co0(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-            value: input,
-          });
+        if ($io0(input)) return $co0(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+          value: input,
+        });
       })();
     const $cu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $co4(input);
-        else if ($io2(input)) return $co2(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-            value: input,
-          });
+        if ($io2(input)) return $co2(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+          value: input,
+        });
       })();
     const $cu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $co10(input);
-        else if ($io8(input)) return $co8(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-            value: input,
-          });
+        if ($io8(input)) return $co8(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+          value: input,
+        });
       })();
     return Array.isArray(input) ? $cp0(input) : (input as any);
   })(input),

--- a/test/src/generated/output/misc.clone/test_misc_clone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_ObjectUnionNonPredictable.ts
@@ -85,14 +85,13 @@ export const test_misc_clone_ObjectUnionNonPredictable = _test_misc_clone(
     const $cu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $co7(input);
-        else if ($io5(input)) return $co5(input);
-        else if ($io3(input)) return $co3(input);
-        else
-          $throws({
-            expected:
-              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-            value: input,
-          });
+        if ($io5(input)) return $co5(input);
+        if ($io3(input)) return $co3(input);
+        $throws({
+          expected:
+            "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+          value: input,
+        });
       })();
     return "object" === typeof input && null !== input
       ? $co0(input)

--- a/test/src/generated/output/misc.clone/test_misc_clone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.clone/test_misc_clone_UltimateUnion.ts
@@ -387,14 +387,12 @@ export const test_misc_clone_UltimateUnion = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -490,14 +488,12 @@ export const test_misc_clone_UltimateUnion = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -1726,18 +1722,17 @@ export const test_misc_clone_UltimateUnion = _test_misc_clone(
         else
           return (() => {
             if ($io5(input)) return $co5(input);
-            else if ($io4(input)) return $co4(input);
-            else if ($io1(input)) return $co1(input);
-            else if ($io6(input)) return $co6(input);
-            else if ($io9(input)) return $co9(input);
-            else if ($io10(input)) return $co10(input);
-            else if ($io18(input)) return $co18(input);
-            else
-              $throws({
-                expected:
-                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                value: input,
-              });
+            if ($io4(input)) return $co4(input);
+            if ($io1(input)) return $co1(input);
+            if ($io6(input)) return $co6(input);
+            if ($io9(input)) return $co9(input);
+            if ($io10(input)) return $co10(input);
+            if ($io18(input)) return $co18(input);
+            $throws({
+              expected:
+                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+              value: input,
+            });
           })();
       })();
     const $cu1 = (input: any): any =>
@@ -1768,18 +1763,17 @@ export const test_misc_clone_UltimateUnion = _test_misc_clone(
         else
           return (() => {
             if ($io23(input)) return $co23(input);
-            else if ($io22(input)) return $co22(input);
-            else if ($io21(input)) return $co21(input);
-            else if ($io24(input)) return $co24(input);
-            else if ($io26(input)) return $co26(input);
-            else if ($io27(input)) return $co27(input);
-            else if ($io34(input)) return $co34(input);
-            else
-              $throws({
-                expected:
-                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                value: input,
-              });
+            if ($io22(input)) return $co22(input);
+            if ($io21(input)) return $co21(input);
+            if ($io24(input)) return $co24(input);
+            if ($io26(input)) return $co26(input);
+            if ($io27(input)) return $co27(input);
+            if ($io34(input)) return $co34(input);
+            $throws({
+              expected:
+                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+              value: input,
+            });
           })();
       })();
     return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_misc_createAssertClone_DynamicNever = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -39,22 +38,20 @@ export const test_misc_createAssertClone_DynamicNever = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_misc_createAssertClone_DynamicTree = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -79,22 +77,20 @@ export const test_misc_createAssertClone_DynamicTree = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||
@@ -125,9 +121,7 @@ export const test_misc_createAssertClone_DynamicTree = _test_misc_assertClone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     const $co0 = (input: any): any => ({
       id: input.id as any,

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_misc_createAssertClone_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -40,22 +39,20 @@ export const test_misc_createAssertClone_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_misc_createAssertClone_ObjectDynamic = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -44,18 +42,16 @@ export const test_misc_createAssertClone_ObjectDynamic = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_misc_createAssertClone_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -326,14 +326,13 @@ export const test_misc_createAssertClone_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)

--- a/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.createAssertClone/test_misc_createAssertClone_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2873,26 +2869,24 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -3293,26 +3287,24 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,
@@ -5966,14 +5958,12 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -6069,14 +6059,12 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -7305,18 +7293,17 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
         else
           return (() => {
             if ($io5(input)) return $co5(input);
-            else if ($io4(input)) return $co4(input);
-            else if ($io1(input)) return $co1(input);
-            else if ($io6(input)) return $co6(input);
-            else if ($io9(input)) return $co9(input);
-            else if ($io10(input)) return $co10(input);
-            else if ($io18(input)) return $co18(input);
-            else
-              $throws({
-                expected:
-                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                value: input,
-              });
+            if ($io4(input)) return $co4(input);
+            if ($io1(input)) return $co1(input);
+            if ($io6(input)) return $co6(input);
+            if ($io9(input)) return $co9(input);
+            if ($io10(input)) return $co10(input);
+            if ($io18(input)) return $co18(input);
+            $throws({
+              expected:
+                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+              value: input,
+            });
           })();
       })();
     const $cu1 = (input: any): any =>
@@ -7347,18 +7334,17 @@ export const test_misc_createAssertClone_UltimateUnion = _test_misc_assertClone(
         else
           return (() => {
             if ($io23(input)) return $co23(input);
-            else if ($io22(input)) return $co22(input);
-            else if ($io21(input)) return $co21(input);
-            else if ($io24(input)) return $co24(input);
-            else if ($io26(input)) return $co26(input);
-            else if ($io27(input)) return $co27(input);
-            else if ($io34(input)) return $co34(input);
-            else
-              $throws({
-                expected:
-                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                value: input,
-              });
+            if ($io22(input)) return $co22(input);
+            if ($io21(input)) return $co21(input);
+            if ($io24(input)) return $co24(input);
+            if ($io26(input)) return $co26(input);
+            if ($io27(input)) return $co27(input);
+            if ($io34(input)) return $co34(input);
+            $throws({
+              expected:
+                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+              value: input,
+            });
           })();
       })();
     return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createAssertPrune/test_misc_createAssertPrune_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_misc_createAssertPrune_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -343,14 +343,13 @@ export const test_misc_createAssertPrune_ObjectUnionNonPredictable =
         const $pu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $po7(input);
-            else if ($io5(input)) return $po5(input);
-            else if ($io3(input)) return $po3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $po5(input);
+            if ($io3(input)) return $po3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         if ("object" === typeof input && null !== input) $po0(input);
       };

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicArray.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicArray.ts
@@ -11,12 +11,10 @@ export const test_misc_createClone_DynamicArray = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            Array.isArray(value) &&
-            value.every((elem: any) => "string" === typeof elem)
-          );
-        return true;
+        return (
+          Array.isArray(value) &&
+          value.every((elem: any) => "string" === typeof elem)
+        );
       });
     const $cp0 = (input: any) => input.map((elem: any) => elem as any);
     const $co0 = (input: any): any => ({

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicSimple.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicSimple.ts
@@ -11,8 +11,7 @@ export const test_misc_createClone_DynamicSimple = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true) return "number" === typeof value;
-        return true;
+        return "number" === typeof value;
       });
     const $co0 = (input: any): any => ({
       value:

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_DynamicTree.ts
@@ -18,9 +18,7 @@ export const test_misc_createClone_DynamicTree = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return "object" === typeof value && null !== value && $io0(value);
-        return true;
+        return "object" === typeof value && null !== value && $io0(value);
       });
     const $co0 = (input: any): any => ({
       id: input.id as any,

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_ObjectUnionDouble.ts
@@ -118,32 +118,29 @@ export const test_misc_createClone_ObjectUnionDouble = _test_misc_clone(
     const $cu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $co6(input);
-        else if ($io0(input)) return $co0(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-            value: input,
-          });
+        if ($io0(input)) return $co0(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+          value: input,
+        });
       })();
     const $cu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $co4(input);
-        else if ($io2(input)) return $co2(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-            value: input,
-          });
+        if ($io2(input)) return $co2(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+          value: input,
+        });
       })();
     const $cu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $co10(input);
-        else if ($io8(input)) return $co8(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-            value: input,
-          });
+        if ($io8(input)) return $co8(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+          value: input,
+        });
       })();
     return Array.isArray(input) ? $cp0(input) : (input as any);
   },

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_ObjectUnionNonPredictable.ts
@@ -85,14 +85,13 @@ export const test_misc_createClone_ObjectUnionNonPredictable = _test_misc_clone(
     const $cu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $co7(input);
-        else if ($io5(input)) return $co5(input);
-        else if ($io3(input)) return $co3(input);
-        else
-          $throws({
-            expected:
-              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-            value: input,
-          });
+        if ($io5(input)) return $co5(input);
+        if ($io3(input)) return $co3(input);
+        $throws({
+          expected:
+            "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+          value: input,
+        });
       })();
     return "object" === typeof input && null !== input
       ? $co0(input)

--- a/test/src/generated/output/misc.createClone/test_misc_createClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.createClone/test_misc_createClone_UltimateUnion.ts
@@ -387,14 +387,12 @@ export const test_misc_createClone_UltimateUnion = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu0(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu0(value)
+        );
       });
     const $io15 = (input: any): boolean =>
       "string" === typeof input.$ref &&
@@ -490,14 +488,12 @@ export const test_misc_createClone_UltimateUnion = _test_misc_clone(
       Object.keys(input).every((key: any) => {
         const value = input[key];
         if (undefined === value) return true;
-        if (true)
-          return (
-            "object" === typeof value &&
-            null !== value &&
-            false === Array.isArray(value) &&
-            $iu1(value)
-          );
-        return true;
+        return (
+          "object" === typeof value &&
+          null !== value &&
+          false === Array.isArray(value) &&
+          $iu1(value)
+        );
       });
     const $io21 = (input: any): boolean =>
       Array.isArray(input["enum"]) &&
@@ -1726,18 +1722,17 @@ export const test_misc_createClone_UltimateUnion = _test_misc_clone(
         else
           return (() => {
             if ($io5(input)) return $co5(input);
-            else if ($io4(input)) return $co4(input);
-            else if ($io1(input)) return $co1(input);
-            else if ($io6(input)) return $co6(input);
-            else if ($io9(input)) return $co9(input);
-            else if ($io10(input)) return $co10(input);
-            else if ($io18(input)) return $co18(input);
-            else
-              $throws({
-                expected:
-                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                value: input,
-              });
+            if ($io4(input)) return $co4(input);
+            if ($io1(input)) return $co1(input);
+            if ($io6(input)) return $co6(input);
+            if ($io9(input)) return $co9(input);
+            if ($io10(input)) return $co10(input);
+            if ($io18(input)) return $co18(input);
+            $throws({
+              expected:
+                '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+              value: input,
+            });
           })();
       })();
     const $cu1 = (input: any): any =>
@@ -1768,18 +1763,17 @@ export const test_misc_createClone_UltimateUnion = _test_misc_clone(
         else
           return (() => {
             if ($io23(input)) return $co23(input);
-            else if ($io22(input)) return $co22(input);
-            else if ($io21(input)) return $co21(input);
-            else if ($io24(input)) return $co24(input);
-            else if ($io26(input)) return $co26(input);
-            else if ($io27(input)) return $co27(input);
-            else if ($io34(input)) return $co34(input);
-            else
-              $throws({
-                expected:
-                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                value: input,
-              });
+            if ($io22(input)) return $co22(input);
+            if ($io21(input)) return $co21(input);
+            if ($io24(input)) return $co24(input);
+            if ($io26(input)) return $co26(input);
+            if ($io27(input)) return $co27(input);
+            if ($io34(input)) return $co34(input);
+            $throws({
+              expected:
+                '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+              value: input,
+            });
           })();
       })();
     return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicArray.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicArray.ts
@@ -17,12 +17,10 @@ export const test_misc_createIsClone_DynamicArray = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -31,12 +29,10 @@ export const test_misc_createIsClone_DynamicArray = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       const $cp0 = (input: any) => input.map((elem: any) => elem as any);
       const $co0 = (input: any): any => ({

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_misc_createIsClone_DynamicNever = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicSimple.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_misc_createIsClone_DynamicSimple = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -27,8 +26,7 @@ export const test_misc_createIsClone_DynamicSimple = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value;
-          return true;
+          return "number" === typeof value;
         });
       const $co0 = (input: any): any => ({
         value:

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_misc_createIsClone_DynamicTree = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -38,9 +36,7 @@ export const test_misc_createIsClone_DynamicTree = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $co0 = (input: any): any => ({
         id: input.id as any,

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_misc_createIsClone_DynamicUndefined = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_misc_createIsClone_ObjectDynamic = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_misc_createIsClone_ObjectUnionDouble = _test_misc_isClone(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -187,32 +187,29 @@ export const test_misc_createIsClone_ObjectUnionDouble = _test_misc_isClone(
       const $cu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $co6(input);
-          else if ($io0(input)) return $co0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $co0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $cu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $co4(input);
-          else if ($io2(input)) return $co2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $co2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $cu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $co10(input);
-          else if ($io8(input)) return $co8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $co8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);
     };

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_misc_createIsClone_ObjectUnionNonPredictable =
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -126,14 +126,13 @@ export const test_misc_createIsClone_ObjectUnionNonPredictable =
       const $cu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $co7(input);
-          else if ($io5(input)) return $co5(input);
-          else if ($io3(input)) return $co3(input);
-          else
-            $throws({
-              expected:
-                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-              value: input,
-            });
+          if ($io5(input)) return $co5(input);
+          if ($io3(input)) return $co3(input);
+          $throws({
+            expected:
+              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+            value: input,
+          });
         })();
       return "object" === typeof input && null !== input
         ? $co0(input)

--- a/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.createIsClone/test_misc_createIsClone_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -1475,14 +1471,12 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -1578,14 +1572,12 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -2826,18 +2818,17 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io5(input)) return $co5(input);
-              else if ($io4(input)) return $co4(input);
-              else if ($io1(input)) return $co1(input);
-              else if ($io6(input)) return $co6(input);
-              else if ($io9(input)) return $co9(input);
-              else if ($io10(input)) return $co10(input);
-              else if ($io18(input)) return $co18(input);
-              else
-                $throws({
-                  expected:
-                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                  value: input,
-                });
+              if ($io4(input)) return $co4(input);
+              if ($io1(input)) return $co1(input);
+              if ($io6(input)) return $co6(input);
+              if ($io9(input)) return $co9(input);
+              if ($io10(input)) return $co10(input);
+              if ($io18(input)) return $co18(input);
+              $throws({
+                expected:
+                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                value: input,
+              });
             })();
         })();
       const $cu1 = (input: any): any =>
@@ -2868,18 +2859,17 @@ export const test_misc_createIsClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io23(input)) return $co23(input);
-              else if ($io22(input)) return $co22(input);
-              else if ($io21(input)) return $co21(input);
-              else if ($io24(input)) return $co24(input);
-              else if ($io26(input)) return $co26(input);
-              else if ($io27(input)) return $co27(input);
-              else if ($io34(input)) return $co34(input);
-              else
-                $throws({
-                  expected:
-                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                  value: input,
-                });
+              if ($io22(input)) return $co22(input);
+              if ($io21(input)) return $co21(input);
+              if ($io24(input)) return $co24(input);
+              if ($io26(input)) return $co26(input);
+              if ($io27(input)) return $co27(input);
+              if ($io34(input)) return $co34(input);
+              $throws({
+                expected:
+                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                value: input,
+              });
             })();
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_misc_createIsPrune_ObjectUnionDouble = _test_misc_isPrune(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -208,32 +208,29 @@ export const test_misc_createIsPrune_ObjectUnionDouble = _test_misc_isPrune(
       const $pu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $po6(input);
-          else if ($io0(input)) return $po0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $po0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $pu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $po4(input);
-          else if ($io2(input)) return $po2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $po2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $pu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $po10(input);
-          else if ($io8(input)) return $po8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $po8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       if (Array.isArray(input)) $pp0(input);
     };

--- a/test/src/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createIsPrune/test_misc_createIsPrune_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_misc_createIsPrune_ObjectUnionNonPredictable =
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -143,14 +143,13 @@ export const test_misc_createIsPrune_ObjectUnionNonPredictable =
       const $pu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $po7(input);
-          else if ($io5(input)) return $po5(input);
-          else if ($io3(input)) return $po3(input);
-          else
-            $throws({
-              expected:
-                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-              value: input,
-            });
+          if ($io5(input)) return $po5(input);
+          if ($io3(input)) return $po3(input);
+          $throws({
+            expected:
+              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+            value: input,
+          });
         })();
       if ("object" === typeof input && null !== input) $po0(input);
     };

--- a/test/src/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionDouble.ts
@@ -142,32 +142,29 @@ export const test_misc_createPrune_ObjectUnionDouble = _test_misc_prune(
   const $pu0 = (input: any): any =>
     (() => {
       if ($io6(input)) return $po6(input);
-      else if ($io0(input)) return $po0(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-          value: input,
-        });
+      if ($io0(input)) return $po0(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+        value: input,
+      });
     })();
   const $pu1 = (input: any): any =>
     (() => {
       if ($io4(input)) return $po4(input);
-      else if ($io2(input)) return $po2(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-          value: input,
-        });
+      if ($io2(input)) return $po2(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+        value: input,
+      });
     })();
   const $pu2 = (input: any): any =>
     (() => {
       if ($io10(input)) return $po10(input);
-      else if ($io8(input)) return $po8(input);
-      else
-        $throws({
-          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-          value: input,
-        });
+      if ($io8(input)) return $po8(input);
+      $throws({
+        expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+        value: input,
+      });
     })();
   if (Array.isArray(input)) $pp0(input);
 });

--- a/test/src/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createPrune/test_misc_createPrune_ObjectUnionNonPredictable.ts
@@ -104,14 +104,13 @@ export const test_misc_createPrune_ObjectUnionNonPredictable = _test_misc_prune(
     const $pu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $po7(input);
-        else if ($io5(input)) return $po5(input);
-        else if ($io3(input)) return $po3(input);
-        else
-          $throws({
-            expected:
-              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-            value: input,
-          });
+        if ($io5(input)) return $po5(input);
+        if ($io3(input)) return $po3(input);
+        $throws({
+          expected:
+            "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+          value: input,
+        });
       })();
     if ("object" === typeof input && null !== input) $po0(input);
   },

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_misc_createValidateClone_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_misc_createValidateClone_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicTree.ts
@@ -21,11 +21,7 @@ export const test_misc_createValidateClone_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -88,26 +84,24 @@ export const test_misc_createValidateClone_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -146,9 +140,7 @@ export const test_misc_createValidateClone_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         const $co0 = (input: any): any => ({
           id: input.id as any,

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_DynamicUndefined.ts
@@ -14,8 +14,7 @@ export const test_misc_createValidateClone_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -43,22 +42,20 @@ export const test_misc_createValidateClone_DynamicUndefined =
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        (null !== value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          })) &&
-                        (undefined === value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          }))
-                      );
-                    return true;
+                    return (
+                      (null !== value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        })) &&
+                      (undefined === value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        }))
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_misc_createValidateClone_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -49,19 +47,16 @@ export const test_misc_createValidateClone_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_misc_createValidateClone_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -373,14 +373,13 @@ export const test_misc_createValidateClone_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)

--- a/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.createValidateClone/test_misc_createValidateClone_UltimateUnion.ts
@@ -431,14 +431,12 @@ export const test_misc_createValidateClone_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -534,14 +532,12 @@ export const test_misc_createValidateClone_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -1072,13 +1068,13 @@ export const test_misc_createValidateClone_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $io5(input);
-                  else if ($io4(input)) return $io4(input);
-                  else if ($io1(input)) return $io1(input);
-                  else if ($io6(input)) return $io6(input);
-                  else if ($io9(input)) return $io9(input);
-                  else if ($io10(input)) return $io10(input);
-                  else if ($io18(input)) return $io18(input);
-                  else return false;
+                  if ($io4(input)) return $io4(input);
+                  if ($io1(input)) return $io1(input);
+                  if ($io6(input)) return $io6(input);
+                  if ($io9(input)) return $io9(input);
+                  if ($io10(input)) return $io10(input);
+                  if ($io18(input)) return $io18(input);
+                  return false;
                 })();
             })();
           const $iu1 = (input: any): any =>
@@ -1109,13 +1105,13 @@ export const test_misc_createValidateClone_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $io23(input);
-                  else if ($io22(input)) return $io22(input);
-                  else if ($io21(input)) return $io21(input);
-                  else if ($io24(input)) return $io24(input);
-                  else if ($io26(input)) return $io26(input);
-                  else if ($io27(input)) return $io27(input);
-                  else if ($io34(input)) return $io34(input);
-                  else return false;
+                  if ($io22(input)) return $io22(input);
+                  if ($io21(input)) return $io21(input);
+                  if ($io24(input)) return $io24(input);
+                  if ($io26(input)) return $io26(input);
+                  if ($io27(input)) return $io27(input);
+                  if ($io34(input)) return $io34(input);
+                  return false;
                 })();
             })();
           return (
@@ -3065,30 +3061,28 @@ export const test_misc_createValidateClone_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                              value: value,
-                            })) &&
-                            $vu0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -3539,30 +3533,28 @@ export const test_misc_createValidateClone_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                              value: value,
-                            })) &&
-                            $vu1(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu1(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -6410,14 +6402,12 @@ export const test_misc_createValidateClone_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -6513,14 +6503,12 @@ export const test_misc_createValidateClone_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -7771,18 +7759,17 @@ export const test_misc_createValidateClone_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $co5(input);
-                else if ($io4(input)) return $co4(input);
-                else if ($io1(input)) return $co1(input);
-                else if ($io6(input)) return $co6(input);
-                else if ($io9(input)) return $co9(input);
-                else if ($io10(input)) return $co10(input);
-                else if ($io18(input)) return $co18(input);
-                else
-                  $throws({
-                    expected:
-                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                    value: input,
-                  });
+                if ($io4(input)) return $co4(input);
+                if ($io1(input)) return $co1(input);
+                if ($io6(input)) return $co6(input);
+                if ($io9(input)) return $co9(input);
+                if ($io10(input)) return $co10(input);
+                if ($io18(input)) return $co18(input);
+                $throws({
+                  expected:
+                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                  value: input,
+                });
               })();
           })();
         const $cu1 = (input: any): any =>
@@ -7813,18 +7800,17 @@ export const test_misc_createValidateClone_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $co23(input);
-                else if ($io22(input)) return $co22(input);
-                else if ($io21(input)) return $co21(input);
-                else if ($io24(input)) return $co24(input);
-                else if ($io26(input)) return $co26(input);
-                else if ($io27(input)) return $co27(input);
-                else if ($io34(input)) return $co34(input);
-                else
-                  $throws({
-                    expected:
-                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                    value: input,
-                  });
+                if ($io22(input)) return $co22(input);
+                if ($io21(input)) return $co21(input);
+                if ($io24(input)) return $co24(input);
+                if ($io26(input)) return $co26(input);
+                if ($io27(input)) return $co27(input);
+                if ($io34(input)) return $co34(input);
+                $throws({
+                  expected:
+                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                  value: input,
+                });
               })();
           })();
         return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.createValidatePrune/test_misc_createValidatePrune_ObjectUnionNonPredictable.ts
@@ -43,9 +43,9 @@ export const test_misc_createValidatePrune_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -388,14 +388,13 @@ export const test_misc_createValidatePrune_ObjectUnionNonPredictable =
         const $pu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $po7(input);
-            else if ($io5(input)) return $po5(input);
-            else if ($io3(input)) return $po3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $po5(input);
+            if ($io3(input)) return $po3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         if ("object" === typeof input && null !== input) $po0(input);
       };

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicArray.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicArray.ts
@@ -17,12 +17,10 @@ export const test_misc_isClone_DynamicArray = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -31,12 +29,10 @@ export const test_misc_isClone_DynamicArray = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              Array.isArray(value) &&
-              value.every((elem: any) => "string" === typeof elem)
-            );
-          return true;
+          return (
+            Array.isArray(value) &&
+            value.every((elem: any) => "string" === typeof elem)
+          );
         });
       const $cp0 = (input: any) => input.map((elem: any) => elem as any);
       const $co0 = (input: any): any => ({

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicNever.ts
@@ -12,8 +12,7 @@ export const test_misc_isClone_DynamicNever = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicSimple.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicSimple.ts
@@ -17,8 +17,7 @@ export const test_misc_isClone_DynamicSimple = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value && Number.isFinite(value);
-          return true;
+          return "number" === typeof value && Number.isFinite(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -27,8 +26,7 @@ export const test_misc_isClone_DynamicSimple = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return "number" === typeof value;
-          return true;
+          return "number" === typeof value;
         });
       const $co0 = (input: any): any => ({
         value:

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_misc_isClone_DynamicTree = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -38,9 +36,7 @@ export const test_misc_isClone_DynamicTree = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $co0 = (input: any): any => ({
         id: input.id as any,

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_DynamicUndefined.ts
@@ -12,8 +12,7 @@ export const test_misc_isClone_DynamicUndefined = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectDynamic.ts
@@ -12,13 +12,11 @@ export const test_misc_isClone_ObjectDynamic = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_misc_isClone_ObjectUnionDouble = _test_misc_isClone(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -187,32 +187,29 @@ export const test_misc_isClone_ObjectUnionDouble = _test_misc_isClone(
       const $cu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $co6(input);
-          else if ($io0(input)) return $co0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $co0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $cu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $co4(input);
-          else if ($io2(input)) return $co2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $co2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $cu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $co10(input);
-          else if ($io8(input)) return $co8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $co8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);
     };

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_misc_isClone_ObjectUnionNonPredictable = _test_misc_isClone(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -126,14 +126,13 @@ export const test_misc_isClone_ObjectUnionNonPredictable = _test_misc_isClone(
       const $cu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $co7(input);
-          else if ($io5(input)) return $co5(input);
-          else if ($io3(input)) return $co3(input);
-          else
-            $throws({
-              expected:
-                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-              value: input,
-            });
+          if ($io5(input)) return $co5(input);
+          if ($io3(input)) return $co3(input);
+          $throws({
+            expected:
+              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+            value: input,
+          });
         })();
       return "object" === typeof input && null !== input
         ? $co0(input)

--- a/test/src/generated/output/misc.isClone/test_misc_isClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.isClone/test_misc_isClone_UltimateUnion.ts
@@ -413,14 +413,12 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -516,14 +514,12 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1040,13 +1036,13 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1077,13 +1073,13 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -1475,14 +1471,12 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -1578,14 +1572,12 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -2826,18 +2818,17 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io5(input)) return $co5(input);
-              else if ($io4(input)) return $co4(input);
-              else if ($io1(input)) return $co1(input);
-              else if ($io6(input)) return $co6(input);
-              else if ($io9(input)) return $co9(input);
-              else if ($io10(input)) return $co10(input);
-              else if ($io18(input)) return $co18(input);
-              else
-                $throws({
-                  expected:
-                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                  value: input,
-                });
+              if ($io4(input)) return $co4(input);
+              if ($io1(input)) return $co1(input);
+              if ($io6(input)) return $co6(input);
+              if ($io9(input)) return $co9(input);
+              if ($io10(input)) return $co10(input);
+              if ($io18(input)) return $co18(input);
+              $throws({
+                expected:
+                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                value: input,
+              });
             })();
         })();
       const $cu1 = (input: any): any =>
@@ -2868,18 +2859,17 @@ export const test_misc_isClone_UltimateUnion = _test_misc_isClone(
           else
             return (() => {
               if ($io23(input)) return $co23(input);
-              else if ($io22(input)) return $co22(input);
-              else if ($io21(input)) return $co21(input);
-              else if ($io24(input)) return $co24(input);
-              else if ($io26(input)) return $co26(input);
-              else if ($io27(input)) return $co27(input);
-              else if ($io34(input)) return $co34(input);
-              else
-                $throws({
-                  expected:
-                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                  value: input,
-                });
+              if ($io22(input)) return $co22(input);
+              if ($io21(input)) return $co21(input);
+              if ($io24(input)) return $co24(input);
+              if ($io26(input)) return $co26(input);
+              if ($io27(input)) return $co27(input);
+              if ($io34(input)) return $co34(input);
+              $throws({
+                expected:
+                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                value: input,
+              });
             })();
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionDouble.ts
@@ -48,20 +48,20 @@ export const test_misc_isPrune_ObjectUnionDouble = _test_misc_isPrune(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $io6(input);
-          else if ($io0(input)) return $io0(input);
-          else return false;
+          if ($io0(input)) return $io0(input);
+          return false;
         })();
       const $iu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $io4(input);
-          else if ($io2(input)) return $io2(input);
-          else return false;
+          if ($io2(input)) return $io2(input);
+          return false;
         })();
       const $iu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $io10(input);
-          else if ($io8(input)) return $io8(input);
-          else return false;
+          if ($io8(input)) return $io8(input);
+          return false;
         })();
       return (
         Array.isArray(input) &&
@@ -208,32 +208,29 @@ export const test_misc_isPrune_ObjectUnionDouble = _test_misc_isPrune(
       const $pu0 = (input: any): any =>
         (() => {
           if ($io6(input)) return $po6(input);
-          else if ($io0(input)) return $po0(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-              value: input,
-            });
+          if ($io0(input)) return $po0(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+            value: input,
+          });
         })();
       const $pu1 = (input: any): any =>
         (() => {
           if ($io4(input)) return $po4(input);
-          else if ($io2(input)) return $po2(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-              value: input,
-            });
+          if ($io2(input)) return $po2(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+            value: input,
+          });
         })();
       const $pu2 = (input: any): any =>
         (() => {
           if ($io10(input)) return $po10(input);
-          else if ($io8(input)) return $po8(input);
-          else
-            $throws({
-              expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-              value: input,
-            });
+          if ($io8(input)) return $po8(input);
+          $throws({
+            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+            value: input,
+          });
         })();
       if (Array.isArray(input)) $pp0(input);
     };

--- a/test/src/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.isPrune/test_misc_isPrune_ObjectUnionNonPredictable.ts
@@ -38,9 +38,9 @@ export const test_misc_isPrune_ObjectUnionNonPredictable = _test_misc_isPrune(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -143,14 +143,13 @@ export const test_misc_isPrune_ObjectUnionNonPredictable = _test_misc_isPrune(
       const $pu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $po7(input);
-          else if ($io5(input)) return $po5(input);
-          else if ($io3(input)) return $po3(input);
-          else
-            $throws({
-              expected:
-                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-              value: input,
-            });
+          if ($io5(input)) return $po5(input);
+          if ($io3(input)) return $po3(input);
+          $throws({
+            expected:
+              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+            value: input,
+          });
         })();
       if ("object" === typeof input && null !== input) $po0(input);
     };

--- a/test/src/generated/output/misc.prune/test_misc_prune_ObjectUnionDouble.ts
+++ b/test/src/generated/output/misc.prune/test_misc_prune_ObjectUnionDouble.ts
@@ -143,32 +143,29 @@ export const test_misc_prune_ObjectUnionDouble = _test_misc_prune(
     const $pu0 = (input: any): any =>
       (() => {
         if ($io6(input)) return $po6(input);
-        else if ($io0(input)) return $po0(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
-            value: input,
-          });
+        if ($io0(input)) return $po0(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IB | ObjectUnionDouble.IA)",
+          value: input,
+        });
       })();
     const $pu1 = (input: any): any =>
       (() => {
         if ($io4(input)) return $po4(input);
-        else if ($io2(input)) return $po2(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
-            value: input,
-          });
+        if ($io2(input)) return $po2(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IAB | ObjectUnionDouble.IAA)",
+          value: input,
+        });
       })();
     const $pu2 = (input: any): any =>
       (() => {
         if ($io10(input)) return $po10(input);
-        else if ($io8(input)) return $po8(input);
-        else
-          $throws({
-            expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
-            value: input,
-          });
+        if ($io8(input)) return $po8(input);
+        $throws({
+          expected: "(ObjectUnionDouble.IBB | ObjectUnionDouble.IBA)",
+          value: input,
+        });
       })();
     if (Array.isArray(input)) $pp0(input);
   })(input),

--- a/test/src/generated/output/misc.prune/test_misc_prune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.prune/test_misc_prune_ObjectUnionNonPredictable.ts
@@ -104,14 +104,13 @@ export const test_misc_prune_ObjectUnionNonPredictable = _test_misc_prune(
     const $pu0 = (input: any): any =>
       (() => {
         if ($io7(input)) return $po7(input);
-        else if ($io5(input)) return $po5(input);
-        else if ($io3(input)) return $po3(input);
-        else
-          $throws({
-            expected:
-              "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-            value: input,
-          });
+        if ($io5(input)) return $po5(input);
+        if ($io3(input)) return $po3(input);
+        $throws({
+          expected:
+            "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+          value: input,
+        });
       })();
     if ("object" === typeof input && null !== input) $po0(input);
   })(input),

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicNever.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicNever.ts
@@ -14,8 +14,7 @@ export const test_misc_validateClone_DynamicNever = _test_misc_validateClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -43,22 +42,20 @@ export const test_misc_validateClone_DynamicNever = _test_misc_validateClone(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        (null !== value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          })) &&
-                        (undefined === value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "undefined",
-                            value: value,
-                          }))
-                      );
-                    return true;
+                    return (
+                      (null !== value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        })) &&
+                      (undefined === value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "undefined",
+                          value: value,
+                        }))
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicTree.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicTree.ts
@@ -22,9 +22,7 @@ export const test_misc_validateClone_DynamicTree = _test_misc_validateClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -85,26 +83,24 @@ export const test_misc_validateClone_DynamicTree = _test_misc_validateClone(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value && null !== value) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "DynamicTree",
-                            value: value,
-                          })) &&
-                          $vo0(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value && null !== value) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected: "DynamicTree",
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vo0(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "DynamicTree",
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);
@@ -143,9 +139,7 @@ export const test_misc_validateClone_DynamicTree = _test_misc_validateClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       const $co0 = (input: any): any => ({
         id: input.id as any,

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicUndefined.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_DynamicUndefined.ts
@@ -15,8 +15,7 @@ export const test_misc_validateClone_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -44,22 +43,20 @@ export const test_misc_validateClone_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_ObjectDynamic.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_ObjectDynamic.ts
@@ -14,13 +14,11 @@ export const test_misc_validateClone_ObjectDynamic = _test_misc_validateClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -48,18 +46,16 @@ export const test_misc_validateClone_ObjectDynamic = _test_misc_validateClone(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        "string" === typeof value ||
-                        ("number" === typeof value && Number.isFinite(value)) ||
-                        "boolean" === typeof value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "(boolean | number | string)",
-                          value: value,
-                        })
-                      );
-                    return true;
+                    return (
+                      "string" === typeof value ||
+                      ("number" === typeof value && Number.isFinite(value)) ||
+                      "boolean" === typeof value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "(boolean | number | string)",
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_misc_validateClone_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -371,14 +371,13 @@ export const test_misc_validateClone_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)

--- a/test/src/generated/output/misc.validateClone/test_misc_validateClone_UltimateUnion.ts
+++ b/test/src/generated/output/misc.validateClone/test_misc_validateClone_UltimateUnion.ts
@@ -427,14 +427,12 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -530,14 +528,12 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -1064,13 +1060,13 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -1101,13 +1097,13 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -3005,30 +3001,28 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value &&
-                          null !== value &&
-                          false === Array.isArray(value)) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected:
-                              '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                            value: value,
-                          })) &&
-                          $vu0(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value &&
+                        null !== value &&
+                        false === Array.isArray(value)) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected:
                             '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vu0(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected:
+                          '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);
@@ -3467,30 +3461,28 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
                   .map((key: any) => {
                     const value = input[key];
                     if (undefined === value) return true;
-                    if (true)
-                      return (
-                        ((("object" === typeof value &&
-                          null !== value &&
-                          false === Array.isArray(value)) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected:
-                              '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                            value: value,
-                          })) &&
-                          $vu1(
-                            value,
-                            _path + $join(key),
-                            true && _exceptionable,
-                          )) ||
+                    return (
+                      ((("object" === typeof value &&
+                        null !== value &&
+                        false === Array.isArray(value)) ||
                         $report(_exceptionable, {
                           path: _path + $join(key),
                           expected:
                             '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                           value: value,
-                        })
-                      );
-                    return true;
+                        })) &&
+                        $vu1(
+                          value,
+                          _path + $join(key),
+                          true && _exceptionable,
+                        )) ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected:
+                          '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                        value: value,
+                      })
+                    );
                   })
                   .every((flag: boolean) => flag),
             ].every((flag: boolean) => flag);
@@ -6264,14 +6256,12 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -6367,14 +6357,12 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -7615,18 +7603,17 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
           else
             return (() => {
               if ($io5(input)) return $co5(input);
-              else if ($io4(input)) return $co4(input);
-              else if ($io1(input)) return $co1(input);
-              else if ($io6(input)) return $co6(input);
-              else if ($io9(input)) return $co9(input);
-              else if ($io10(input)) return $co10(input);
-              else if ($io18(input)) return $co18(input);
-              else
-                $throws({
-                  expected:
-                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                  value: input,
-                });
+              if ($io4(input)) return $co4(input);
+              if ($io1(input)) return $co1(input);
+              if ($io6(input)) return $co6(input);
+              if ($io9(input)) return $co9(input);
+              if ($io10(input)) return $co10(input);
+              if ($io18(input)) return $co18(input);
+              $throws({
+                expected:
+                  '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                value: input,
+              });
             })();
         })();
       const $cu1 = (input: any): any =>
@@ -7657,18 +7644,17 @@ export const test_misc_validateClone_UltimateUnion = _test_misc_validateClone(
           else
             return (() => {
               if ($io23(input)) return $co23(input);
-              else if ($io22(input)) return $co22(input);
-              else if ($io21(input)) return $co21(input);
-              else if ($io24(input)) return $co24(input);
-              else if ($io26(input)) return $co26(input);
-              else if ($io27(input)) return $co27(input);
-              else if ($io34(input)) return $co34(input);
-              else
-                $throws({
-                  expected:
-                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                  value: input,
-                });
+              if ($io22(input)) return $co22(input);
+              if ($io21(input)) return $co21(input);
+              if ($io24(input)) return $co24(input);
+              if ($io26(input)) return $co26(input);
+              if ($io27(input)) return $co27(input);
+              if ($io34(input)) return $co34(input);
+              $throws({
+                expected:
+                  '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                value: input,
+              });
             })();
         })();
       return Array.isArray(input) ? $cp0(input) : (input as any);

--- a/test/src/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/misc.validatePrune/test_misc_validatePrune_ObjectUnionNonPredictable.ts
@@ -43,9 +43,9 @@ export const test_misc_validatePrune_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -386,14 +386,13 @@ export const test_misc_validatePrune_ObjectUnionNonPredictable =
         const $pu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $po7(input);
-            else if ($io5(input)) return $po5(input);
-            else if ($io3(input)) return $po3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $po5(input);
+            if ($io3(input)) return $po3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         if ("object" === typeof input && null !== input) $po0(input);
       };

--- a/test/src/generated/output/notation.camel/test_notation_camel_DynamicNever.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_DynamicNever.ts
@@ -16,8 +16,7 @@ export const test_notation_validateCamel_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validateCamel_DynamicNever =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -118,8 +115,7 @@ export const test_notation_validateCamel_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -145,22 +141,20 @@ export const test_notation_validateCamel_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.camel/test_notation_camel_DynamicTree.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_DynamicTree.ts
@@ -24,11 +24,9 @@ export const test_notation_validateCamel_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -91,26 +89,24 @@ export const test_notation_validateCamel_DynamicTree =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value && null !== value) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "DynamicTree",
-                                value: value,
-                              })) &&
-                              $vo0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value && null !== value) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected: "DynamicTree",
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vo0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "DynamicTree",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -149,11 +145,7 @@ export const test_notation_validateCamel_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           const $co0 = (input: any): any => ({
             id: input.id as any,
@@ -198,9 +190,7 @@ export const test_notation_validateCamel_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -257,22 +247,20 @@ export const test_notation_validateCamel_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/notation.camel/test_notation_camel_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_DynamicUndefined.ts
@@ -16,8 +16,7 @@ export const test_notation_validateCamel_DynamicUndefined =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validateCamel_DynamicUndefined =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -118,8 +115,7 @@ export const test_notation_validateCamel_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -145,22 +141,20 @@ export const test_notation_validateCamel_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.camel/test_notation_camel_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_ObjectDynamic.ts
@@ -16,13 +16,11 @@ export const test_notation_validateCamel_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value
+                );
               });
             return (
               "object" === typeof input &&
@@ -52,19 +50,17 @@ export const test_notation_validateCamel_ObjectDynamic =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            "string" === typeof value ||
-                            ("number" === typeof value &&
-                              Number.isFinite(value)) ||
-                            "boolean" === typeof value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "(boolean | number | string)",
-                              value: value,
-                            })
-                          );
-                        return true;
+                        return (
+                          "string" === typeof value ||
+                          ("number" === typeof value &&
+                            Number.isFinite(value)) ||
+                          "boolean" === typeof value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "(boolean | number | string)",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -120,13 +116,11 @@ export const test_notation_validateCamel_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -152,18 +146,16 @@ export const test_notation_validateCamel_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.camel/test_notation_camel_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_ObjectUnionNonPredictable.ts
@@ -48,9 +48,9 @@ export const test_notation_validateCamel_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -377,14 +377,13 @@ export const test_notation_validateCamel_ObjectUnionNonPredictable =
           const $cu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $co7(input);
-              else if ($io5(input)) return $co5(input);
-              else if ($io3(input)) return $co3(input);
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input,
-                });
+              if ($io5(input)) return $co5(input);
+              if ($io3(input)) return $co3(input);
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input,
+              });
             })();
           return "object" === typeof input && null !== input
             ? $co0(input)
@@ -428,9 +427,9 @@ export const test_notation_validateCamel_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };

--- a/test/src/generated/output/notation.camel/test_notation_camel_UltimateUnion.ts
+++ b/test/src/generated/output/notation.camel/test_notation_camel_UltimateUnion.ts
@@ -436,14 +436,12 @@ export const test_notation_validateCamel_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu0(value)
+                );
               });
             const $io15 = (input: any): boolean =>
               "string" === typeof input.$ref &&
@@ -539,14 +537,12 @@ export const test_notation_validateCamel_UltimateUnion =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value) &&
-                    $iu1(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value) &&
+                  $iu1(value)
+                );
               });
             const $io21 = (input: any): boolean =>
               Array.isArray(input["enum"]) &&
@@ -1079,13 +1075,13 @@ export const test_notation_validateCamel_UltimateUnion =
                 else
                   return (() => {
                     if ($io5(input)) return $io5(input);
-                    else if ($io4(input)) return $io4(input);
-                    else if ($io1(input)) return $io1(input);
-                    else if ($io6(input)) return $io6(input);
-                    else if ($io9(input)) return $io9(input);
-                    else if ($io10(input)) return $io10(input);
-                    else if ($io18(input)) return $io18(input);
-                    else return false;
+                    if ($io4(input)) return $io4(input);
+                    if ($io1(input)) return $io1(input);
+                    if ($io6(input)) return $io6(input);
+                    if ($io9(input)) return $io9(input);
+                    if ($io10(input)) return $io10(input);
+                    if ($io18(input)) return $io18(input);
+                    return false;
                   })();
               })();
             const $iu1 = (input: any): any =>
@@ -1116,13 +1112,13 @@ export const test_notation_validateCamel_UltimateUnion =
                 else
                   return (() => {
                     if ($io23(input)) return $io23(input);
-                    else if ($io22(input)) return $io22(input);
-                    else if ($io21(input)) return $io21(input);
-                    else if ($io24(input)) return $io24(input);
-                    else if ($io26(input)) return $io26(input);
-                    else if ($io27(input)) return $io27(input);
-                    else if ($io34(input)) return $io34(input);
-                    else return false;
+                    if ($io22(input)) return $io22(input);
+                    if ($io21(input)) return $io21(input);
+                    if ($io24(input)) return $io24(input);
+                    if ($io26(input)) return $io26(input);
+                    if ($io27(input)) return $io27(input);
+                    if ($io34(input)) return $io34(input);
+                    return false;
                   })();
               })();
             return (
@@ -3162,30 +3158,28 @@ export const test_notation_validateCamel_UltimateUnion =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value &&
-                              null !== value &&
-                              false === Array.isArray(value)) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected:
-                                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                                value: value,
-                              })) &&
-                              $vu0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value &&
+                            null !== value &&
+                            false === Array.isArray(value)) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected:
                                 '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vu0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected:
+                              '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -3660,30 +3654,28 @@ export const test_notation_validateCamel_UltimateUnion =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value &&
-                              null !== value &&
-                              false === Array.isArray(value)) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected:
-                                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                                value: value,
-                              })) &&
-                              $vu1(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value &&
+                            null !== value &&
+                            false === Array.isArray(value)) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected:
                                 '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vu1(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected:
+                              '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -6654,14 +6646,12 @@ export const test_notation_validateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -6757,14 +6747,12 @@ export const test_notation_validateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -8021,18 +8009,17 @@ export const test_notation_validateCamel_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $co5(input);
-                  else if ($io4(input)) return $co4(input);
-                  else if ($io1(input)) return $co1(input);
-                  else if ($io6(input)) return $co6(input);
-                  else if ($io9(input)) return $co9(input);
-                  else if ($io10(input)) return $co10(input);
-                  else if ($io18(input)) return $co18(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                      value: input,
-                    });
+                  if ($io4(input)) return $co4(input);
+                  if ($io1(input)) return $co1(input);
+                  if ($io6(input)) return $co6(input);
+                  if ($io9(input)) return $co9(input);
+                  if ($io10(input)) return $co10(input);
+                  if ($io18(input)) return $co18(input);
+                  $throws({
+                    expected:
+                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                    value: input,
+                  });
                 })();
             })();
           const $cu1 = (input: any): any =>
@@ -8063,18 +8050,17 @@ export const test_notation_validateCamel_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $co23(input);
-                  else if ($io22(input)) return $co22(input);
-                  else if ($io21(input)) return $co21(input);
-                  else if ($io24(input)) return $co24(input);
-                  else if ($io26(input)) return $co26(input);
-                  else if ($io27(input)) return $co27(input);
-                  else if ($io34(input)) return $co34(input);
-                  else
-                    $throws({
-                      expected:
-                        '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                      value: input,
-                    });
+                  if ($io22(input)) return $co22(input);
+                  if ($io21(input)) return $co21(input);
+                  if ($io24(input)) return $co24(input);
+                  if ($io26(input)) return $co26(input);
+                  if ($io27(input)) return $co27(input);
+                  if ($io34(input)) return $co34(input);
+                  $throws({
+                    expected:
+                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                    value: input,
+                  });
                 })();
             })();
           return Array.isArray(input) ? $cp0(input) : (input as any);
@@ -8502,14 +8488,12 @@ export const test_notation_validateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -8605,14 +8589,12 @@ export const test_notation_validateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -9139,13 +9121,13 @@ export const test_notation_validateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -9176,13 +9158,13 @@ export const test_notation_validateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -10973,26 +10955,24 @@ export const test_notation_validateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                      value: value,
-                    })) &&
-                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                  value: value,
+                })
+              );
             });
           const $ao15 = (
             input: any,
@@ -11398,26 +11378,24 @@ export const test_notation_validateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                      value: value,
-                    })) &&
-                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                  value: value,
+                })
+              );
             });
           const $ao21 = (
             input: any,

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicNever.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicNever.ts
@@ -15,8 +15,7 @@ export const test_notation_createValidateCamel_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -46,22 +45,20 @@ export const test_notation_createValidateCamel_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -115,8 +112,7 @@ export const test_notation_createValidateCamel_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -142,22 +138,20 @@ export const test_notation_createValidateCamel_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicTree.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicTree.ts
@@ -23,11 +23,7 @@ export const test_notation_createValidateCamel_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -90,26 +86,24 @@ export const test_notation_createValidateCamel_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -148,9 +142,7 @@ export const test_notation_createValidateCamel_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         const $co0 = (input: any): any => ({
           id: input.id as any,
@@ -195,9 +187,7 @@ export const test_notation_createValidateCamel_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -254,22 +244,20 @@ export const test_notation_createValidateCamel_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_DynamicUndefined.ts
@@ -17,8 +17,7 @@ export const test_notation_createValidateCamel_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -48,22 +47,20 @@ export const test_notation_createValidateCamel_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -119,8 +116,7 @@ export const test_notation_createValidateCamel_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -146,22 +142,20 @@ export const test_notation_createValidateCamel_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_ObjectDynamic.ts
@@ -17,13 +17,11 @@ export const test_notation_createValidateCamel_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -53,19 +51,16 @@ export const test_notation_createValidateCamel_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -121,13 +116,11 @@ export const test_notation_createValidateCamel_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -153,18 +146,16 @@ export const test_notation_createValidateCamel_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_ObjectUnionNonPredictable.ts
@@ -47,9 +47,9 @@ export const test_notation_createValidateCamel_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -375,14 +375,13 @@ export const test_notation_createValidateCamel_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)
@@ -426,9 +425,9 @@ export const test_notation_createValidateCamel_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };

--- a/test/src/generated/output/notation.createCamel/test_notation_createCamel_UltimateUnion.ts
+++ b/test/src/generated/output/notation.createCamel/test_notation_createCamel_UltimateUnion.ts
@@ -435,14 +435,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu0(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu0(value)
+              );
             });
           const $io15 = (input: any): boolean =>
             "string" === typeof input.$ref &&
@@ -538,14 +536,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $iu1(value)
-                );
-              return true;
+              return (
+                "object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $iu1(value)
+              );
             });
           const $io21 = (input: any): boolean =>
             Array.isArray(input["enum"]) &&
@@ -1076,13 +1072,13 @@ export const test_notation_createValidateCamel_UltimateUnion =
               else
                 return (() => {
                   if ($io5(input)) return $io5(input);
-                  else if ($io4(input)) return $io4(input);
-                  else if ($io1(input)) return $io1(input);
-                  else if ($io6(input)) return $io6(input);
-                  else if ($io9(input)) return $io9(input);
-                  else if ($io10(input)) return $io10(input);
-                  else if ($io18(input)) return $io18(input);
-                  else return false;
+                  if ($io4(input)) return $io4(input);
+                  if ($io1(input)) return $io1(input);
+                  if ($io6(input)) return $io6(input);
+                  if ($io9(input)) return $io9(input);
+                  if ($io10(input)) return $io10(input);
+                  if ($io18(input)) return $io18(input);
+                  return false;
                 })();
             })();
           const $iu1 = (input: any): any =>
@@ -1113,13 +1109,13 @@ export const test_notation_createValidateCamel_UltimateUnion =
               else
                 return (() => {
                   if ($io23(input)) return $io23(input);
-                  else if ($io22(input)) return $io22(input);
-                  else if ($io21(input)) return $io21(input);
-                  else if ($io24(input)) return $io24(input);
-                  else if ($io26(input)) return $io26(input);
-                  else if ($io27(input)) return $io27(input);
-                  else if ($io34(input)) return $io34(input);
-                  else return false;
+                  if ($io22(input)) return $io22(input);
+                  if ($io21(input)) return $io21(input);
+                  if ($io24(input)) return $io24(input);
+                  if ($io26(input)) return $io26(input);
+                  if ($io27(input)) return $io27(input);
+                  if ($io34(input)) return $io34(input);
+                  return false;
                 })();
             })();
           return (
@@ -3069,30 +3065,28 @@ export const test_notation_createValidateCamel_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                              value: value,
-                            })) &&
-                            $vu0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -3543,30 +3537,28 @@ export const test_notation_createValidateCamel_UltimateUnion =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value &&
-                            null !== value &&
-                            false === Array.isArray(value)) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected:
-                                '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                              value: value,
-                            })) &&
-                            $vu1(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value &&
+                          null !== value &&
+                          false === Array.isArray(value)) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected:
                               '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vu1(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected:
+                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -6416,14 +6408,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -6519,14 +6509,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -7777,18 +7765,17 @@ export const test_notation_createValidateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $co5(input);
-                else if ($io4(input)) return $co4(input);
-                else if ($io1(input)) return $co1(input);
-                else if ($io6(input)) return $co6(input);
-                else if ($io9(input)) return $co9(input);
-                else if ($io10(input)) return $co10(input);
-                else if ($io18(input)) return $co18(input);
-                else
-                  $throws({
-                    expected:
-                      '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
-                    value: input,
-                  });
+                if ($io4(input)) return $co4(input);
+                if ($io1(input)) return $co1(input);
+                if ($io6(input)) return $co6(input);
+                if ($io9(input)) return $co9(input);
+                if ($io10(input)) return $co10(input);
+                if ($io18(input)) return $co18(input);
+                $throws({
+                  expected:
+                    '(IJsonSchema.IEnumeration<"string"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IBoolean | IJsonSchema.INumber | IJsonSchema.IString | IJsonSchema.IUnknown)',
+                  value: input,
+                });
               })();
           })();
         const $cu1 = (input: any): any =>
@@ -7819,18 +7806,17 @@ export const test_notation_createValidateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $co23(input);
-                else if ($io22(input)) return $co22(input);
-                else if ($io21(input)) return $co21(input);
-                else if ($io24(input)) return $co24(input);
-                else if ($io26(input)) return $co26(input);
-                else if ($io27(input)) return $co27(input);
-                else if ($io34(input)) return $co34(input);
-                else
-                  $throws({
-                    expected:
-                      '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
-                    value: input,
-                  });
+                if ($io22(input)) return $co22(input);
+                if ($io21(input)) return $co21(input);
+                if ($io24(input)) return $co24(input);
+                if ($io26(input)) return $co26(input);
+                if ($io27(input)) return $co27(input);
+                if ($io34(input)) return $co34(input);
+                $throws({
+                  expected:
+                    '(IEnumeration<"string"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"boolean"> & IIdentified | IBoolean & IIdentified | INumber & IIdentified | IString & IIdentified | IUnknown & IIdentified)',
+                  value: input,
+                });
               })();
           })();
         return Array.isArray(input) ? $cp0(input) : (input as any);
@@ -8258,14 +8244,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu0(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu0(value)
+            );
           });
         const $io15 = (input: any): boolean =>
           "string" === typeof input.$ref &&
@@ -8361,14 +8345,12 @@ export const test_notation_createValidateCamel_UltimateUnion =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $iu1(value)
-              );
-            return true;
+            return (
+              "object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $iu1(value)
+            );
           });
         const $io21 = (input: any): boolean =>
           Array.isArray(input["enum"]) &&
@@ -8895,13 +8877,13 @@ export const test_notation_createValidateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io5(input)) return $io5(input);
-                else if ($io4(input)) return $io4(input);
-                else if ($io1(input)) return $io1(input);
-                else if ($io6(input)) return $io6(input);
-                else if ($io9(input)) return $io9(input);
-                else if ($io10(input)) return $io10(input);
-                else if ($io18(input)) return $io18(input);
-                else return false;
+                if ($io4(input)) return $io4(input);
+                if ($io1(input)) return $io1(input);
+                if ($io6(input)) return $io6(input);
+                if ($io9(input)) return $io9(input);
+                if ($io10(input)) return $io10(input);
+                if ($io18(input)) return $io18(input);
+                return false;
               })();
           })();
         const $iu1 = (input: any): any =>
@@ -8932,13 +8914,13 @@ export const test_notation_createValidateCamel_UltimateUnion =
             else
               return (() => {
                 if ($io23(input)) return $io23(input);
-                else if ($io22(input)) return $io22(input);
-                else if ($io21(input)) return $io21(input);
-                else if ($io24(input)) return $io24(input);
-                else if ($io26(input)) return $io26(input);
-                else if ($io27(input)) return $io27(input);
-                else if ($io34(input)) return $io34(input);
-                else return false;
+                if ($io22(input)) return $io22(input);
+                if ($io21(input)) return $io21(input);
+                if ($io24(input)) return $io24(input);
+                if ($io26(input)) return $io26(input);
+                if ($io27(input)) return $io27(input);
+                if ($io34(input)) return $io34(input);
+                return false;
               })();
           })();
         return (
@@ -10729,26 +10711,24 @@ export const test_notation_createValidateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                      value: value,
-                    })) &&
-                    $au0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                  value: value,
+                })
+              );
             });
           const $ao15 = (
             input: any,
@@ -11154,26 +11134,24 @@ export const test_notation_createValidateCamel_UltimateUnion =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value &&
-                    null !== value &&
-                    false === Array.isArray(value)) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected:
-                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                      value: value,
-                    })) &&
-                    $au1(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value &&
+                  null !== value &&
+                  false === Array.isArray(value)) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected:
                       '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected:
+                    '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                  value: value,
+                })
+              );
             });
           const $ao21 = (
             input: any,

--- a/test/src/generated/output/notation.createPascal/test_notation_createPascal_DynamicNever.ts
+++ b/test/src/generated/output/notation.createPascal/test_notation_createPascal_DynamicNever.ts
@@ -17,8 +17,7 @@ export const test_notation_createValidatePascal_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -48,22 +47,20 @@ export const test_notation_createValidatePascal_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -117,8 +114,7 @@ export const test_notation_createValidatePascal_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -144,22 +140,20 @@ export const test_notation_createValidatePascal_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createPascal/test_notation_createPascal_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.createPascal/test_notation_createPascal_DynamicUndefined.ts
@@ -17,8 +17,7 @@ export const test_notation_createValidatePascal_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -48,22 +47,20 @@ export const test_notation_createValidatePascal_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -121,8 +118,7 @@ export const test_notation_createValidatePascal_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -148,22 +144,20 @@ export const test_notation_createValidatePascal_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createPascal/test_notation_createPascal_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.createPascal/test_notation_createPascal_ObjectDynamic.ts
@@ -17,13 +17,11 @@ export const test_notation_createValidatePascal_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -53,19 +51,16 @@ export const test_notation_createValidatePascal_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -121,13 +116,11 @@ export const test_notation_createValidatePascal_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -153,18 +146,16 @@ export const test_notation_createValidatePascal_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicNever.ts
+++ b/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicNever.ts
@@ -15,8 +15,7 @@ export const test_notation_createValidateSnake_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -46,22 +45,20 @@ export const test_notation_createValidateSnake_DynamicNever =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -115,8 +112,7 @@ export const test_notation_createValidateSnake_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -142,22 +138,20 @@ export const test_notation_createValidateSnake_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicTree.ts
+++ b/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicTree.ts
@@ -23,11 +23,7 @@ export const test_notation_createValidateSnake_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -90,26 +86,24 @@ export const test_notation_createValidateSnake_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -148,9 +142,7 @@ export const test_notation_createValidateSnake_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         const $co0 = (input: any): any => ({
           id: input.id as any,
@@ -195,9 +187,7 @@ export const test_notation_createValidateSnake_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -254,22 +244,20 @@ export const test_notation_createValidateSnake_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.createSnake/test_notation_createSnake_DynamicUndefined.ts
@@ -17,8 +17,7 @@ export const test_notation_createValidateSnake_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true) return null !== value && undefined === value;
-              return true;
+              return null !== value && undefined === value;
             });
           return (
             "object" === typeof input &&
@@ -48,22 +47,20 @@ export const test_notation_createValidateSnake_DynamicUndefined =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          (null !== value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            })) &&
-                          (undefined === value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "undefined",
-                              value: value,
-                            }))
-                        );
-                      return true;
+                      return (
+                        (null !== value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          })) &&
+                        (undefined === value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "undefined",
+                            value: value,
+                          }))
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -119,8 +116,7 @@ export const test_notation_createValidateSnake_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -146,22 +142,20 @@ export const test_notation_createValidateSnake_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createSnake/test_notation_createSnake_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.createSnake/test_notation_createSnake_ObjectDynamic.ts
@@ -17,13 +17,11 @@ export const test_notation_createValidateSnake_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value
+              );
             });
           return (
             "object" === typeof input &&
@@ -53,19 +51,16 @@ export const test_notation_createValidateSnake_ObjectDynamic =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          "string" === typeof value ||
-                          ("number" === typeof value &&
-                            Number.isFinite(value)) ||
-                          "boolean" === typeof value ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "(boolean | number | string)",
-                            value: value,
-                          })
-                        );
-                      return true;
+                      return (
+                        "string" === typeof value ||
+                        ("number" === typeof value && Number.isFinite(value)) ||
+                        "boolean" === typeof value ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "(boolean | number | string)",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -121,13 +116,11 @@ export const test_notation_createValidateSnake_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -153,18 +146,16 @@ export const test_notation_createValidateSnake_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.createSnake/test_notation_createSnake_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/notation.createSnake/test_notation_createSnake_ObjectUnionNonPredictable.ts
@@ -47,9 +47,9 @@ export const test_notation_createValidateSnake_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -375,14 +375,13 @@ export const test_notation_createValidateSnake_ObjectUnionNonPredictable =
         const $cu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $co7(input);
-            else if ($io5(input)) return $co5(input);
-            else if ($io3(input)) return $co3(input);
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input,
-              });
+            if ($io5(input)) return $co5(input);
+            if ($io3(input)) return $co3(input);
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input,
+            });
           })();
         return "object" === typeof input && null !== input
           ? $co0(input)
@@ -426,9 +425,9 @@ export const test_notation_createValidateSnake_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };

--- a/test/src/generated/output/notation.pascal/test_notation_pascal_DynamicNever.ts
+++ b/test/src/generated/output/notation.pascal/test_notation_pascal_DynamicNever.ts
@@ -16,8 +16,7 @@ export const test_notation_validatePascal_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validatePascal_DynamicNever =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -118,8 +115,7 @@ export const test_notation_validatePascal_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -145,22 +141,20 @@ export const test_notation_validatePascal_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.pascal/test_notation_pascal_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.pascal/test_notation_pascal_DynamicUndefined.ts
@@ -16,8 +16,7 @@ export const test_notation_validatePascal_DynamicUndefined =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validatePascal_DynamicUndefined =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -120,8 +117,7 @@ export const test_notation_validatePascal_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -147,22 +143,20 @@ export const test_notation_validatePascal_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.pascal/test_notation_pascal_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.pascal/test_notation_pascal_ObjectDynamic.ts
@@ -16,13 +16,11 @@ export const test_notation_validatePascal_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value
+                );
               });
             return (
               "object" === typeof input &&
@@ -52,19 +50,17 @@ export const test_notation_validatePascal_ObjectDynamic =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            "string" === typeof value ||
-                            ("number" === typeof value &&
-                              Number.isFinite(value)) ||
-                            "boolean" === typeof value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "(boolean | number | string)",
-                              value: value,
-                            })
-                          );
-                        return true;
+                        return (
+                          "string" === typeof value ||
+                          ("number" === typeof value &&
+                            Number.isFinite(value)) ||
+                          "boolean" === typeof value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "(boolean | number | string)",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -120,13 +116,11 @@ export const test_notation_validatePascal_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -152,18 +146,16 @@ export const test_notation_validatePascal_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.snake/test_notation_snake_DynamicNever.ts
+++ b/test/src/generated/output/notation.snake/test_notation_snake_DynamicNever.ts
@@ -16,8 +16,7 @@ export const test_notation_validateSnake_DynamicNever =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validateSnake_DynamicNever =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -118,8 +115,7 @@ export const test_notation_validateSnake_DynamicNever =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -145,22 +141,20 @@ export const test_notation_validateSnake_DynamicNever =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.snake/test_notation_snake_DynamicTree.ts
+++ b/test/src/generated/output/notation.snake/test_notation_snake_DynamicTree.ts
@@ -24,11 +24,9 @@ export const test_notation_validateSnake_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -91,26 +89,24 @@ export const test_notation_validateSnake_DynamicTree =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value && null !== value) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "DynamicTree",
-                                value: value,
-                              })) &&
-                              $vo0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value && null !== value) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected: "DynamicTree",
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vo0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "DynamicTree",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -149,11 +145,7 @@ export const test_notation_validateSnake_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           const $co0 = (input: any): any => ({
             id: input.id as any,
@@ -198,9 +190,7 @@ export const test_notation_validateSnake_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -257,22 +247,20 @@ export const test_notation_validateSnake_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  ((("object" === typeof value && null !== value) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicTree",
-                      value: value,
-                    })) &&
-                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              return (
+                ((("object" === typeof value && null !== value) ||
                   $guard(_exceptionable, {
                     path: _path + $join(key),
                     expected: "DynamicTree",
                     value: value,
-                  })
-                );
-              return true;
+                  })) &&
+                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "DynamicTree",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/notation.snake/test_notation_snake_DynamicUndefined.ts
+++ b/test/src/generated/output/notation.snake/test_notation_snake_DynamicUndefined.ts
@@ -16,8 +16,7 @@ export const test_notation_validateSnake_DynamicUndefined =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true) return null !== value && undefined === value;
-                return true;
+                return null !== value && undefined === value;
               });
             return (
               "object" === typeof input &&
@@ -47,22 +46,20 @@ export const test_notation_validateSnake_DynamicUndefined =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            (null !== value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              })) &&
-                            (undefined === value ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "undefined",
-                                value: value,
-                              }))
-                          );
-                        return true;
+                        return (
+                          (null !== value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            })) &&
+                          (undefined === value ||
+                            $report(_exceptionable, {
+                              path: _path + $join(key),
+                              expected: "undefined",
+                              value: value,
+                            }))
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -118,8 +115,7 @@ export const test_notation_validateSnake_DynamicUndefined =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true) return null !== value && undefined === value;
-            return true;
+            return null !== value && undefined === value;
           });
         return (
           "object" === typeof input &&
@@ -145,22 +141,20 @@ export const test_notation_validateSnake_DynamicUndefined =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  (null !== value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    })) &&
-                  (undefined === value ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "undefined",
-                      value: value,
-                    }))
-                );
-              return true;
+              return (
+                (null !== value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  })) &&
+                (undefined === value ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "undefined",
+                    value: value,
+                  }))
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.snake/test_notation_snake_ObjectDynamic.ts
+++ b/test/src/generated/output/notation.snake/test_notation_snake_ObjectDynamic.ts
@@ -16,13 +16,11 @@ export const test_notation_validateSnake_ObjectDynamic =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "string" === typeof value ||
-                    ("number" === typeof value && Number.isFinite(value)) ||
-                    "boolean" === typeof value
-                  );
-                return true;
+                return (
+                  "string" === typeof value ||
+                  ("number" === typeof value && Number.isFinite(value)) ||
+                  "boolean" === typeof value
+                );
               });
             return (
               "object" === typeof input &&
@@ -52,19 +50,17 @@ export const test_notation_validateSnake_ObjectDynamic =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            "string" === typeof value ||
-                            ("number" === typeof value &&
-                              Number.isFinite(value)) ||
-                            "boolean" === typeof value ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "(boolean | number | string)",
-                              value: value,
-                            })
-                          );
-                        return true;
+                        return (
+                          "string" === typeof value ||
+                          ("number" === typeof value &&
+                            Number.isFinite(value)) ||
+                          "boolean" === typeof value ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "(boolean | number | string)",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -120,13 +116,11 @@ export const test_notation_validateSnake_ObjectDynamic =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value
+            );
           });
         return (
           "object" === typeof input &&
@@ -152,18 +146,16 @@ export const test_notation_validateSnake_ObjectDynamic =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "string" === typeof value ||
-                  ("number" === typeof value && Number.isFinite(value)) ||
-                  "boolean" === typeof value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "(boolean | number | string)",
-                    value: value,
-                  })
-                );
-              return true;
+              return (
+                "string" === typeof value ||
+                ("number" === typeof value && Number.isFinite(value)) ||
+                "boolean" === typeof value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "(boolean | number | string)",
+                  value: value,
+                })
+              );
             });
           return (
             ((("object" === typeof input &&

--- a/test/src/generated/output/notation.snake/test_notation_snake_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/notation.snake/test_notation_snake_ObjectUnionNonPredictable.ts
@@ -48,9 +48,9 @@ export const test_notation_validateSnake_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -377,14 +377,13 @@ export const test_notation_validateSnake_ObjectUnionNonPredictable =
           const $cu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $co7(input);
-              else if ($io5(input)) return $co5(input);
-              else if ($io3(input)) return $co3(input);
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input,
-                });
+              if ($io5(input)) return $co5(input);
+              if ($io3(input)) return $co3(input);
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input,
+              });
             })();
           return "object" === typeof input && null !== input
             ? $co0(input)
@@ -428,9 +427,9 @@ export const test_notation_validateSnake_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };

--- a/test/src/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_DynamicTree.ts
@@ -78,11 +78,9 @@ export const test_protobuf_createAssertDecode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -139,26 +137,24 @@ export const test_protobuf_createAssertDecode_DynamicTree =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value && null !== value) ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "DynamicTree",
-                          value: value,
-                        })) &&
-                        $ao0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value && null !== value) ||
                       $guard(_exceptionable, {
                         path: _path + $join(key),
                         expected: "DynamicTree",
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $ao0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "DynamicTree",
+                      value: value,
+                    })
+                  );
                 });
               return (
                 ((("object" === typeof input && null !== input) ||
@@ -216,9 +212,7 @@ export const test_protobuf_createAssertDecode_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.assertDecode/test_protobuf_assertDecode_ObjectUnionNonPredictable.ts
@@ -227,9 +227,9 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -490,7 +490,7 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -498,7 +498,7 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -506,12 +506,11 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_DynamicTree.ts
@@ -21,11 +21,9 @@ export const test_protobuf_createAssertEncode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -82,26 +80,24 @@ export const test_protobuf_createAssertEncode_DynamicTree =
                 Object.keys(input).every((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value && null !== value) ||
-                        $guard(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "DynamicTree",
-                          value: value,
-                        })) &&
-                        $ao0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value && null !== value) ||
                       $guard(_exceptionable, {
                         path: _path + $join(key),
                         expected: "DynamicTree",
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $ao0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $guard(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "DynamicTree",
+                      value: value,
+                    })
+                  );
                 });
               return (
                 ((("object" === typeof input && null !== input) ||
@@ -156,11 +152,9 @@ export const test_protobuf_createAssertEncode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             //DynamicTree;
             $peo0(input);

--- a/test/src/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.assertEncode/test_protobuf_assertEncode_ObjectUnionNonPredictable.ts
@@ -41,9 +41,9 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -301,7 +301,7 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                     $peo7(input.value);
                     writer.ldelim();
                   })();
-                else if ($io5(input.value))
+                if ($io5(input.value))
                   return (() => {
                     // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                     writer.uint32(18);
@@ -309,7 +309,7 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                     $peo5(input.value);
                     writer.ldelim();
                   })();
-                else if ($io3(input.value))
+                if ($io3(input.value))
                   return (() => {
                     // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                     writer.uint32(26);
@@ -317,12 +317,11 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                     $peo3(input.value);
                     writer.ldelim();
                   })();
-                else
-                  $throws({
-                    expected:
-                      "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                    value: input.value,
-                  });
+                $throws({
+                  expected:
+                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                  value: input.value,
+                });
               })();
             };
             const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_DynamicTree.ts
@@ -77,11 +77,7 @@ export const test_protobuf_createAssertDecode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -138,26 +134,20 @@ export const test_protobuf_createAssertDecode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value && null !== value) ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "DynamicTree",
-                        value: value,
-                      })) &&
-                      $ao0(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value && null !== value) ||
                     $guard(_exceptionable, {
                       path: _path + $join(key),
                       expected: "DynamicTree",
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicTree",
+                    value: value,
+                  })
+                );
               });
             return (
               ((("object" === typeof input && null !== input) ||
@@ -215,9 +205,7 @@ export const test_protobuf_createAssertDecode_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createAssertDecode/test_protobuf_createAssertDecode_ObjectUnionNonPredictable.ts
@@ -226,9 +226,9 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -469,7 +469,7 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -477,7 +477,7 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -485,12 +485,11 @@ export const test_protobuf_createAssertDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_DynamicTree.ts
@@ -20,11 +20,7 @@ export const test_protobuf_createAssertEncode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -81,26 +77,20 @@ export const test_protobuf_createAssertEncode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    ((("object" === typeof value && null !== value) ||
-                      $guard(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "DynamicTree",
-                        value: value,
-                      })) &&
-                      $ao0(
-                        value,
-                        _path + $join(key),
-                        true && _exceptionable,
-                      )) ||
+                return (
+                  ((("object" === typeof value && null !== value) ||
                     $guard(_exceptionable, {
                       path: _path + $join(key),
                       expected: "DynamicTree",
                       value: value,
-                    })
-                  );
-                return true;
+                    })) &&
+                    $ao0(value, _path + $join(key), true && _exceptionable)) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicTree",
+                    value: value,
+                  })
+                );
               });
             return (
               ((("object" === typeof input && null !== input) ||
@@ -155,11 +145,7 @@ export const test_protobuf_createAssertEncode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           //DynamicTree;
           $peo0(input);

--- a/test/src/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createAssertEncode/test_protobuf_createAssertEncode_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -280,7 +280,7 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                   $peo7(input.value);
                   writer.ldelim();
                 })();
-              else if ($io5(input.value))
+              if ($io5(input.value))
                 return (() => {
                   // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                   writer.uint32(18);
@@ -288,7 +288,7 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                   $peo5(input.value);
                   writer.ldelim();
                 })();
-              else if ($io3(input.value))
+              if ($io3(input.value))
                 return (() => {
                   // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                   writer.uint32(26);
@@ -296,12 +296,11 @@ export const test_protobuf_createAssertEncode_ObjectUnionNonPredictable =
                   $peo3(input.value);
                   writer.ldelim();
                 })();
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input.value,
-                });
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input.value,
+              });
             })();
           };
           const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createDecode/test_protobuf_createDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createDecode/test_protobuf_createDecode_DynamicTree.ts
@@ -99,9 +99,7 @@ export const test_protobuf_createDecode_DynamicTree = _test_protobuf_decode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       //DynamicTree;
       $peo0(input);

--- a/test/src/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createDecode/test_protobuf_createDecode_ObjectUnionNonPredictable.ts
@@ -227,7 +227,7 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -235,7 +235,7 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -243,12 +243,11 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createEncode/test_protobuf_createEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createEncode/test_protobuf_createEncode_DynamicTree.ts
@@ -42,9 +42,7 @@ export const test_protobuf_createEncode_DynamicTree = _test_protobuf_encode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       //DynamicTree;
       $peo0(input);

--- a/test/src/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createEncode/test_protobuf_createEncode_ObjectUnionNonPredictable.ts
@@ -43,7 +43,7 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -51,7 +51,7 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -59,12 +59,11 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_protobuf_createIsDecode_DynamicTree = _test_protobuf_isDecode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -123,9 +121,7 @@ export const test_protobuf_createIsDecode_DynamicTree = _test_protobuf_isDecode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       //DynamicTree;
       $peo0(input);

--- a/test/src/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createIsDecode/test_protobuf_createIsDecode_ObjectUnionNonPredictable.ts
@@ -41,9 +41,9 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -273,7 +273,7 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -281,7 +281,7 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -289,12 +289,11 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_DynamicTree.ts
@@ -20,9 +20,7 @@ export const test_protobuf_createIsEncode_DynamicTree = _test_protobuf_isEncode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -62,9 +60,7 @@ export const test_protobuf_createIsEncode_DynamicTree = _test_protobuf_isEncode(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createIsEncode/test_protobuf_createIsEncode_ObjectUnionNonPredictable.ts
@@ -39,9 +39,9 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
         const $iu0 = (input: any): any =>
           (() => {
             if ($io7(input)) return $io7(input);
-            else if ($io5(input)) return $io5(input);
-            else if ($io3(input)) return $io3(input);
-            else return false;
+            if ($io5(input)) return $io5(input);
+            if ($io3(input)) return $io3(input);
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -81,7 +81,7 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                   $peo7(input.value);
                   writer.ldelim();
                 })();
-              else if ($io5(input.value))
+              if ($io5(input.value))
                 return (() => {
                   // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                   writer.uint32(18);
@@ -89,7 +89,7 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                   $peo5(input.value);
                   writer.ldelim();
                 })();
-              else if ($io3(input.value))
+              if ($io3(input.value))
                 return (() => {
                   // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                   writer.uint32(26);
@@ -97,12 +97,11 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                   $peo3(input.value);
                   writer.ldelim();
                 })();
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input.value,
-                });
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input.value,
+              });
             })();
           };
           const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_DynamicTree.ts
@@ -23,11 +23,7 @@ export const test_protobuf_createValidateDecode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -90,26 +86,24 @@ export const test_protobuf_createValidateDecode_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -232,9 +226,7 @@ export const test_protobuf_createValidateDecode_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createValidateDecode/test_protobuf_createValidateDecode_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -516,7 +516,7 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -524,7 +524,7 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -532,12 +532,11 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_DynamicTree.ts
@@ -21,11 +21,7 @@ export const test_protobuf_createValidateEncode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -88,26 +84,24 @@ export const test_protobuf_createValidateEncode_DynamicTree =
                     .map((key: any) => {
                       const value = input[key];
                       if (undefined === value) return true;
-                      if (true)
-                        return (
-                          ((("object" === typeof value && null !== value) ||
-                            $report(_exceptionable, {
-                              path: _path + $join(key),
-                              expected: "DynamicTree",
-                              value: value,
-                            })) &&
-                            $vo0(
-                              value,
-                              _path + $join(key),
-                              true && _exceptionable,
-                            )) ||
+                      return (
+                        ((("object" === typeof value && null !== value) ||
                           $report(_exceptionable, {
                             path: _path + $join(key),
                             expected: "DynamicTree",
                             value: value,
-                          })
-                        );
-                      return true;
+                          })) &&
+                          $vo0(
+                            value,
+                            _path + $join(key),
+                            true && _exceptionable,
+                          )) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicTree",
+                          value: value,
+                        })
+                      );
                     })
                     .every((flag: boolean) => flag),
               ].every((flag: boolean) => flag);
@@ -170,11 +164,7 @@ export const test_protobuf_createValidateEncode_DynamicTree =
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           //DynamicTree;
           $peo0(input);

--- a/test/src/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.createValidateEncode/test_protobuf_createValidateEncode_ObjectUnionNonPredictable.ts
@@ -45,9 +45,9 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -327,7 +327,7 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                   $peo7(input.value);
                   writer.ldelim();
                 })();
-              else if ($io5(input.value))
+              if ($io5(input.value))
                 return (() => {
                   // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                   writer.uint32(18);
@@ -335,7 +335,7 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                   $peo5(input.value);
                   writer.ldelim();
                 })();
-              else if ($io3(input.value))
+              if ($io3(input.value))
                 return (() => {
                   // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                   writer.uint32(26);
@@ -343,12 +343,11 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                   $peo3(input.value);
                   writer.ldelim();
                 })();
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input.value,
-                });
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input.value,
+              });
             })();
           };
           const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.decode/test_protobuf_decode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.decode/test_protobuf_decode_DynamicTree.ts
@@ -100,9 +100,7 @@ export const test_protobuf_createDecode_DynamicTree = _test_protobuf_decode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       //DynamicTree;
       $peo0(input);

--- a/test/src/generated/output/protobuf.decode/test_protobuf_decode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.decode/test_protobuf_decode_ObjectUnionNonPredictable.ts
@@ -228,7 +228,7 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -236,7 +236,7 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -244,12 +244,11 @@ export const test_protobuf_createDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.encode/test_protobuf_encode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.encode/test_protobuf_encode_DynamicTree.ts
@@ -43,9 +43,7 @@ export const test_protobuf_createEncode_DynamicTree = _test_protobuf_encode(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.encode/test_protobuf_encode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.encode/test_protobuf_encode_ObjectUnionNonPredictable.ts
@@ -44,7 +44,7 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                   $peo7(input.value);
                   writer.ldelim();
                 })();
-              else if ($io5(input.value))
+              if ($io5(input.value))
                 return (() => {
                   // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                   writer.uint32(18);
@@ -52,7 +52,7 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                   $peo5(input.value);
                   writer.ldelim();
                 })();
-              else if ($io3(input.value))
+              if ($io3(input.value))
                 return (() => {
                   // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                   writer.uint32(26);
@@ -60,12 +60,11 @@ export const test_protobuf_createEncode_ObjectUnionNonPredictable =
                   $peo3(input.value);
                   writer.ldelim();
                 })();
-              else
-                $throws({
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input.value,
-                });
+              $throws({
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input.value,
+              });
             })();
           };
           const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.isDecode/test_protobuf_isDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.isDecode/test_protobuf_isDecode_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_protobuf_createIsDecode_DynamicTree = _test_protobuf_isDecode(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -124,9 +122,7 @@ export const test_protobuf_createIsDecode_DynamicTree = _test_protobuf_isDecode(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       //DynamicTree;
       $peo0(input);

--- a/test/src/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.isDecode/test_protobuf_isDecode_ObjectUnionNonPredictable.ts
@@ -42,9 +42,9 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -274,7 +274,7 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -282,7 +282,7 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -290,12 +290,11 @@ export const test_protobuf_createIsDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.isEncode/test_protobuf_isEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.isEncode/test_protobuf_isEncode_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_protobuf_createIsEncode_DynamicTree = _test_protobuf_isEncode(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         return "object" === typeof input && null !== input && $io0(input);
       };
@@ -63,11 +61,7 @@ export const test_protobuf_createIsEncode_DynamicTree = _test_protobuf_isEncode(
             Object.keys(input).every((key: any) => {
               const value = input[key];
               if (undefined === value) return true;
-              if (true)
-                return (
-                  "object" === typeof value && null !== value && $io0(value)
-                );
-              return true;
+              return "object" === typeof value && null !== value && $io0(value);
             });
           //DynamicTree;
           $peo0(input);

--- a/test/src/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.isEncode/test_protobuf_isEncode_ObjectUnionNonPredictable.ts
@@ -40,9 +40,9 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
           const $iu0 = (input: any): any =>
             (() => {
               if ($io7(input)) return $io7(input);
-              else if ($io5(input)) return $io5(input);
-              else if ($io3(input)) return $io3(input);
-              else return false;
+              if ($io5(input)) return $io5(input);
+              if ($io3(input)) return $io3(input);
+              return false;
             })();
           return "object" === typeof input && null !== input && $io0(input);
         };
@@ -82,7 +82,7 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                     $peo7(input.value);
                     writer.ldelim();
                   })();
-                else if ($io5(input.value))
+                if ($io5(input.value))
                   return (() => {
                     // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                     writer.uint32(18);
@@ -90,7 +90,7 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                     $peo5(input.value);
                     writer.ldelim();
                   })();
-                else if ($io3(input.value))
+                if ($io3(input.value))
                   return (() => {
                     // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                     writer.uint32(26);
@@ -98,12 +98,11 @@ export const test_protobuf_createIsEncode_ObjectUnionNonPredictable =
                     $peo3(input.value);
                     writer.ldelim();
                   })();
-                else
-                  $throws({
-                    expected:
-                      "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                    value: input.value,
-                  });
+                $throws({
+                  expected:
+                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                  value: input.value,
+                });
               })();
             };
             const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_DynamicTree.ts
@@ -22,11 +22,9 @@ export const test_protobuf_createValidateDecode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -89,26 +87,24 @@ export const test_protobuf_createValidateDecode_DynamicTree =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value && null !== value) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "DynamicTree",
-                                value: value,
-                              })) &&
-                              $vo0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value && null !== value) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected: "DynamicTree",
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vo0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "DynamicTree",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -231,9 +227,7 @@ export const test_protobuf_createValidateDecode_DynamicTree =
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return "object" === typeof value && null !== value && $io0(value);
-            return true;
+            return "object" === typeof value && null !== value && $io0(value);
           });
         //DynamicTree;
         $peo0(input);

--- a/test/src/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.validateDecode/test_protobuf_validateDecode_ObjectUnionNonPredictable.ts
@@ -46,9 +46,9 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -517,7 +517,7 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo7(input.value);
                 writer.ldelim();
               })();
-            else if ($io5(input.value))
+            if ($io5(input.value))
               return (() => {
                 // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                 writer.uint32(18);
@@ -525,7 +525,7 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo5(input.value);
                 writer.ldelim();
               })();
-            else if ($io3(input.value))
+            if ($io3(input.value))
               return (() => {
                 // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                 writer.uint32(26);
@@ -533,12 +533,11 @@ export const test_protobuf_createValidateDecode_ObjectUnionNonPredictable =
                 $peo3(input.value);
                 writer.ldelim();
               })();
-            else
-              $throws({
-                expected:
-                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                value: input.value,
-              });
+            $throws({
+              expected:
+                "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+              value: input.value,
+            });
           })();
         };
         const $peo3 = (input: any): any => {

--- a/test/src/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_DynamicTree.ts
+++ b/test/src/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_DynamicTree.ts
@@ -22,11 +22,9 @@ export const test_protobuf_createValidateEncode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -89,26 +87,24 @@ export const test_protobuf_createValidateEncode_DynamicTree =
                       .map((key: any) => {
                         const value = input[key];
                         if (undefined === value) return true;
-                        if (true)
-                          return (
-                            ((("object" === typeof value && null !== value) ||
-                              $report(_exceptionable, {
-                                path: _path + $join(key),
-                                expected: "DynamicTree",
-                                value: value,
-                              })) &&
-                              $vo0(
-                                value,
-                                _path + $join(key),
-                                true && _exceptionable,
-                              )) ||
+                        return (
+                          ((("object" === typeof value && null !== value) ||
                             $report(_exceptionable, {
                               path: _path + $join(key),
                               expected: "DynamicTree",
                               value: value,
-                            })
-                          );
-                        return true;
+                            })) &&
+                            $vo0(
+                              value,
+                              _path + $join(key),
+                              true && _exceptionable,
+                            )) ||
+                          $report(_exceptionable, {
+                            path: _path + $join(key),
+                            expected: "DynamicTree",
+                            value: value,
+                          })
+                        );
                       })
                       .every((flag: boolean) => flag),
                 ].every((flag: boolean) => flag);
@@ -171,11 +167,9 @@ export const test_protobuf_createValidateEncode_DynamicTree =
               Object.keys(input).every((key: any) => {
                 const value = input[key];
                 if (undefined === value) return true;
-                if (true)
-                  return (
-                    "object" === typeof value && null !== value && $io0(value)
-                  );
-                return true;
+                return (
+                  "object" === typeof value && null !== value && $io0(value)
+                );
               });
             //DynamicTree;
             $peo0(input);

--- a/test/src/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/protobuf.validateEncode/test_protobuf_validateEncode_ObjectUnionNonPredictable.ts
@@ -44,9 +44,9 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
             const $iu0 = (input: any): any =>
               (() => {
                 if ($io7(input)) return $io7(input);
-                else if ($io5(input)) return $io5(input);
-                else if ($io3(input)) return $io3(input);
-                else return false;
+                if ($io5(input)) return $io5(input);
+                if ($io3(input)) return $io3(input);
+                return false;
               })();
             return "object" === typeof input && null !== input && $io0(input);
           };
@@ -326,7 +326,7 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                     $peo7(input.value);
                     writer.ldelim();
                   })();
-                else if ($io5(input.value))
+                if ($io5(input.value))
                   return (() => {
                     // 2 -> ObjectUnionNonPredictable.IWrapper<number>;
                     writer.uint32(18);
@@ -334,7 +334,7 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                     $peo5(input.value);
                     writer.ldelim();
                   })();
-                else if ($io3(input.value))
+                if ($io3(input.value))
                   return (() => {
                     // 3 -> ObjectUnionNonPredictable.IWrapper<boolean>;
                     writer.uint32(26);
@@ -342,12 +342,11 @@ export const test_protobuf_createValidateEncode_ObjectUnionNonPredictable =
                     $peo3(input.value);
                     writer.ldelim();
                   })();
-                else
-                  $throws({
-                    expected:
-                      "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                    value: input.value,
-                  });
+                $throws({
+                  expected:
+                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                  value: input.value,
+                });
               })();
             };
             const $peo3 = (input: any): any => {

--- a/test/src/generated/output/random/test_random_DynamicJsonValue.ts
+++ b/test/src/generated/output/random/test_random_DynamicJsonValue.ts
@@ -90,20 +90,18 @@ export const test_random_DynamicJsonValue = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -149,38 +147,36 @@ export const test_random_DynamicJsonValue = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                null === value ||
-                undefined === value ||
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                (Array.isArray(value) &&
-                  ($aa0(value, _path + $join(key), true && _exceptionable) ||
-                    $guard(_exceptionable, {
-                      path: _path + $join(key),
-                      expected: "DynamicJsonValue.JsonArray",
-                      value: value,
-                    }))) ||
-                ("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                }) ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected:
-                    "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              null === value ||
+              undefined === value ||
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              (Array.isArray(value) &&
+                ($aa0(value, _path + $join(key), true && _exceptionable) ||
+                  $guard(_exceptionable, {
+                    path: _path + $join(key),
+                    expected: "DynamicJsonValue.JsonArray",
+                    value: value,
+                  }))) ||
+              ("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              }) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                value: value,
+              })
+            );
           });
         const $aa0 = (
           input: any,

--- a/test/src/generated/output/random/test_random_DynamicNever.ts
+++ b/test/src/generated/output/random/test_random_DynamicNever.ts
@@ -31,8 +31,7 @@ export const test_random_DynamicNever = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -58,22 +57,20 @@ export const test_random_DynamicNever = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/random/test_random_DynamicTree.ts
+++ b/test/src/generated/output/random/test_random_DynamicTree.ts
@@ -50,9 +50,7 @@ export const test_random_DynamicTree = _test_random("DynamicTree")<DynamicTree>(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -109,22 +107,20 @@ export const test_random_DynamicTree = _test_random("DynamicTree")<DynamicTree>(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value && null !== value) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "DynamicTree",
-                    value: value,
-                  })) &&
-                  $ao0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value && null !== value) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected: "DynamicTree",
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $ao0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "DynamicTree",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/random/test_random_DynamicUndefined.ts
+++ b/test/src/generated/output/random/test_random_DynamicUndefined.ts
@@ -31,8 +31,7 @@ export const test_random_DynamicUndefined = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -58,22 +57,20 @@ export const test_random_DynamicUndefined = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                (null !== value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  })) &&
-                (undefined === value ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected: "undefined",
-                    value: value,
-                  }))
-              );
-            return true;
+            return (
+              (null !== value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                })) &&
+              (undefined === value ||
+                $guard(_exceptionable, {
+                  path: _path + $join(key),
+                  expected: "undefined",
+                  value: value,
+                }))
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/random/test_random_ObjectDynamic.ts
+++ b/test/src/generated/output/random/test_random_ObjectDynamic.ts
@@ -40,13 +40,11 @@ export const test_random_ObjectDynamic = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -72,18 +70,16 @@ export const test_random_ObjectDynamic = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                "string" === typeof value ||
-                ("number" === typeof value && Number.isFinite(value)) ||
-                "boolean" === typeof value ||
-                $guard(_exceptionable, {
-                  path: _path + $join(key),
-                  expected: "(boolean | number | string)",
-                  value: value,
-                })
-              );
-            return true;
+            return (
+              "string" === typeof value ||
+              ("number" === typeof value && Number.isFinite(value)) ||
+              "boolean" === typeof value ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected: "(boolean | number | string)",
+                value: value,
+              })
+            );
           });
         return (
           ((("object" === typeof input &&

--- a/test/src/generated/output/random/test_random_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/random/test_random_ObjectUnionNonPredictable.ts
@@ -83,9 +83,9 @@ export const test_random_ObjectUnionNonPredictable = _test_random(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/random/test_random_UltimateUnion.ts
+++ b/test/src/generated/output/random/test_random_UltimateUnion.ts
@@ -2549,14 +2549,12 @@ export const test_random_UltimateUnion = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -2652,14 +2650,12 @@ export const test_random_UltimateUnion = _test_random(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -3176,13 +3172,13 @@ export const test_random_UltimateUnion = _test_random(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -3213,13 +3209,13 @@ export const test_random_UltimateUnion = _test_random(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -5009,26 +5005,24 @@ export const test_random_UltimateUnion = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                    value: value,
-                  })) &&
-                  $au0(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au0(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                value: value,
+              })
+            );
           });
         const $ao15 = (
           input: any,
@@ -5429,26 +5423,24 @@ export const test_random_UltimateUnion = _test_random(
           Object.keys(input).every((key: any) => {
             const value = input[key];
             if (undefined === value) return true;
-            if (true)
-              return (
-                ((("object" === typeof value &&
-                  null !== value &&
-                  false === Array.isArray(value)) ||
-                  $guard(_exceptionable, {
-                    path: _path + $join(key),
-                    expected:
-                      '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                    value: value,
-                  })) &&
-                  $au1(value, _path + $join(key), true && _exceptionable)) ||
+            return (
+              ((("object" === typeof value &&
+                null !== value &&
+                false === Array.isArray(value)) ||
                 $guard(_exceptionable, {
                   path: _path + $join(key),
                   expected:
                     '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                   value: value,
-                })
-              );
-            return true;
+                })) &&
+                $au1(value, _path + $join(key), true && _exceptionable)) ||
+              $guard(_exceptionable, {
+                path: _path + $join(key),
+                expected:
+                  '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                value: value,
+              })
+            );
           });
         const $ao21 = (
           input: any,

--- a/test/src/generated/output/validate/test_validate_DynamicJsonValue.ts
+++ b/test/src/generated/output/validate/test_validate_DynamicJsonValue.ts
@@ -13,20 +13,18 @@ export const test_validate_DynamicJsonValue = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              null === value ||
-              undefined === value ||
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value ||
-              (Array.isArray(value) && ($ia0(value) || false)) ||
-              ("object" === typeof value &&
-                null !== value &&
-                false === Array.isArray(value) &&
-                $io0(value))
-            );
-          return true;
+          return (
+            null === value ||
+            undefined === value ||
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value ||
+            (Array.isArray(value) && ($ia0(value) || false)) ||
+            ("object" === typeof value &&
+              null !== value &&
+              false === Array.isArray(value) &&
+              $io0(value))
+          );
         });
       const $ia0 = (input: any): any =>
         input.every(
@@ -74,46 +72,44 @@ export const test_validate_DynamicJsonValue = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      null === value ||
-                      undefined === value ||
-                      "string" === typeof value ||
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      "boolean" === typeof value ||
-                      (Array.isArray(value) &&
-                        ($va0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        ) ||
-                          $report(_exceptionable, {
-                            path: _path + $join(key),
-                            expected: "DynamicJsonValue.JsonArray",
-                            value: value,
-                          }))) ||
-                      ("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value) &&
-                        $vo0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                        value: value,
-                      }) ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected:
-                          "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    null === value ||
+                    undefined === value ||
+                    "string" === typeof value ||
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    "boolean" === typeof value ||
+                    (Array.isArray(value) &&
+                      ($va0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      ) ||
+                        $report(_exceptionable, {
+                          path: _path + $join(key),
+                          expected: "DynamicJsonValue.JsonArray",
+                          value: value,
+                        }))) ||
+                    ("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value) &&
+                      $vo0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                      value: value,
+                    }) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        "(DynamicJsonValue.JsonArray | DynamicJsonValue.JsonObject | boolean | null | number | string | undefined)",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validate/test_validate_DynamicNever.ts
+++ b/test/src/generated/output/validate/test_validate_DynamicNever.ts
@@ -13,8 +13,7 @@ export const test_validate_DynamicNever = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -42,22 +41,20 @@ export const test_validate_DynamicNever = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      (null !== value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        })) &&
-                      (undefined === value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        }))
-                    );
-                  return true;
+                  return (
+                    (null !== value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      })) &&
+                    (undefined === value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      }))
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validate/test_validate_DynamicTree.ts
+++ b/test/src/generated/output/validate/test_validate_DynamicTree.ts
@@ -21,9 +21,7 @@ export const test_validate_DynamicTree = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return "object" === typeof value && null !== value && $io0(value);
-          return true;
+          return "object" === typeof value && null !== value && $io0(value);
         });
       return "object" === typeof input && null !== input && $io0(input);
     };
@@ -84,26 +82,24 @@ export const test_validate_DynamicTree = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value && null !== value) ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "DynamicTree",
-                          value: value,
-                        })) &&
-                        $vo0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value && null !== value) ||
                       $report(_exceptionable, {
                         path: _path + $join(key),
                         expected: "DynamicTree",
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $vo0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "DynamicTree",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validate/test_validate_DynamicUndefined.ts
+++ b/test/src/generated/output/validate/test_validate_DynamicUndefined.ts
@@ -13,8 +13,7 @@ export const test_validate_DynamicUndefined = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true) return null !== value && undefined === value;
-          return true;
+          return null !== value && undefined === value;
         });
       return (
         "object" === typeof input &&
@@ -42,22 +41,20 @@ export const test_validate_DynamicUndefined = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      (null !== value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        })) &&
-                      (undefined === value ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected: "undefined",
-                          value: value,
-                        }))
-                    );
-                  return true;
+                  return (
+                    (null !== value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      })) &&
+                    (undefined === value ||
+                      $report(_exceptionable, {
+                        path: _path + $join(key),
+                        expected: "undefined",
+                        value: value,
+                      }))
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validate/test_validate_ObjectDynamic.ts
+++ b/test/src/generated/output/validate/test_validate_ObjectDynamic.ts
@@ -13,13 +13,11 @@ export const test_validate_ObjectDynamic = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "string" === typeof value ||
-              ("number" === typeof value && Number.isFinite(value)) ||
-              "boolean" === typeof value
-            );
-          return true;
+          return (
+            "string" === typeof value ||
+            ("number" === typeof value && Number.isFinite(value)) ||
+            "boolean" === typeof value
+          );
         });
       return (
         "object" === typeof input &&
@@ -47,18 +45,16 @@ export const test_validate_ObjectDynamic = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      "string" === typeof value ||
-                      ("number" === typeof value && Number.isFinite(value)) ||
-                      "boolean" === typeof value ||
-                      $report(_exceptionable, {
-                        path: _path + $join(key),
-                        expected: "(boolean | number | string)",
-                        value: value,
-                      })
-                    );
-                  return true;
+                  return (
+                    "string" === typeof value ||
+                    ("number" === typeof value && Number.isFinite(value)) ||
+                    "boolean" === typeof value ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected: "(boolean | number | string)",
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validate/test_validate_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/validate/test_validate_ObjectUnionNonPredictable.ts
@@ -39,9 +39,9 @@ export const test_validate_ObjectUnionNonPredictable = _test_validate(
       const $iu0 = (input: any): any =>
         (() => {
           if ($io7(input)) return $io7(input);
-          else if ($io5(input)) return $io5(input);
-          else if ($io3(input)) return $io3(input);
-          else return false;
+          if ($io5(input)) return $io5(input);
+          if ($io3(input)) return $io3(input);
+          return false;
         })();
       return "object" === typeof input && null !== input && $io0(input);
     };

--- a/test/src/generated/output/validate/test_validate_ToJsonUnion.ts
+++ b/test/src/generated/output/validate/test_validate_ToJsonUnion.ts
@@ -23,9 +23,9 @@ export const test_validate_ToJsonUnion = _test_validate(
           else
             return (() => {
               if ($io3(input)) return $io3(input);
-              else if ($io2(input)) return $io2(input);
-              else if ($io1(input)) return $io1(input);
-              else return false;
+              if ($io2(input)) return $io2(input);
+              if ($io1(input)) return $io1(input);
+              return false;
             })();
         })();
       return (

--- a/test/src/generated/output/validate/test_validate_UltimateUnion.ts
+++ b/test/src/generated/output/validate/test_validate_UltimateUnion.ts
@@ -414,14 +414,12 @@ export const test_validate_UltimateUnion = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu0(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu0(value)
+          );
         });
       const $io15 = (input: any): boolean =>
         "string" === typeof input.$ref &&
@@ -517,14 +515,12 @@ export const test_validate_UltimateUnion = _test_validate(
         Object.keys(input).every((key: any) => {
           const value = input[key];
           if (undefined === value) return true;
-          if (true)
-            return (
-              "object" === typeof value &&
-              null !== value &&
-              false === Array.isArray(value) &&
-              $iu1(value)
-            );
-          return true;
+          return (
+            "object" === typeof value &&
+            null !== value &&
+            false === Array.isArray(value) &&
+            $iu1(value)
+          );
         });
       const $io21 = (input: any): boolean =>
         Array.isArray(input["enum"]) &&
@@ -1041,13 +1037,13 @@ export const test_validate_UltimateUnion = _test_validate(
           else
             return (() => {
               if ($io5(input)) return $io5(input);
-              else if ($io4(input)) return $io4(input);
-              else if ($io1(input)) return $io1(input);
-              else if ($io6(input)) return $io6(input);
-              else if ($io9(input)) return $io9(input);
-              else if ($io10(input)) return $io10(input);
-              else if ($io18(input)) return $io18(input);
-              else return false;
+              if ($io4(input)) return $io4(input);
+              if ($io1(input)) return $io1(input);
+              if ($io6(input)) return $io6(input);
+              if ($io9(input)) return $io9(input);
+              if ($io10(input)) return $io10(input);
+              if ($io18(input)) return $io18(input);
+              return false;
             })();
         })();
       const $iu1 = (input: any): any =>
@@ -1078,13 +1074,13 @@ export const test_validate_UltimateUnion = _test_validate(
           else
             return (() => {
               if ($io23(input)) return $io23(input);
-              else if ($io22(input)) return $io22(input);
-              else if ($io21(input)) return $io21(input);
-              else if ($io24(input)) return $io24(input);
-              else if ($io26(input)) return $io26(input);
-              else if ($io27(input)) return $io27(input);
-              else if ($io34(input)) return $io34(input);
-              else return false;
+              if ($io22(input)) return $io22(input);
+              if ($io21(input)) return $io21(input);
+              if ($io24(input)) return $io24(input);
+              if ($io26(input)) return $io26(input);
+              if ($io27(input)) return $io27(input);
+              if ($io34(input)) return $io34(input);
+              return false;
             })();
         })();
       return (
@@ -2966,30 +2962,28 @@ export const test_validate_UltimateUnion = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
-                          value: value,
-                        })) &&
-                        $vu0(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $report(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $vu0(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IJsonSchema.IArray | IJsonSchema.IBoolean | IJsonSchema.IEnumeration<"boolean"> | IJsonSchema.IEnumeration<"number"> | IJsonSchema.IEnumeration<"string"> | IJsonSchema.IInteger | IJsonSchema.INullOnly | IJsonSchema.INumber | IJsonSchema.IObject | IJsonSchema.IOneOf | IJsonSchema.IReference | IJsonSchema.IString | IJsonSchema.ITuple | IJsonSchema.IUnknown)',
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);
@@ -3424,30 +3418,28 @@ export const test_validate_UltimateUnion = _test_validate(
                 .map((key: any) => {
                   const value = input[key];
                   if (undefined === value) return true;
-                  if (true)
-                    return (
-                      ((("object" === typeof value &&
-                        null !== value &&
-                        false === Array.isArray(value)) ||
-                        $report(_exceptionable, {
-                          path: _path + $join(key),
-                          expected:
-                            '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
-                          value: value,
-                        })) &&
-                        $vu1(
-                          value,
-                          _path + $join(key),
-                          true && _exceptionable,
-                        )) ||
+                  return (
+                    ((("object" === typeof value &&
+                      null !== value &&
+                      false === Array.isArray(value)) ||
                       $report(_exceptionable, {
                         path: _path + $join(key),
                         expected:
                           '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
                         value: value,
-                      })
-                    );
-                  return true;
+                      })) &&
+                      $vu1(
+                        value,
+                        _path + $join(key),
+                        true && _exceptionable,
+                      )) ||
+                    $report(_exceptionable, {
+                      path: _path + $join(key),
+                      expected:
+                        '(IArray & IIdentified | IBoolean & IIdentified | IEnumeration<"boolean"> & IIdentified | IEnumeration<"number"> & IIdentified | IEnumeration<"string"> & IIdentified | IInteger & IIdentified | INullOnly & IIdentified | INumber & IIdentified | IObject & IIdentified | IOneOf & IIdentified | IReference & IIdentified | IString & IIdentified | ITuple & IIdentified | IUnknown & IIdentified)',
+                      value: value,
+                    })
+                  );
                 })
                 .every((flag: boolean) => flag),
           ].every((flag: boolean) => flag);

--- a/test/src/generated/output/validateEquals/test_validateEquals_ObjectUnionNonPredictable.ts
+++ b/test/src/generated/output/validateEquals/test_validateEquals_ObjectUnionNonPredictable.ts
@@ -115,11 +115,11 @@ export const test_validateEquals_ObjectUnionNonPredictable =
           (() => {
             if ($io7(input, false && _exceptionable))
               return $io7(input, true && _exceptionable);
-            else if ($io5(input, false && _exceptionable))
+            if ($io5(input, false && _exceptionable))
               return $io5(input, true && _exceptionable);
-            else if ($io3(input, false && _exceptionable))
+            if ($io3(input, false && _exceptionable))
               return $io3(input, true && _exceptionable);
-            else return false;
+            return false;
           })();
         return "object" === typeof input && null !== input && $io0(input, true);
       };
@@ -454,17 +454,16 @@ export const test_validateEquals_ObjectUnionNonPredictable =
             (() => {
               if ($vo7(input, _path, false && _exceptionable))
                 return $vo7(input, _path, true && _exceptionable);
-              else if ($vo5(input, _path, false && _exceptionable))
+              if ($vo5(input, _path, false && _exceptionable))
                 return $vo5(input, _path, true && _exceptionable);
-              else if ($vo3(input, _path, false && _exceptionable))
+              if ($vo3(input, _path, false && _exceptionable))
                 return $vo3(input, _path, true && _exceptionable);
-              else
-                return $report(_exceptionable, {
-                  path: _path,
-                  expected:
-                    "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
-                  value: input,
-                });
+              return $report(_exceptionable, {
+                path: _path,
+                expected:
+                  "(ObjectUnionNonPredictable.IWrapper<string> | ObjectUnionNonPredictable.IWrapper<number> | ObjectUnionNonPredictable.IWrapper<boolean>)",
+                value: input,
+              });
             })();
           return (
             ((("object" === typeof input && null !== input) ||

--- a/test/src/generated/output/validateEquals/test_validateEquals_ToJsonUnion.ts
+++ b/test/src/generated/output/validateEquals/test_validateEquals_ToJsonUnion.ts
@@ -60,11 +60,11 @@ export const test_validateEquals_ToJsonUnion = _test_validateEquals(
             return (() => {
               if ($io3(input, false && _exceptionable))
                 return $io3(input, true && _exceptionable);
-              else if ($io2(input, false && _exceptionable))
+              if ($io2(input, false && _exceptionable))
                 return $io2(input, true && _exceptionable);
-              else if ($io1(input, false && _exceptionable))
+              if ($io1(input, false && _exceptionable))
                 return $io1(input, true && _exceptionable);
-              else return false;
+              return false;
             })();
         })();
       return (
@@ -222,17 +222,16 @@ export const test_validateEquals_ToJsonUnion = _test_validateEquals(
               return (() => {
                 if ($vo3(input, _path, false && _exceptionable))
                   return $vo3(input, _path, true && _exceptionable);
-                else if ($vo2(input, _path, false && _exceptionable))
+                if ($vo2(input, _path, false && _exceptionable))
                   return $vo2(input, _path, true && _exceptionable);
-                else if ($vo1(input, _path, false && _exceptionable))
+                if ($vo1(input, _path, false && _exceptionable))
                   return $vo1(input, _path, true && _exceptionable);
-                else
-                  return $report(_exceptionable, {
-                    path: _path,
-                    expected:
-                      "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
-                    value: input,
-                  });
+                return $report(_exceptionable, {
+                  path: _path,
+                  expected:
+                    "(ToJsonUnion.IWrapper<ToJsonUnion.IProduct> | ToJsonUnion.IWrapper<ToJsonUnion.ICitizen> | ToJsonUnion.IWrapper<boolean>)",
+                  value: input,
+                });
               })();
           })();
         return (


### PR DESCRIPTION
No more generate such unreachable code:

```typescript
const $ao2 = (
  input: any,
  _path: string,
  _exceptionable: boolean = true,
): boolean =>
  false === _exceptionable ||
  Object.keys(input).every((key: any) => {
    const value = input[key];
    if (undefined === value) return true;
    if (true)
      return (
        "number" === typeof value ||
        $guard(_exceptionable, {
          path: _path + $join(key),
          expected: "number",
          value: value,
        })
      );
    return $guard(_exceptionable, {
      path: _path + $join(key),
      expected: "undefined",
      value: value,
    });
  });
```
