### PR TITLE
Break change from `@samchon/openapi`.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.3.tgz"
+    "typia": "../typia-6.5.0.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.4.3.tgz"
+    "typia": "../typia-6.5.0.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -67,7 +67,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^0.3.1",
+    "@samchon/openapi": "^0.4.1",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.4.3"
+    "typia": "6.5.0"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.4.3.tgz"
+    "typia": "../typia-6.5.0.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.4.3.tgz"
+    "typia": "../typia-6.5.0.tgz"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -36,8 +36,8 @@
     "react-dom": "^18.2.0",
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
-    "typescript": "^5.5.2",
-    "typia": "^6.4.3"
+    "typescript": "^5.5.3",
+    "typia": "^6.5.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
Not critical for `typia`, but import for `nestia` of my 3rd party library.

So that takes minor level update.

