### PR TITLE
Close #1119: new function `typia.reflect.name<T>()`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.2.1.tgz"
+    "typia": "../typia-6.3.0-dev.20240624.tgz"
   }
 }

--- a/debug/features/name.ts
+++ b/debug/features/name.ts
@@ -1,0 +1,19 @@
+import typia, { tags } from "typia";
+
+type Something = string & tags.Format<"uuid">;
+const value: number = 3;
+
+console.log(
+  typia.reflect.name<string & tags.Format<"uuid">>(),
+  typia.reflect.name<number & tags.Type<"uint32">>(),
+  typia.reflect.name<Something, true>(),
+  typia.reflect.name<Something, false>(),
+  typia.reflect.name<typeof value>(),
+  typia.reflect.name<typeof value, false>(),
+  typia.reflect.name<
+    string &
+      tags.JsonSchemaPlugin<{
+        "x-typia-something": true;
+      }>
+  >(),
+);

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "../typia-7.0.0-dev.20240620.tgz"
+    "typia": "../typia-6.2.1.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.2.1.tgz"
+    "typia": "../typia-6.3.0-dev.20240624.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.2.1",
+  "version": "6.3.0-dev.20240624",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.2.1",
+  "version": "6.3.0-dev.20240624",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.2.1"
+    "typia": "6.3.0-dev.20240624"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.5.0"

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -47,6 +47,12 @@ const metadataPure = /** @__PURE__ */ Object.assign<typeof metadata, {}>(
 );
 export { metadataPure as metadata };
 
+export function name<T, Regular extends boolean = false>(): string;
+export function name(): never;
+export function name(): never {
+  halt("name");
+}
+
 /**
  * @internal
  */

--- a/src/transformers/CallExpressionTransformer.ts
+++ b/src/transformers/CallExpressionTransformer.ts
@@ -107,6 +107,7 @@ import { ProtobufMessageTransformer } from "./features/protobuf/ProtobufMessageT
 import { ProtobufValidateDecodeTransformer } from "./features/protobuf/ProtobufValidateDecodeTransformer";
 import { ProtobufValidateEncodeTransformer } from "./features/protobuf/ProtobufValidateEncodeTransformer";
 import { ReflectMetadataTransformer } from "./features/reflect/ReflectMetadataTransformer";
+import { ReflectNameTransformer } from "./features/reflect/ReflectNameTransformer";
 
 export namespace CallExpressionTransformer {
   export const transform =
@@ -179,7 +180,8 @@ const FUNCTORS: Record<string, Record<string, () => Task>> = {
 
     // RANDOM + INTERNAL
     random: () => RandomTransformer.transform,
-    metadata: () => ReflectMetadataTransformer.transform,
+    metadata: () => (project) => () =>
+      ReflectMetadataTransformer.transform(project),
 
     // FACTORIES
     createAssert: () =>
@@ -405,7 +407,9 @@ const FUNCTORS: Record<string, Record<string, () => Task>> = {
       ProtobufCreateValidateDecodeTransformer.transform,
   },
   reflect: {
-    metadata: () => ReflectMetadataTransformer.transform,
+    metadata: () => (project) => () =>
+      ReflectMetadataTransformer.transform(project),
+    name: () => (project) => () => ReflectNameTransformer.transform(project),
   },
   misc: {
     literals: () => (project) => () =>

--- a/src/transformers/features/reflect/ReflectMetadataTransformer.ts
+++ b/src/transformers/features/reflect/ReflectMetadataTransformer.ts
@@ -13,11 +13,10 @@ import { TransformerError } from "../../TransformerError";
 export namespace ReflectMetadataTransformer {
   export const transform =
     (project: IProject) =>
-    (_modulo: ts.LeftHandSideExpression) =>
     (expression: ts.CallExpression): ts.Expression => {
       if (!expression.typeArguments?.length)
         throw new TransformerError({
-          code: "typia.metadata",
+          code: "typia.reflect.metadata",
           message: "no generic argument.",
         });
 

--- a/src/transformers/features/reflect/ReflectNameTransformer.ts
+++ b/src/transformers/features/reflect/ReflectNameTransformer.ts
@@ -1,0 +1,66 @@
+import ts from "typescript";
+
+import { MetadataCollection } from "../../../factories/MetadataCollection";
+import { MetadataFactory } from "../../../factories/MetadataFactory";
+
+import { Metadata } from "../../../schemas/metadata/Metadata";
+
+import { ValidationPipe } from "../../../typings/ValidationPipe";
+
+import { IProject } from "../../IProject";
+import { TransformerError } from "../../TransformerError";
+
+export namespace ReflectNameTransformer {
+  export const transform =
+    (project: IProject) =>
+    (expression: ts.CallExpression): ts.Expression => {
+      if (!expression.typeArguments?.length)
+        throw new TransformerError({
+          code: "typia.reflect.metadata",
+          message: "no generic argument.",
+        });
+      const top: ts.Node = expression.typeArguments[0]!;
+      const regular: boolean = (() => {
+        // CHECK SECOND ARGUMENT EXISTENCE
+        const second: ts.Node | undefined = expression.typeArguments[1]!;
+        if (second === undefined) return false;
+
+        // GET BOOELAN VALUE
+        const value: Metadata = getMetadata(project)(second);
+        return value.size() === 1 &&
+          value.constants.length === 1 &&
+          value.constants[0]!.type === "boolean" &&
+          value.constants[0]!.values.length === 1
+          ? (value.constants[0]!.values[0]!.value as boolean)
+          : false;
+      })();
+
+      // RETURNS NAME
+      return ts.factory.createStringLiteral(
+        regular ? getMetadata(project)(top).getName() : top.getFullText(),
+      );
+    };
+}
+
+const getMetadata =
+  (project: IProject) =>
+  (node: ts.Node): Metadata => {
+    const type: ts.Type = project.checker.getTypeFromTypeNode(
+      node as ts.TypeNode,
+    );
+    const collection: MetadataCollection = new MetadataCollection({
+      replace: MetadataCollection.replace,
+    });
+    const result: ValidationPipe<Metadata, MetadataFactory.IError> =
+      MetadataFactory.analyze(
+        project.checker,
+        project.context,
+      )({
+        escape: false,
+        constant: true,
+        absorb: false,
+      })(collection)(type);
+    if (result.success === false)
+      throw TransformerError.from("typia.reflect.name")(result.errors);
+    return result.data;
+  };

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.2.1.tgz"
+    "typia": "../typia-6.3.0-dev.20240624.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.2.1.tgz"
+    "typia": "../typia-6.3.0-dev.20240624.tgz"
   }
 }


### PR DESCRIPTION
```typescript
import typia, { tags } from "typia";

type Something = string & tags.Format<"uuid">;
const value: number = 3;

console.log(
  typia.reflect.name<string & tags.Format<"uuid">>(),
  typia.reflect.name<number & tags.Type<"uint32">>(),
  typia.reflect.name<Something, true>(),
  typia.reflect.name<Something, false>(),
  typia.reflect.name<typeof value>(),
  typia.reflect.name<typeof value, false>(),
  typia.reflect.name<
    string &
      tags.JsonSchemaPlugin<{
        "x-typia-something": true;
      }>
  >(),
);
```

> ```bash
> string & tags.Format<"uuid"> number & tags.Type<"uint32"> Something Something typeof value typeof value
>     string &
>       tags.JsonSchemaPlugin<{
>         "x-typia-something": true;
>       }>
> ```