### PR TITLE
Fix #974 - roll back to the previous `$string` function.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.10.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.11.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.10.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.11.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.4.10",
+  "version": "5.4.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.4.10",
+  "version": "5.4.11",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.4.10"
+    "typia": "5.4.11"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/functional/$string.ts
+++ b/src/functional/$string.ts
@@ -12,17 +12,13 @@
  * @blog https://dev.to/samchon/good-bye-typescript-is-ancestor-of-typia-20000x-faster-validator-49fi
  */
 export const $string = (str: string): string => {
-  if (STR_ESCAPE.test(str) === false) return `"${str}"`;
-
-  const length: number = str.length;
-  if (length > 41) return JSON.stringify(str);
-
+  const len = str.length;
   let result = "";
   let last = -1;
   let point = 255;
 
   // eslint-disable-next-line
-  for (let i = 0; i < length; ++i) {
+  for (var i = 0; i < len; i++) {
     point = str.charCodeAt(i);
     if (point < 32) {
       return JSON.stringify(str);
@@ -45,6 +41,3 @@ export const $string = (str: string): string => {
     (last === -1 && '"' + str + '"') || '"' + result + str.slice(last) + '"'
   );
 };
-
-const STR_ESCAPE =
-  /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/;

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.4.10.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.4.11.tgz"
   }
 }


### PR DESCRIPTION
As current string to JSON string serialization function is not good for non-optimized case, I rolled back it to the previous logic, a little bit faster when non-optimized case.
