### PR TITLE
feat: Add exports field to package.json/ fix rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,42 @@
     "lib",
     "src"
   ],
-  "private": true
+  "private": true,
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "bun": "./src/index.ts",
+        "node": "./lib/index.js",
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./lib": {
+        "bun": "./src/index.ts",
+        "node": "./lib/index.js",
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./lib/transform": {
+        "bun": "./src/transform.ts",
+        "node": "./lib/transform.js",
+        "import": "./lib/transform.mjs",
+        "require": "./lib/transform.js",
+        "types": "./lib/transform.d.ts",
+        "default": "./lib/transform.js"
+      },
+      "./lib/executable/*.js": {
+        "bun": "./src/executable/*.ts",
+        "node": "./lib/executable/*.js",
+        "import": "./lib/executable/*.mjs",
+        "require": "./lib/executable/*.js",
+        "types": "./lib/executable/*.d.ts",
+        "default": "./lib/executable/*.js"
+      },
+      "./package.json": "./package.json"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "rimraf": "^5.0.5",
     "rollup": "^4.18.0",
     "suppress-warnings": "^1.0.2",
+    "tiny-glob": "^0.2.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -130,9 +130,6 @@
         "default": "./lib/transform.js"
       },
       "./lib/executable/*.js": {
-        "bun": "./src/executable/*.ts",
-        "node": "./lib/executable/*.js",
-        "import": "./lib/executable/*.mjs",
         "require": "./lib/executable/*.js",
         "types": "./lib/executable/*.d.ts",
         "default": "./lib/executable/*.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,29 +1,50 @@
 const typescript = require("@rollup/plugin-typescript");
 const terser = require("@rollup/plugin-terser");
 
-module.exports = {
-  input: "./src/index.ts",
-  output: {
-    dir: "lib",
-    format: "esm",
-    entryFileNames: "[name].mjs",
-    sourcemap: true,
-  },
-  plugins: [
-    typescript({
-      tsconfig: "tsconfig.json",
-      module: "ES2020",
-      target: "ES2020",
-    }),
-    terser({
-      format: {
-        comments: "some",
-        beautify: true,
-        ecma: "2020",
-      },
-      compress: false,
-      mangle: false,
-      module: true,
-    }),
-  ],
+const glob = require("glob");
+
+const input = glob.sync("src/**/*.ts");
+
+const outputConfig = {
+  dir: "lib",
+  sourcemap: true,
+  preserveModules: true,
 };
+
+const plugins = [
+  typescript({
+    tsconfig: "tsconfig.json",
+    module: "ES2020",
+    target: "ES2020",
+  }),
+  terser({
+    format: {
+      comments: "some",
+      beautify: true,
+      ecma: "2020",
+    },
+    compress: false,
+    mangle: false,
+    module: true,
+  }),
+];
+
+module.exports = [
+  {
+    input,
+    output: {
+      ...outputConfig,
+      entryFileNames: "[name].mjs",
+      format: "esm",
+    },
+    plugins,
+  },
+  {
+    input,
+    output: {
+      ...outputConfig,
+      format: "cjs",
+    },
+    plugins,
+  },
+];

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,16 +1,18 @@
-const typescript = require("@rollup/plugin-typescript");
-const terser = require("@rollup/plugin-terser");
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import glob from "tiny-glob";
 
-const glob = require("glob");
+/** @type {import('rollup').InputOptions} */
+const input = await glob("src/**/*.ts");
 
-const input = glob.sync("src/**/*.ts");
-
+/** @type {import('rollup').OutputOptions} */
 const outputConfig = {
   dir: "lib",
   sourcemap: true,
   preserveModules: true,
 };
 
+/** @type {import('rollup').Plugin[]} */
 const plugins = [
   typescript({
     tsconfig: "tsconfig.json",
@@ -29,7 +31,8 @@ const plugins = [
   }),
 ];
 
-module.exports = [
+/** @type {import('rollup').RollupOptions[]} */
+export default [
   {
     input,
     output: {


### PR DESCRIPTION
Related to #1078
In this PR.
- You can set the `exports` filed only when published, so that only the appropriate ones are published.
- The exports are set to publishConfig. This means that internal packages can also be used in test, but direct import is no longer possible once published
- The `exports` filed allows you to read the typescript directly when using `bun`, so that the build does not fail!
- rollup has been re-configured to generate `mjs` files according to the directory structure

related: #1078 



======

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)


