### PR TITLE
feat(docs): setup for @ryoppippi/unplugin-typia

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -251,7 +251,9 @@ Currently, `unplugin-typia` supports the following bundlers:
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab>
 ```bash filename="Terminal" showLineNumbers copy
-npx jsr add -D @ryoppippi/unplugin-typia
+npx jsr add -D @ryoppippi/unplugin-typia # via jsr (recommended)
+# npm install -D @ryoppippi/unplugin-typia # via npm
+
 npm install --save typia
 npx typia setup
 ```


### PR DESCRIPTION
now unplugin-typia is available at npm
https://www.npmjs.com/package/@ryoppippi/unplugin-typia

Related: https://github.com/samchon/typia/issues/1249
cc: @akirarika
