### PR TITLE
fix : a typo in docs

### DIFF
--- a/website/pages/docs/validators/assert.mdx
+++ b/website/pages/docs/validators/assert.mdx
@@ -440,10 +440,10 @@ import { v4 } from "uuid";
 ]}>
   <Tab>
 ```typescript
-export function assertGuard<T>(input: T): asserts inut is T;
+export function assertGuard<T>(input: T): asserts input is T;
 export function assertGuard<T>(input: unknown): asserts input is T;
 
-export function assertGuardEquals<T>(input: T): asserts inut is T;
+export function assertGuardEquals<T>(input: T): asserts input is T;
 export function assertGuardEquals<T>(input: unknown): asserts input is T;
 ```
   </Tab>


### PR DESCRIPTION
Just fix a typo in docs. link as follows. 

https://typia.io/docs/validators/assert/

<img width="777" alt="Screenshot 2024-08-12 at 10 45 05" src="https://github.com/user-attachments/assets/725f7cb6-05f0-4337-9c95-dba6c8f12e56">
