### PR TITLE
feat: Add Hono utilization documentation

### DIFF
--- a/website/pages/docs/utilization/_meta.json
+++ b/website/pages/docs/utilization/_meta.json
@@ -1,5 +1,6 @@
 {
   "nestjs": "NestJS",
   "prisma": "Prisma",
-  "trpc": "tRPC"
+  "trpc": "tRPC",
+  "hono": "Hono"
 }

--- a/website/pages/docs/utilization/hono.mdx
+++ b/website/pages/docs/utilization/hono.mdx
@@ -1,0 +1,31 @@
+[Hono](https://hono.dev) is a small, simple, and ultrafast web framework for the Edges.
+
+If you are using `Hono` with `typia`, you can use [ `@hono/typia-validator` ](https://github.com/honojs/middleware/tree/main/packages/typia-validator) to validate the request body.
+
+
+```typescript copy showLineNumbers {11-12}
+import { Hono } from "hono";
+import { typiaValidator } from '@hono/typia-validator'
+import typia, { type tags } from "typia";
+
+import { IBbsArticle } from "../structures/IBbsArticle";
+
+/** create a validate function */
+const validate = typia.createValidate<IBbsArticle>();
+
+const app = new Hono();
+
+app.post("/",
+  typiaValidator('json', validate),
+  (c) => {
+    const data = c.req.valid("json");
+    return c.json({
+      id: data.id,
+      title: data.title,
+      body: data.body,
+      created_at: data.created_at,
+    });
+  });
+
+export default app;
+```


### PR DESCRIPTION
This commit introduces documentation for the Hono web framework. It includes a new file `hono.mdx` which provides an example of how to use Hono with typia. Additionally, it updates the `_meta.json` file to include Hono in the list of technologies.

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)