### PR TITLE
feat: add rollup plugins and update config to convert CJS module(`randexp.js`) to ESM format on build 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "typescript": ">=4.8.0 <5.6.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,21 @@
 const typescript = require("@rollup/plugin-typescript");
 const terser = require("@rollup/plugin-terser");
+const nodeResolve = require("@rollup/plugin-node-resolve");
+const commomnjs = require("@rollup/plugin-commonjs");
+
+const outDir = "lib";
 
 module.exports = {
   input: "./src/index.ts",
   output: {
-    dir: "lib",
+    dir: outDir,
     format: "esm",
     entryFileNames: "[name].mjs",
     sourcemap: true,
   },
   plugins: [
+    nodeResolve(),
+    commomnjs(),
     typescript({
       tsconfig: "tsconfig.json",
       module: "ES2020",


### PR DESCRIPTION
This solves `randregex` library for esm.

Before this PR, we saw that warning like below

https://github.com/samchon/typia/actions/runs/9464501210/job/26071971132
```
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
randexp (imported by "src/utils/RandomGenerator/RandomGenerator.ts")
created lib in 5.7s
```

This PR solves this warning

More clear descriptions here:
- Some bundlers like bun are not good at handling cjs
- [@rollup/plugin-commonjs](https://www.npmjs.com/package/@rollup/plugin-commonjs) converts packages written in commonjs to es6 format, so it resolves dependencies nicely when building esm
- randexp.js is written using `module.exports` and this `@rollup/plugin-commonjs` converts this package to esm format
- also, to find the `randexp.js` code, I added [`@rollup/plugin-node-resolve
`](https://github.com/rollup/plugins/tree/master/packages/node-resolve)

I built with this plugin in hand and the bun build went through fine.

I'll paste a part of the new build result
<details><summary>libs/index.mjs</summary>
<p>

```js

function getDefaultExportFromCjs(x) {
    return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, "default") ? x["default"] : x;
}

/* --------------------------------------- */

var randexp = class RandExp {
    constructor(regexp, m) {
        this._setDefaults(regexp);
        if (regexp instanceof RegExp) {
            this.ignoreCase = regexp.ignoreCase;
            this.multiline = regexp.multiline;
            regexp = regexp.source;
        } else if (typeof regexp === "string") {
            this.ignoreCase = m && m.indexOf("i") !== -1;
            this.multiline = m && m.indexOf("m") !== -1;
        } else {
            throw new Error("Expected a regexp or string");
        }
        this.tokens = ret(regexp);
    }
    _setDefaults(regexp) {
        this.max = regexp.max != null ? regexp.max : RandExp.prototype.max != null ? RandExp.prototype.max : 100;
        this.defaultRange = regexp.defaultRange ? regexp.defaultRange : this.defaultRange.clone();
        if (regexp.randInt) {
            this.randInt = regexp.randInt;
        }
    }
    gen() {
        return this._gen(this.tokens, []);
    }
    _gen(token, groups) {
        var stack, str, n, i, l;
        switch (token.type) {
          case types.ROOT:
          case types.GROUP:
            if (token.followedBy || token.notFollowedBy) {
                return "";
            }
            if (token.remember && token.groupNumber === undefined) {
                token.groupNumber = groups.push(null) - 1;
            }
            stack = token.options ? this._randSelect(token.options) : token.stack;
            str = "";
            for (i = 0, l = stack.length; i < l; i++) {
                str += this._gen(stack[i], groups);
            }
            if (token.remember) {
                groups[token.groupNumber] = str;
            }
            return str;

          case types.POSITION:
            return "";

          case types.SET:
            var expandedSet = this._expand(token);
            if (!expandedSet.length) {
                return "";
            }
            return String.fromCharCode(this._randSelect(expandedSet));

          case types.REPETITION:
            n = this.randInt(token.min, token.max === Infinity ? token.min + this.max : token.max);
            str = "";
            for (i = 0; i < n; i++) {
                str += this._gen(token.value, groups);
            }
            return str;

          case types.REFERENCE:
            return groups[token.value - 1] || "";

          case types.CHAR:
            var code = this.ignoreCase && this._randBool() ? this._toOtherCase(token.value) : token.value;
            return String.fromCharCode(code);
        }
    }
    _toOtherCase(code) {
        return code + (97 <= code && code <= 122 ? -32 : 65 <= code && code <= 90 ? 32 : 0);
    }
    _randBool() {
        return !this.randInt(0, 1);
    }
    _randSelect(arr) {
        if (arr instanceof DRange) {
            return arr.index(this.randInt(0, arr.length - 1));
        }
        return arr[this.randInt(0, arr.length - 1)];
    }
    _expand(token) {
        if (token.type === ret.types.CHAR) {
            return new DRange(token.value);
        } else if (token.type === ret.types.RANGE) {
            return new DRange(token.from, token.to);
        } else {
            let drange = new DRange;
            for (let i = 0; i < token.set.length; i++) {
                let subrange = this._expand(token.set[i]);
                drange.add(subrange);
                if (this.ignoreCase) {
                    for (let j = 0; j < subrange.length; j++) {
                        let code = subrange.index(j);
                        let otherCaseCode = this._toOtherCase(code);
                        if (code !== otherCaseCode) {
                            drange.add(otherCaseCode);
                        }
                    }
                }
            }
            if (token.not) {
                return this.defaultRange.clone().subtract(drange);
            } else {
                return this.defaultRange.clone().intersect(drange);
            }
        }
    }
    randInt(a, b) {
        return a + Math.floor(Math.random() * (1 + b - a));
    }
    get defaultRange() {
        return this._range = this._range || new DRange(32, 126);
    }
    set defaultRange(range) {
        this._range = range;
    }
    static randexp(regexp, m) {
        var randexp;
        if (typeof regexp === "string") {
            regexp = new RegExp(regexp, m);
        }
        if (regexp._randexp === undefined) {
            randexp = new RandExp(regexp, m);
            regexp._randexp = randexp;
        } else {
            randexp = regexp._randexp;
            randexp._setDefaults(regexp);
        }
        return randexp.gen();
    }
    static sugar() {
        RegExp.prototype.gen = function() {
            return RandExp.randexp(this);
        };
    }
};

var RandExp = getDefaultExportFromCjs(randexp);
```

</p>
</details> 