### PR TITLE
Fix samchon/nestia#859: JSON schema of dynamic object.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.5.7.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.5.8.tgz"
   }
 }

--- a/debug/features/dynamic.ts
+++ b/debug/features/dynamic.ts
@@ -1,0 +1,11 @@
+import typia from "typia";
+
+console.log(
+  JSON.stringify(
+    typia.json.application<
+      [Record<string, boolean | number | string | { x: number }>]
+    >(),
+    null,
+    2,
+  ),
+);

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia@master\\typia-5.5.7-dev.20240320.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.5.8-dev.20240402.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-5.5.7.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.5.8.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "5.5.7"
+    "typia": "5.5.8"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/programmers/internal/application_object.ts
+++ b/src/programmers/internal/application_object.ts
@@ -159,7 +159,9 @@ const create_object_schema =
               "x-typia-patternProperties": extraProps.patternProperties,
               additionalProperties: join(options)(components)(extraMeta),
             }
-          : {}),
+          : {
+              additionalProperties: join(options)(components)(extraMeta),
+            }),
     };
   };
 

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-5.5.7.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-5.5.8.tgz"
   }
 }

--- a/test/schemas/json/swagger_standard/DynamicArray.json
+++ b/test/schemas/json/swagger_standard/DynamicArray.json
@@ -12,7 +12,13 @@
           "value": {
             "type": "object",
             "properties": {},
-            "nullable": false
+            "nullable": false,
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger_standard/DynamicComposite.json
+++ b/test/schemas/json/swagger_standard/DynamicComposite.json
@@ -20,7 +20,20 @@
         "required": [
           "id",
           "name"
-        ]
+        ],
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
       }
     }
   },

--- a/test/schemas/json/swagger_standard/DynamicSimple.json
+++ b/test/schemas/json/swagger_standard/DynamicSimple.json
@@ -12,7 +12,10 @@
           "value": {
             "type": "object",
             "properties": {},
-            "nullable": false
+            "nullable": false,
+            "additionalProperties": {
+              "type": "number"
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/swagger_standard/DynamicTemplate.json
+++ b/test/schemas/json/swagger_standard/DynamicTemplate.json
@@ -9,7 +9,20 @@
       "DynamicTemplate": {
         "type": "object",
         "properties": {},
-        "nullable": false
+        "nullable": false,
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
       }
     }
   },

--- a/test/schemas/json/swagger_standard/DynamicTree.json
+++ b/test/schemas/json/swagger_standard/DynamicTree.json
@@ -30,7 +30,10 @@
         "type": "object",
         "properties": {},
         "nullable": false,
-        "description": "Construct a type with a set of properties K of type T"
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/DynamicTree"
+        }
       }
     }
   },

--- a/test/schemas/json/swagger_standard/DynamicUnion.json
+++ b/test/schemas/json/swagger_standard/DynamicUnion.json
@@ -9,7 +9,17 @@
       "DynamicUnion": {
         "type": "object",
         "properties": {},
-        "nullable": false
+        "nullable": false,
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       }
     }
   },

--- a/test/schemas/json/swagger_standard/ObjectDynamic.json
+++ b/test/schemas/json/swagger_standard/ObjectDynamic.json
@@ -9,7 +9,20 @@
       "ObjectDynamic": {
         "type": "object",
         "properties": {},
-        "nullable": false
+        "nullable": false,
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
       }
     }
   },

--- a/test/schemas/json/swagger_standard/UltimateUnion.json
+++ b/test/schemas/json/swagger_standard/UltimateUnion.json
@@ -869,7 +869,10 @@
         "type": "object",
         "properties": {},
         "nullable": false,
-        "description": "Construct a type with a set of properties K of type T"
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/IJsonSchema"
+        }
       },
       "IJsonSchema.IReference": {
         "type": "object",
@@ -1028,7 +1031,10 @@
         "type": "object",
         "properties": {},
         "nullable": false,
-        "description": "Construct a type with a set of properties K of type T"
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/IJsonComponents.IAlias"
+        }
       },
       "IJsonComponents.IAlias": {
         "oneOf": [

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicArray.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicArray.ts
@@ -23,6 +23,12 @@ export const test_json_application_swagger_standard_DynamicArray =
               type: "object",
               properties: {},
               nullable: false,
+              additionalProperties: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
             },
           },
           nullable: false,

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicComposite.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicComposite.ts
@@ -28,6 +28,19 @@ export const test_json_application_swagger_standard_DynamicComposite =
           },
           nullable: false,
           required: ["id", "name"],
+          additionalProperties: {
+            oneOf: [
+              {
+                type: "number",
+              },
+              {
+                type: "string",
+              },
+              {
+                type: "boolean",
+              },
+            ],
+          },
         },
       },
     },

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicSimple.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicSimple.ts
@@ -23,6 +23,9 @@ export const test_json_application_swagger_standard_DynamicSimple =
               type: "object",
               properties: {},
               nullable: false,
+              additionalProperties: {
+                type: "number",
+              },
             },
           },
           nullable: false,

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicTemplate.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicTemplate.ts
@@ -20,6 +20,19 @@ export const test_json_application_swagger_standard_DynamicTemplate =
           type: "object",
           properties: {},
           nullable: false,
+          additionalProperties: {
+            oneOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+              {
+                type: "boolean",
+              },
+            ],
+          },
         },
       },
     },

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicTree.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicTree.ts
@@ -37,6 +37,9 @@ export const test_json_application_swagger_standard_DynamicTree =
           properties: {},
           nullable: false,
           description: "Construct a type with a set of properties K of type T",
+          additionalProperties: {
+            $ref: "#/components/schemas/DynamicTree",
+          },
         },
       },
     },

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicUnion.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_DynamicUnion.ts
@@ -20,6 +20,16 @@ export const test_json_application_swagger_standard_DynamicUnion =
           type: "object",
           properties: {},
           nullable: false,
+          additionalProperties: {
+            oneOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
         },
       },
     },

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_ObjectDynamic.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_ObjectDynamic.ts
@@ -20,6 +20,19 @@ export const test_json_application_swagger_standard_ObjectDynamic =
           type: "object",
           properties: {},
           nullable: false,
+          additionalProperties: {
+            oneOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+              {
+                type: "boolean",
+              },
+            ],
+          },
         },
       },
     },

--- a/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_UltimateUnion.ts
+++ b/test/src/generated/output/json.application/swagger_standard/test_json_application_swagger_standard_UltimateUnion.ts
@@ -809,6 +809,9 @@ export const test_json_application_swagger_standard_UltimateUnion =
           properties: {},
           nullable: false,
           description: "Construct a type with a set of properties K of type T",
+          additionalProperties: {
+            $ref: "#/components/schemas/IJsonSchema",
+          },
         },
         "IJsonSchema.IReference": {
           type: "object",
@@ -960,6 +963,9 @@ export const test_json_application_swagger_standard_UltimateUnion =
           properties: {},
           nullable: false,
           description: "Construct a type with a set of properties K of type T",
+          additionalProperties: {
+            $ref: "#/components/schemas/IJsonComponents.IAlias",
+          },
         },
         "IJsonComponents.IAlias": {
           oneOf: [

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^0.10.0",
     "tstl": "^3.0.0",
     "typescript": "^5.4.2",
-    "typia": "^5.5.7"
+    "typia": "^5.5.8"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
When dynamic object type comes, `typia.json.application<Types>()` function could not parse it exactly. 

This PR fixes the bug, so that `IJsonSchema.IObject.additionalProperties` be parsed exactly.
