### PR TITLE
Fix #1161: change `$clone()` proper.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.5.0.tgz"
+    "typia": "../typia-6.5.1.tgz"
   }
 }

--- a/debug/features/clone.ts
+++ b/debug/features/clone.ts
@@ -1,0 +1,38 @@
+import typia, { tags } from "typia";
+
+import { $clone } from "typia/lib/functional/$clone";
+
+interface IBbsGroup {
+  id: string & tags.Format<"uuid">;
+  code: string;
+  name: string;
+  articles: IBbsArticle[];
+}
+interface IBbsArticle {
+  id: string & tags.Format<"uuid">;
+  title: string;
+  content: string;
+  files: IAttachmentFile[];
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+}
+interface IAttachmentFile {
+  id: string & tags.Format<"uri">;
+  name: string;
+  extension: string | null;
+  data: Uint8Array | DataView | Blob | File;
+}
+
+new Array(1_000).fill(null).forEach(() => {
+  const group: IBbsGroup = {
+    ...typia.random<IBbsGroup>(),
+    articles: new Array(10).fill(null).map(() => ({
+      ...typia.random<IBbsArticle>(),
+      files: new Array(10)
+        .fill(null)
+        .map(() => typia.random<IAttachmentFile>()),
+    })),
+  };
+  typia.assert<IBbsGroup>($clone(group));
+});

--- a/debug/package.json
+++ b/debug/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "typia": "../typia-6.4.0.tgz"
+    "typia": "../typia-6.5.0.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.5.0.tgz"
+    "typia": "../typia-6.5.1.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.5.0"
+    "typia": "6.5.1"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/functional/$any.ts
+++ b/src/functional/$any.ts
@@ -1,4 +1,3 @@
 import { $clone } from "./$clone";
 
-export const $any = (val: any): any =>
-  val !== undefined ? $clone(val) : undefined;
+export const $any = (val: any): any => $clone(val);

--- a/src/functional/$clone.ts
+++ b/src/functional/$clone.ts
@@ -1,4 +1,48 @@
-import { Primitive } from "../Primitive";
+import { Resolved } from "../Resolved";
 
-export const $clone = <T>(value: T): Primitive<T> =>
-  JSON.parse(JSON.stringify(value));
+export const $clone = <T>(value: T): Resolved<T> =>
+  $cloneMain(value) as Resolved<T>;
+
+const $cloneMain = (value: any): any => {
+  if (value === undefined) return undefined;
+  else if (typeof value === "object")
+    if (value === null) return null;
+    else if (Array.isArray(value)) return value.map($cloneMain);
+    else if (value instanceof Date) return new Date(value);
+    else if (value instanceof Uint8Array) return new Uint8Array(value);
+    else if (value instanceof Uint8ClampedArray)
+      return new Uint8ClampedArray(value);
+    else if (value instanceof Uint16Array) return new Uint16Array(value);
+    else if (value instanceof Uint32Array) return new Uint32Array(value);
+    else if (value instanceof BigUint64Array) return new BigUint64Array(value);
+    else if (value instanceof Int8Array) return new Int8Array(value);
+    else if (value instanceof Int16Array) return new Int16Array(value);
+    else if (value instanceof Int32Array) return new Int32Array(value);
+    else if (value instanceof BigInt64Array) return new BigInt64Array(value);
+    else if (value instanceof Float32Array) return new Float32Array(value);
+    else if (value instanceof Float64Array) return new Float64Array(value);
+    else if (value instanceof ArrayBuffer) return value.slice(0);
+    else if (value instanceof SharedArrayBuffer) return value.slice(0);
+    else if (value instanceof DataView)
+      return new DataView(value.buffer.slice(0));
+    else if (value instanceof Blob)
+      return new Blob([value], { type: value.type });
+    else if (value instanceof File)
+      return new File([value], value.name, { type: value.type });
+    else if (value instanceof Set) return new Set([...value].map($cloneMain));
+    else if (value instanceof Map)
+      return new Map(
+        [...value].map(([k, v]) => [$cloneMain(k), $cloneMain(v)]),
+      );
+    else if (value instanceof WeakSet || value instanceof WeakMap)
+      throw new Error("WeakSet and WeakMap are not supported");
+    else if (value.valueOf() !== value) return $cloneMain(value.valueOf());
+    else
+      return Object.fromEntries(
+        Object.entries(value)
+          .map(([k, v]) => [k, $cloneMain(v)])
+          .filter(([, v]) => v !== undefined),
+      );
+  else if (typeof value === "function") return undefined;
+  return value;
+};

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.5.0.tgz"
+    "typia": "../typia-6.5.1.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.5.0.tgz"
+    "typia": "../typia-6.5.1.tgz"
   }
 }

--- a/test/src/features/issues/test_issue_1161_clone_was_wrong.ts
+++ b/test/src/features/issues/test_issue_1161_clone_was_wrong.ts
@@ -1,0 +1,38 @@
+import typia, { tags } from "typia";
+
+export const test_issue_1161_clone_was_wrong = (): void => {
+  new Array(1_000).fill(null).forEach(() => {
+    const group: IBbsGroup = {
+      ...typia.random<IBbsGroup>(),
+      articles: new Array(10).fill(null).map(() => ({
+        ...typia.random<IBbsArticle>(),
+        files: new Array(10)
+          .fill(null)
+          .map(() => typia.random<IAttachmentFile>()),
+      })),
+    };
+    typia.assert<IBbsGroup>(typia.misc.clone<any>(group));
+  });
+};
+
+interface IBbsGroup {
+  id: string & tags.Format<"uuid">;
+  code: string;
+  name: string;
+  articles: IBbsArticle[];
+}
+interface IBbsArticle {
+  id: string & tags.Format<"uuid">;
+  title: string;
+  content: string;
+  files: IAttachmentFile[];
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+}
+interface IAttachmentFile {
+  id: string & tags.Format<"uri">;
+  name: string;
+  extension: string | null;
+  data: Uint8Array | DataView | Blob | File;
+}

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "tgrid": "^1.0.2",
     "tstl": "^3.0.0",
     "typescript": "^5.5.3",
-    "typia": "^6.5.0"
+    "typia": "^6.5.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
The `$clone()` function is used by `typia.misc.clone<T>()` function when some value has `any` type.

By the way, return type of `typia.misc.clone<T>()` is `Resolved<T>`, but `$clone()` function is returning `Primitive<T>` type.

Also, its function is just returning JSON level hard copying: `JSON.parse(JSON.stringify(value))`.

Therefore, the `$clone()` function's return type and main logic must be changed, suitable for its origin spec.
