### PR TITLE
refactor: improve tree-shaking in ESM target

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "lib",
     "src"
   ],
-  "private": true
+  "private": true,
+  "sideEffects": false
 }
-

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/inquirer": "^8.2.5",
@@ -107,3 +106,4 @@
   ],
   "private": true
 }
+

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,9 +4,12 @@ const commomnjs = require("@rollup/plugin-commonjs");
 
 const outDir = "lib";
 
+/** @type {import('rollup').RollupOptions} */
 module.exports = {
   input: "./src/index.ts",
   output: {
+    preserveModules: true,
+    preserveModulesRoot: "src",
     dir: outDir,
     format: "esm",
     entryFileNames: "[name].mjs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 const typescript = require("@rollup/plugin-typescript");
-const terser = require("@rollup/plugin-terser");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const commomnjs = require("@rollup/plugin-commonjs");
 
@@ -18,18 +17,8 @@ module.exports = {
     commomnjs(),
     typescript({
       tsconfig: "tsconfig.json",
-      module: "ES2020",
-      target: "ES2020",
-    }),
-    terser({
-      format: {
-        comments: "some",
-        beautify: true,
-        ecma: "2020",
-      },
-      compress: false,
-      mangle: false,
-      module: true,
+      module: "ESNext",
+      target: "ESNext",
     }),
   ],
 };

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -54,14 +54,14 @@ function assertFunction<T extends (...args: any[]) => any>(
 function assertFunction(): never {
   halt("assertFunction");
 }
-const assertFunctionPure = /** @__PURE__ */ Object.assign<
+const assertFunctionPure = /** #__PURE__*/ Object.assign<
   typeof assertFunction,
   {},
   {}
 >(
   assertFunction,
-  /** @__PURE__ */ Namespace.assert("functional.assertFunction"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertFunction"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertFunctionPure as assertFunction };
 
@@ -104,14 +104,14 @@ function assertParameters<T extends (...args: any[]) => any>(
 function assertParameters(): never {
   halt("assertParameters");
 }
-const assertParametersPure = /** @__PURE__ */ Object.assign<
+const assertParametersPure = /** #__PURE__*/ Object.assign<
   typeof assertParameters,
   {},
   {}
 >(
   assertFunction,
-  /** @__PURE__ */ Namespace.assert("functional.assertFunction"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertFunction"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertParametersPure as assertParameters };
 
@@ -154,14 +154,14 @@ function assertReturn<T extends (...args: any[]) => any>(
 function assertReturn(): never {
   halt("assertReturn");
 }
-const assertReturnPure = /** @__PURE__ */ Object.assign<
+const assertReturnPure = /** #__PURE__*/ Object.assign<
   typeof assertReturn,
   {},
   {}
 >(
   assertReturn,
-  /** @__PURE__ */ Namespace.assert("functional.assertReturn"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertReturn"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertReturnPure as assertReturn };
 
@@ -209,14 +209,14 @@ function assertEqualsFunction<T extends (...args: any[]) => any>(
 function assertEqualsFunction(): never {
   halt("assertEqualsFunction");
 }
-const assertEqualsFunctionPure = /** @__PURE__ */ Object.assign<
+const assertEqualsFunctionPure = /** #__PURE__*/ Object.assign<
   typeof assertEqualsFunction,
   {},
   {}
 >(
   assertEqualsFunction,
-  /** @__PURE__ */ Namespace.assert("functional.assertEqualsFunction"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertEqualsFunction"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertEqualsFunctionPure as assertEqualsFunction };
 
@@ -260,14 +260,14 @@ function assertEqualsParameters<T extends (...args: any[]) => any>(
 function assertEqualsParameters(): never {
   halt("assertEqualsParameters");
 }
-const assertEqualsParametersPure = /** @__PURE__ */ Object.assign<
+const assertEqualsParametersPure = /** #__PURE__*/ Object.assign<
   typeof assertEqualsParameters,
   {},
   {}
 >(
   assertEqualsParameters,
-  /** @__PURE__ */ Namespace.assert("functional.assertEqualsParameters"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertEqualsParameters"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertEqualsParametersPure as assertEqualsParameters };
 
@@ -310,14 +310,14 @@ function assertEqualsReturn<T extends (...args: any[]) => any>(
 function assertEqualsReturn(): never {
   halt("assertEqualsReturn");
 }
-const assertEqualsReturnPure = /** @__PURE__ */ Object.assign<
+const assertEqualsReturnPure = /** #__PURE__*/ Object.assign<
   typeof assertEqualsReturn,
   {},
   {}
 >(
   assertEqualsReturn,
-  /** @__PURE__ */ Namespace.assert("functional.assertEqualsReturn"),
-  /** @__PURE__ */ Namespace.functional.functionalAssert(),
+  /** #__PURE__*/ Namespace.assert("functional.assertEqualsReturn"),
+  /** #__PURE__*/ Namespace.functional.functionalAssert(),
 );
 export { assertEqualsReturnPure as assertEqualsReturn };
 
@@ -360,9 +360,9 @@ function isFunction<T extends (...args: any[]) => any>(
 function isFunction(): never {
   halt("isFunction");
 }
-const isFunctionPure = /** @__PURE__ */ Object.assign<typeof isFunction, {}>(
+const isFunctionPure = /** #__PURE__*/ Object.assign<typeof isFunction, {}>(
   isFunction,
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isFunctionPure as isFunction };
 
@@ -402,10 +402,10 @@ function isParameters<T extends (...args: any[]) => any>(
 function isParameters(): never {
   halt("isParameters");
 }
-const isParametersPure = /** @__PURE__ */ Object.assign<
-  typeof isParameters,
-  {}
->(isParameters, /** @__PURE__ */ Namespace.is());
+const isParametersPure = /** #__PURE__*/ Object.assign<typeof isParameters, {}>(
+  isParameters,
+  /** #__PURE__*/ Namespace.is(),
+);
 export { isParametersPure as isParameters };
 
 /**
@@ -444,9 +444,9 @@ function isReturn<T extends (...args: any[]) => any>(
 function isReturn(): never {
   halt("isReturn");
 }
-const isReturnPure = /** @__PURE__ */ Object.assign<typeof isReturn, {}>(
+const isReturnPure = /** #__PURE__*/ Object.assign<typeof isReturn, {}>(
   isReturn,
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isReturnPure as isReturn };
 
@@ -485,10 +485,10 @@ function equalsFunction<T extends (...args: any[]) => any>(
 function equalsFunction(): never {
   halt("equalsFunction");
 }
-const equalsFunctionPure = /** @__PURE__ */ Object.assign<
+const equalsFunctionPure = /** #__PURE__*/ Object.assign<
   typeof equalsFunction,
   {}
->(equalsFunction, /** @__PURE__ */ Namespace.is());
+>(equalsFunction, /** #__PURE__*/ Namespace.is());
 export { equalsFunctionPure as equalsFunction };
 
 /**
@@ -523,10 +523,10 @@ function equalsParameters<T extends (...args: any[]) => any>(
 function equalsParameters(): never {
   halt("equalsParameters");
 }
-const equalsParametersPure = /** @__PURE__ */ Object.assign<
+const equalsParametersPure = /** #__PURE__*/ Object.assign<
   typeof equalsParameters,
   {}
->(equalsParameters, /** @__PURE__ */ Namespace.is());
+>(equalsParameters, /** #__PURE__*/ Namespace.is());
 export { equalsParametersPure as equalsParameters };
 
 /**
@@ -564,10 +564,10 @@ function equalsReturn<T extends (...args: any[]) => any>(
 function equalsReturn(): never {
   halt("equalsReturn");
 }
-const equalsReturnPure = /** @__PURE__ */ Object.assign<
-  typeof equalsReturn,
-  {}
->(equalsReturn, /** @__PURE__ */ Namespace.is());
+const equalsReturnPure = /** #__PURE__*/ Object.assign<typeof equalsReturn, {}>(
+  equalsReturn,
+  /** #__PURE__*/ Namespace.is(),
+);
 export { equalsReturnPure as equalsReturn };
 
 /* -----------------------------------------------------------
@@ -618,10 +618,10 @@ function validateFunction<T extends (...args: any[]) => any>(
 function validateFunction(): never {
   halt("validateFunction");
 }
-const validateFunctionPure = /** @__PURE__ */ Object.assign<
+const validateFunctionPure = /** #__PURE__*/ Object.assign<
   typeof validateFunction,
   {}
->(validateFunction, /** @__PURE__ */ Namespace.validate());
+>(validateFunction, /** #__PURE__*/ Namespace.validate());
 export { validateFunctionPure as validateFunction };
 
 /**
@@ -664,10 +664,10 @@ function validateParameters<T extends (...args: any[]) => any>(
 function validateParameters(): never {
   halt("validateReturn");
 }
-const validateParametersPure = /** @__PURE__ */ Object.assign<
+const validateParametersPure = /** #__PURE__*/ Object.assign<
   typeof validateParameters,
   {}
->(validateParameters, /** @__PURE__ */ Namespace.validate());
+>(validateParameters, /** #__PURE__*/ Namespace.validate());
 export { validateParametersPure as validateParameters };
 
 /**
@@ -710,10 +710,10 @@ function validateReturn<T extends (...args: any[]) => any>(
 function validateReturn(): never {
   halt("validateReturn");
 }
-const validateReturnPure = /** @__PURE__ */ Object.assign<
+const validateReturnPure = /** #__PURE__*/ Object.assign<
   typeof validateReturn,
   {}
->(validateReturn, /** @__PURE__ */ Namespace.validate());
+>(validateReturn, /** #__PURE__*/ Namespace.validate());
 export { validateReturnPure as validateReturn };
 
 /**
@@ -761,10 +761,10 @@ function validateEqualsFunction<T extends (...args: any[]) => any>(
 function validateEqualsFunction(): never {
   halt("validateEqualsFunction");
 }
-const validateEqualsFunctionPure = /** @__PURE__ */ Object.assign<
+const validateEqualsFunctionPure = /** #__PURE__*/ Object.assign<
   typeof validateEqualsFunction,
   {}
->(validateEqualsFunction, /** @__PURE__ */ Namespace.validate());
+>(validateEqualsFunction, /** #__PURE__*/ Namespace.validate());
 export { validateEqualsFunctionPure as validateEqualsFunction };
 
 /**
@@ -807,10 +807,10 @@ function validateEqualsParameters<T extends (...args: any[]) => any>(
 function validateEqualsParameters(): never {
   halt("validateEqualsParameters");
 }
-const validateEqualsParametersPure = /** @__PURE__ */ Object.assign<
+const validateEqualsParametersPure = /** #__PURE__*/ Object.assign<
   typeof validateEqualsParameters,
   {}
->(validateEqualsParameters, /** @__PURE__ */ Namespace.validate());
+>(validateEqualsParameters, /** #__PURE__*/ Namespace.validate());
 export { validateEqualsParametersPure as validateEqualsParameters };
 
 /**
@@ -853,10 +853,10 @@ function validateEqualsReturn<T extends (...args: any[]) => any>(
 function validateEqualsReturn(): never {
   halt("validateEqualsReturn");
 }
-const validateEqualsReturnPure = /** @__PURE__ */ Object.assign<
+const validateEqualsReturnPure = /** #__PURE__*/ Object.assign<
   typeof validateEqualsReturn,
   {}
->(validateEqualsReturn, /** @__PURE__ */ Namespace.validate());
+>(validateEqualsReturn, /** #__PURE__*/ Namespace.validate());
 export { validateEqualsReturnPure as validateEqualsReturn };
 
 /* -----------------------------------------------------------

--- a/src/functional/$ProtobufReader.ts
+++ b/src/functional/$ProtobufReader.ts
@@ -189,7 +189,7 @@ export class $ProtobufReader {
   }
 }
 
-const utf8 = /** @__PURE__ */ new TextDecoder();
-const N01 = /** @__PURE__ */ BigInt(0x01);
-const N7F = /** @__PURE__ */ BigInt(0x7f);
-const N80 = /** @__PURE__ */ BigInt(0x80);
+const utf8 = /** #__PURE__*/ new TextDecoder();
+const N01 = /** #__PURE__*/ BigInt(0x01);
+const N7F = /** #__PURE__*/ BigInt(0x7f);
+const N80 = /** #__PURE__*/ BigInt(0x80);

--- a/src/functional/$ProtobufSizer.ts
+++ b/src/functional/$ProtobufSizer.ts
@@ -143,5 +143,5 @@ export class $ProtobufSizer implements IProtobufWriter {
   }
 }
 
-const ND07 = /** @__PURE__ */ BigInt(7);
-const NX7F = /** @__PURE__ */ BigInt(0x7f);
+const ND07 = /** #__PURE__*/ BigInt(7);
+const NX7F = /** #__PURE__*/ BigInt(0x7f);

--- a/src/functional/$ProtobufWriter.ts
+++ b/src/functional/$ProtobufWriter.ts
@@ -141,10 +141,10 @@ export class $ProtobufWriter implements IProtobufWriter {
   }
 }
 
-const utf8 = /** @__PURE__ */ new TextEncoder();
+const utf8 = /** #__PURE__*/ new TextEncoder();
 
-const ND01 = /** @__PURE__ */ BigInt(1);
-const ND07 = /** @__PURE__ */ BigInt(7);
-const ND63 = /** @__PURE__ */ BigInt(63);
-const NX7F = /** @__PURE__ */ BigInt(0x7f);
-const NX80 = /** @__PURE__ */ BigInt(0x80);
+const ND01 = /** #__PURE__*/ BigInt(1);
+const ND07 = /** #__PURE__*/ BigInt(7);
+const ND63 = /** #__PURE__*/ BigInt(63);
+const NX7F = /** #__PURE__*/ BigInt(0x7f);
+const NX80 = /** #__PURE__*/ BigInt(0x80);

--- a/src/http.ts
+++ b/src/http.ts
@@ -51,9 +51,9 @@ function formData<T extends object>(input: FormData): Resolved<T>;
 function formData(): never {
   halt("formData");
 }
-const formDataPure = /** @__PURE__ */ Object.assign<typeof formData, {}>(
+const formDataPure = /** #__PURE__*/ Object.assign<typeof formData, {}>(
   formData,
-  /** @__PURE__ */ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.http.formData(),
 );
 export { formDataPure as formData };
 
@@ -97,14 +97,14 @@ function assertFormData<T extends object>(
 function assertFormData(): never {
   halt("assertFormData");
 }
-const assertFormDataPure = /** @__PURE__ */ Object.assign<
+const assertFormDataPure = /** #__PURE__*/ Object.assign<
   typeof assertFormData,
   {},
   {}
 >(
   assertFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.assert("http.assertFormData"),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.assert("http.assertFormData"),
 );
 export { assertFormDataPure as assertFormData };
 
@@ -143,14 +143,10 @@ function isFormData<T extends object>(input: FormData): Resolved<T> | null;
 function isFormData(): never {
   halt("isFormData");
 }
-const isFormDataPure = /** @__PURE__ */ Object.assign<
-  typeof isFormData,
-  {},
-  {}
->(
+const isFormDataPure = /** #__PURE__*/ Object.assign<typeof isFormData, {}, {}>(
   isFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isFormDataPure as isFormData };
 
@@ -193,14 +189,14 @@ function validateFormData<T extends object>(
 function validateFormData(): never {
   halt("validateFormData");
 }
-const validateFormDataPure = /** @__PURE__ */ Object.assign<
+const validateFormDataPure = /** #__PURE__*/ Object.assign<
   typeof validateFormData,
   {},
   {}
 >(
   validateFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validateFormDataPure as validateFormData };
 
@@ -246,9 +242,9 @@ function query<T extends object>(input: string | URLSearchParams): Resolved<T>;
 function query(): never {
   halt("query");
 }
-const queryPure = /** @__PURE__ */ Object.assign<typeof query, {}>(
+const queryPure = /** #__PURE__*/ Object.assign<typeof query, {}>(
   query,
-  /** @__PURE__ */ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.http.query(),
 );
 export { queryPure as query };
 
@@ -292,14 +288,14 @@ function assertQuery<T extends object>(
 function assertQuery(): never {
   halt("assertQuery");
 }
-const assertQueryPure = /** @__PURE__ */ Object.assign<
+const assertQueryPure = /** #__PURE__*/ Object.assign<
   typeof assertQuery,
   {},
   {}
 >(
   assertQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.assert("http.assertQuery"),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.assert("http.assertQuery"),
 );
 export { assertQueryPure as assertQuery };
 
@@ -341,10 +337,10 @@ function isQuery(): never {
   halt("isQuery");
 }
 
-const isQueryPure = /** @__PURE__ */ Object.assign<typeof isQuery, {}, {}>(
+const isQueryPure = /** #__PURE__*/ Object.assign<typeof isQuery, {}, {}>(
   isQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isQueryPure as isQuery };
 
@@ -386,14 +382,14 @@ function validateQuery<T extends object>(
 function validateQuery(): never {
   halt("validateQuery");
 }
-const validateQueryPure = /** @__PURE__ */ Object.assign<
+const validateQueryPure = /** #__PURE__*/ Object.assign<
   typeof validateQuery,
   {},
   {}
 >(
   validateQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validateQueryPure as validateQuery };
 
@@ -463,9 +459,9 @@ function headers(): never {
   halt("headers");
 }
 
-const headersPure = /** @__PURE__ */ Object.assign<typeof headers, {}>(
+const headersPure = /** #__PURE__*/ Object.assign<typeof headers, {}>(
   headers,
-  /** @__PURE__ */ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.http.headers(),
 );
 export { headersPure as headers };
 
@@ -532,14 +528,14 @@ function assertHeaders(): never {
   halt("assertHeaders");
 }
 
-const assertHeadersPure = /** @__PURE__ */ Object.assign<
+const assertHeadersPure = /** #__PURE__*/ Object.assign<
   typeof assertHeaders,
   {},
   {}
 >(
   assertHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.assert("http.assertHeaders"),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.assert("http.assertHeaders"),
 );
 export { assertHeadersPure as assertHeaders };
 
@@ -604,10 +600,10 @@ function isHeaders<T extends object>(
 function isHeaders(): never {
   halt("isHeaders");
 }
-const isHeadersPure = /** @__PURE__ */ Object.assign<typeof isHeaders, {}, {}>(
+const isHeadersPure = /** #__PURE__*/ Object.assign<typeof isHeaders, {}, {}>(
   isHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isHeadersPure as isHeaders };
 
@@ -672,14 +668,14 @@ function validateHeaders(): never {
   halt("validateHeaders");
 }
 
-const validateHeadersPure = /** @__PURE__ */ Object.assign<
+const validateHeadersPure = /** #__PURE__*/ Object.assign<
   typeof validateHeaders,
   {},
   {}
 >(
   validateHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validateHeadersPure as validateHeaders };
 
@@ -710,10 +706,10 @@ function parameter(): never {
   halt("parameter");
 }
 
-const parameterPure = /** @__PURE__ */ Object.assign<typeof parameter, {}, {}>(
+const parameterPure = /** #__PURE__*/ Object.assign<typeof parameter, {}, {}>(
   parameter,
-  /** @__PURE__ */ Namespace.http.parameter(),
-  /** @__PURE__ */ Namespace.assert("http.parameter"),
+  /** #__PURE__*/ Namespace.http.parameter(),
+  /** #__PURE__*/ Namespace.assert("http.parameter"),
 );
 export { parameterPure as parameter };
 
@@ -748,10 +744,10 @@ function createFormData<T>(): (input: FormData) => T {
   halt("createFormData");
 }
 
-const createFormDataPure = /** @__PURE__ */ Object.assign<
+const createFormDataPure = /** #__PURE__*/ Object.assign<
   typeof createFormData,
   {}
->(createFormData, /** @__PURE__ */ Namespace.http.formData());
+>(createFormData, /** #__PURE__*/ Namespace.http.formData());
 export { createFormDataPure as createFormData };
 
 /**
@@ -788,14 +784,14 @@ function createAssertFormData<T>(): (input: FormData) => T {
   halt("createAssertFormData");
 }
 
-const createAssertFormDataPure = /** @__PURE__ */ Object.assign<
+const createAssertFormDataPure = /** #__PURE__*/ Object.assign<
   typeof createAssertFormData,
   {},
   {}
 >(
   createAssertFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.assert("http.createAssertFormData"),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.assert("http.createAssertFormData"),
 );
 export { createAssertFormDataPure as createAssertFormData };
 
@@ -827,14 +823,14 @@ function createIsFormData<T>(): (input: FormData) => T | null {
   halt("createIsFormData");
 }
 
-const createIsFormDataPure = /** @__PURE__ */ Object.assign<
+const createIsFormDataPure = /** #__PURE__*/ Object.assign<
   typeof createIsFormData,
   {},
   {}
 >(
   createIsFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsFormDataPure as createIsFormData };
 
@@ -870,14 +866,14 @@ function createValidateFormData<T>(): (
   halt("createValidateFormData");
 }
 
-const createValidateFormDataPure = /** @__PURE__ */ Object.assign<
+const createValidateFormDataPure = /** #__PURE__*/ Object.assign<
   typeof createValidateFormData,
   {},
   {}
 >(
   createValidateFormData,
-  /** @__PURE__ */ Namespace.http.formData(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.formData(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidateFormDataPure as createValidateFormData };
 
@@ -911,9 +907,9 @@ function createQuery<T>(): (input: string | URLSearchParams) => T {
   halt("createQuery");
 }
 
-const createQueryPure = /** @__PURE__ */ Object.assign<typeof createQuery, {}>(
+const createQueryPure = /** #__PURE__*/ Object.assign<typeof createQuery, {}>(
   createQuery,
-  /** @__PURE__ */ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.http.query(),
 );
 export { createQueryPure as createQuery };
 
@@ -951,14 +947,14 @@ function createAssertQuery<T>(): (input: string | URLSearchParams) => T {
   halt("createAssertQuery");
 }
 
-const createAssertQueryPure = /** @__PURE__ */ Object.assign<
+const createAssertQueryPure = /** #__PURE__*/ Object.assign<
   typeof createAssertQuery,
   {},
   {}
 >(
   createAssertQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.assert("http.createAssertQuery"),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.assert("http.createAssertQuery"),
 );
 export { createAssertQueryPure as createAssertQuery };
 
@@ -992,14 +988,14 @@ function createIsQuery<T>(): (input: string | URLSearchParams) => T | null {
   halt("createIsQuery");
 }
 
-const createIsQueryPure = /** @__PURE__ */ Object.assign<
+const createIsQueryPure = /** #__PURE__*/ Object.assign<
   typeof createIsQuery,
   {},
   {}
 >(
   createIsQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsQueryPure as createIsQuery };
 
@@ -1035,14 +1031,14 @@ function createValidateQuery<T>(): (
   halt("createValidateQuery");
 }
 
-const createValidateQueryPure = /** @__PURE__ */ Object.assign<
+const createValidateQueryPure = /** #__PURE__*/ Object.assign<
   typeof createValidateQuery,
   {},
   {}
 >(
   createValidateQuery,
-  /** @__PURE__ */ Namespace.http.query(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.query(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidateQueryPure as createValidateQuery };
 
@@ -1078,10 +1074,10 @@ function createHeaders<T>(): (
   halt("createHeaders");
 }
 
-const createHeadersPure = /** @__PURE__ */ Object.assign<
+const createHeadersPure = /** #__PURE__*/ Object.assign<
   typeof createHeaders,
   {}
->(createHeaders, /** @__PURE__ */ Namespace.http.headers());
+>(createHeaders, /** #__PURE__*/ Namespace.http.headers());
 export { createHeadersPure as createHeaders };
 
 /**
@@ -1120,14 +1116,14 @@ function createAssertHeaders<T>(): (
   halt("createAssertHeaders");
 }
 
-const createAssertHeadersPure = /** @__PURE__ */ Object.assign<
+const createAssertHeadersPure = /** #__PURE__*/ Object.assign<
   typeof createAssertHeaders,
   {},
   {}
 >(
   createAssertHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.assert("http.createAssertHeaders"),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.assert("http.createAssertHeaders"),
 );
 export { createAssertHeadersPure as createAssertHeaders };
 
@@ -1163,14 +1159,14 @@ function createIsHeaders<T>(): (
   halt("createIsHeaders");
 }
 
-const createIsHeadersPure = /** @__PURE__ */ Object.assign<
+const createIsHeadersPure = /** #__PURE__*/ Object.assign<
   typeof createIsHeaders,
   {},
   {}
 >(
   createIsHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsHeadersPure as createIsHeaders };
 
@@ -1206,14 +1202,14 @@ function createValidateHeaders<T>(): (
   halt("createValidateHeaders");
 }
 
-const createValidateHeadersPure = /** @__PURE__ */ Object.assign<
+const createValidateHeadersPure = /** #__PURE__*/ Object.assign<
   typeof createValidateHeaders,
   {},
   {}
 >(
   createValidateHeaders,
-  /** @__PURE__ */ Namespace.http.headers(),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.http.headers(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidateHeadersPure as createValidateHeaders };
 
@@ -1245,14 +1241,14 @@ function createParameter<T extends Atomic.Type | null>(): (input: string) => T {
   halt("createParameter");
 }
 
-const createParameterPure = /** @__PURE__ */ Object.assign<
+const createParameterPure = /** #__PURE__*/ Object.assign<
   typeof createParameter,
   {},
   {}
 >(
   createParameter,
-  /** @__PURE__ */ Namespace.http.parameter(),
-  /** @__PURE__ */ Namespace.assert("http.createParameter"),
+  /** #__PURE__*/ Namespace.http.parameter(),
+  /** #__PURE__*/ Namespace.assert("http.createParameter"),
 );
 export { createParameterPure as createParameter };
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -124,9 +124,9 @@ function assertParse<T>(
 function assertParse<T>(): Primitive<T> {
   halt("assertParse");
 }
-const assertParsePure = /** @__PURE__ */ Object.assign<typeof assertParse, {}>(
+const assertParsePure = /** #__PURE__*/ Object.assign<typeof assertParse, {}>(
   assertParse,
-  /** @__PURE__ */ Namespace.assert("json.assertParse"),
+  /** #__PURE__*/ Namespace.assert("json.assertParse"),
 );
 export { assertParsePure as assertParse };
 
@@ -176,9 +176,9 @@ function isParse<T>(input: string): Primitive<T> | null;
 function isParse<T>(): Primitive<T> | null {
   halt("isParse");
 }
-const isParsePure = /** @__PURE__ */ Object.assign<typeof isParse, {}>(
+const isParsePure = /** #__PURE__*/ Object.assign<typeof isParse, {}>(
   isParse,
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isParsePure as isParse };
 
@@ -230,10 +230,10 @@ function validateParse<T>(input: string): IValidation<Primitive<T>>;
 function validateParse<T>(): IValidation<Primitive<T>> {
   halt("validateParse");
 }
-const validateParsePure = /** @__PURE__ */ Object.assign<
+const validateParsePure = /** #__PURE__*/ Object.assign<
   typeof validateParse,
   {}
->(validateParse, /** @__PURE__ */ Namespace.validate());
+>(validateParse, /** #__PURE__*/ Namespace.validate());
 export { validateParsePure as validateParse };
 
 /* -----------------------------------------------------------
@@ -269,9 +269,9 @@ function stringify<T>(input: T): string;
 function stringify(): never {
   halt("stringify");
 }
-const stringifyPure = /** @__PURE__ */ Object.assign<typeof stringify, {}>(
+const stringifyPure = /** #__PURE__*/ Object.assign<typeof stringify, {}>(
   stringify,
-  /** @__PURE__ */ Namespace.json.stringify("stringify"),
+  /** #__PURE__*/ Namespace.json.stringify("stringify"),
 );
 export { stringifyPure as stringify };
 
@@ -335,14 +335,14 @@ function assertStringify<T>(
 function assertStringify(): string {
   halt("assertStringify");
 }
-const assertStringifyPure = /** @__PURE__ */ Object.assign<
+const assertStringifyPure = /** #__PURE__*/ Object.assign<
   typeof assertStringify,
   {},
   {}
 >(
   assertStringify,
-  /** @__PURE__ */ Namespace.assert("json.assertStringify"),
-  /** @__PURE__ */ Namespace.json.stringify("assertStringify"),
+  /** #__PURE__*/ Namespace.assert("json.assertStringify"),
+  /** #__PURE__*/ Namespace.json.stringify("assertStringify"),
 );
 export { assertStringifyPure as assertStringify };
 
@@ -399,14 +399,14 @@ function isStringify(): string | null {
   halt("isStringify");
 }
 
-const isStringifyPure = /** @__PURE__ */ Object.assign<
+const isStringifyPure = /** #__PURE__*/ Object.assign<
   typeof isStringify,
   {},
   {}
 >(
   isStringify,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.json.stringify("isStringify"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.json.stringify("isStringify"),
 );
 export { isStringifyPure as isStringify };
 
@@ -464,14 +464,14 @@ function validateStringify<T>(input: unknown): IValidation<string>;
 function validateStringify(): IValidation<string> {
   halt("validateStringify");
 }
-const validateStringifyPure = /** @__PURE__ */ Object.assign<
+const validateStringifyPure = /** #__PURE__*/ Object.assign<
   typeof validateStringify,
   {},
   {}
 >(
   validateStringify,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.json.stringify("validateStringify"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.json.stringify("validateStringify"),
 );
 export { validateStringifyPure as validateStringify };
 
@@ -505,7 +505,7 @@ function createIsParse<T>(): (input: string) => Primitive<T> | null;
 function createIsParse<T>(): (input: string) => Primitive<T> | null {
   halt("createIsParse");
 }
-const createIsParsePure = /** @__PURE__ */ Object.assign<
+const createIsParsePure = /** #__PURE__*/ Object.assign<
   typeof createIsParse,
   {}
 >(createIsParse, isParsePure);
@@ -544,7 +544,7 @@ function createAssertParse<T>(
 function createAssertParse<T>(): (input: string) => Primitive<T> {
   halt("createAssertParse");
 }
-const createAssertParsePure = /** @__PURE__ */ Object.assign<
+const createAssertParsePure = /** #__PURE__*/ Object.assign<
   typeof createAssertParse,
   {}
 >(createAssertParse, assertParsePure);
@@ -580,7 +580,7 @@ function createValidateParse<T>(): (
   halt("createValidateParse");
 }
 
-const createValidateParsePure = /** @__PURE__ */ Object.assign<
+const createValidateParsePure = /** #__PURE__*/ Object.assign<
   typeof createValidateParse,
   {}
 >(createValidateParse, validateParsePure);
@@ -614,7 +614,7 @@ function createStringify<T>(): (input: T) => string {
   halt("createStringify");
 }
 
-const createStringifyPure = /** @__PURE__ */ Object.assign<
+const createStringifyPure = /** #__PURE__*/ Object.assign<
   typeof createStringify,
   {}
 >(createStringify, stringifyPure);
@@ -654,7 +654,7 @@ function createAssertStringify(): (input: unknown) => string {
   halt("createAssertStringify");
 }
 
-const createAssertStringifyPure = /** @__PURE__ */ Object.assign<
+const createAssertStringifyPure = /** #__PURE__*/ Object.assign<
   typeof createAssertStringify,
   {}
 >(createAssertStringify, assertStringifyPure);
@@ -688,7 +688,7 @@ function createIsStringify(): (input: unknown) => string | null {
   halt("createIsStringify");
 }
 
-const createIsStringifyPure = /** @__PURE__ */ Object.assign<
+const createIsStringifyPure = /** #__PURE__*/ Object.assign<
   typeof createIsStringify,
   {}
 >(createIsStringify, isStringifyPure);
@@ -722,7 +722,7 @@ function createValidateStringify(): (input: unknown) => IValidation<string> {
   halt("createValidateStringify");
 }
 
-const createValidateStringifyPure = /** @__PURE__ */ Object.assign<
+const createValidateStringifyPure = /** #__PURE__*/ Object.assign<
   typeof createValidateStringify,
   {}
 >(createValidateStringify, validateStringifyPure);

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -85,9 +85,9 @@ function clone<T>(input: T): Resolved<T>;
 function clone(): never {
   halt("clone");
 }
-const clonePure = /** @__PURE__ */ Object.assign<typeof clone, {}>(
+const clonePure = /** #__PURE__*/ Object.assign<typeof clone, {}>(
   clone,
-  /** @__PURE__ */ Namespace.misc.clone("clone"),
+  /** #__PURE__*/ Namespace.misc.clone("clone"),
 );
 export { clonePure as clone };
 
@@ -143,14 +143,14 @@ function assertClone<T>(
 function assertClone(): never {
   halt("assertClone");
 }
-const assertClonePure = /** @__PURE__ */ Object.assign<
+const assertClonePure = /** #__PURE__*/ Object.assign<
   typeof assertClone,
   {},
   {}
 >(
   assertClone,
-  /** @__PURE__ */ Namespace.assert("misc.assertClone"),
-  /** @__PURE__ */ Namespace.misc.clone("assertClone"),
+  /** #__PURE__*/ Namespace.assert("misc.assertClone"),
+  /** #__PURE__*/ Namespace.misc.clone("assertClone"),
 );
 export { assertClonePure as assertClone };
 
@@ -198,10 +198,10 @@ function isClone<T>(input: unknown): Resolved<T> | null;
 function isClone(): never {
   halt("isClone");
 }
-const isClonePure = /** @__PURE__ */ Object.assign<typeof isClone, {}, {}>(
+const isClonePure = /** #__PURE__*/ Object.assign<typeof isClone, {}, {}>(
   isClone,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.misc.clone("isClone"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.misc.clone("isClone"),
 );
 export { isClonePure as isClone };
 
@@ -247,14 +247,14 @@ function validateClone<T>(input: unknown): IValidation<Resolved<T>>;
 function validateClone(): never {
   halt("validateClone");
 }
-const validateClonePure = /** @__PURE__ */ Object.assign<
+const validateClonePure = /** #__PURE__*/ Object.assign<
   typeof validateClone,
   {},
   {}
 >(
   validateClone,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.misc.clone("validateClone"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.misc.clone("validateClone"),
 );
 export { validateClonePure as validateClone };
 
@@ -290,9 +290,9 @@ function prune<T extends object>(input: T): void;
 function prune(): never {
   halt("prune");
 }
-const prunePure = /** @__PURE__ */ Object.assign<typeof prune, {}>(
+const prunePure = /** #__PURE__*/ Object.assign<typeof prune, {}>(
   prune,
-  /** @__PURE__ */ Namespace.misc.prune("prune"),
+  /** #__PURE__*/ Namespace.misc.prune("prune"),
 );
 export { prunePure as prune };
 
@@ -348,14 +348,14 @@ function assertPrune<T>(
 function assertPrune(): unknown {
   halt("assertPrune");
 }
-const assertPrunePure = /** @__PURE__ */ Object.assign<
+const assertPrunePure = /** #__PURE__*/ Object.assign<
   typeof assertPrune,
   {},
   {}
 >(
   assertPrune,
-  /** @__PURE__ */ Namespace.assert("misc.assertPrune"),
-  /** @__PURE__ */ Namespace.misc.prune("assertPrune"),
+  /** #__PURE__*/ Namespace.assert("misc.assertPrune"),
+  /** #__PURE__*/ Namespace.misc.prune("assertPrune"),
 );
 export { assertPrunePure as assertPrune };
 
@@ -403,10 +403,10 @@ function isPrune<T>(input: unknown): input is T;
 function isPrune(): never {
   halt("isPrune");
 }
-const isPrunePure = /** @__PURE__ */ Object.assign<typeof isPrune, {}, {}>(
+const isPrunePure = /** #__PURE__*/ Object.assign<typeof isPrune, {}, {}>(
   isPrune,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.misc.prune("isPrune"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.misc.prune("isPrune"),
 );
 export { isPrunePure as isPrune };
 
@@ -457,14 +457,14 @@ function validatePrune<T>(): IValidation<T> {
   halt("validatePrune");
 }
 
-const validatePrunePure = /** @__PURE__ */ Object.assign<
+const validatePrunePure = /** #__PURE__*/ Object.assign<
   typeof validatePrune,
   {},
   {}
 >(
   validatePrune,
-  /** @__PURE__ */ Namespace.misc.prune("validatePrune"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.misc.prune("validatePrune"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validatePrunePure as validatePrune };
 
@@ -498,7 +498,7 @@ function createClone<T>(): (input: T) => Resolved<T>;
 function createClone(): never {
   halt("createClone");
 }
-const createClonePure = /** @__PURE__ */ Object.assign<typeof createClone, {}>(
+const createClonePure = /** #__PURE__*/ Object.assign<typeof createClone, {}>(
   createClone,
   clonePure,
 );
@@ -537,7 +537,7 @@ function createAssertClone<T>(
 function createAssertClone(): never {
   halt("createAssertClone");
 }
-const createAssertClonePure = /** @__PURE__ */ Object.assign<
+const createAssertClonePure = /** #__PURE__*/ Object.assign<
   typeof createAssertClone,
   {}
 >(createAssertClone, assertClonePure);
@@ -570,7 +570,7 @@ function createIsClone<T>(): (input: unknown) => Resolved<T> | null;
 function createIsClone(): never {
   halt("createIsClone");
 }
-const createIsClonePure = /** @__PURE__ */ Object.assign<
+const createIsClonePure = /** #__PURE__*/ Object.assign<
   typeof createIsClone,
   {}
 >(createIsClone, isClonePure);
@@ -603,7 +603,7 @@ function createValidateClone<T>(): (input: unknown) => IValidation<Resolved<T>>;
 function createValidateClone(): never {
   halt("createValidateClone");
 }
-const createValidateClonePure = /** @__PURE__ */ Object.assign<
+const createValidateClonePure = /** #__PURE__*/ Object.assign<
   typeof createValidateClone,
   {}
 >(createValidateClone, validateClonePure);
@@ -636,7 +636,7 @@ function createPrune<T extends object>(): (input: T) => void;
 function createPrune<T extends object>(): (input: T) => void {
   halt("createPrune");
 }
-const createPrunePure = /** @__PURE__ */ Object.assign<typeof createPrune, {}>(
+const createPrunePure = /** #__PURE__*/ Object.assign<typeof createPrune, {}>(
   createPrune,
   prunePure,
 );
@@ -675,7 +675,7 @@ function createAssertPrune<T extends object>(
 function createAssertPrune<T extends object>(): (input: T) => T {
   halt("createAssertPrune");
 }
-const createAssertPrunePure = /** @__PURE__ */ Object.assign<
+const createAssertPrunePure = /** #__PURE__*/ Object.assign<
   typeof createAssertPrune,
   {}
 >(createAssertPrune, assertPrunePure);
@@ -708,7 +708,7 @@ function createIsPrune<T extends object>(): (input: T) => input is T;
 function createIsPrune<T extends object>(): (input: T) => input is T {
   halt("createIsPrune");
 }
-const createIsPrunePure = /** @__PURE__ */ Object.assign<
+const createIsPrunePure = /** #__PURE__*/ Object.assign<
   typeof createIsPrune,
   {}
 >(createIsPrune, isPrunePure);
@@ -741,7 +741,7 @@ function createValidatePrune<T extends object>(): (input: T) => IValidation<T>;
 function createValidatePrune<T extends object>(): (input: T) => IValidation<T> {
   halt("createValidatePrune");
 }
-const createValidatePrunePure = /** @__PURE__ */ Object.assign<
+const createValidatePrunePure = /** #__PURE__*/ Object.assign<
   typeof createValidatePrune,
   {}
 >(createValidatePrune, validatePrunePure);

--- a/src/module.ts
+++ b/src/module.ts
@@ -93,9 +93,9 @@ function assert<T>(
 function assert(): never {
   halt("assert");
 }
-const assertPure = /** @__PURE__ */ Object.assign<typeof assert, {}>(
+const assertPure = /** #__PURE__*/ Object.assign<typeof assert, {}>(
   assert,
-  /** @__PURE__ */ Namespace.assert("assert"),
+  /** #__PURE__*/ Namespace.assert("assert"),
 );
 export { assertPure as assert };
 
@@ -165,9 +165,9 @@ function assertGuard<T>(
 function assertGuard(): never {
   halt("assertGuard");
 }
-const assertGuardPure = /** @__PURE__ */ Object.assign<typeof assertGuard, {}>(
+const assertGuardPure = /** #__PURE__*/ Object.assign<typeof assertGuard, {}>(
   assertGuard,
-  /** @__PURE__ */ Namespace.assert("assertGuard"),
+  /** #__PURE__*/ Namespace.assert("assertGuard"),
 );
 export { assertGuardPure as assertGuard };
 
@@ -226,9 +226,9 @@ function is<T>(input: unknown): input is T;
 function is(): never {
   halt("is");
 }
-const isPure = /** @__PURE__ */ Object.assign<typeof is, {}>(
+const isPure = /** #__PURE__*/ Object.assign<typeof is, {}>(
   is,
-  /** @__PURE__ */ Namespace.assert("is"),
+  /** #__PURE__*/ Namespace.assert("is"),
 );
 export { isPure as is };
 
@@ -288,9 +288,9 @@ function validate<T>(input: unknown): IValidation<T>;
 function validate(): never {
   halt("validate");
 }
-const validatePure = /** @__PURE__ */ Object.assign<typeof validate, {}>(
+const validatePure = /** #__PURE__*/ Object.assign<typeof validate, {}>(
   validate,
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validatePure as validate };
 
@@ -361,10 +361,10 @@ function assertEquals<T>(
 function assertEquals(): never {
   halt("assertEquals");
 }
-const assertEqualsPure = /** @__PURE__ */ Object.assign<
-  typeof assertEquals,
-  {}
->(assertEquals, /** @__PURE__ */ Namespace.assert("assertEquals"));
+const assertEqualsPure = /** #__PURE__*/ Object.assign<typeof assertEquals, {}>(
+  assertEquals,
+  /** #__PURE__*/ Namespace.assert("assertEquals"),
+);
 export { assertEqualsPure as assertEquals };
 
 /**
@@ -439,10 +439,10 @@ function assertGuardEquals<T>(
 function assertGuardEquals(): never {
   halt("assertGuardEquals");
 }
-const assertGuardEqualsPure = /** @__PURE__ */ Object.assign<
+const assertGuardEqualsPure = /** #__PURE__*/ Object.assign<
   typeof assertGuardEquals,
   {}
->(assertGuardEquals, /** @__PURE__ */ Namespace.assert("assertGuardEquals"));
+>(assertGuardEquals, /** #__PURE__*/ Namespace.assert("assertGuardEquals"));
 export { assertGuardEqualsPure as assertGuardEquals };
 
 /**
@@ -501,9 +501,9 @@ function equals<T>(input: unknown): input is T;
 function equals(): never {
   halt("equals");
 }
-const equalsPure = /** @__PURE__ */ Object.assign<typeof equals, {}>(
+const equalsPure = /** #__PURE__*/ Object.assign<typeof equals, {}>(
   equals,
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { equalsPure as equals };
 
@@ -565,10 +565,10 @@ function validateEquals<T>(input: unknown): IValidation<T>;
 function validateEquals(): never {
   halt("validateEquals");
 }
-const validateEqualsPure = /** @__PURE__ */ Object.assign<
+const validateEqualsPure = /** #__PURE__*/ Object.assign<
   typeof validateEquals,
   {}
->(validateEquals, /** @__PURE__ */ Namespace.validate());
+>(validateEquals, /** #__PURE__*/ Namespace.validate());
 export { validateEqualsPure as validateEquals };
 
 /* -----------------------------------------------------------
@@ -618,9 +618,9 @@ function random<T>(generator?: Partial<IRandomGenerator>): Resolved<T>;
 function random(): never {
   halt("random");
 }
-const randomPure = /** @__PURE__ */ Object.assign<typeof random, {}>(
+const randomPure = /** #__PURE__*/ Object.assign<typeof random, {}>(
   random,
-  /** @__PURE__ */ Namespace.random(),
+  /** #__PURE__*/ Namespace.random(),
 );
 export { randomPure as random };
 
@@ -660,10 +660,10 @@ function createAssert<T>(
 function createAssert<T>(): (input: unknown) => T {
   halt("createAssert");
 }
-const createAssertPure = /** @__PURE__ */ Object.assign<
-  typeof createAssert,
-  {}
->(createAssert, assertPure);
+const createAssertPure = /** #__PURE__*/ Object.assign<typeof createAssert, {}>(
+  createAssert,
+  assertPure,
+);
 export { createAssertPure as createAssert };
 
 /**
@@ -729,7 +729,7 @@ function createAssertGuard<T>(
 function createAssertGuard<T>(): (input: unknown) => AssertionGuard<T> {
   halt("createAssertGuard");
 }
-const createAssertGuardPure = /** @__PURE__ */ Object.assign<
+const createAssertGuardPure = /** #__PURE__*/ Object.assign<
   typeof createAssertGuard,
   {}
 >(createAssertGuard, assertGuardPure);
@@ -762,7 +762,7 @@ function createIs<T>(): (input: unknown) => input is T;
 function createIs<T>(): (input: unknown) => input is T {
   halt("createIs");
 }
-const createIsPure = /** @__PURE__ */ Object.assign<typeof createIs, {}>(
+const createIsPure = /** #__PURE__*/ Object.assign<typeof createIs, {}>(
   createIs,
   isPure,
 );
@@ -795,7 +795,7 @@ function createValidate<T>(): (input: unknown) => IValidation<T>;
 function createValidate(): (input: unknown) => IValidation {
   halt("createValidate");
 }
-const createValidatePure = /** @__PURE__ */ Object.assign<
+const createValidatePure = /** #__PURE__*/ Object.assign<
   typeof createValidate,
   {}
 >(createValidate, validatePure);
@@ -834,7 +834,7 @@ function createAssertEquals<T>(
 function createAssertEquals<T>(): (input: unknown) => T {
   halt("createAssertEquals");
 }
-const createAssertEqualsPure = /** @__PURE__ */ Object.assign<
+const createAssertEqualsPure = /** #__PURE__*/ Object.assign<
   typeof createAssertEquals,
   {}
 >(createAssertEquals, assertEqualsPure);
@@ -903,7 +903,7 @@ function createAssertGuardEquals<T>(
 function createAssertGuardEquals<T>(): (input: unknown) => AssertionGuard<T> {
   halt("createAssertGuardEquals");
 }
-const createAssertGuardEqualsPure = /** @__PURE__ */ Object.assign<
+const createAssertGuardEqualsPure = /** #__PURE__*/ Object.assign<
   typeof createAssertGuardEquals,
   {}
 >(createAssertGuardEquals, assertGuardEqualsPure);
@@ -936,10 +936,10 @@ function createEquals<T>(): (input: unknown) => input is T;
 function createEquals<T>(): (input: unknown) => input is T {
   halt("createEquals");
 }
-const createEqualsPure = /** @__PURE__ */ Object.assign<
-  typeof createEquals,
-  {}
->(createEquals, equalsPure);
+const createEqualsPure = /** #__PURE__*/ Object.assign<typeof createEquals, {}>(
+  createEquals,
+  equalsPure,
+);
 export { createEqualsPure as createEquals };
 
 /**
@@ -969,7 +969,7 @@ function createValidateEquals<T>(): (input: unknown) => IValidation<T>;
 function createValidateEquals(): (input: unknown) => IValidation {
   halt("createValidateEquals");
 }
-const createValidateEqualsPure = /** @__PURE__ */ Object.assign<
+const createValidateEqualsPure = /** #__PURE__*/ Object.assign<
   typeof createValidateEquals,
   {}
 >(createValidateEquals, validateEqualsPure);
@@ -1006,10 +1006,10 @@ function createRandom<T>(
 function createRandom(): never {
   halt("createRandom");
 }
-const createRandomPure = /** @__PURE__ */ Object.assign<
-  typeof createRandom,
-  {}
->(createRandom, randomPure);
+const createRandomPure = /** #__PURE__*/ Object.assign<typeof createRandom, {}>(
+  createRandom,
+  randomPure,
+);
 export { createRandomPure as createRandom };
 
 /**

--- a/src/notations.ts
+++ b/src/notations.ts
@@ -42,9 +42,9 @@ function camel<T>(input: T): CamelCase<T>;
 function camel(): never {
   return halt("camel");
 }
-const camelPure = /** @__PURE__ */ Object.assign<typeof camel, {}>(
+const camelPure = /** #__PURE__*/ Object.assign<typeof camel, {}>(
   camel,
-  /** @__PURE__ */ Namespace.notations.camel("camel"),
+  /** #__PURE__*/ Namespace.notations.camel("camel"),
 );
 export { camelPure as camel };
 
@@ -90,14 +90,14 @@ function assertCamel<T>(
 function assertCamel(): never {
   return halt("assertCamel");
 }
-const assertCamelPure = /** @__PURE__ */ Object.assign<
+const assertCamelPure = /** #__PURE__*/ Object.assign<
   typeof assertCamel,
   {},
   {}
 >(
   assertCamel,
-  /** @__PURE__ */ Namespace.notations.camel("assertCamel"),
-  /** @__PURE__ */ Namespace.assert("notations.assertCamel"),
+  /** #__PURE__*/ Namespace.notations.camel("assertCamel"),
+  /** #__PURE__*/ Namespace.assert("notations.assertCamel"),
 );
 export { assertCamelPure as assertCamel };
 
@@ -135,10 +135,10 @@ function isCamel<T>(input: unknown): CamelCase<T> | null;
 function isCamel(): never {
   return halt("isCamel");
 }
-const isCamelPure = /** @__PURE__ */ Object.assign<typeof isCamel, {}, {}>(
+const isCamelPure = /** #__PURE__*/ Object.assign<typeof isCamel, {}, {}>(
   isCamel,
-  /** @__PURE__ */ Namespace.notations.camel("isCamel"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.camel("isCamel"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isCamelPure as isCamel };
 
@@ -180,14 +180,14 @@ function validateCamel<T>(input: unknown): IValidation<CamelCase<T>>;
 function validateCamel(): never {
   return halt("validateCamel");
 }
-const validateCamelPure = /** @__PURE__ */ Object.assign<
+const validateCamelPure = /** #__PURE__*/ Object.assign<
   typeof validateCamel,
   {},
   {}
 >(
   validateCamel,
-  /** @__PURE__ */ Namespace.notations.camel("validateCamel"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.camel("validateCamel"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validateCamelPure as validateCamel };
 
@@ -221,9 +221,9 @@ function pascal<T>(input: T): PascalCase<T>;
 function pascal(): never {
   return halt("pascal");
 }
-const pascalPure = /** @__PURE__ */ Object.assign<typeof pascal, {}>(
+const pascalPure = /** #__PURE__*/ Object.assign<typeof pascal, {}>(
   pascal,
-  /** @__PURE__ */ Namespace.notations.pascal("pascal"),
+  /** #__PURE__*/ Namespace.notations.pascal("pascal"),
 );
 export { pascalPure as pascal };
 
@@ -269,14 +269,14 @@ function assertPascal<T>(
 function assertPascal(): never {
   return halt("assertPascal");
 }
-const assertPascalPure = /** @__PURE__ */ Object.assign<
+const assertPascalPure = /** #__PURE__*/ Object.assign<
   typeof assertPascal,
   {},
   {}
 >(
   assertPascal,
-  /** @__PURE__ */ Namespace.notations.pascal("assertPascal"),
-  /** @__PURE__ */ Namespace.assert("notations.assertPascal"),
+  /** #__PURE__*/ Namespace.notations.pascal("assertPascal"),
+  /** #__PURE__*/ Namespace.assert("notations.assertPascal"),
 );
 export { assertPascalPure as assertPascal };
 
@@ -314,10 +314,10 @@ function isPascal<T>(input: unknown): PascalCase<T> | null;
 function isPascal(): never {
   return halt("isPascal");
 }
-const isPascalPure = /** @__PURE__ */ Object.assign<typeof isPascal, {}, {}>(
+const isPascalPure = /** #__PURE__*/ Object.assign<typeof isPascal, {}, {}>(
   isPascal,
-  /** @__PURE__ */ Namespace.notations.pascal("isPascal"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.pascal("isPascal"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isPascalPure as isPascal };
 
@@ -359,14 +359,14 @@ function validatePascal<T>(input: unknown): IValidation<PascalCase<T>>;
 function validatePascal(): never {
   return halt("validatePascal");
 }
-const validatePascalPure = /** @__PURE__ */ Object.assign<
+const validatePascalPure = /** #__PURE__*/ Object.assign<
   typeof validatePascal,
   {},
   {}
 >(
   validatePascal,
-  /** @__PURE__ */ Namespace.notations.pascal("validatePascal"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.pascal("validatePascal"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validatePascalPure as validatePascal };
 
@@ -400,9 +400,9 @@ function snake<T>(input: T): SnakeCase<T>;
 function snake(): never {
   return halt("snake");
 }
-const snakePure = /** @__PURE__ */ Object.assign<typeof snake, {}>(
+const snakePure = /** #__PURE__*/ Object.assign<typeof snake, {}>(
   snake,
-  /** @__PURE__ */ Namespace.notations.snake("snake"),
+  /** #__PURE__*/ Namespace.notations.snake("snake"),
 );
 export { snakePure as snake };
 
@@ -448,14 +448,14 @@ function assertSnake<T>(
 function assertSnake(): never {
   return halt("assertSnake");
 }
-const assertSnakePure = /** @__PURE__ */ Object.assign<
+const assertSnakePure = /** #__PURE__*/ Object.assign<
   typeof assertSnake,
   {},
   {}
 >(
   assertSnake,
-  /** @__PURE__ */ Namespace.notations.snake("assertSnake"),
-  /** @__PURE__ */ Namespace.assert("notations.assertSnake"),
+  /** #__PURE__*/ Namespace.notations.snake("assertSnake"),
+  /** #__PURE__*/ Namespace.assert("notations.assertSnake"),
 );
 export { assertSnakePure as assertSnake };
 
@@ -493,10 +493,10 @@ function isSnake<T>(input: unknown): SnakeCase<T> | null;
 function isSnake(): never {
   return halt("isSnake");
 }
-const isSnakePure = /** @__PURE__ */ Object.assign<typeof isSnake, {}, {}>(
+const isSnakePure = /** #__PURE__*/ Object.assign<typeof isSnake, {}, {}>(
   isSnake,
-  /** @__PURE__ */ Namespace.notations.snake("isSnake"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.snake("isSnake"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { isSnakePure as isSnake };
 
@@ -538,14 +538,14 @@ function validateSnake<T>(input: unknown): IValidation<SnakeCase<T>>;
 function validateSnake(): never {
   return halt("validateSnake");
 }
-const validateSnakePure = /** @__PURE__ */ Object.assign<
+const validateSnakePure = /** #__PURE__*/ Object.assign<
   typeof validateSnake,
   {},
   {}
 >(
   validateSnake,
-  /** @__PURE__ */ Namespace.notations.snake("validateSnake"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.snake("validateSnake"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { validateSnakePure as validateSnake };
 /* -----------------------------------------------------------
@@ -578,9 +578,9 @@ function createCamel<T>(): (input: T) => CamelCase<T>;
 function createCamel(): never {
   halt("createCamel");
 }
-const createCamelPure = /** @__PURE__ */ Object.assign<typeof createCamel, {}>(
+const createCamelPure = /** #__PURE__*/ Object.assign<typeof createCamel, {}>(
   createCamel,
-  /** @__PURE__ */ Namespace.notations.camel("createCamel"),
+  /** #__PURE__*/ Namespace.notations.camel("createCamel"),
 );
 export { createCamelPure as createCamel };
 
@@ -617,14 +617,14 @@ function createAssertCamel<T>(
 function createAssertCamel(): never {
   halt("createAssertCamel");
 }
-const createAssertCamelPure = /** @__PURE__ */ Object.assign<
+const createAssertCamelPure = /** #__PURE__*/ Object.assign<
   typeof createAssertCamel,
   {},
   {}
 >(
   createAssertCamel,
-  /** @__PURE__ */ Namespace.notations.camel("createAssertCamel"),
-  /** @__PURE__ */ Namespace.assert("notations.createAssertCamel"),
+  /** #__PURE__*/ Namespace.notations.camel("createAssertCamel"),
+  /** #__PURE__*/ Namespace.assert("notations.createAssertCamel"),
 );
 export { createAssertCamelPure as createAssertCamel };
 
@@ -655,14 +655,14 @@ function createIsCamel<T>(): (input: T) => CamelCase<T> | null;
 function createIsCamel(): never {
   halt("createIsCamel");
 }
-const createIsCamelPure = /** @__PURE__ */ Object.assign<
+const createIsCamelPure = /** #__PURE__*/ Object.assign<
   typeof createIsCamel,
   {},
   {}
 >(
   createIsCamel,
-  /** @__PURE__ */ Namespace.notations.camel("createIsCamel"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.camel("createIsCamel"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsCamelPure as createIsCamel };
 
@@ -693,14 +693,14 @@ function createValidateCamel<T>(): (input: T) => IValidation<CamelCase<T>>;
 function createValidateCamel(): never {
   halt("createValidateCamel");
 }
-const createValidateCamelPure = /** @__PURE__ */ Object.assign<
+const createValidateCamelPure = /** #__PURE__*/ Object.assign<
   typeof createValidateCamel,
   {},
   {}
 >(
   createValidateCamel,
-  /** @__PURE__ */ Namespace.notations.camel("createValidateCamel"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.camel("createValidateCamel"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidateCamelPure as createValidateCamel };
 
@@ -731,10 +731,10 @@ function createPascal<T>(): (input: T) => PascalCase<T>;
 function createPascal(): never {
   halt("createPascal");
 }
-const createPascalPure = /** @__PURE__ */ Object.assign<
-  typeof createPascal,
-  {}
->(createPascal, /** @__PURE__ */ Namespace.notations.pascal("createPascal"));
+const createPascalPure = /** #__PURE__*/ Object.assign<typeof createPascal, {}>(
+  createPascal,
+  /** #__PURE__*/ Namespace.notations.pascal("createPascal"),
+);
 export { createPascalPure as createPascal };
 
 /**
@@ -770,14 +770,14 @@ function createAssertPascal<T>(
 function createAssertPascal(): never {
   halt("createAssertPascal");
 }
-const createAssertPascalPure = /** @__PURE__ */ Object.assign<
+const createAssertPascalPure = /** #__PURE__*/ Object.assign<
   typeof createAssertPascal,
   {},
   {}
 >(
   createAssertPascal,
-  /** @__PURE__ */ Namespace.notations.pascal("createAssertPascal"),
-  /** @__PURE__ */ Namespace.assert("notations.createAssertPascal"),
+  /** #__PURE__*/ Namespace.notations.pascal("createAssertPascal"),
+  /** #__PURE__*/ Namespace.assert("notations.createAssertPascal"),
 );
 export { createAssertPascalPure as createAssertPascal };
 
@@ -808,14 +808,14 @@ function createIsPascal<T>(): (input: T) => PascalCase<T> | null;
 function createIsPascal(): never {
   halt("createIsPascal");
 }
-const createIsPascalPure = /** @__PURE__ */ Object.assign<
+const createIsPascalPure = /** #__PURE__*/ Object.assign<
   typeof createIsPascal,
   {},
   {}
 >(
   createIsPascal,
-  /** @__PURE__ */ Namespace.notations.pascal("createIsPascal"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.pascal("createIsPascal"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsPascalPure as createIsPascal };
 
@@ -846,14 +846,14 @@ function createValidatePascal<T>(): (input: T) => IValidation<PascalCase<T>>;
 function createValidatePascal(): never {
   halt("createValidatePascal");
 }
-const createValidatePascalPure = /** @__PURE__ */ Object.assign<
+const createValidatePascalPure = /** #__PURE__*/ Object.assign<
   typeof createValidatePascal,
   {},
   {}
 >(
   createValidatePascal,
-  /** @__PURE__ */ Namespace.notations.pascal("createValidatePascal"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.pascal("createValidatePascal"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidatePascalPure as createValidatePascal };
 
@@ -884,9 +884,9 @@ function createSnake<T>(): (input: T) => SnakeCase<T>;
 function createSnake(): never {
   halt("createSnake");
 }
-const createSnakePure = /** @__PURE__ */ Object.assign<typeof createSnake, {}>(
+const createSnakePure = /** #__PURE__*/ Object.assign<typeof createSnake, {}>(
   createSnake,
-  /** @__PURE__ */ Namespace.notations.snake("createSnake"),
+  /** #__PURE__*/ Namespace.notations.snake("createSnake"),
 );
 export { createSnakePure as createSnake };
 
@@ -923,14 +923,14 @@ function createAssertSnake<T>(
 function createAssertSnake(): never {
   halt("createAssertSnake");
 }
-const createAssertSnakePure = /** @__PURE__ */ Object.assign<
+const createAssertSnakePure = /** #__PURE__*/ Object.assign<
   typeof createAssertSnake,
   {},
   {}
 >(
   createAssertSnake,
-  /** @__PURE__ */ Namespace.notations.snake("createAssertSnake"),
-  /** @__PURE__ */ Namespace.assert("notations.createAssertSnake"),
+  /** #__PURE__*/ Namespace.notations.snake("createAssertSnake"),
+  /** #__PURE__*/ Namespace.assert("notations.createAssertSnake"),
 );
 export { createAssertSnakePure as createAssertSnake };
 
@@ -961,14 +961,14 @@ function createIsSnake<T>(): (input: T) => SnakeCase<T> | null;
 function createIsSnake(): never {
   halt("createIsSnake");
 }
-const createIsSnakePure = /** @__PURE__ */ Object.assign<
+const createIsSnakePure = /** #__PURE__*/ Object.assign<
   typeof createIsSnake,
   {},
   {}
 >(
   createIsSnake,
-  /** @__PURE__ */ Namespace.notations.snake("createIsSnake"),
-  /** @__PURE__ */ Namespace.is(),
+  /** #__PURE__*/ Namespace.notations.snake("createIsSnake"),
+  /** #__PURE__*/ Namespace.is(),
 );
 export { createIsSnakePure as createIsSnake };
 
@@ -999,14 +999,14 @@ function createValidateSnake<T>(): (input: T) => IValidation<SnakeCase<T>>;
 function createValidateSnake(): never {
   halt("createValidateSnake");
 }
-const createValidateSnakePure = /** @__PURE__ */ Object.assign<
+const createValidateSnakePure = /** #__PURE__*/ Object.assign<
   typeof createValidateSnake,
   {},
   {}
 >(
   createValidateSnake,
-  /** @__PURE__ */ Namespace.notations.snake("createValidateSnake"),
-  /** @__PURE__ */ Namespace.validate(),
+  /** #__PURE__*/ Namespace.notations.snake("createValidateSnake"),
+  /** #__PURE__*/ Namespace.validate(),
 );
 export { createValidateSnakePure as createValidateSnake };
 

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -133,9 +133,9 @@ function decode<T>(input: Uint8Array): Resolved<T>;
 function decode(): never {
   halt("decode");
 }
-const decodePure = /** @__PURE__ */ Object.assign<typeof decode, {}>(
+const decodePure = /** #__PURE__*/ Object.assign<typeof decode, {}>(
   decode,
-  /** @__PURE__ */ Namespace.protobuf.decode("decode"),
+  /** #__PURE__*/ Namespace.protobuf.decode("decode"),
 );
 export { decodePure as decode };
 
@@ -214,14 +214,14 @@ function assertDecode(): never {
   halt("assertDecode");
 }
 
-const assertDecodePure = /** @__PURE__ */ Object.assign<
+const assertDecodePure = /** #__PURE__*/ Object.assign<
   typeof assertDecode,
   {},
   {}
 >(
   assertDecode,
-  /** @__PURE__ */ Namespace.assert("protobuf.assertDecode"),
-  /** @__PURE__ */ Namespace.protobuf.decode("assertDecode"),
+  /** #__PURE__*/ Namespace.assert("protobuf.assertDecode"),
+  /** #__PURE__*/ Namespace.protobuf.decode("assertDecode"),
 );
 export { assertDecodePure as assertDecode };
 
@@ -291,10 +291,10 @@ function isDecode<T>(input: Uint8Array): Resolved<T> | null;
 function isDecode(): never {
   halt("isDecode");
 }
-const isDecodePure = /** @__PURE__ */ Object.assign<typeof isDecode, {}, {}>(
+const isDecodePure = /** #__PURE__*/ Object.assign<typeof isDecode, {}, {}>(
   isDecode,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.protobuf.decode("isDecode"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.protobuf.decode("isDecode"),
 );
 export { isDecodePure as isDecode };
 
@@ -366,14 +366,14 @@ function validateDecode<T>(input: Uint8Array): IValidation<Resolved<T>>;
 function validateDecode(): never {
   halt("validateDecode");
 }
-const validateDecodePure = /** @__PURE__ */ Object.assign<
+const validateDecodePure = /** #__PURE__*/ Object.assign<
   typeof validateDecode,
   {},
   {}
 >(
   validateDecode,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.protobuf.decode("validateDecode"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.protobuf.decode("validateDecode"),
 );
 export { validateDecodePure as validateDecode };
 
@@ -415,9 +415,9 @@ function encode<T>(input: T): Uint8Array;
 function encode(): never {
   halt("encode");
 }
-const encodePure = /** @__PURE__ */ Object.assign<typeof encode, {}>(
+const encodePure = /** #__PURE__*/ Object.assign<typeof encode, {}>(
   encode,
-  /** @__PURE__ */ Namespace.protobuf.encode("encode"),
+  /** #__PURE__*/ Namespace.protobuf.encode("encode"),
 );
 export { encodePure as encode };
 
@@ -501,14 +501,14 @@ function assertEncode<T>(
 function assertEncode(): never {
   halt("assertEncode");
 }
-const assertEncodePure = /** @__PURE__ */ Object.assign<
+const assertEncodePure = /** #__PURE__*/ Object.assign<
   typeof assertEncode,
   {},
   {}
 >(
   assertEncode,
-  /** @__PURE__ */ Namespace.assert("protobuf.assertEncode"),
-  /** @__PURE__ */ Namespace.protobuf.encode("assertEncode"),
+  /** #__PURE__*/ Namespace.assert("protobuf.assertEncode"),
+  /** #__PURE__*/ Namespace.protobuf.encode("assertEncode"),
 );
 export { assertEncodePure as assertEncode };
 
@@ -584,10 +584,10 @@ function isEncode<T>(input: unknown): Uint8Array | null;
 function isEncode(): never {
   halt("isEncode");
 }
-const isEncodePure = /** @__PURE__ */ Object.assign<typeof isEncode, {}, {}>(
+const isEncodePure = /** #__PURE__*/ Object.assign<typeof isEncode, {}, {}>(
   isEncode,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.protobuf.encode("isEncode"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.protobuf.encode("isEncode"),
 );
 export { isEncodePure as isEncode };
 
@@ -665,14 +665,14 @@ function validateEncode<T>(input: unknown): IValidation<Uint8Array>;
 function validateEncode(): never {
   halt("validateEncode");
 }
-const validateEncodePure = /** @__PURE__ */ Object.assign<
+const validateEncodePure = /** #__PURE__*/ Object.assign<
   typeof validateEncode,
   {},
   {}
 >(
   validateEncode,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.protobuf.encode("validateEncode"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.protobuf.encode("validateEncode"),
 );
 export { validateEncodePure as validateEncode };
 
@@ -706,10 +706,10 @@ function createDecode<T>(): (input: Uint8Array) => Resolved<T>;
 function createDecode<T>(): (input: Uint8Array) => Resolved<T> {
   halt("createDecode");
 }
-const createDecodePure = /** @__PURE__ */ Object.assign<
-  typeof createDecode,
-  {}
->(createDecode, /** @__PURE__ */ Namespace.protobuf.decode("createDecode"));
+const createDecodePure = /** #__PURE__*/ Object.assign<typeof createDecode, {}>(
+  createDecode,
+  /** #__PURE__*/ Namespace.protobuf.decode("createDecode"),
+);
 export { createDecodePure as createDecode };
 
 /**
@@ -739,14 +739,14 @@ function createIsDecode<T>(): (input: Uint8Array) => Resolved<T> | null;
 function createIsDecode<T>(): (input: Uint8Array) => Resolved<T> | null {
   halt("createIsDecode");
 }
-const createIsDecodePure = /** @__PURE__ */ Object.assign<
+const createIsDecodePure = /** #__PURE__*/ Object.assign<
   typeof createIsDecode,
   {},
   {}
 >(
   createIsDecode,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.protobuf.decode("createIsDecode"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.protobuf.decode("createIsDecode"),
 );
 export { createIsDecodePure as createIsDecode };
 
@@ -783,14 +783,14 @@ function createAssertDecode<T>(
 function createAssertDecode<T>(): (input: Uint8Array) => Resolved<T> {
   halt("createAssertDecode");
 }
-const createAssertDecodePure = /** @__PURE__ */ Object.assign<
+const createAssertDecodePure = /** #__PURE__*/ Object.assign<
   typeof createAssertDecode,
   {},
   {}
 >(
   createAssertDecode,
-  /** @__PURE__ */ Namespace.assert("protobuf.createAssertDecode"),
-  /** @__PURE__ */ Namespace.protobuf.decode("createAssertDecode"),
+  /** #__PURE__*/ Namespace.assert("protobuf.createAssertDecode"),
+  /** #__PURE__*/ Namespace.protobuf.decode("createAssertDecode"),
 );
 export { createAssertDecodePure as createAssertDecode };
 
@@ -825,14 +825,14 @@ function createValidateDecode<T>(): (
 ) => IValidation<Resolved<T>> {
   halt("createValidateDecode");
 }
-const createValidateDecodePure = /** @__PURE__ */ Object.assign<
+const createValidateDecodePure = /** #__PURE__*/ Object.assign<
   typeof createValidateDecode,
   {},
   {}
 >(
   createValidateDecode,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.protobuf.decode("createValidateDecode"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.protobuf.decode("createValidateDecode"),
 );
 export { createValidateDecodePure as createValidateDecode };
 
@@ -863,10 +863,10 @@ function createEncode<T>(): (input: T) => Uint8Array;
 function createEncode<T>(): (input: T) => Uint8Array {
   halt("createEncode");
 }
-const createEncodePure = /** @__PURE__ */ Object.assign<
-  typeof createEncode,
-  {}
->(createEncode, /** @__PURE__ */ Namespace.protobuf.encode("createEncode"));
+const createEncodePure = /** #__PURE__*/ Object.assign<typeof createEncode, {}>(
+  createEncode,
+  /** #__PURE__*/ Namespace.protobuf.encode("createEncode"),
+);
 export { createEncodePure as createEncode };
 
 /**
@@ -896,14 +896,14 @@ function createIsEncode<T>(): (input: T) => Uint8Array | null;
 function createIsEncode<T>(): (input: T) => Uint8Array | null {
   halt("createIsEncode");
 }
-const createIsEncodePure = /** @__PURE__ */ Object.assign<
+const createIsEncodePure = /** #__PURE__*/ Object.assign<
   typeof createIsEncode,
   {},
   {}
 >(
   createIsEncode,
-  /** @__PURE__ */ Namespace.is(),
-  /** @__PURE__ */ Namespace.protobuf.encode("createIsEncode"),
+  /** #__PURE__*/ Namespace.is(),
+  /** #__PURE__*/ Namespace.protobuf.encode("createIsEncode"),
 );
 export { createIsEncodePure as createIsEncode };
 
@@ -940,14 +940,14 @@ function createAssertEncode<T>(
 function createAssertEncode<T>(): (input: T) => Uint8Array {
   halt("createAssertEncode");
 }
-const createAssertEncodePure = /** @__PURE__ */ Object.assign<
+const createAssertEncodePure = /** #__PURE__*/ Object.assign<
   typeof createAssertEncode,
   {},
   {}
 >(
   createAssertEncode,
-  /** @__PURE__ */ Namespace.assert("protobuf.createAssertEncode"),
-  /** @__PURE__ */ Namespace.protobuf.encode("createAssertEncode"),
+  /** #__PURE__*/ Namespace.assert("protobuf.createAssertEncode"),
+  /** #__PURE__*/ Namespace.protobuf.encode("createAssertEncode"),
 );
 export { createAssertEncodePure as createAssertEncode };
 
@@ -978,14 +978,14 @@ function createValidateEncode<T>(): (input: T) => IValidation<Uint8Array>;
 function createValidateEncode<T>(): (input: T) => IValidation<Uint8Array> {
   halt("createValidateEncode");
 }
-const createValidateEncodePure = /** @__PURE__ */ Object.assign<
+const createValidateEncodePure = /** #__PURE__*/ Object.assign<
   typeof createValidateEncode,
   {},
   {}
 >(
   createValidateEncode,
-  /** @__PURE__ */ Namespace.validate(),
-  /** @__PURE__ */ Namespace.protobuf.encode("createValidateEncode"),
+  /** #__PURE__*/ Namespace.validate(),
+  /** #__PURE__*/ Namespace.protobuf.encode("createValidateEncode"),
 );
 export { createValidateEncodePure as createValidateEncode };
 

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -41,7 +41,7 @@ function metadata(): never {
   halt("metadata");
 }
 
-const metadataPure = /** @__PURE__ */ Object.assign<typeof metadata, {}>(
+const metadataPure = /** #__PURE__*/ Object.assign<typeof metadata, {}>(
   metadata,
   { from: (input: unknown) => input },
 );


### PR DESCRIPTION
The /*#__PURE__*/ comment was missing from the build in the previous roolup configuration.
After modifying the configuration, /*#__PURE__*/ comments now remain after the build, and vite, bun and esbuild can use this information for tree-shaking.

Also, the PURE comment has been changed, as the current mainstream one is "/*#__PURE__*/" instead of "/* @__PURE__ */".

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)