### PR TITLE
fix(docs): update SWC usage instructions

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -611,7 +611,7 @@ If you are using a non-standard TypeScript compiler such as the following, you w
   - Non-standard TypeScript compilers:
     - [Babel](https://babeljs.io/) in Create-React-App
     - [esbuild](https://esbuild.github.io/) in Vite -> covered by [`unplugin-typia`](#unplugin-typia)
-    - [SWC](https://swc.rs/) in Next.js -> only `Next.js` is covered by [`unplugin-typia`](#unplugin-typia)
+    - [SWC](https://swc.rs/) -> use [`unplugin-typia`](#unplugin-typia) with your bundlers ( including `next.js`, `vite`, `webpack`, `rollup`, etc )
 
 Instead you should utilise the generation mode. 
 


### PR DESCRIPTION
I fixed a statement about SWC.
My friend misunderstood that he cannot use typia on swc+vite environment because of this statement.
I'd like to show that unplugin-typia enables typia running on swc + several boulders.