### PR TITLE
docs: fix typo

### DIFF
--- a/website/pages/docs/validators/tags.mdx
+++ b/website/pages/docs/validators/tags.mdx
@@ -206,7 +206,7 @@ For reference, when you take a mistake that choosing different target type, Type
       - `json-pointer`
       - `relative-json-pointer`
 
-Also, if you need custom validation logic, just make it by yourself referencing [Customization](#customzation) section. It is easy to define. For such type safety and generous use case reasons even customization supporting, I recommend you to use type tags instead of [comment tags](#comment-tags), unless you are maintaining a legacy JSDoc styled project.
+Also, if you need custom validation logic, just make it by yourself referencing [Customization](#customization) section. It is easy to define. For such type safety and generous use case reasons even customization supporting, I recommend you to use type tags instead of [comment tags](#comment-tags), unless you are maintaining a legacy JSDoc styled project.
 
 <Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
   <Tab>


### PR DESCRIPTION
Found the link wasn't working when clicking on it