### PR TITLE
feat(rollup.config): support multiple formats and preserve modules/ split esm bundle files

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "rimraf": "^5.0.5",
     "rollup": "^4.18.0",
     "suppress-warnings": "^1.0.2",
+    "tiny-glob": "^0.2.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,29 +1,50 @@
 const typescript = require("@rollup/plugin-typescript");
 const terser = require("@rollup/plugin-terser");
 
-module.exports = {
-  input: "./src/index.ts",
-  output: {
-    dir: "lib",
-    format: "esm",
-    entryFileNames: "[name].mjs",
-    sourcemap: true,
-  },
-  plugins: [
-    typescript({
-      tsconfig: "tsconfig.json",
-      module: "ES2020",
-      target: "ES2020",
-    }),
-    terser({
-      format: {
-        comments: "some",
-        beautify: true,
-        ecma: "2020",
-      },
-      compress: false,
-      mangle: false,
-      module: true,
-    }),
-  ],
+const glob = require("glob");
+
+const input = glob.sync("src/**/*.ts");
+
+const outputConfig = {
+  dir: "lib",
+  sourcemap: true,
+  preserveModules: true,
 };
+
+const plugins = [
+  typescript({
+    tsconfig: "tsconfig.json",
+    module: "ES2020",
+    target: "ES2020",
+  }),
+  terser({
+    format: {
+      comments: "some",
+      beautify: true,
+      ecma: "2020",
+    },
+    compress: false,
+    mangle: false,
+    module: true,
+  }),
+];
+
+module.exports = [
+  {
+    input,
+    output: {
+      ...outputConfig,
+      entryFileNames: "[name].mjs",
+      format: "esm",
+    },
+    plugins,
+  },
+  {
+    input,
+    output: {
+      ...outputConfig,
+      format: "cjs",
+    },
+    plugins,
+  },
+];

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,16 +1,18 @@
-const typescript = require("@rollup/plugin-typescript");
-const terser = require("@rollup/plugin-terser");
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import glob from "tiny-glob";
 
-const glob = require("glob");
+/** @type {import('rollup').InputOptions} */
+const input = await glob("src/**/*.ts");
 
-const input = glob.sync("src/**/*.ts");
-
+/** @type {import('rollup').OutputOptions} */
 const outputConfig = {
   dir: "lib",
   sourcemap: true,
   preserveModules: true,
 };
 
+/** @type {import('rollup').Plugin[]} */
 const plugins = [
   typescript({
     tsconfig: "tsconfig.json",
@@ -29,7 +31,8 @@ const plugins = [
   }),
 ];
 
-module.exports = [
+/** @type {import('rollup').RollupOptions[]} */
+export default [
   {
     input,
     output: {


### PR DESCRIPTION
So this PR fixes how to generate `esm` and `cjs`.
This works fine with bun 
```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)