### PR TITLE
refactor: stop using enum and use named import for tree shaking

### DIFF
--- a/src/functional/$ProtobufReader.ts
+++ b/src/functional/$ProtobufReader.ts
@@ -1,4 +1,4 @@
-import { ProtobufWire } from "../programmers/helpers/ProtobufWire";
+import * as ProtobufWire from "../programmers/helpers/ProtobufWire";
 
 /// @reference https://github.com/piotr-oles/as-proto/blob/main/packages/as-proto/assembly/internal/FixedReader.ts
 export class $ProtobufReader {

--- a/src/functional/$ProtobufReader.ts
+++ b/src/functional/$ProtobufReader.ts
@@ -1,5 +1,7 @@
 import * as ProtobufWire from "../programmers/helpers/ProtobufWire";
 
+type ValueOf<T> = T[keyof T];
+
 /// @reference https://github.com/piotr-oles/as-proto/blob/main/packages/as-proto/assembly/internal/FixedReader.ts
 export class $ProtobufReader {
   /**
@@ -93,7 +95,7 @@ export class $ProtobufReader {
     }
   }
 
-  public skipType(wireType: ProtobufWire): void {
+  public skipType(wireType: ValueOf<typeof ProtobufWire>): void {
     switch (wireType) {
       case ProtobufWire.VARIANT:
         this.skip(0);
@@ -105,6 +107,7 @@ export class $ProtobufReader {
         this.skip(this.uint32());
         break;
       case ProtobufWire.START_GROUP:
+        // @ts-expect-error this.uint32() & 0x07 is not included in the ProtobufWire
         while ((wireType = this.uint32() & 0x07) !== ProtobufWire.END_GROUP)
           this.skipType(wireType);
         break;

--- a/src/programmers/helpers/ProtobufWire.ts
+++ b/src/programmers/helpers/ProtobufWire.ts
@@ -1,34 +1,32 @@
-export const enum ProtobufWire {
-  /**
-   * - integers
-   * - bool
-   * - enum
-   */
-  VARIANT = 0,
+/**
+ * - integers
+ * - bool
+ * - enum
+ */
+export const VARIANT = 0;
 
-  /**
-   * - fixed64
-   * - sfixed64
-   * - double
-   */
-  I64 = 1,
+/**
+ * - fixed64
+ * - sfixed64
+ * - double
+ */
+export const I64 = 1;
 
-  /**
-   * - string
-   * - bytes
-   * - mebedded messages
-   * - packed repeated fields
-   */
-  LEN = 2,
+/**
+ * - string
+ * - bytes
+ * - mebedded messages
+ * - packed repeated fields
+ */
+export const LEN = 2;
 
-  START_GROUP = 3,
+export const START_GROUP = 3;
 
-  END_GROUP = 4,
+export const END_GROUP = 4;
 
-  /**
-   * - fixed
-   * - sfixed32
-   * - float
-   */
-  I32 = 5,
-}
+/**
+ * - fixed
+ * - sfixed32
+ * - float
+ */
+export const I32 = 5;

--- a/src/programmers/misc/MiscLiteralsProgrammer.ts
+++ b/src/programmers/misc/MiscLiteralsProgrammer.ts
@@ -64,7 +64,8 @@ export namespace MiscLiteralsProgrammer {
   };
 }
 
-enum ErrorMessages {
-  NO = "no constant literal type found.",
-  ONLY = "only constant literal types are allowed.",
-}
+const ErrorMessages = {
+  NO: "no constant literal type found.",
+  ONLY: "only constant literal types are allowed.",
+} as const;
+

--- a/src/programmers/protobuf/ProtobufEncodeProgrammer.ts
+++ b/src/programmers/protobuf/ProtobufEncodeProgrammer.ts
@@ -22,9 +22,11 @@ import { FeatureProgrammer } from "../FeatureProgrammer";
 import { IsProgrammer } from "../IsProgrammer";
 import { FunctionImporter } from "../helpers/FunctionImporter";
 import { ProtobufUtil } from "../helpers/ProtobufUtil";
-import { ProtobufWire } from "../helpers/ProtobufWire";
+import * as ProtobufWire from "../helpers/ProtobufWire";
 import { UnionPredicator } from "../helpers/UnionPredicator";
 import { decode_union_object } from "../internal/decode_union_object";
+
+type ValueOf<T> = T[keyof T];
 
 export namespace ProtobufEncodeProgrammer {
   export const write =
@@ -649,7 +651,7 @@ export namespace ProtobufEncodeProgrammer {
       );
 
   const decode_tag =
-    (wire: ProtobufWire) =>
+    (wire: ValueOf<typeof ProtobufWire>) =>
     (index: number): ts.CallExpression =>
       ts.factory.createCallExpression(
         IdentifierFactory.access(WRITER())("uint32"),
@@ -657,7 +659,9 @@ export namespace ProtobufEncodeProgrammer {
         [ExpressionFactory.number((index << 3) | wire)],
       );
 
-  const get_standalone_wire = (meta: Metadata): ProtobufWire => {
+  const get_standalone_wire = (
+    meta: Metadata,
+  ): ValueOf<typeof ProtobufWire> => {
     if (
       meta.arrays.length ||
       meta.objects.length ||


### PR DESCRIPTION
- Change import of ProtobufWire to use import * as syntax.
- Refactor ProtobufWire enum to individual exports.
- Change ErrorMessages from enum to const object.
- Update type usage in ProtobufEncodeProgrammer to reflect changes.

This PR reduce bundle size.
Enum in TypeScript is not recommended.	



Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)