### PR TITLE
feat: add `Equal` type of Comparison of equivalence

### DIFF
--- a/src/CamelCase.ts
+++ b/src/CamelCase.ts
@@ -14,7 +14,6 @@ export type CamelCase<T> =
 /* -----------------------------------------------------------
     OBJECT CONVERSION
 ----------------------------------------------------------- */
-type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
 type CamelizeMain<T> = T extends [never]
   ? never // special trick for (jsonable | null) type

--- a/src/CamelCase.ts
+++ b/src/CamelCase.ts
@@ -1,3 +1,5 @@
+import type { Equal } from "./typings/Equal";
+
 /**
  * Camel case type.
  *

--- a/src/PascalCase.ts
+++ b/src/PascalCase.ts
@@ -1,3 +1,5 @@
+import type { Equal } from "./typings/Equal";
+
 /**
  * Pascal case type.
  *

--- a/src/PascalCase.ts
+++ b/src/PascalCase.ts
@@ -14,7 +14,6 @@ export type PascalCase<T> =
 /* -----------------------------------------------------------
     OBJECT CONVERSION
 ----------------------------------------------------------- */
-type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
 type PascalizeMain<T> = T extends [never]
   ? never // special trick for (jsonable | null) type

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -1,3 +1,5 @@
+import type { Equal } from "./typings/Equal";
+
 /**
  * Primitive type of JSON.
  *

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -35,8 +35,6 @@
 export type Primitive<T> =
   Equal<T, PrimitiveMain<T>> extends true ? T : PrimitiveMain<T>;
 
-type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
-
 type PrimitiveMain<Instance> = Instance extends [never]
   ? never // (special trick for jsonable | null) type
   : ValueOf<Instance> extends bigint

--- a/src/Resolved.ts
+++ b/src/Resolved.ts
@@ -1,3 +1,5 @@
+import type { Equal } from "./typings/Equal";
+
 /**
  * Resolved type erased every methods.
  *

--- a/src/Resolved.ts
+++ b/src/Resolved.ts
@@ -29,8 +29,6 @@
 export type Resolved<T> =
   Equal<T, ResolvedMain<T>> extends true ? T : ResolvedMain<T>;
 
-type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
-
 type ResolvedMain<T> = T extends [never]
   ? never // (special trick for jsonable | null) type
   : ValueOf<T> extends boolean | number | bigint | string

--- a/src/SnakeCase.ts
+++ b/src/SnakeCase.ts
@@ -1,3 +1,5 @@
+import type { Equal } from "./typings/Equal";
+
 /**
  * Snake case type.
  *

--- a/src/SnakeCase.ts
+++ b/src/SnakeCase.ts
@@ -14,7 +14,6 @@ export type SnakeCase<T> =
 /* -----------------------------------------------------------
     OBJECT CONVERSION
 ----------------------------------------------------------- */
-type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
 type SnakageMain<T> = T extends [never]
   ? never // special trick for (jsonable | null) type

--- a/src/typings/Equal.ts
+++ b/src/typings/Equal.ts
@@ -1,0 +1,12 @@
+/**
+ * In order to determine whether it is the same in the union type,
+ * the types are compared by wrapping them with a function with a generic type as a factor once more.
+ *
+ * ```ts
+ * type Answer = Equal<1 | 2, 1 | 2>; // true
+ * ```
+ */
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;

--- a/src/typings/Equal.ts
+++ b/src/typings/Equal.ts
@@ -1,12 +1,15 @@
 /**
- * In order to determine whether it is the same in the union type,
- * the types are compared by wrapping them with a function with a generic type as a factor once more.
+ * Compare the equivalence of the two types X and Y.
+ * The two types X and Y refer to any type that can be expressed in the type script, such as the union type and the object type.
+ *
+ * @template X One of the types to compare
+ * @template Y One of the types to compare
  *
  * ```ts
  * type Answer = Equal<1 | 2, 1 | 2>; // true
  * ```
  */
-type Equal<X, Y> =
+export type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
     ? true
     : false;


### PR DESCRIPTION
The existing `Equal` type did not work for the union type. For a more complete type comparison, it is recommended to use the Equal type separately as a separate file.

- https://github.com/toss/es-toolkit/pull/206#discussion_r1680242129