### PR TITLE
Fix #1138: `typia.random<T>()` for `UniqueItems` tag.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.3.1.tgz"
+    "typia": "../typia-6.3.2.tgz"
   }
 }

--- a/debug/features/random.ts
+++ b/debug/features/random.ts
@@ -1,9 +1,8 @@
-import typia from "typia";
+import typia, { tags } from "typia";
 
-new Array(1_000).fill(0).forEach(() => {
-  const app = typia.random<typia.IJsonApplication>();
-  const result = typia.validate(app);
-  if (result.success === false)
-    console.log(JSON.stringify(result.errors, null, 2));
-});
-console.log("completed");
+interface IMember {
+  unique: string[] & tags.UniqueItems;
+  plain: number[];
+}
+
+console.log(typia.createRandom<IMember>().toString());

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "../typia-6.2.1.tgz"
+    "typia": "../typia-6.3.2-dev.20240701.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.3.1.tgz"
+    "typia": "../typia-6.3.2.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.3.1"
+    "typia": "6.3.2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/IRandomGenerator.ts
+++ b/src/IRandomGenerator.ts
@@ -8,7 +8,11 @@ export interface IRandomGenerator {
   number(minimum?: number, maximum?: number): number;
   string(length?: number): string;
 
-  array<T>(closure: (index: number) => T, count?: number): T[];
+  array<T>(
+    closure: (index: number) => T,
+    count?: number,
+    unique?: boolean,
+  ): T[];
   length(): number;
   pattern(regex: RegExp): string;
 

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -22,7 +22,7 @@ export namespace TypiaSetupWizard {
 
     // INSTALL TYPESCRIPT COMPILERS
     pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
-    pack.install({ dev: true, modulo: "typescript", version: "5.4.2" });
+    pack.install({ dev: true, modulo: "typescript", version: "5.5.2" });
     args.project ??= (() => {
       const runner: string = pack.manager === "npm" ? "npx" : pack.manager;
       CommandExecutor.run(`${runner} tsc --init`);

--- a/src/programmers/helpers/RandomJoiner.ts
+++ b/src/programmers/helpers/RandomJoiner.ts
@@ -17,7 +17,7 @@ export namespace RandomJoiner {
     (coalesce: (method: string) => ts.Expression) =>
     (decoder: Decoder) =>
     (explore: IExplore) =>
-    (length: ts.Expression | undefined) =>
+    (length: ts.Expression | undefined, unique: ts.Expression | undefined) =>
     (item: Metadata): ts.Expression => {
       const generator: ts.Expression = ts.factory.createCallExpression(
         coalesce("array"),
@@ -31,7 +31,12 @@ export namespace RandomJoiner {
             undefined,
             decoder(item),
           ),
-          ...(length ? [length] : []),
+          ...(length
+            ? [length]
+            : unique
+              ? [ts.factory.createIdentifier("undefined")]
+              : []),
+          ...(unique ? [unique] : []),
         ],
       );
       if (explore.recursive === false) return generator;

--- a/src/utils/RandomGenerator/RandomGenerator.ts
+++ b/src/utils/RandomGenerator/RandomGenerator.ts
@@ -24,8 +24,23 @@ export const string = (length?: number): string =>
     .map(() => ALPHABETS[integer(0, ALPHABETS.length - 1)])
     .join("");
 
-export const array = <T>(closure: (index: number) => T, count?: number): T[] =>
-  new Array(count ?? length()).fill(0).map((_e, index) => closure(index));
+export const array = <T>(
+  closure: (index: number) => T,
+  count?: number,
+  unique?: boolean,
+): T[] => {
+  count ??= length();
+  unique ??= false;
+  if (unique === false)
+    return new Array(count ?? length())
+      .fill(0)
+      .map((_e, index) => closure(index));
+  else {
+    const set = new Set<T>();
+    while (set.size < count) set.add(closure(set.size));
+    return Array.from(set);
+  }
+};
 export const pick = <T>(array: T[]): T => array[integer(0, array.length - 1)]!;
 export const length = () => integer(0, 3);
 export const pattern = (regex: RegExp): string => {

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.3.1.tgz"
+    "typia": "../typia-6.3.2.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.3.1.tgz"
+    "typia": "../typia-6.3.2.tgz"
   }
 }

--- a/test/src/features/issues/test_issue_1138_random_uniqueItems.ts
+++ b/test/src/features/issues/test_issue_1138_random_uniqueItems.ts
@@ -1,0 +1,15 @@
+import typia, { tags } from "typia";
+
+export function test_issue_1138_random_uniqueItems(): void {
+  for (let i: number = 0; i < 100; ++i) {
+    const member: IMember = typia.random<IMember>();
+    typia.assert(member);
+  }
+}
+interface IMember {
+  uidArray: Array<number & tags.Type<"uint32"> & tags.Maximum<100>> &
+    tags.UniqueItems &
+    tags.MinItems<20> &
+    tags.MaxItems<20>;
+  tags: string[] & tags.UniqueItems;
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -27,7 +27,7 @@
         "tgrid": "^1.0.1",
         "tstl": "^3.0.0",
         "typescript": "^5.5.2",
-        "typia": "^6.3.1"
+        "typia": "^6.3.2"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^1.0.1",
     "tstl": "^3.0.0",
     "typescript": "^5.5.2",
-    "typia": "^6.3.1"
+    "typia": "^6.3.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
`typia.random<T>()` had not consider `UniqueItems` tag, so that duplicate item could generated.

This PR fixes the problem.