### PR TITLE
Fix #1054: utilize `Set<T>` for a lot of constant values type case.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.3.2.tgz"
+    "typia": "../typia-6.3.3-dev.20240702.tgz"
   }
 }

--- a/debug/features/set.ts
+++ b/debug/features/set.ts
@@ -1,0 +1,21 @@
+import typia from "typia";
+
+type Values =
+  | false
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | "six"
+  | "seven"
+  | 8n
+  | 9n
+  | "ten"
+  | "eleven";
+
+console.log(
+  typia.createIs<Values>().toString(),
+  typia.createAssert<Values>().toString(),
+  typia.createValidate<Values>().toString(),
+);

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "../typia-6.3.2-dev.20240701.tgz"
+    "typia": "../typia-6.3.2.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.3.2.tgz"
+    "typia": "../typia-6.3.3-dev.20240702.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.3.2",
+  "version": "6.3.3-dev.20240702",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -93,7 +93,7 @@
     "rollup": "^4.18.0",
     "suppress-warnings": "^1.0.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "stackblitzs": {
     "startCommand": "npm install && npm run test"

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.3.2",
+  "version": "6.3.3-dev.20240702",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.3.2"
+    "typia": "6.3.3-dev.20240702"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -21,8 +21,8 @@ export namespace TypiaSetupWizard {
     const args: IArguments = await ArgumentParser.parse(pack)(inquiry);
 
     // INSTALL TYPESCRIPT COMPILERS
-    pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
     pack.install({ dev: true, modulo: "typescript", version: "5.5.2" });
+    pack.install({ dev: true, modulo: "ts-patch", version: "latest" });
     args.project ??= (() => {
       const runner: string = pack.manager === "npm" ? "npx" : pack.manager;
       CommandExecutor.run(`${runner} tsc --init`);

--- a/src/programmers/helpers/FunctionImporter.ts
+++ b/src/programmers/helpers/FunctionImporter.ts
@@ -8,6 +8,7 @@ export class FunctionImporter {
   private readonly used_: Set<string> = new Set();
   private readonly local_: Set<string> = new Set();
   private readonly unions_: Map<string, [string, ts.ArrowFunction]> = new Map();
+  private readonly variables_: Map<string, ts.Expression> = new Map();
   private sequence_: number = 0;
 
   public constructor(public readonly method: string) {}
@@ -45,6 +46,9 @@ export class FunctionImporter {
           )(name),
         ),
       ),
+      ...[...this.variables_.entries()].map(([key, value]) =>
+        StatementFactory.constant(key, value),
+      ),
       ...(includeUnions === true
         ? [...this.unions_.values()].map(([key, arrow]) =>
             StatementFactory.constant(key, arrow),
@@ -78,6 +82,11 @@ export class FunctionImporter {
     this.unions_.set(name, tuple);
     tuple[1] = factory();
     return accessor;
+  }
+
+  public emplaceVariable(name: string, value: ts.Expression): ts.Expression {
+    this.variables_.set(name, value);
+    return ts.factory.createIdentifier(name);
   }
 
   public trace(): void {

--- a/src/programmers/helpers/disable_function_importer_declare.ts
+++ b/src/programmers/helpers/disable_function_importer_declare.ts
@@ -20,6 +20,7 @@ const disable = (importer: FunctionImporter): MethodOnly<FunctionImporter> => ({
     name: string,
     factory: () => ts.ArrowFunction,
   ): string => importer.emplaceUnion(prefix, name, factory),
+  emplaceVariable: (key, value) => importer.emplaceVariable(key, value),
   trace: (): void => importer.trace(),
 });
 

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.3.2.tgz"
+    "typia": "../typia-6.3.3-dev.20240702.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.3.2.tgz"
+    "typia": "../typia-6.3.3-dev.20240702.tgz"
   }
 }

--- a/test/src/features/issues/test_issue_1054_check_constants_by_set.ts
+++ b/test/src/features/issues/test_issue_1054_check_constants_by_set.ts
@@ -1,0 +1,82 @@
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_1054_check_constants_by_set = (): void => {
+  for (const boolean of [false] as const)
+    for (const bigint of [1n, 2n, 3n, 4n] as const)
+      for (const number of [5, 6, 7] as const)
+        for (const string of ["eight", "nine"] as const)
+          for (const huge of [
+            false,
+            1n,
+            2n,
+            3n,
+            4n,
+            5,
+            6,
+            7,
+            "eight",
+            "nine",
+            10,
+            11,
+            12n,
+            "thirteen",
+            "fourteen",
+            15n,
+          ] as const) {
+            const obj: ConstantDictionary = {
+              boolean,
+              bigint,
+              number,
+              string,
+              huge,
+            };
+            typia.assert(obj);
+            typia.assertGuard(obj);
+            TestValidator.equals("is")(true)(typia.is(obj));
+            TestValidator.equals("validate")({
+              success: true,
+            })(typia.validate(obj));
+          }
+
+  const invalid: ConstantDictionary = {
+    boolean: false,
+    bigint: 2n,
+    number: 7,
+    string: "nine",
+    huge: 13 as any,
+  };
+  TestValidator.equals("is-false")(false)(typia.is(invalid));
+  TestValidator.error("assert-error")(() => typia.assert(invalid));
+  TestValidator.error("assertGuard-error")(() => typia.assertGuard(invalid));
+  TestValidator.equals("validate-false")({ success: false })(
+    typia.validate(invalid),
+  );
+};
+// console.log(typia.createIs<ConstantDictionary>().toString());
+// test_issue_1054_check_constants_by_set();
+
+interface ConstantDictionary {
+  boolean: false;
+  bigint: 1n | 2n | 3n | 4n;
+  number: 5 | 6 | 7;
+  string: "eight" | "nine";
+  huge:
+    | false
+    | 1n
+    | 2n
+    | 3n
+    | 4n
+    | 5
+    | 6
+    | 7
+    | "eight"
+    | "nine"
+    | 10
+    | 11
+    | 12n
+    | "thirteen"
+    | "fourteen"
+    | 15n;
+}


### PR DESCRIPTION
```typescript
import typia from "typia";

type Values =
  | false
  | 1
  | 2
  | 3
  | 4
  | 5
  | "six"
  | "seven"
  | 8n
  | 9n
  | "ten"
  | "eleven";
console.log(typia.createIs<Values>().toString());
```

> ```javascript
> input => {
>   const $iv1 = new Set([false, 1, 2, 3, 4, 5, "six", "seven", "ten", "eleven", BigInt(8), BigInt(9)]);
>   return true === $iv1.has(input);
> }
> ```