### PR TITLE
feat(rollup.config): improve tree-shaking using `preserveModules: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/inquirer": "^8.2.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,12 +3,9 @@ const terser = require("@rollup/plugin-terser");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const commomnjs = require("@rollup/plugin-commonjs");
 
-
 module.exports = {
   input: "./src/index.ts",
   output: {
-    preserveModules: true,
-    preserveModulesRoot: "src",
     dir: "./lib",
     format: "esm",
     sourcemap: true,
@@ -22,6 +19,8 @@ module.exports = {
       }
       return `[name].${ext}`;
     },
+    preserveModules: true,
+    preserveModulesRoot: "src",
   },
   plugins: [
     nodeResolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 const typescript = require("@rollup/plugin-typescript");
-const terser = require("@rollup/plugin-terser");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const commomnjs = require("@rollup/plugin-commonjs");
 
@@ -29,16 +28,6 @@ module.exports = {
       tsconfig: "tsconfig.json",
       module: "ES2020",
       target: "ES2020",
-    }),
-    terser({
-      format: {
-        comments: "some",
-        beautify: true,
-        ecma: "2020",
-      },
-      compress: false,
-      mangle: false,
-      module: true,
     }),
   ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,8 +10,17 @@ module.exports = {
   output: {
     dir: outDir,
     format: "esm",
-    entryFileNames: "[name].mjs",
     sourcemap: true,
+    entryFileNames: (chunkInfo) => {
+      const ext = `mjs`
+      const externalDir = `_external`;
+      const nodeModulesDir = `node_modules`;
+      if (chunkInfo.name.includes(nodeModulesDir)) {
+        console.log(chunkInfo.name);
+        return `${chunkInfo.name.replace(nodeModulesDir, externalDir)}.${ext}`;
+      }
+      return `[name].${ext}`;
+    },
   },
   plugins: [
     nodeResolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const typescript = require("@rollup/plugin-typescript");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const commomnjs = require("@rollup/plugin-commonjs");
@@ -13,8 +14,14 @@ module.exports = {
       const externalDir = `_external`;
       const nodeModulesDir = `node_modules`;
       if (chunkInfo.name.includes(nodeModulesDir)) {
-        console.log(chunkInfo.name);
-        return `${chunkInfo.name.replace(nodeModulesDir, externalDir)}.${ext}`;
+        /** replace / to _ and the last part of the path is the file name */
+        const nameSplit = chunkInfo.name.split('/')
+        const chunkName = path.join(externalDir, nameSplit.slice(0, -1).join('_'), nameSplit.at(-1))
+        console.table({
+          before: chunkInfo.name,
+          after: chunkName,
+        })
+        return `${chunkName}.${ext}`;
       }
       return `[name].${ext}`;
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,12 +3,13 @@ const terser = require("@rollup/plugin-terser");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const commomnjs = require("@rollup/plugin-commonjs");
 
-const outDir = "lib";
 
 module.exports = {
   input: "./src/index.ts",
   output: {
-    dir: outDir,
+    preserveModules: true,
+    preserveModulesRoot: "src",
+    dir: "./lib",
     format: "esm",
     sourcemap: true,
     entryFileNames: (chunkInfo) => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,8 +26,8 @@ module.exports = {
     commomnjs(),
     typescript({
       tsconfig: "tsconfig.json",
-      module: "ES2020",
-      target: "ES2020",
+      module: "ESNext",
+      target: "ESNext",
     }),
   ],
 };


### PR DESCRIPTION
Related to #1128 
I fixed the import path of randexp

