### PR TITLE
feat(package.json): add publishConfig for package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,39 @@
     "lib",
     "src"
   ],
-  "private": true
+  "private": true,
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "bun": "./src/index.ts",
+        "node": "./lib/index.js",
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./lib": {
+        "bun": "./src/index.ts",
+        "node": "./lib/index.js",
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./lib/transform": {
+        "bun": "./src/transform.ts",
+        "node": "./lib/transform.js",
+        "import": "./lib/transform.mjs",
+        "require": "./lib/transform.js",
+        "types": "./lib/transform.d.ts",
+        "default": "./lib/transform.js"
+      },
+      "./lib/executable/*.js": {
+        "require": "./lib/executable/*.js",
+        "types": "./lib/executable/*.d.ts",
+        "default": "./lib/executable/*.js"
+      },
+      "./package.json": "./package.json"
+    }
+  }
 }


### PR DESCRIPTION
Related to #1078
In this PR.
- You can set the `exports` filed only when published, so that only the appropriate ones are published.
- The exports are set to publishConfig. This means that internal packages can also be used in test, but direct import is no longer possible once published
- The `exports` filed allows you to read the typescript directly when using `bun`, so that the build does not fail!


This should be merged after #1081

======
Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)