### PR TITLE
fix(website/setup.mdx): add typia installation step for pnpm/yarn

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -601,6 +601,7 @@ npx typia setup
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 pnpm dlx jsr add -D @ryoppippi/unplugin-typia
+pnpm install typia
 pnpm typia setup --manager pnpm
 ```
   </Tab>
@@ -608,6 +609,7 @@ pnpm typia setup --manager pnpm
 ```bash filename="Terminal" showLineNumbers copy
 # YARN BERRY IS NOT SUPPORTED
 yarn dlx jsr add -D @ryoppippi/unplugin-typia
+yarn add typia
 yarn typia setup --manager yarn
 ```
   </Tab>


### PR DESCRIPTION

Sorry, I missed that.
The part about installing typia with pnpm and yarn was missing, so I added it.