### PR TITLE
docs(setup.mdx): Correct setup command for unplugin-typia with Bun

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -284,7 +284,7 @@ yarn typia setup --manager yarn
   </Tab>
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
-bun add @ryoppippi/unplugin-typia
+bunx jsr add @ryoppippi/unplugin-typia
 bun add typia
 bun typia setup
 ```


### PR DESCRIPTION
There is a mistake in the guidance of installing ``unplugin-typia`` with ``Bun`` as the package manager.

Previous:
```
bun add @ryoppippi/unplugin-typia
```

This command does not contain ``jsr`` which means bun will search the package on ``npmjs`` instead of ``jsr``, resulting in an older version of ``unplugin-typia`` causing issues with newer ``typescript`` version.

Further discussion can be seen at: https://github.com/ryoppippi/unplugin-typia/issues/170