### PR TITLE
fix: improve SEO

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -7,7 +7,7 @@ const withNextra = require("nextra")({
 const config = {
   ...withNextra(),
   output: "export",
-  exportTrailingSlash: true,
+  trailingSlash: true,
   images: {
     unoptimized: true,
   },

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -50,6 +50,7 @@ const config: DocsThemeConfig = {
     return {
       defaultTitle: "Typia Guide Documents",
       titleTemplate: "Typia Guide Documents - %s",
+      description: "Superfast Runtime Validator with only one line",
       additionalLinkTags: [
         {
           rel: "apple-touch-icon",
@@ -115,6 +116,7 @@ const config: DocsThemeConfig = {
       ],
     };
   },
+  head: (<></>),
 };
 
 export default config;


### PR DESCRIPTION
typia.io website is currently displaying the description meta tag `Nextra: the next docs builder` and Nextra's default description and og tags. it's overriding other meta tags

<img width="1840" alt="스크린샷 2024-08-03 오후 5 11 37" src="https://github.com/user-attachments/assets/ea793060-f22a-4c53-883b-3a942d114f72">

Applied:
- add description tag
- add default `head` option with empty component

The `head` option, it must be a bug with Nextra, I found [an issue](https://github.com/shuding/nextra/issues/2918) with this but it hasn't been updated yet.

This may be addressed in a future version update, but I think this will not affect anything else.