### PR TITLE
Fix bug of `application_plugin()` function.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.1.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-6.0.2.tgz"
   }
 }

--- a/debug/features/schema.ts
+++ b/debug/features/schema.ts
@@ -1,34 +1,11 @@
 import typia, { tags } from "typia";
 
-type Monetary<Value extends string> = tags.TagBase<{
-  target: "number";
-  kind: "monetary";
-  value: Value;
-  schema: {
-    "x-monetary": Value;
-  };
-}>;
-
-type Placeholder<Value extends string> = tags.TagBase<{
-  target: "string";
-  kind: "placeholder";
-  value: Value;
-  schema: {
-    "x-placeholder": Value;
-  };
-}>;
-
-console.log(
-  JSON.stringify(
-    typia.json.application<
-      [
-        number & Monetary<"dollar">,
-        string &
-          tags.Format<"email"> &
-          Placeholder<"Insert your email address please">,
-      ]
-    >(),
-    null,
-    2,
-  ),
-);
+const app =
+  typia.json.application<
+    [
+      string & tags.Format<"uuid">,
+      number & tags.Minimum<3>,
+      number & tags.Type<"int32">,
+    ]
+  >();
+console.log(app.schemas);

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.0.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-6.0.2.tgz"
   }
 }

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -93,7 +93,7 @@ const main = (): void => {
   test(version)("test")(
     tag === "tgz" && process.argv[3] === "template"
       ? ["npm run template", "npm run build", "npm start"]
-      : ["npm run build:actions", "npm start"],
+      : ["npm run build", "npm start"],
   );
   test(version)("errors")(["npm start"]);
   test(version)("benchmark")(["npm run build"]);

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.1.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-6.0.2.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -65,7 +65,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^0.1.4",
+    "@samchon/openapi": "^0.1.12",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.0.1"
+    "typia": "6.0.2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/programmers/internal/application_plugin.ts
+++ b/src/programmers/internal/application_plugin.ts
@@ -10,7 +10,7 @@ export const application_plugin = <Schema extends object>(
   const plugins: IMetadataTypeTag[][] = tags
     .map((row) => row.filter((t) => t.schema !== undefined))
     .filter((row) => row.length !== 0);
-  if (tags.length === 0) return [schema];
+  if (plugins.length === 0) return [schema];
   return plugins.map((row) => {
     const base: Schema = { ...schema };
     for (const tag of row) Object.assign(base, tag.schema);

--- a/src/schemas/metadata/MetadataAtomic.ts
+++ b/src/schemas/metadata/MetadataAtomic.ts
@@ -37,6 +37,7 @@ export class MetadataAtomic {
               : tag.value,
           validate: tag.validate,
           exclusive: tag.exclusive,
+          schema: tag.schema,
         })),
       ),
     });

--- a/test/package.json
+++ b/test/package.json
@@ -10,8 +10,7 @@
     }
   },
   "scripts": {
-    "build": "rimraf bin && node --max-old-space-size=8192 node_modules/typescript/bin/tsc",
-    "build:actions": "rimraf bin && tsc -p tsconfig.actions.json",
+    "build": "rimraf bin && tsc",
     "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",
@@ -44,7 +43,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@samchon/openapi": "^0.1.5",
+    "@samchon/openapi": "^0.1.12",
     "cli": "^1.0.1",
     "protobufjs": "^7.2.5",
     "randexp": "^0.5.3",
@@ -52,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.1.tgz"
+    "typia": "D:\\github\\samchon\\typia\\typia-6.0.2.tgz"
   }
 }

--- a/test/schemas/json/v3_0/CommentTagType.json
+++ b/test/schemas/json/v3_0/CommentTagType.json
@@ -19,8 +19,43 @@
       },
       "CommentTagType.Type": {
         "type": "object",
-        "properties": {},
-        "nullable": false
+        "properties": {
+          "int": {
+            "type": "number",
+            "title": "Integer value",
+            "description": "Integer value."
+          },
+          "uint": {
+            "type": "number",
+            "title": "Unsigned integer value",
+            "description": "Unsigned integer value."
+          },
+          "int32": {
+            "type": "number"
+          },
+          "uint32": {
+            "type": "number"
+          },
+          "int64": {
+            "type": "number"
+          },
+          "uint64": {
+            "type": "number"
+          },
+          "float": {
+            "type": "number"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "int",
+          "uint",
+          "int32",
+          "uint32",
+          "int64",
+          "uint64",
+          "float"
+        ]
       }
     }
   },

--- a/test/schemas/json/v3_0/UltimateUnion.json
+++ b/test/schemas/json/v3_0/UltimateUnion.json
@@ -44,10 +44,7 @@
             "$ref": "#/components/schemas/RecordstringOpenApi.ISecurityScheme"
           }
         },
-        "nullable": false,
-        "required": [
-          "schemas"
-        ]
+        "nullable": false
       },
       "RecordstringOpenApi.IJsonSchema": {
         "type": "object",
@@ -159,11 +156,23 @@
       "OpenApi.IJsonSchema.IInteger": {
         "type": "object",
         "properties": {
+          "default": {
+            "type": "number"
+          },
+          "minimum": {
+            "type": "number"
+          },
+          "maximum": {
+            "type": "number"
+          },
           "exclusiveMinimum": {
             "type": "boolean"
           },
           "exclusiveMaximum": {
             "type": "boolean"
+          },
+          "multipleOf": {
+            "type": "number"
           },
           "type": {
             "type": "string",
@@ -249,6 +258,12 @@
           "pattern": {
             "type": "string"
           },
+          "minLength": {
+            "type": "number"
+          },
+          "maxLength": {
+            "type": "number"
+          },
           "type": {
             "type": "string",
             "enum": [
@@ -275,6 +290,12 @@
         "properties": {
           "items": {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema"
+          },
+          "minItems": {
+            "type": "number"
+          },
+          "maxItems": {
+            "type": "number"
           },
           "type": {
             "type": "string",
@@ -349,6 +370,12 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ]
+          },
+          "minItems": {
+            "type": "number"
+          },
+          "maxItems": {
+            "type": "number"
           },
           "type": {
             "type": "string",

--- a/test/schemas/json/v3_1/CommentTagType.json
+++ b/test/schemas/json/v3_1/CommentTagType.json
@@ -18,7 +18,42 @@
       },
       "CommentTagType.Type": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "int": {
+            "type": "number",
+            "title": "Integer value",
+            "description": "Integer value."
+          },
+          "uint": {
+            "type": "number",
+            "title": "Unsigned integer value",
+            "description": "Unsigned integer value."
+          },
+          "int32": {
+            "type": "number"
+          },
+          "uint32": {
+            "type": "number"
+          },
+          "int64": {
+            "type": "number"
+          },
+          "uint64": {
+            "type": "number"
+          },
+          "float": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "int",
+          "uint",
+          "int32",
+          "uint32",
+          "int64",
+          "uint64",
+          "float"
+        ]
       }
     }
   },

--- a/test/schemas/json/v3_1/UltimateUnion.json
+++ b/test/schemas/json/v3_1/UltimateUnion.json
@@ -39,10 +39,7 @@
           "securitySchemes": {
             "$ref": "#/components/schemas/RecordstringOpenApi.ISecurityScheme"
           }
-        },
-        "required": [
-          "schemas"
-        ]
+        }
       },
       "RecordstringOpenApi.IJsonSchema": {
         "type": "object",
@@ -148,11 +145,23 @@
       "OpenApi.IJsonSchema.IInteger": {
         "type": "object",
         "properties": {
+          "default": {
+            "type": "number"
+          },
+          "minimum": {
+            "type": "number"
+          },
+          "maximum": {
+            "type": "number"
+          },
           "exclusiveMinimum": {
             "type": "boolean"
           },
           "exclusiveMaximum": {
             "type": "boolean"
+          },
+          "multipleOf": {
+            "type": "number"
           },
           "type": {
             "const": "integer"
@@ -230,6 +239,12 @@
           "pattern": {
             "type": "string"
           },
+          "minLength": {
+            "type": "number"
+          },
+          "maxLength": {
+            "type": "number"
+          },
           "type": {
             "const": "string"
           },
@@ -252,6 +267,12 @@
         "properties": {
           "items": {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema"
+          },
+          "minItems": {
+            "type": "number"
+          },
+          "maxItems": {
+            "type": "number"
           },
           "type": {
             "const": "array"
@@ -322,6 +343,12 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ]
+          },
+          "minItems": {
+            "type": "number"
+          },
+          "maxItems": {
+            "type": "number"
           },
           "type": {
             "const": "array"

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -243,7 +243,7 @@
             "value": {
               "any": false,
               "required": true,
-              "optional": false,
+              "optional": true,
               "nullable": false,
               "functional": false,
               "atomics": [],
@@ -1224,17 +1224,7 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": [
-              {
-                "name": "type",
-                "text": [
-                  {
-                    "text": "int",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ]
+            "jsDocTags": []
           },
           {
             "key": {
@@ -1290,17 +1280,7 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": [
-              {
-                "name": "type",
-                "text": [
-                  {
-                    "text": "int",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ]
+            "jsDocTags": []
           },
           {
             "key": {

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^0.10.2",
     "tstl": "^3.0.0",
     "typescript": "^5.4.5",
-    "typia": "^6.0.1"
+    "typia": "^6.0.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
When type tags being utilized, but none of them has the `schema` property, `typia.json.application<T>()` failed to generate the JSON schema with "invalid type on argument" error message.

The bug has occured by mistake on the filter implementation of `application_plugin()` function. This PR fixes the bug, so that same error would not be occured again.
