### PR TITLE
feat: add orphan Type to `IJSONApplication` to save types

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -57,7 +57,7 @@ export function application(): never;
 export function application<
   Types extends unknown[],
   Version extends "3.0" | "3.1" = "3.1",
->(): IJsonApplication<Version>;
+>(): IJsonApplication<Version, Types>;
 
 /**
  * @internal

--- a/src/programmers/json/JsonApplicationProgrammer.ts
+++ b/src/programmers/json/JsonApplicationProgrammer.ts
@@ -1,6 +1,6 @@
 import { OpenApi, OpenApiV3 } from "@samchon/openapi";
 
-import { IJsonApplication } from "../../schemas/json/IJsonApplication";
+import { IJsonApplication, type tag as IJSONTag } from "../../schemas/json/IJsonApplication";
 import { Metadata } from "../../schemas/metadata/Metadata";
 
 import { TransformerError } from "../../transformers/TransformerError";
@@ -44,7 +44,7 @@ export namespace JsonApplicationProgrammer {
     const components: OpenApiV3.IComponents = {};
     const generator = (meta: Metadata): OpenApiV3.IJsonSchema | null =>
       application_v30_schema(true)(components)({})(meta);
-    return {
+    const schema = ({
       version: "3.0",
       components,
       schemas: metadatas.map((meta, i) => {
@@ -56,7 +56,8 @@ export namespace JsonApplicationProgrammer {
           });
         return schema;
       }),
-    };
+    } satisfies Omit<IJsonApplication<"3.0">, typeof IJSONTag>); // check types before as assertion
+    return schema as IJsonApplication<"3.0">;
   };
 
   const v31 = (metadatas: Array<Metadata>): IJsonApplication<"3.1"> => {
@@ -65,7 +66,7 @@ export namespace JsonApplicationProgrammer {
     };
     const generator = (meta: Metadata): OpenApi.IJsonSchema | null =>
       application_v31_schema(true)(components)({})(meta);
-    return {
+    const schema = ({
       version: "3.1",
       components,
       schemas: metadatas.map((meta, i) => {
@@ -77,6 +78,7 @@ export namespace JsonApplicationProgrammer {
           });
         return schema;
       }),
-    };
+    } satisfies Omit<IJsonApplication<"3.1">, typeof IJSONTag>); // check types before as assertion
+    return schema as IJsonApplication<"3.1">;
   };
 }

--- a/src/schemas/json/IJsonApplication.ts
+++ b/src/schemas/json/IJsonApplication.ts
@@ -1,17 +1,17 @@
 import type { OpenApi, OpenApiV3 } from "@samchon/openapi";
 
-declare const tag: unique symbol;
+export declare const tag: unique symbol;
 
 export type IJsonApplication<Version extends "3.0" | "3.1" = "3.1", Types = unknown[]> =
   Version extends "3.0" ? IJsonApplication.IV3_0<Types> : IJsonApplication.IV3_1<Types>;
 export namespace IJsonApplication {
-  export interface IV3_0<Types> {
+  export interface IV3_0<Types = unknown[]> {
     [tag]: Types;
     version: "3.0";
     schemas: OpenApiV3.IJsonSchema[];
     components: OpenApiV3.IComponents;
   }
-  export interface IV3_1<Types> {
+  export interface IV3_1<Types = unknown[]> {
     [tag]: Types;
     version: "3.1";
     components: OpenApi.IComponents;

--- a/src/schemas/json/IJsonApplication.ts
+++ b/src/schemas/json/IJsonApplication.ts
@@ -2,17 +2,17 @@ import type { OpenApi, OpenApiV3 } from "@samchon/openapi";
 
 declare const tag: unique symbol;
 
-export type IJsonApplication<Version extends "3.0" | "3.1" = "3.1", T = unknown[]> =
-  Version extends "3.0" ? IJsonApplication.IV3_0<T> : IJsonApplication.IV3_1<T>;
+export type IJsonApplication<Version extends "3.0" | "3.1" = "3.1", Types = unknown[]> =
+  Version extends "3.0" ? IJsonApplication.IV3_0<Types> : IJsonApplication.IV3_1<Types>;
 export namespace IJsonApplication {
-  export interface IV3_0<T> {
-    [tag]: T;
+  export interface IV3_0<Types> {
+    [tag]: Types;
     version: "3.0";
     schemas: OpenApiV3.IJsonSchema[];
     components: OpenApiV3.IComponents;
   }
-  export interface IV3_1<T> {
-    [tag]: T;
+  export interface IV3_1<Types> {
+    [tag]: Types;
     version: "3.1";
     components: OpenApi.IComponents;
     schemas: OpenApi.IJsonSchema[];

--- a/src/schemas/json/IJsonApplication.ts
+++ b/src/schemas/json/IJsonApplication.ts
@@ -1,14 +1,18 @@
 import type { OpenApi, OpenApiV3 } from "@samchon/openapi";
 
-export type IJsonApplication<Version extends "3.0" | "3.1" = "3.1"> =
-  Version extends "3.0" ? IJsonApplication.IV3_0 : IJsonApplication.IV3_1;
+declare const tag: unique symbol;
+
+export type IJsonApplication<Version extends "3.0" | "3.1" = "3.1", T = unknown[]> =
+  Version extends "3.0" ? IJsonApplication.IV3_0<T> : IJsonApplication.IV3_1<T>;
 export namespace IJsonApplication {
-  export interface IV3_0 {
+  export interface IV3_0<T> {
+    [tag]: T;
     version: "3.0";
     schemas: OpenApiV3.IJsonSchema[];
     components: OpenApiV3.IComponents;
   }
-  export interface IV3_1 {
+  export interface IV3_1<T> {
+    [tag]: T;
     version: "3.1";
     components: OpenApi.IComponents;
     schemas: OpenApi.IJsonSchema[];


### PR DESCRIPTION
This is a small PR.
This PR modify `IJsonApplication` types.
Now `IJsonApplication` keeps the original Type which is passed to `typia.json.application`.
This is useful if we make third-party library using typia(ex. https://github.com/ryoppippi/typiautil/blob/ab71cf9cbb73c751474136c6698a3ea23eb8f4b1/openai/mod.ts#L17)

~~~~
Before submitting a Pull Request, please test your code. 

If you created a new feature, then create the unit test function, too.

```bash
# COMPILE
npm run build

# RE-WRITE TEST PROGRAMS IF REQUIRED
npm run test:template

# BUILD TEST PROGRAM
npm run build:test

# DO TEST
npm run test
```

Learn more about the [CONTRIBUTING](CONTRIBUTING.md)