### PR TITLE
Fix #1152: stop using `BigInt` global variables for super old browsers.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.2.tgz"
+    "typia": "../typia-6.4.3.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.4.2.tgz"
+    "typia": "../typia-6.4.3.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.4.2"
+    "typia": "6.4.3"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/functional/$ProtobufReader.ts
+++ b/src/functional/$ProtobufReader.ts
@@ -1,5 +1,7 @@
 import { ProtobufWire } from "../programmers/helpers/ProtobufWire";
 
+import { Singleton } from "../utils/Singleton";
+
 /// @reference https://github.com/piotr-oles/as-proto/blob/main/packages/as-proto/assembly/internal/FixedReader.ts
 export class $ProtobufReader {
   /**
@@ -54,7 +56,7 @@ export class $ProtobufReader {
 
   public sint64(): bigint {
     const value = this.varint64();
-    return (value >> N01) ^ -(value & N01);
+    return (value >> BigInt(0x01)) ^ -(value & BigInt(0x01));
   }
 
   public bool(): boolean {
@@ -81,7 +83,7 @@ export class $ProtobufReader {
   }
 
   public string(): string {
-    return utf8.decode(this.bytes());
+    return utf8.get().decode(this.bytes());
   }
 
   public skip(length: number): void {
@@ -149,34 +151,34 @@ export class $ProtobufReader {
     let loaded: bigint;
     let value: bigint;
 
-    value = (loaded = this.u8n()) & N7F;
-    if (loaded < N80) return value;
+    value = (loaded = this.u8n()) & BigInt(0x7f);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(7);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(7);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(14);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(14);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(21);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(21);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(28);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(28);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(35);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(35);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(42);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(42);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(49);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(49);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= ((loaded = this.u8n()) & N7F) << BigInt(56);
-    if (loaded < N80) return value;
+    value |= ((loaded = this.u8n()) & BigInt(0x7f)) << BigInt(56);
+    if (loaded < BigInt(0x80)) return value;
 
-    value |= (this.u8n() & N01) << BigInt(63);
+    value |= (this.u8n() & BigInt(0x01)) << BigInt(63);
     return BigInt.asIntN(64, value);
   }
 
@@ -189,7 +191,4 @@ export class $ProtobufReader {
   }
 }
 
-const utf8 = /** @__PURE__ */ new TextDecoder();
-const N01 = /** @__PURE__ */ BigInt(0x01);
-const N7F = /** @__PURE__ */ BigInt(0x7f);
-const N80 = /** @__PURE__ */ BigInt(0x80);
+const utf8 = /** @__PURE__ */ new Singleton(() => new TextDecoder("utf-8"));

--- a/src/functional/$ProtobufSizer.ts
+++ b/src/functional/$ProtobufSizer.ts
@@ -135,13 +135,10 @@ export class $ProtobufSizer implements IProtobufWriter {
 
   private varint64(val: bigint): void {
     val = BigInt.asUintN(64, val);
-    while (val > NX7F) {
+    while (val > BigInt(0x7f)) {
       ++this.len;
-      val = val >> ND07;
+      val = val >> BigInt(0x07);
     }
     ++this.len;
   }
 }
-
-const ND07 = /** @__PURE__ */ BigInt(7);
-const NX7F = /** @__PURE__ */ BigInt(0x7f);

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.4.2.tgz"
+    "typia": "../typia-6.4.3.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.2.tgz"
+    "typia": "../typia-6.4.3.tgz"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
     "typescript": "^5.5.2",
-    "typia": "^6.4.1"
+    "typia": "^6.4.3"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
#1152 issue reported me that the global `BigInt` typed variable brakes very old browsers even not supporting the `BigInt` type.

This PR avoids bug, by not using global level `BigInt` variable more.
