### PR TITLE
Fix dependabot tgz wrong path bug

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -73,6 +73,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.4.tgz"
+    "typia": "../typia-6.0.4.tgz"
   }
 }

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import cp from "child_process";
 import fs from "fs";
-import path from "path";
 
 import { ReplicaPublisher } from "./internal/ReplicaPublisher";
 
@@ -57,9 +56,7 @@ const test =
 
     const pack: any = JSON.parse(fs.readFileSync("package.json", "utf8"));
     pack.dependencies ??= {};
-    pack.dependencies.typia = path.resolve(
-      `${__dirname}/../typia-${version}.tgz`,
-    );
+    pack.dependencies.typia = `../typia-${version}.tgz`;
     fs.writeFileSync("package.json", JSON.stringify(pack, null, 2), "utf8");
 
     if (commands.length) {

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "D:\\github\\samchon\\typia\\typia-6.0.4.tgz"
+    "typia": "../typia-6.0.4.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "D:\github\samchon\typia\typia-6.0.4.tgz"
+    "typia": "../typia-6.0.4.tgz"
   }
 }


### PR DESCRIPTION
Whenever dependabot sends a PR of dependencies, `test/package.json` file had occured invalid path bug.

This PR fixes the bug by changing the `test/package.json` to have relative `tgz` path.