### PR TITLE
feat(build.yml): Add artifact upload step to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,14 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
+      - name: Upload tgz for Artifactory
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-result
+          path: |
+            *.tgz
+            src
+            lib
 
   Bun:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit introduces a new step in the GitHub Actions workflow for uploading build artifacts. The artifacts include the .tgz files, and the src and lib directories. This will help in debugging and preserving the state of the build at each commit.

