### PR TITLE
Fix generaton mode's non-initialized `let` variable problem.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.7.1.tgz"
+    "typia": "../typia-6.7.2.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.7.1.tgz"
+    "typia": "../typia-6.7.2.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.7.1"
+    "typia": "6.7.2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.6.0"

--- a/src/factories/StatementFactory.ts
+++ b/src/factories/StatementFactory.ts
@@ -1,5 +1,7 @@
 import ts from "typescript";
 
+import { TypeFactory } from "./TypeFactory";
+
 export namespace StatementFactory {
   export const mut = (name: string, initializer?: ts.Expression) =>
     ts.factory.createVariableStatement(
@@ -9,7 +11,7 @@ export namespace StatementFactory {
           ts.factory.createVariableDeclaration(
             name,
             undefined,
-            undefined,
+            initializer === undefined ? TypeFactory.keyword("any") : undefined,
             initializer,
           ),
         ],

--- a/src/programmers/misc/MiscAssertPruneProgrammer.ts
+++ b/src/programmers/misc/MiscAssertPruneProgrammer.ts
@@ -46,21 +46,39 @@ export namespace MiscAssertPruneProgrammer {
           IdentifierFactory.parameter("input", TypeFactory.keyword("any")),
           AssertProgrammer.Guardian.parameter(props.init),
         ],
-        prune.arrow.type,
+        ts.factory.createTypeReferenceNode(
+          props.name ??
+            TypeFactory.getFullName(props.project.checker)(props.type),
+        ),
         undefined,
-        ts.factory.createCallExpression(
-          ts.factory.createIdentifier("__prune"),
-          undefined,
+        ts.factory.createBlock(
           [
-            ts.factory.createCallExpression(
-              ts.factory.createIdentifier("__assert"),
-              undefined,
-              [
+            ts.factory.createExpressionStatement(
+              ts.factory.createBinaryExpression(
                 ts.factory.createIdentifier("input"),
-                AssertProgrammer.Guardian.identifier(),
-              ],
+                ts.SyntaxKind.EqualsToken,
+                ts.factory.createCallExpression(
+                  ts.factory.createIdentifier("__assert"),
+                  undefined,
+                  [
+                    ts.factory.createIdentifier("input"),
+                    AssertProgrammer.Guardian.identifier(),
+                  ],
+                ),
+              ),
+            ),
+            ts.factory.createExpressionStatement(
+              ts.factory.createCallExpression(
+                ts.factory.createIdentifier("__prune"),
+                undefined,
+                [ts.factory.createIdentifier("input")],
+              ),
+            ),
+            ts.factory.createReturnStatement(
+              ts.factory.createIdentifier("input"),
             ),
           ],
+          true,
         ),
       ),
     };

--- a/src/programmers/misc/MiscIsPruneProgrammer.ts
+++ b/src/programmers/misc/MiscIsPruneProgrammer.ts
@@ -41,10 +41,7 @@ export namespace MiscIsPruneProgrammer {
         undefined,
         undefined,
         [IdentifierFactory.parameter("input", TypeFactory.keyword("any"))],
-        ts.factory.createUnionTypeNode([
-          prune.arrow.type ?? TypeFactory.keyword("any"),
-          ts.factory.createTypeReferenceNode("null"),
-        ]),
+        is.arrow.type,
         undefined,
         ts.factory.createBlock(
           [

--- a/src/programmers/misc/MiscValidatePruneProgrammer.ts
+++ b/src/programmers/misc/MiscValidatePruneProgrammer.ts
@@ -43,9 +43,12 @@ export namespace MiscValidatePruneProgrammer {
         undefined,
         undefined,
         [IdentifierFactory.parameter("input", TypeFactory.keyword("any"))],
-        ts.factory.createTypeReferenceNode("typia.IValidation", [
-          prune.arrow.type ?? TypeFactory.keyword("any"),
-        ]),
+        ts.factory.createTypeReferenceNode(
+          `typia.IValidation<${
+            props.name ??
+            TypeFactory.getFullName(props.project.checker)(props.type)
+          }>`,
+        ),
         undefined,
         ts.factory.createBlock(
           [

--- a/src/programmers/notations/NotationGeneralProgrammer.ts
+++ b/src/programmers/notations/NotationGeneralProgrammer.ts
@@ -56,7 +56,12 @@ export namespace NotationGeneralProgrammer {
         undefined,
         undefined,
         composed.parameters,
-        TypeFactory.keyword("void"),
+        ts.factory.createTypeReferenceNode(
+          returnType(props.rename)(
+            props.name ??
+              TypeFactory.getFullName(props.project.checker)(props.type),
+          ),
+        ),
         undefined,
         composed.body,
       ),

--- a/src/programmers/notations/NotationValidateGeneralProgrammer.ts
+++ b/src/programmers/notations/NotationValidateGeneralProgrammer.ts
@@ -75,7 +75,10 @@ export namespace NotationValidateGeneralProgrammer {
               ),
             ),
             ts.factory.createReturnStatement(
-              ts.factory.createIdentifier("result"),
+              ts.factory.createAsExpression(
+                ts.factory.createIdentifier("result"),
+                TypeFactory.keyword("any"),
+              ),
             ),
           ],
           true,

--- a/src/schemas/metadata/IMetadataConstantValue.ts
+++ b/src/schemas/metadata/IMetadataConstantValue.ts
@@ -5,7 +5,7 @@ import { IMetadataTypeTag } from "./IMetadataTypeTag";
 
 export interface IMetadataConstantValue<T extends Atomic.Type> {
   value: T;
-  tags: IMetadataTypeTag[][] | undefined;
+  tags?: IMetadataTypeTag[][] | undefined;
   description?: string | null;
   jsDocTags?: IJsDocTagInfo[];
 }

--- a/src/schemas/metadata/IMetadataTemplate.ts
+++ b/src/schemas/metadata/IMetadataTemplate.ts
@@ -3,5 +3,5 @@ import { IMetadataTypeTag } from "./IMetadataTypeTag";
 
 export interface IMetadataTemplate {
   row: IMetadata[];
-  tags: IMetadataTypeTag[][] | undefined;
+  tags?: IMetadataTypeTag[][] | undefined;
 }

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.7.1.tgz"
+    "typia": "../typia-6.7.2.tgz"
   }
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+bin-generated
+generated

--- a/test/package.json
+++ b/test/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "rimraf bin && tsc",
     "build_run": "npm run build",
+    "generate": "rimraf generated && rimraf bin-generated && node --max-old-space-size=8000 node_modules/typia/lib/executable/typia generate --input src --output generated --project tsconfig.generated.json && rimraf generated/features/functional* && rimraf generated/features/issues && node --max-old-space-size=8000 node_modules/typescript/bin/tsc --project tsconfig.generated.json",
     "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",
@@ -51,6 +52,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.7.1.tgz"
+    "typia": "../typia-6.7.2.tgz"
   }
 }

--- a/test/tsconfig.actions.json
+++ b/test/tsconfig.actions.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",  
-  "include": ["./src"],
-  "exclude": ["./src/generated"],
-}

--- a/test/tsconfig.generated.json
+++ b/test/tsconfig.generated.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./bin-generated",
+  },
+  "include": ["generated"],
+}

--- a/website/package.json
+++ b/website/package.json
@@ -38,7 +38,7 @@
     "tgrid": "^1.0.3",
     "tstl": "^3.0.0",
     "typescript": "^5.5.4",
-    "typia": "^6.7.1"
+    "typia": "^6.7.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",


### PR DESCRIPTION
When non-initialized `let` variable being generated by `typia` in the JavaScript transformation mode, there would not be any problem. However, it occurs TypeScript compile error in the TypeScript generation mode.

This PR avoids the problem by declaring the non-initailized `let` variable as `any` type. Also, during the generation mode testing, fixed many other miscellaneous bugs.

- Return type problem of
  - `typia.misc.validatePrune()`
  - `typia.misc.assertPrune()`
  - `typia.misc.assertPascal()`, ...
  - `typia.misc.validateCamel()`, ...
