### PR TITLE
feat(rollup.config.js): Enable inline source maps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - 'test/**'
       - 'test-esm/**'
       - 'package.json'
+      - 'tsconfig.json'
+      - 'rollup.config.js'
       - '.github/workflows/build.yml'
   pull_request:
     paths:
@@ -13,6 +15,8 @@ on:
       - 'test/**'
       - 'test-esm/**'
       - 'package.json'
+      - 'tsconfig.json'
+      - 'rollup.config.js'
       - '.github/workflows/build.yml'
 jobs:
   Build-and-Upload-to-pkg-pr-new-and-artifactory:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ module.exports = {
   output: {
     dir: "./lib",
     format: "esm",
-    sourcemap: true,
+    sourcemap: "inline",
     entryFileNames: (chunkInfo) => {
       const ext = `mjs`
       const externalDir = `_external`;
@@ -32,6 +32,8 @@ module.exports = {
     nodeResolve(),
     commomnjs(),
     typescript({
+      sourceMap: true,
+      inlineSources: true,
       tsconfig: "tsconfig.json",
       module: "ESNext",
       target: "ESNext",


### PR DESCRIPTION
In current rollup configuration, sourcemap is not linked to typescript file.
So I confugired as an inline sourcemap, so it does not conflict with CJS sourcemaps