### PR TITLE
feat: remove ts-node from project dependencies

### DIFF
--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -22,7 +22,6 @@ export namespace TypiaSetupWizard {
 
     // INSTALL TYPESCRIPT COMPILERS
     pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
-    pack.install({ dev: true, modulo: "ts-node", version: "latest" });
     pack.install({ dev: true, modulo: "typescript", version: "5.4.2" });
     args.project ??= (() => {
       const runner: string = pack.manager === "npm" ? "npx" : pack.manager;

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -167,27 +167,27 @@ Setup wizard would be executed, and it will do everything for the transformation
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 npm install --save typia
-npm install --save-dev typescript ts-patch ts-node
+npm install --save-dev typescript ts-patch
 ```
   </Tab>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 pnpm install --save typia
-pnpm install --save-dev typescript ts-patch ts-node
+pnpm install --save-dev typescript ts-patch
 ```
   </Tab>
   <Tab>
 ```bash filename="Terminal" copy showLineNumbers
 # YARN BERRY IS NOT SUPPORTED
 yarn add typia
-yarn add -D typescript ts-patch ts-node
+yarn add -D typescript ts-patch
 ```
   </Tab>
 </Tabs>
 
 If you want to install `typia` manually, just follow the steps.
 
-Firstly install `typia` as a dependency. And then, install `typescript`, `ts-patch` and `ts-node` as `devDependencies`.
+Firstly install `typia` as a dependency. And then, install `typescript`, `ts-patch` and as `devDependencies`.
 
 ```json filename="tsconfig.json" copy showLineNumbers
 {
@@ -214,7 +214,6 @@ As `typia` generates optimal operation code through transformation, it must be c
     "typia": "^6.0.6"
   },
   "devDependencies": {
-    "ts-node": "^10.9.1",
     "ts-patch": "^3.2.0",
     "typescript": "^5.4.5"
   }


### PR DESCRIPTION
This commit removes the ts-node package from the project's dependencies. The ts-node package was previously used for TypeScript execution, but it is no longer necessary. The documentation and setup wizard have been updated to reflect this change.

fixes: https://github.com/samchon/typia/issues/1083

Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)