### PR TITLE
Close #1149: `IJsonSchema.IOneOf.discriminator`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.0.tgz"
+    "typia": "../typia-6.4.1.tgz"
   }
 }

--- a/debug/features/discriminator.ts
+++ b/debug/features/discriminator.ts
@@ -1,0 +1,43 @@
+import typia from "typia";
+
+interface Point {
+  type: "point";
+  x: number;
+  y: number;
+}
+interface Line {
+  type: "line";
+  p1: Point;
+  p2: Point;
+}
+interface Triangle {
+  type: "triangle";
+  p1: Point;
+  p2: Point;
+  p3: Point;
+}
+interface Rectangle {
+  type: "rectangle";
+  p1: Point;
+  p2: Point;
+  p3: Point;
+  p4: Point;
+}
+interface Polyline {
+  type: "polyline";
+  points: Point[];
+}
+interface Circle {
+  radius: number;
+}
+
+console.log(
+  typia.json.application<[Point | Line | Triangle | Rectangle | Polyline]>()
+    .schemas[0],
+  typia.json.application<
+    [Point | Line | Triangle | Rectangle | Polyline | null]
+  >().schemas[0],
+  typia.json.application<
+    [Point | Line | Triangle | Rectangle | Polyline | Circle]
+  >().schemas[0],
+);

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "../typia-6.3.2.tgz"
+    "typia": "../typia-6.4.0.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.4.0.tgz"
+    "typia": "../typia-6.4.1.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -67,7 +67,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^0.3.0",
+    "@samchon/openapi": "^0.3.1",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -56,6 +56,11 @@ Thanks for your support.
 
 Your donation encourages `typia` development.
 
+Also, `typia` is re-distributing half of your donations to core contributors of `typia`.
+
+  - [@nonara](https://github.com/nonara): developer of [`ts-patch`](https://github.com/nonara/ts-patch)
+  - [@ryoppippi](https://github.com/ryoppippi): developer of [`unplugin-typia`](https://github.com/ryoppippi/unplugin-typia)
+
 [![Sponsers](https://opencollective.com/typia/badge.svg?avatarHeight=75&width=600)](https://opencollective.com/typia)
 
 

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.4.0"
+    "typia": "6.4.1"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"
@@ -71,6 +71,7 @@
   "stackblitz": {
     "startCommand": "npm install && npm run test"
   },
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/src/programmers/internal/application_union_discriminator.ts
+++ b/src/programmers/internal/application_union_discriminator.ts
@@ -1,0 +1,35 @@
+import { OpenApi } from "@samchon/openapi";
+
+import { Metadata } from "../../schemas/metadata/Metadata";
+
+import { UnionPredicator } from "../helpers/UnionPredicator";
+
+export const application_union_discriminator = (
+  meta: Metadata,
+): OpenApi.IJsonSchema.IOneOf.IDiscriminator | undefined => {
+  if (
+    meta.size() === 0 ||
+    meta.size() !== meta.objects.length ||
+    meta.objects.some((o) => o._Is_literal()) === true
+  )
+    return undefined;
+  const specialized: UnionPredicator.ISpecialized[] = UnionPredicator.object(
+    meta.objects,
+  );
+  const meet: boolean =
+    specialized.length === meta.objects.length &&
+    specialized.every(
+      (s) => s.property.key.isSoleLiteral() && s.property.value.isSoleLiteral(),
+    ) &&
+    new Set(specialized.map((s) => s.property.key.getSoleLiteral())).size === 1;
+  if (meet === false) return undefined;
+  return {
+    propertyName: specialized[0]!.property.key.getSoleLiteral()!,
+    mapping: Object.fromEntries(
+      specialized.map((s) => [
+        s.property.value.getSoleLiteral()!,
+        `#/components/schemas/${s.object.name}`,
+      ]),
+    ),
+  };
+};

--- a/src/programmers/internal/application_v30_schema.ts
+++ b/src/programmers/internal/application_v30_schema.ts
@@ -10,6 +10,7 @@ import { application_escaped } from "./application_escaped";
 import { application_number } from "./application_number";
 import { application_string } from "./application_string";
 import { application_templates } from "./application_templates";
+import { application_union_discriminator } from "./application_union_discriminator";
 import { application_v30_alias } from "./application_v30_alias";
 import { application_v30_constant } from "./application_v30_constant";
 import { application_v30_native } from "./application_v30_native";
@@ -139,7 +140,10 @@ export const application_v30_schema =
         ? { type: undefined }
         : union.length === 1
           ? union[0]!
-          : { oneOf: union };
+          : {
+              oneOf: union,
+              discriminator: application_union_discriminator(meta),
+            };
     return {
       ...schema,
       ...attribute,

--- a/src/programmers/internal/application_v31_schema.ts
+++ b/src/programmers/internal/application_v31_schema.ts
@@ -10,6 +10,7 @@ import { application_escaped } from "./application_escaped";
 import { application_number } from "./application_number";
 import { application_string } from "./application_string";
 import { application_templates } from "./application_templates";
+import { application_union_discriminator } from "./application_union_discriminator";
 import { application_v31_alias } from "./application_v31_alias";
 import { application_v31_constant } from "./application_v31_constant";
 import { application_v31_native } from "./application_v31_native";
@@ -134,7 +135,10 @@ export const application_v31_schema =
         ? { type: undefined }
         : union.length === 1
           ? union[0]!
-          : { oneOf: union };
+          : {
+              oneOf: union,
+              discriminator: application_union_discriminator(meta),
+            };
     return {
       ...schema,
       ...attribute,

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.4.0.tgz"
+    "typia": "../typia-6.4.1.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.0.tgz"
+    "typia": "../typia-6.4.1.tgz"
   }
 }

--- a/test/schemas/json/v3_0/ObjectNullable.json
+++ b/test/schemas/json/v3_0/ObjectNullable.json
@@ -37,7 +37,14 @@
               {
                 "$ref": "#/components/schemas/ObjectNullable.IManufacturer.Nullable"
               }
-            ]
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "brand": "#/components/schemas/ObjectNullable.IBrand",
+                "manufacturer": "#/components/schemas/ObjectNullable.IManufacturer"
+              }
+            }
           }
         },
         "nullable": false,

--- a/test/schemas/json/v3_0/UltimateUnion.json
+++ b/test/schemas/json/v3_0/UltimateUnion.json
@@ -424,7 +424,7 @@
           "items",
           "type"
         ],
-        "description": "Array type."
+        "description": "Array type info."
       },
       "OpenApi.IJsonSchema.ITupleOpenApi.IJsonSchema": {
         "type": "object",
@@ -694,6 +694,11 @@
             "title": "List of the union types",
             "description": "List of the union types."
           },
+          "discriminator": {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf.IDiscriminator",
+            "title": "Discriminator info of the union type",
+            "description": "Discriminator info of the union type."
+          },
           "title": {
             "type": "string",
             "title": "Title of the schema",
@@ -770,6 +775,35 @@
           "type"
         ],
         "description": "Null type."
+      },
+      "OpenApi.IJsonSchema.IOneOf.IDiscriminator": {
+        "type": "object",
+        "properties": {
+          "propertyName": {
+            "type": "string",
+            "title": "Property name for the discriminator",
+            "description": "Property name for the discriminator."
+          },
+          "mapping": {
+            "$ref": "#/components/schemas/Recordstringstring",
+            "title": "Mapping of the discriminator value to the schema name",
+            "description": "Mapping of the discriminator value to the schema name.\n\nThis property is valid only for {@link IReference} typed\n{@link IOneOf.oneof} elements. Therefore, `key` of `mapping` is\nthe discriminator value, and `value` of `mapping` is the\nschema name like `#/components/schemas/SomeObject`."
+          }
+        },
+        "nullable": false,
+        "required": [
+          "propertyName"
+        ],
+        "description": "Discriminator info of the union type."
+      },
+      "Recordstringstring": {
+        "type": "object",
+        "properties": {},
+        "nullable": false,
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "RecordstringOpenApi.ISecurityScheme": {
         "type": "object",
@@ -943,15 +977,6 @@
           }
         },
         "nullable": false
-      },
-      "Recordstringstring": {
-        "type": "object",
-        "properties": {},
-        "nullable": false,
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {
-          "type": "string"
-        }
       },
       "OmitOpenApi.ISecurityScheme.IOAuth2.IFlowtokenUrl": {
         "type": "object",

--- a/test/schemas/json/v3_1/ObjectNullable.json
+++ b/test/schemas/json/v3_1/ObjectNullable.json
@@ -33,7 +33,13 @@
               {
                 "$ref": "#/components/schemas/ObjectNullable.IBrand"
               }
-            ]
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "brand": "#/components/schemas/ObjectNullable.IBrand"
+              }
+            }
           },
           "similar": {
             "oneOf": [
@@ -46,7 +52,14 @@
               {
                 "$ref": "#/components/schemas/ObjectNullable.IManufacturer"
               }
-            ]
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "brand": "#/components/schemas/ObjectNullable.IBrand",
+                "manufacturer": "#/components/schemas/ObjectNullable.IManufacturer"
+              }
+            }
           }
         },
         "required": [

--- a/test/schemas/json/v3_1/UltimateUnion.json
+++ b/test/schemas/json/v3_1/UltimateUnion.json
@@ -397,7 +397,7 @@
           "items",
           "type"
         ],
-        "description": "Array type."
+        "description": "Array type info."
       },
       "OpenApi.IJsonSchema.ITupleOpenApi.IJsonSchema": {
         "type": "object",
@@ -658,6 +658,11 @@
             "title": "List of the union types",
             "description": "List of the union types."
           },
+          "discriminator": {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf.IDiscriminator",
+            "title": "Discriminator info of the union type",
+            "description": "Discriminator info of the union type."
+          },
           "title": {
             "type": "string",
             "title": "Title of the schema",
@@ -728,6 +733,33 @@
           "type"
         ],
         "description": "Null type."
+      },
+      "OpenApi.IJsonSchema.IOneOf.IDiscriminator": {
+        "type": "object",
+        "properties": {
+          "propertyName": {
+            "type": "string",
+            "title": "Property name for the discriminator",
+            "description": "Property name for the discriminator."
+          },
+          "mapping": {
+            "$ref": "#/components/schemas/Recordstringstring",
+            "title": "Mapping of the discriminator value to the schema name",
+            "description": "Mapping of the discriminator value to the schema name.\n\nThis property is valid only for {@link IReference} typed\n{@link IOneOf.oneof} elements. Therefore, `key` of `mapping` is\nthe discriminator value, and `value` of `mapping` is the\nschema name like `#/components/schemas/SomeObject`."
+          }
+        },
+        "required": [
+          "propertyName"
+        ],
+        "description": "Discriminator info of the union type."
+      },
+      "Recordstringstring": {
+        "type": "object",
+        "properties": {},
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "RecordstringOpenApi.ISecurityScheme": {
         "type": "object",
@@ -880,14 +912,6 @@
           "scopes": {
             "$ref": "#/components/schemas/Recordstringstring"
           }
-        }
-      },
-      "Recordstringstring": {
-        "type": "object",
-        "properties": {},
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {
-          "type": "string"
         }
       },
       "OmitOpenApi.ISecurityScheme.IOAuth2.IFlowtokenUrl": {

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -3379,7 +3379,7 @@
             "jsDocTags": []
           }
         ],
-        "description": "Array type.",
+        "description": "Array type info.",
         "jsDocTags": [],
         "index": 8,
         "recursive": true,
@@ -4696,6 +4696,59 @@
                   "type": "string",
                   "values": [
                     {
+                      "value": "discriminator"
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functional": false,
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [
+                "OpenApi.IJsonSchema.IOneOf.IDiscriminator"
+              ],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Discriminator info of the union type.",
+            "jsDocTags": []
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
                       "value": "title"
                     }
                   ]
@@ -5333,6 +5386,191 @@
         ]
       },
       {
+        "name": "OpenApi.IJsonSchema.IOneOf.IDiscriminator",
+        "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "propertyName"
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Property name for the discriminator.",
+            "jsDocTags": []
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "mapping"
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functional": false,
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [
+                "Record<string, string>"
+              ],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Mapping of the discriminator value to the schema name.\n\nThis property is valid only for {@link IReference} typed\n{@link IOneOf.oneof} elements. Therefore, `key` of `mapping` is\nthe discriminator value, and `value` of `mapping` is the\nschema name like `#/components/schemas/SomeObject`.",
+            "jsDocTags": []
+          }
+        ],
+        "description": "Discriminator info of the union type.",
+        "jsDocTags": [],
+        "index": 15,
+        "recursive": false,
+        "nullables": [
+          false
+        ]
+      },
+      {
+        "name": "Record<string, string>",
+        "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functional": false,
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": null,
+            "jsDocTags": []
+          }
+        ],
+        "description": "Construct a type with a set of properties K of type T",
+        "jsDocTags": [],
+        "index": 16,
+        "recursive": false,
+        "nullables": [
+          false
+        ]
+      },
+      {
         "name": "Record<string, OpenApi.ISecurityScheme>",
         "properties": [
           {
@@ -5391,7 +5629,7 @@
         ],
         "description": "Construct a type with a set of properties K of type T",
         "jsDocTags": [],
-        "index": 15,
+        "index": 17,
         "recursive": false,
         "nullables": [
           false
@@ -5645,7 +5883,7 @@
         ],
         "description": "Normal API key type.",
         "jsDocTags": [],
-        "index": 16,
+        "index": 18,
         "recursive": false,
         "nullables": [
           false
@@ -5835,7 +6073,7 @@
         ],
         "description": "HTTP basic authentication type.",
         "jsDocTags": [],
-        "index": 17,
+        "index": 19,
         "recursive": false,
         "nullables": [
           false
@@ -6081,7 +6319,7 @@
         ],
         "description": "HTTP bearer authentication type.",
         "jsDocTags": [],
-        "index": 18,
+        "index": 20,
         "recursive": false,
         "nullables": [
           false
@@ -6263,7 +6501,7 @@
         ],
         "description": "OAuth2 authentication type.",
         "jsDocTags": [],
-        "index": 19,
+        "index": 21,
         "recursive": false,
         "nullables": [
           false
@@ -6486,7 +6724,7 @@
           }
         ],
         "jsDocTags": [],
-        "index": 20,
+        "index": 22,
         "recursive": false,
         "nullables": [
           false
@@ -6718,71 +6956,7 @@
           }
         ],
         "jsDocTags": [],
-        "index": 21,
-        "recursive": false,
-        "nullables": [
-          false
-        ]
-      },
-      {
-        "name": "Record<string, string>",
-        "properties": [
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functional": false,
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functional": false,
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": null,
-            "jsDocTags": []
-          }
-        ],
-        "description": "Construct a type with a set of properties K of type T",
-        "jsDocTags": [],
-        "index": 22,
+        "index": 23,
         "recursive": false,
         "nullables": [
           false
@@ -6959,7 +7133,7 @@
         ],
         "description": "Construct a type with the properties of T except for those in type K.",
         "jsDocTags": [],
-        "index": 23,
+        "index": 24,
         "recursive": false,
         "nullables": [
           false
@@ -7136,7 +7310,7 @@
         ],
         "description": "Construct a type with the properties of T except for those in type K.",
         "jsDocTags": [],
-        "index": 24,
+        "index": 25,
         "recursive": false,
         "nullables": [
           false
@@ -7320,7 +7494,7 @@
           }
         ],
         "jsDocTags": [],
-        "index": 25,
+        "index": 26,
         "recursive": false,
         "nullables": [
           false

--- a/test/src/features/issues/test_issue_1149_json_schema_oneof_discriminator.ts
+++ b/test/src/features/issues/test_issue_1149_json_schema_oneof_discriminator.ts
@@ -1,0 +1,79 @@
+import { OpenApi } from "@samchon/openapi";
+import typia, { IJsonApplication } from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_1149_json_schema_oneof_discriminator = (): void => {
+  const discriminated: IJsonApplication =
+    typia.json.application<
+      [Point | Line | Triangle | Rectangle | Polyline | null]
+    >();
+  TestValidator.equals("discriminated")({
+    oneOf: [
+      { type: "null" },
+      { $ref: "#/components/schemas/Point" },
+      { $ref: "#/components/schemas/Line" },
+      { $ref: "#/components/schemas/Triangle" },
+      { $ref: "#/components/schemas/Rectangle" },
+      { $ref: "#/components/schemas/Polyline" },
+    ],
+    discriminator: {
+      propertyName: "type",
+      mapping: {
+        point: "#/components/schemas/Point",
+        line: "#/components/schemas/Line",
+        triangle: "#/components/schemas/Triangle",
+        rectangle: "#/components/schemas/Rectangle",
+        polyline: "#/components/schemas/Polyline",
+      },
+    },
+  } satisfies OpenApi.IJsonSchema.IOneOf as OpenApi.IJsonSchema.IOneOf)(
+    discriminated.schemas[0] as OpenApi.IJsonSchema.IOneOf,
+  );
+
+  const plain: IJsonApplication =
+    typia.json.application<
+      [Point | Line | Triangle | Rectangle | Polyline | Circle]
+    >();
+  TestValidator.equals("plain")(plain.schemas[0])({
+    oneOf: [
+      { $ref: "#/components/schemas/Point" },
+      { $ref: "#/components/schemas/Line" },
+      { $ref: "#/components/schemas/Triangle" },
+      { $ref: "#/components/schemas/Rectangle" },
+      { $ref: "#/components/schemas/Polyline" },
+      { $ref: "#/components/schemas/Circle" },
+    ],
+  } satisfies OpenApi.IJsonSchema.IOneOf);
+};
+
+interface Point {
+  type: "point";
+  x: number;
+  y: number;
+}
+interface Line {
+  type: "line";
+  p1: Point;
+  p2: Point;
+}
+interface Triangle {
+  type: "triangle";
+  p1: Point;
+  p2: Point;
+  p3: Point;
+}
+interface Rectangle {
+  type: "rectangle";
+  p1: Point;
+  p2: Point;
+  p3: Point;
+  p4: Point;
+}
+interface Polyline {
+  type: "polyline";
+  points: Point[];
+}
+interface Circle {
+  radius: number;
+}

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
     "typescript": "^5.5.2",
-    "typia": "^6.4.0"
+    "typia": "^6.4.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
`typia.json.application<[Types]>()` starts supporting `IJsonSchema.IOneOf.discriminator` property.

This is the spec of the `IJsonSchema.IOneOf.discriminator`.

https://github.com/samchon/openapi/blob/0cf6d4e5cd211200b2a7f3a30a56ff86f49e4d9d/src/OpenApi.ts#L983-L1015

```typescript
    export interface IOneOf<Schema extends IJsonSchema = IJsonSchema>
      extends __IAttribute {
      /**
       * List of the union types.
       */
      oneOf: Exclude<Schema, IJsonSchema.IOneOf>[];

      /**
       * Discriminator info of the union type.
       */
      discriminator?: IOneOf.IDiscriminator;
    }
    export namespace IOneOf {
      /**
       * Discriminator info of the union type.
       */
      export interface IDiscriminator {
        /**
         * Property name for the discriminator.
         */
        propertyName: string;

        /**
         * Mapping of the discriminator value to the schema name.
         *
         * This property is valid only for {@link IReference} typed
         * {@link IOneOf.oneof} elements. Therefore, `key` of `mapping` is
         * the discriminator value, and `value` of `mapping` is the
         * schema name like `#/components/schemas/SomeObject`.
         */
        mapping?: Record<string, string>;
      }
    }
```