### PR TITLE
feat: Add support for 'bun' package manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
       - uses: actions/cache@v4
         with:
           path: ~/.npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,13 @@ on:
     paths:
       - 'src/**'
       - 'test/**'
+      - 'test-esm/**'
       - 'package.json'
   pull_request:
     paths:
       - 'src/**'
       - 'test/**'
+      - 'test-esm/**'
       - 'package.json'
 jobs:
   Ubuntu:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 packages/typescript-json/src/
 package-lock.json
 pnpm-lock.yaml
+bun.lockb
 
 *.log
 *.tgz

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import cp from "child_process";
+import $ from "dax-sh";
 import fs from "fs";
 
 import { ReplicaPublisher } from "./internal/ReplicaPublisher";
@@ -73,16 +74,12 @@ const title = (label: string): void => {
   console.log("---------------------------------------------------------");
 };
 
-const detectComanndAvailable = (command: string): boolean => {
-  try {
-    cp.execSync(`which ${command}`);
-    return true;
-  } catch {
-    return false;
-  }
+const detectComanndAvailable = async (command: string): Promise<boolean> => {
+  const path = await $.which(command);
+  return path !== null;
 };
 
-const main = (): void => {
+const main = async (): Promise<void> => {
   const tag: string | undefined = process.argv[2];
   if (tag === undefined) {
     console.log("specify tag name like latest or next");
@@ -103,7 +100,7 @@ const main = (): void => {
   );
   test(version)("test-esm")(["npm run build", "npm start"]);
   /* if bun is available, test with bun */
-  if (detectComanndAvailable("bun")) {
+  if (await detectComanndAvailable("bun")) {
     test(version)("test")(["bun --bun run build_run", "bun --bun run start"]);
     test(version)("test-esm")(["bun --bun run build", "bun --bun run start"]);
   }

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -73,6 +73,15 @@ const title = (label: string): void => {
   console.log("---------------------------------------------------------");
 };
 
+const detectComanndAvailable = (command: string): boolean => {
+  try {
+    cp.execSync(`which ${command}`);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const main = (): void => {
   const tag: string | undefined = process.argv[2];
   if (tag === undefined) {
@@ -93,6 +102,11 @@ const main = (): void => {
       : ["npm run build", "npm start"],
   );
   test(version)("test-esm")(["npm run build", "npm start"]);
+  /* if bun is available, test with bun */
+  if (detectComanndAvailable("bun")) {
+    test(version)("test")(["bun --bun run build_run", "bun --bun run start"]);
+    test(version)("test-esm")(["bun --bun run build", "bun --bun run start"]);
+  }
   test(version)("errors")(["npm start"]);
   test(version)("benchmark")(["npm run build"]);
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
     "chalk": "^4.0.0",
+    "dax-sh": "^0.41.0",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "rollup": "^4.18.0",

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -7,7 +7,7 @@ import { PluginConfigurator } from "./setup/PluginConfigurator";
 
 export namespace TypiaSetupWizard {
   export interface IArguments {
-    manager: "npm" | "pnpm" | "yarn";
+    manager: "npm" | "pnpm" | "yarn" | "bun";
     project: string | null;
   }
 
@@ -138,6 +138,7 @@ export namespace TypiaSetupWizard {
         [
           "npm" as const,
           "pnpm" as const,
+          "bun" as const,
           "yarn (berry is not supported)" as "yarn",
         ],
         (value) => value.split(" ")[0] as "yarn",

--- a/src/executable/setup/PackageManager.ts
+++ b/src/executable/setup/PackageManager.ts
@@ -4,8 +4,24 @@ import path from "path";
 import { CommandExecutor } from "./CommandExecutor";
 import { FileRetriever } from "./FileRetriever";
 
+const managers = ["npm", "pnpm", "yarn", "bun"] as const;
+type Manager = (typeof managers)[number];
+
+const installCmdTable = {
+  npm: "install",
+  pnpm: "add",
+  yarn: "add",
+  bun: "add",
+} as const satisfies Record<Manager, string>;
+const devOptionTable = {
+  npm: "--save-dev",
+  pnpm: "--save-dev",
+  yarn: "--dev",
+  bun: "--dev",
+} as const satisfies Record<Manager, string>;
+
 export class PackageManager {
-  public manager: string = "npm";
+  public manager: Manager = "npm";
   public get file(): string {
     return path.join(this.directory, "package.json");
   }
@@ -40,10 +56,9 @@ export class PackageManager {
     modulo: string;
     version: string;
   }): boolean {
-    const middle: string =
-      this.manager === "yarn"
-        ? `add${props.dev ? " -D" : ""}`
-        : `install ${props.dev ? "--save-dev" : "--save"}`;
+    const cmd = installCmdTable[this.manager];
+    const option = props.dev ? devOptionTable[this.manager] : "";
+    const middle: string = `${cmd} ${option}` as const;
     CommandExecutor.run(
       `${this.manager} ${middle} ${props.modulo}${
         props.version ? `@${props.version}` : ""

--- a/test/package.json
+++ b/test/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "rimraf bin && tsc",
+    "build_run": "npm run build",
     "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -5,7 +5,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 
 # Setup
 ## Summary
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 npm install typia
@@ -27,7 +27,13 @@ yarn add typia
 yarn typia setup --manager yarn
 ```
   </Tab>
-</Tabs>
+  <Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add typia
+bun typia setup
+```
+  </Tab>
+  </Tabs>
 
 If you're using standard TypeScript compiler, you can use [transform mode](#transformation).
 
@@ -35,7 +41,7 @@ Assuming you are using [transformation mode](#transformation) simply run `npx ty
 
   - Standard TypeScript Compiler: [Microsoft/TypeScript](https://github.com/microsoft/typescript)
 
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 npm install typia
@@ -64,6 +70,16 @@ yarn add typia
 yarn add -D typescript
 
 yarn typia generate \
+  --input src/templates \
+  --output src/generated \
+  --project tsconfig.json
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add typia
+bun add -d typescript
+bun typia generate \
   --input src/templates \
   --output src/generated \
   --project tsconfig.json
@@ -136,7 +152,7 @@ exports.check = check;
 </Tabs>
 
 ### Setup Wizard
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
@@ -156,6 +172,12 @@ yarn add typia
 yarn typia setup --manager yarn
 ```
   </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun add typia
+bun typia setup --manager bun
+```
+  </Tab>
 </Tabs>
 
 You can turn on transformation mode just by running `npx typia setup` command.
@@ -163,7 +185,7 @@ You can turn on transformation mode just by running `npx typia setup` command.
 Setup wizard would be executed, and it will do everything for the transformation.
 
 ### Manual Setup
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
@@ -181,6 +203,12 @@ pnpm install --save-dev typescript ts-patch ts-node
 # YARN BERRY IS NOT SUPPORTED
 yarn add typia
 yarn add -D typescript ts-patch ts-node
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun add typia
+bun add -d typescript ts-patch ts-node
 ```
   </Tab>
 </Tabs>
@@ -221,7 +249,7 @@ As `typia` generates optimal operation code through transformation, it must be c
 }
 ```
 
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm run prepare
@@ -236,6 +264,11 @@ pnpm prepare
 ```bash filename="Terminal" copy showLineNumbers
 # YARN BERRY IS NOT SUPPORTED
 yarn prepare
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun run prepare
 ```
   </Tab>
 </Tabs>
@@ -264,7 +297,7 @@ Of course, if you don't use any ["Comment Tags"](./validators/tags/#comment-tags
 
 
 ## Generation
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # INSTALL TYPIA
@@ -299,6 +332,17 @@ yarn add -D typescript
 
 # GENERATE TRANSFORMED TYPESCRIPT CODES
 yarn typia generate \
+  --input src/templates \
+  --output src/generated \
+  --project tsconfig.json
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# INSTALL TYPIA
+bun add typia
+bun add -d typescript
+bun typia generate \
   --input src/templates \
   --output src/generated \
   --project tsconfig.json
@@ -421,7 +465,7 @@ export default defineConfig({
 **Also check out the [`unplugin-typia`](#unplugin-typia) guide for easier integration.**
 
 ## webpack
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # TYPIA
@@ -439,7 +483,7 @@ npm install --save-dev webpack webpack-cli
 pnpm install typia
 pnpm typia setup --manager pnpm
 
-# WEBPACK + TS-LOADER
+#WEBPACK + TS-LOADER
 pnpm install --save-dev ts-loader
 pnpm install --save-dev webpack webpack-cli
 ```
@@ -456,6 +500,17 @@ yarn typia setup --manager yarn
 # WEBPACK + TS-LOADER
 yarn add -D ts-loader
 yarn add -D webpack webpack-cli
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+# TYPIA
+bun add typia
+bun typia setup
+
+# WEBPACK + TS-LOADER
+bun add -d ts-loader
+bun add -d webpack webpack-cli
 ```
   </Tab>
 </Tabs>
@@ -499,7 +554,7 @@ module.exports = {
 
 From now on, you can build the single JS file just by running the `npx webpack` command. By the way, when removing `devDependencies` for `--production` install, never forget to add the `--ignore-scripts` option to prevent the `prepare` script.
 
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npx webpack
@@ -519,6 +574,12 @@ rm -rf node_modules
 yarn install --production --ignore-scripts --immutable
 ```
   </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun webpack
+bun install --production --ignore-scripts
+```
+  </Tab>
 </Tabs>
 
 Additionally, if you're using `typia` in the NodeJS project especially for the backend development, *Setup Guide Documents* of [`nestia`](https://github.com/samchon/nestia) would be helpful. Even though you're not using NestJS, you can still utilize below documents, and "Single JS file only" mode would be especially helpful for you.
@@ -531,7 +592,7 @@ Additionally, if you're using `typia` in the NodeJS project especially for the b
 **Also check out the [`unplugin-typia`](#unplugin-typia) guide for easier integration.**
 
 ## NX
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
@@ -549,6 +610,12 @@ pnpm typia setup --manager pnpm
 # YARN BERRY IS NOT SUPPORTED
 yarn add typia
 yarn typia setup --manager yarn
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" copy showLineNumbers
+bun add typia
+bun typia setup --manager bun
 ```
   </Tab>
 </Tabs>
@@ -590,7 +657,7 @@ Currently, `unplugin-typia` supports the following bundlers:
   - [Rolldown](https://rolldown.rs/)
   - [farm](https://farm-fe.github.io/)
 
-<Tabs items={['npm', 'pnpm', 'yarn']}>
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
 npx jsr add -D @ryoppippi/unplugin-typia
@@ -611,6 +678,13 @@ pnpm typia setup --manager pnpm
 yarn dlx jsr add -D @ryoppippi/unplugin-typia
 yarn add typia
 yarn typia setup --manager yarn
+```
+  </Tab>
+  <Tab>
+```bash filename="Terminal" showLineNumbers copy
+bun add -d @ryoppippi/unplugin-typia
+bun add typia
+bun typia setup --manager bun
 ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
fixes: #1078
This commit introduces support for the 'bun' package manager in the
TypiaSetupWizard and updates the documentation accordingly. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)