### PR TITLE
Revise sponsors chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Thanks for your support.
 
 Your donation encourages `typia` development.
 
+Also, `typia` is re-distributing half of your donations to core contributors of `typia`.
+
+  - [@nonara](https://github.com/nonara): developer of [`ts-patch`](https://github.com/nonara/ts-patch)
+  - [@ryoppippi](https://github.com/ryoppippi): developer of [`unplugin-typia`](https://github.com/ryoppippi/unplugin-typia)
+
 [![Sponsers](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
 
 

--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -91,4 +91,7 @@ Thanks for your support.
 
 Your donation would encourage `typia` development.
 
+  - [@nonara](https://github.com/nonara): developer of [`ts-patch`](https://github.com/nonara/ts-patch)
+  - [@ryoppippi](https://github.com/ryoppippi): developer of [`unplugin-typia`](https://github.com/ryoppippi/unplugin-typia)
+
 [![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -23,4 +23,7 @@ Thanks for your support.
 
 Your donation would encourage `typia` development.
 
+  - [@nonara](https://github.com/nonara): developer of [`ts-patch`](https://github.com/nonara/ts-patch)
+  - [@ryoppippi](https://github.com/ryoppippi): developer of [`unplugin-typia`](https://github.com/ryoppippi/unplugin-typia)
+
 [![Sponsors](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)


### PR DESCRIPTION
Introduced `typia` is re-distributing donations to core contributors @nonara and @ryoppippi.

@ryoppippi, I think you need to revise README content of https://github.com/ryoppippi/unplugin-typia, or if you want to link another documentation site, please send me a PR.