### PR TITLE
`HttpQueryProgrammer.allowOptional` configuration for `@nestia/sdk`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.1.tgz"
+    "typia": "../typia-6.4.2.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.4.1.tgz"
+    "typia": "../typia-6.4.2.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.4.1"
+    "typia": "6.4.2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/programmers/http/HttpAssertQueryProgrammer.ts
+++ b/src/programmers/http/HttpAssertQueryProgrammer.ts
@@ -12,7 +12,7 @@ import { HttpQueryProgrammer } from "./HttpQueryProgrammer";
 export namespace HttpAssertQueryProgrammer {
   export const write =
     (project: IProject) =>
-    (modulo: ts.LeftHandSideExpression) =>
+    (modulo: ts.LeftHandSideExpression, allowOptional: boolean = false) =>
     (type: ts.Type, name?: string, init?: ts.Expression): ts.ArrowFunction =>
       ts.factory.createArrowFunction(
         undefined,
@@ -48,7 +48,7 @@ export namespace HttpAssertQueryProgrammer {
                 functional: false,
                 numeric: false,
               },
-            })(modulo)(type, name),
+            })(modulo, allowOptional)(type, name),
           ),
           StatementFactory.constant(
             "assert",

--- a/src/programmers/http/HttpIsQueryProgrammer.ts
+++ b/src/programmers/http/HttpIsQueryProgrammer.ts
@@ -12,7 +12,7 @@ import { HttpQueryProgrammer } from "./HttpQueryProgrammer";
 export namespace HttpIsQueryProgrammer {
   export const write =
     (project: IProject) =>
-    (modulo: ts.LeftHandSideExpression) =>
+    (modulo: ts.LeftHandSideExpression, allowOptional: boolean = false) =>
     (type: ts.Type, name?: string): ts.ArrowFunction =>
       ts.factory.createArrowFunction(
         undefined,
@@ -61,7 +61,7 @@ export namespace HttpIsQueryProgrammer {
                 functional: false,
                 numeric: false,
               },
-            })(modulo)(type, name),
+            })(modulo, allowOptional)(type, name),
           ),
           StatementFactory.constant(
             "output",

--- a/src/programmers/http/HttpValidateQueryProgrammer.ts
+++ b/src/programmers/http/HttpValidateQueryProgrammer.ts
@@ -12,7 +12,7 @@ import { HttpQueryProgrammer } from "./HttpQueryProgrammer";
 export namespace HttpValidateQueryProgrammer {
   export const write =
     (project: IProject) =>
-    (modulo: ts.LeftHandSideExpression) =>
+    (modulo: ts.LeftHandSideExpression, allowOptional: boolean = false) =>
     (type: ts.Type, name?: string): ts.ArrowFunction =>
       ts.factory.createArrowFunction(
         undefined,
@@ -50,7 +50,7 @@ export namespace HttpValidateQueryProgrammer {
                 functional: false,
                 numeric: false,
               },
-            })(modulo)(type, name),
+            })(modulo, allowOptional)(type, name),
           ),
           StatementFactory.constant(
             "output",

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.4.1.tgz"
+    "typia": "../typia-6.4.2.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.1.tgz"
+    "typia": "../typia-6.4.2.tgz"
   }
 }


### PR DESCRIPTION
To support optional `@TypedQuery()` parameter definition, `HttpQueryProgrammer` added a new configurable option `allowOptional` argument.
