### PR TITLE
Block TypeScript v5.5 for a while.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.2.0.tgz"
+    "typia": "../typia-6.2.1.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.2.0.tgz"
+    "typia": "../typia-6.2.1.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -74,7 +74,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0 <5.6.0"
+    "typescript": ">=4.8.0 <5.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,10 +63,10 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.2.0"
+    "typia": "6.2.1"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0 <5.6.0"
+    "typescript": ">=4.8.0 <5.5.0"
   },
   "stackblitzs": {
     "startCommand": "npm install && npm run test"

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.2.0.tgz"
+    "typia": "../typia-6.2.1.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.2.0.tgz"
+    "typia": "../typia-6.2.1.tgz"
   }
 }


### PR DESCRIPTION
As TypeScript v5.5.2 suddenly had taken a break change on its compiler soure code, `ts-patch` has failed to patch transformation to the TypeScript v5.5.2 compiler.

Therefore, block the TypeScript v5.5 through `peerDependencies` untill @nonara fixes the nonara/ts-patch#159 problem.
