### PR TITLE
feat: Replace dax-sh with child_process for check if bun is available

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,6 +1,5 @@
 import chalk from "chalk";
 import cp from "child_process";
-import $ from "dax-sh";
 import fs from "fs";
 
 import { ReplicaPublisher } from "./internal/ReplicaPublisher";
@@ -74,9 +73,15 @@ const title = (label: string): void => {
   console.log("---------------------------------------------------------");
 };
 
-const detectComanndAvailable = async (command: string): Promise<boolean> => {
-  const path = await $.which(command);
-  return path !== null;
+const tryCommand = async (command: string): Promise<boolean> => {
+  return new Promise((resolve) => {
+    try {
+      cp.execSync(command, { stdio: "ignore" });
+      resolve(true);
+    } catch {
+      resolve(false);
+    }
+  });
 };
 
 const main = async (): Promise<void> => {
@@ -100,7 +105,7 @@ const main = async (): Promise<void> => {
   );
   test(version)("test-esm")(["npm run build", "npm start"]);
   /* if bun is available, test with bun */
-  if (await detectComanndAvailable("bun")) {
+  if (await tryCommand("bun --version")) {
     test(version)("test")(["bun --bun run build_run", "bun --bun run start"]);
     test(version)("test-esm")(["bun --bun run build", "bun --bun run start"]);
   }

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -73,17 +73,6 @@ const title = (label: string): void => {
   console.log("---------------------------------------------------------");
 };
 
-const tryCommand = async (command: string): Promise<boolean> => {
-  return new Promise((resolve) => {
-    try {
-      cp.execSync(command, { stdio: "ignore" });
-      resolve(true);
-    } catch {
-      resolve(false);
-    }
-  });
-};
-
 const main = async (): Promise<void> => {
   const tag: string | undefined = process.argv[2];
   if (tag === undefined) {
@@ -105,7 +94,16 @@ const main = async (): Promise<void> => {
   );
   test(version)("test-esm")(["npm run build", "npm start"]);
   /* if bun is available, test with bun */
-  if (await tryCommand("bun --version")) {
+  if (
+    (() => {
+      try {
+        cp.execSync("bun --version", { stdio: "ignore" });
+        return true;
+      } catch {
+        return false;
+      }
+    })()
+  ) {
     test(version)("test")(["bun --bun run build_run", "bun --bun run start"]);
     test(version)("test-esm")(["bun --bun run build", "bun --bun run start"]);
   }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
     "chalk": "^4.0.0",
-    "dax-sh": "^0.41.0",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "rollup": "^4.18.0",


### PR DESCRIPTION
I remove `dax-sh` dependencies because it is too much.
I replaced with `child_process`

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)