### PR TITLE
feat(package.json): add sideEffects property

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "stackblitz": {
     "startCommand": "npm install && npm run test"
   },
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
With experiments at https://github.com/samchon/typia/issues/752 , `rollup.js` unexpectedly bundle `ret.js`.
However, when we add `sideeffect=true` to package.json, rollup.js can remove it.

I think this is a small change, but need it