### PR TITLE
Type resolver refactoring.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.5.1.tgz"
+    "typia": "../typia-6.6.0-dev.20240720.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.5.1.tgz"
+    "typia": "../typia-6.6.0-dev.20240720.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.5.1",
+  "version": "6.6.0-dev.20240720",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.5.1",
+  "version": "6.6.0-dev.20240720",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.5.1"
+    "typia": "6.6.0-dev.20240720"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/CamelCase.ts
+++ b/src/CamelCase.ts
@@ -1,3 +1,7 @@
+import { IsTuple } from "./typings/IsTuple";
+import { NativeClass } from "./typings/NativeClass";
+import { ValueOf } from "./typings/ValueOf";
+
 /**
  * Camel case type.
  *
@@ -11,9 +15,6 @@
 export type CamelCase<T> =
   Equal<T, CamelizeMain<T>> extends true ? T : CamelizeMain<T>;
 
-/* -----------------------------------------------------------
-    OBJECT CONVERSION
------------------------------------------------------------ */
 type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
 type CamelizeMain<T> = T extends [never]
@@ -37,24 +38,7 @@ type CamelizeObject<T extends object> =
         ? Map<CamelizeMain<K>, CamelizeMain<V>>
         : T extends WeakSet<any> | WeakMap<any, any>
           ? never
-          : T extends
-                | Date
-                | Uint8Array
-                | Uint8ClampedArray
-                | Uint16Array
-                | Uint32Array
-                | BigUint64Array
-                | Int8Array
-                | Int16Array
-                | Int32Array
-                | BigInt64Array
-                | Float32Array
-                | Float64Array
-                | ArrayBuffer
-                | SharedArrayBuffer
-                | DataView
-                | Blob
-                | File
+          : T extends NativeClass
             ? T
             : {
                 [Key in keyof T as CamelizeString<Key & string>]: CamelizeMain<
@@ -62,18 +46,6 @@ type CamelizeObject<T extends object> =
                 >;
               };
 
-/* -----------------------------------------------------------
-    SPECIAL CASES
------------------------------------------------------------ */
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
 type CamelizeTuple<T extends readonly any[]> = T extends []
   ? []
   : T extends [infer F]
@@ -86,30 +58,6 @@ type CamelizeTuple<T extends readonly any[]> = T extends []
           ? [CamelizeMain<F>?, ...CamelizeTuple<Rest>]
           : [];
 
-type ValueOf<Instance> =
-  IsValueOf<Instance, Boolean> extends true
-    ? boolean
-    : IsValueOf<Instance, Number> extends true
-      ? number
-      : IsValueOf<Instance, String> extends true
-        ? string
-        : Instance;
-
-type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
-  ? Object extends IValueOf<infer Primitive>
-    ? Instance extends Primitive
-      ? false
-      : true // not Primitive, but Object
-    : false // cannot be
-  : false;
-
-interface IValueOf<T> {
-  valueOf(): T;
-}
-
-/* -----------------------------------------------------------
-    STRING CONVERTER
------------------------------------------------------------ */
 type CamelizeString<Key extends string> = Key extends `_${infer R}`
   ? `_${CamelizeString<R>}`
   : Key extends `${infer F}${infer R}`

--- a/src/PascalCase.ts
+++ b/src/PascalCase.ts
@@ -1,3 +1,7 @@
+import { IsTuple } from "./typings/IsTuple";
+import { NativeClass } from "./typings/NativeClass";
+import { ValueOf } from "./typings/ValueOf";
+
 /**
  * Pascal case type.
  *
@@ -11,9 +15,6 @@
 export type PascalCase<T> =
   Equal<T, PascalizeMain<T>> extends true ? T : PascalizeMain<T>;
 
-/* -----------------------------------------------------------
-    OBJECT CONVERSION
------------------------------------------------------------ */
 type Equal<X, Y> = X extends Y ? (Y extends X ? true : false) : false;
 
 type PascalizeMain<T> = T extends [never]
@@ -37,24 +38,7 @@ type PascalizeObject<T extends object> =
         ? Map<PascalizeMain<K>, PascalizeMain<V>>
         : T extends WeakSet<any> | WeakMap<any, any>
           ? never
-          : T extends
-                | Date
-                | Uint8Array
-                | Uint8ClampedArray
-                | Uint16Array
-                | Uint32Array
-                | BigUint64Array
-                | Int8Array
-                | Int16Array
-                | Int32Array
-                | BigInt64Array
-                | Float32Array
-                | Float64Array
-                | ArrayBuffer
-                | SharedArrayBuffer
-                | DataView
-                | Blob
-                | File
+          : T extends NativeClass
             ? T
             : {
                 [Key in keyof T as PascalizeString<
@@ -62,18 +46,6 @@ type PascalizeObject<T extends object> =
                 >]: PascalizeMain<T[Key]>;
               };
 
-/* -----------------------------------------------------------
-    SPECIAL CASES
------------------------------------------------------------ */
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
 type PascalizeTuple<T extends readonly any[]> = T extends []
   ? []
   : T extends [infer F]
@@ -86,30 +58,6 @@ type PascalizeTuple<T extends readonly any[]> = T extends []
           ? [PascalizeMain<F>?, ...PascalizeTuple<Rest>]
           : [];
 
-type ValueOf<Instance> =
-  IsValueOf<Instance, Boolean> extends true
-    ? boolean
-    : IsValueOf<Instance, Number> extends true
-      ? number
-      : IsValueOf<Instance, String> extends true
-        ? string
-        : Instance;
-
-type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
-  ? Object extends IValueOf<infer Primitive>
-    ? Instance extends Primitive
-      ? false
-      : true // not Primitive, but Object
-    : false // cannot be
-  : false;
-
-interface IValueOf<T> {
-  valueOf(): T;
-}
-
-/* -----------------------------------------------------------
-    STRING CONVERTER
------------------------------------------------------------ */
 type PascalizeString<Key extends string> = Key extends `_${infer R}`
   ? `_${PascalizeString<R>}`
   : Key extends `${infer F}${infer R}`

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -1,3 +1,7 @@
+import { IsTuple } from "./typings/IsTuple";
+import { NativeClass } from "./typings/NativeClass";
+import { ValueOf } from "./typings/ValueOf";
+
 /**
  * Primitive type of JSON.
  *
@@ -79,57 +83,6 @@ type PrimitiveTuple<T extends readonly any[]> = T extends []
         : T extends [(infer F)?, ...infer Rest extends readonly any[]]
           ? [PrimitiveMain<F>?, ...PrimitiveTuple<Rest>]
           : [];
-
-type ValueOf<Instance> =
-  IsValueOf<Instance, Boolean> extends true
-    ? boolean
-    : IsValueOf<Instance, Number> extends true
-      ? number
-      : IsValueOf<Instance, String> extends true
-        ? string
-        : Instance;
-
-type NativeClass =
-  | Set<any>
-  | Map<any, any>
-  | WeakSet<any>
-  | WeakMap<any, any>
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | BigUint64Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | BigInt64Array
-  | Float32Array
-  | Float64Array
-  | ArrayBuffer
-  | SharedArrayBuffer
-  | DataView;
-
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
-
-type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
-  ? Object extends IValueOf<infer U>
-    ? Instance extends U
-      ? false
-      : true // not Primitive, but Object
-    : false // cannot be
-  : false;
-
-interface IValueOf<T> {
-  valueOf(): T;
-}
 
 interface IJsonable<T> {
   toJSON(): T;

--- a/src/Primitive.ts
+++ b/src/Primitive.ts
@@ -3,6 +3,8 @@ import { IsTuple } from "./typings/IsTuple";
 import { NativeClass } from "./typings/NativeClass";
 import { ValueOf } from "./typings/ValueOf";
 
+import { Format } from "./tags";
+
 /**
  * Primitive type of JSON.
  *
@@ -50,15 +52,17 @@ type PrimitiveMain<Instance> = Instance extends [never]
         ? never
         : ValueOf<Instance> extends object
           ? Instance extends object
-            ? Instance extends NativeClass
-              ? never
+            ? Instance extends Date
+              ? string & Format<"date-time">
               : Instance extends IJsonable<infer Raw>
                 ? ValueOf<Raw> extends object
                   ? Raw extends object
                     ? PrimitiveObject<Raw> // object would be primitified
                     : never // cannot be
                   : ValueOf<Raw> // atomic value
-                : PrimitiveObject<Instance> // object would be primitified
+                : Instance extends Exclude<NativeClass, Date>
+                  ? never
+                  : PrimitiveObject<Instance> // object would be primitified
             : never // cannot be
           : ValueOf<Instance>;
 

--- a/src/Resolved.ts
+++ b/src/Resolved.ts
@@ -1,3 +1,7 @@
+import { IsTuple } from "./typings/IsTuple";
+import { NativeClass } from "./typings/NativeClass";
+import { ValueOf } from "./typings/ValueOf";
+
 /**
  * Resolved type erased every methods.
  *
@@ -52,24 +56,7 @@ type ResolvedObject<T extends object> =
         ? Map<ResolvedMain<K>, ResolvedMain<V>>
         : T extends WeakSet<any> | WeakMap<any, any>
           ? never
-          : T extends
-                | Date
-                | Uint8Array
-                | Uint8ClampedArray
-                | Uint16Array
-                | Uint32Array
-                | BigUint64Array
-                | Int8Array
-                | Int16Array
-                | Int32Array
-                | BigInt64Array
-                | Float32Array
-                | Float64Array
-                | ArrayBuffer
-                | SharedArrayBuffer
-                | DataView
-                | Blob
-                | File
+          : T extends NativeClass
             ? T
             : {
                 [P in keyof T]: ResolvedMain<T[P]>;
@@ -86,34 +73,3 @@ type ResolvedTuple<T extends readonly any[]> = T extends []
         : T extends [(infer F)?, ...infer Rest extends readonly any[]]
           ? [ResolvedMain<F>?, ...ResolvedTuple<Rest>]
           : [];
-
-type IsTuple<T extends readonly any[] | { length: number }> = [T] extends [
-  never,
-]
-  ? false
-  : T extends readonly any[]
-    ? number extends T["length"]
-      ? false
-      : true
-    : false;
-
-type ValueOf<Instance> =
-  IsValueOf<Instance, Boolean> extends true
-    ? boolean
-    : IsValueOf<Instance, Number> extends true
-      ? number
-      : IsValueOf<Instance, String> extends true
-        ? string
-        : Instance;
-
-type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
-  ? Object extends IValueOf<infer Primitive>
-    ? Instance extends Primitive
-      ? false
-      : true // not Primitive, but Object
-    : false // cannot be
-  : false;
-
-interface IValueOf<T> {
-  valueOf(): T;
-}

--- a/src/SnakeCase.ts
+++ b/src/SnakeCase.ts
@@ -1,3 +1,6 @@
+import { NativeClass } from "./typings/NativeClass";
+import { ValueOf } from "./typings/ValueOf";
+
 /**
  * Snake case type.
  *
@@ -37,24 +40,7 @@ type SnakageObject<T extends object> =
         ? Map<SnakageMain<K>, SnakageMain<V>>
         : T extends WeakSet<any> | WeakMap<any, any>
           ? never
-          : T extends
-                | Date
-                | Uint8Array
-                | Uint8ClampedArray
-                | Uint16Array
-                | Uint32Array
-                | BigUint64Array
-                | Int8Array
-                | Int16Array
-                | Int32Array
-                | BigInt64Array
-                | Float32Array
-                | Float64Array
-                | ArrayBuffer
-                | SharedArrayBuffer
-                | DataView
-                | Blob
-                | File
+          : T extends NativeClass
             ? T
             : {
                 [Key in keyof T as SnakageString<Key & string>]: SnakageMain<
@@ -85,27 +71,6 @@ type SnakageTuple<T extends readonly any[]> = T extends []
         : T extends [(infer F)?, ...infer Rest extends readonly any[]]
           ? [SnakageMain<F>?, ...SnakageTuple<Rest>]
           : [];
-
-type ValueOf<Instance> =
-  IsValueOf<Instance, Boolean> extends true
-    ? boolean
-    : IsValueOf<Instance, Number> extends true
-      ? number
-      : IsValueOf<Instance, String> extends true
-        ? string
-        : Instance;
-
-type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
-  ? Object extends IValueOf<infer Primitive>
-    ? Instance extends Primitive
-      ? false
-      : true // not Primitive, but Object
-    : false // cannot be
-  : false;
-
-interface IValueOf<T> {
-  valueOf(): T;
-}
 
 /* -----------------------------------------------------------
     STRING CONVERTER

--- a/src/factories/internal/metadata/iterate_metadata_native.ts
+++ b/src/factories/internal/metadata/iterate_metadata_native.ts
@@ -182,6 +182,17 @@ const SIMPLES: Map<string, IClassInfo> = new Map([
       })),
     },
   ],
+  [
+    "RegExp",
+    {
+      methods: [
+        {
+          name: "test",
+          return: "boolean",
+        },
+      ],
+    },
+  ],
 ]);
 const GENERICS: Array<IClassInfo & { name: string }> = [
   "WeakMap",

--- a/src/programmers/RandomProgrammer.ts
+++ b/src/programmers/RandomProgrammer.ts
@@ -650,6 +650,7 @@ export namespace RandomProgrammer {
       else if (type === "DataView") return decode_native_data_view(importer);
       else if (type === "Blob") return decode_native_blob(importer);
       else if (type === "File") return decode_native_file(importer);
+      else if (type === "RegExp") return decode_regexp();
       else
         return ts.factory.createNewExpression(
           ts.factory.createIdentifier(type),
@@ -865,6 +866,13 @@ export namespace RandomProgrammer {
           decode_native_byte_array(importer)("Uint8Array"),
         )("buffer"),
       ],
+    );
+
+  const decode_regexp = () =>
+    ts.factory.createNewExpression(
+      ts.factory.createIdentifier("RegExp"),
+      [],
+      [ts.factory.createIdentifier("/(?:)/")],
     );
 }
 

--- a/src/programmers/misc/MiscCloneProgrammer.ts
+++ b/src/programmers/misc/MiscCloneProgrammer.ts
@@ -378,7 +378,8 @@ export namespace MiscCloneProgrammer {
     type === "Int32Array" ||
     type === "BigInt64Array" ||
     type === "Float32Array" ||
-    type === "Float64Array"
+    type === "Float64Array" ||
+    type === "RegExp"
       ? decode_native_copyable(type)(input)
       : type === "ArrayBuffer" || type === "SharedArrayBuffer"
         ? decode_native_buffer(type)(input)

--- a/src/typings/IsTuple.ts
+++ b/src/typings/IsTuple.ts
@@ -1,0 +1,9 @@
+export type IsTuple<T extends readonly any[] | { length: number }> = [
+  T,
+] extends [never]
+  ? false
+  : T extends readonly any[]
+    ? number extends T["length"]
+      ? false
+      : true
+    : false;

--- a/src/typings/NativeClass.ts
+++ b/src/typings/NativeClass.ts
@@ -1,4 +1,5 @@
 export type NativeClass =
+  | Date
   | Set<any>
   | Map<any, any>
   | WeakSet<any>
@@ -17,4 +18,6 @@ export type NativeClass =
   | ArrayBuffer
   | SharedArrayBuffer
   | DataView
+  | Blob
+  | File
   | RegExp;

--- a/src/typings/NativeClass.ts
+++ b/src/typings/NativeClass.ts
@@ -1,0 +1,20 @@
+export type NativeClass =
+  | Set<any>
+  | Map<any, any>
+  | WeakSet<any>
+  | WeakMap<any, any>
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array
+  | BigUint64Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | BigInt64Array
+  | Float32Array
+  | Float64Array
+  | ArrayBuffer
+  | SharedArrayBuffer
+  | DataView
+  | RegExp;

--- a/src/typings/ValueOf.ts
+++ b/src/typings/ValueOf.ts
@@ -1,0 +1,20 @@
+export type ValueOf<Instance> =
+  IsValueOf<Instance, Boolean> extends true
+    ? boolean
+    : IsValueOf<Instance, Number> extends true
+      ? number
+      : IsValueOf<Instance, String> extends true
+        ? string
+        : Instance;
+
+type IsValueOf<Instance, Object extends IValueOf<any>> = Instance extends Object
+  ? Object extends IValueOf<infer Primitive>
+    ? Instance extends Primitive
+      ? false
+      : true // not Primitive, but Object
+    : false // cannot be
+  : false;
+
+interface IValueOf<T> {
+  valueOf(): T;
+}

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.5.1.tgz"
+    "typia": "../typia-6.6.0-dev.20240720.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -51,6 +51,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.5.1.tgz"
+    "typia": "../typia-6.6.0-dev.20240720.tgz"
   }
 }

--- a/test/src/features/issues/test_pr_1169_native_class_regexp.ts
+++ b/test/src/features/issues/test_pr_1169_native_class_regexp.ts
@@ -1,0 +1,6 @@
+import typia from "typia";
+
+export const test_pr_1169_native_class_regexp = (): void => {
+  typia.assert<RegExp>(new RegExp(/(?:)/));
+  typia.assert<RegExp>(typia.random<RegExp>());
+};


### PR DESCRIPTION
Refactored type resolvers like `Resolved` and `PascalCase`.

Also supported `RegExp` as one of native classes.
