### PR TITLE
Create GH Action to Publish Project Automatically

### DIFF
--- a/.github/workflows/NPM-Publish.yml
+++ b/.github/workflows/NPM-Publish.yml
@@ -1,0 +1,53 @@
+# Display Name of the workflow
+name: Publish NPM Package
+
+# When this workflow triggers
+on:
+  # Manual Execution Call with Requested Operation
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Type of release to publish
+        type: choice
+        required: true
+        options:
+          - latest
+          - next
+          - patch
+          - tgz
+          - deprecate
+        default: latest
+
+# Define each session of execution that should be executed
+jobs:
+  # Execution Session that deploys the project to NPM
+  Deploy-NPM:
+    # Display name of the job
+    name: Deploy to NPM
+
+    # Configures the filter for which operating system that should be used when selecting runners
+    runs-on: ubuntu-latest
+
+    # Sets the scopes available to the github_token injected to the GH Actions runner
+    permissions:
+      id-token: write
+      contents: none
+
+    # The deploy step runs in the Azure environment context
+    environment: NPM
+
+    # Set of commands to run for the build job
+    steps:
+      # Set up NodeJS on the build host with caching support to optimize execution
+      - name: Set up Node.JS Runtime
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: 'npm'
+
+      # Publish the artifact to NPM with attestation
+      - name: Run Corresponding Package Command
+        run: npm run-script package:${{ inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}


### PR DESCRIPTION
## Overview
This PR is to automation to publish the project from the cloud environment automatically.

Other enhancements such as publish step extraction will be recommended with future issues/PRs.

## Important (Admin Steps)
The following steps are required by a repo and NPM admin to complete this PRs integration:
1. Create a new [GitHub Environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) called `NPM`.
1. Create a new [NPM Granular Access Token](https://docs.npmjs.com/about-access-tokens#about-granular-access-tokens) scoped to the `typescript-json` and `typia` packages (a long-lived token would reduce the need to cycle it constantly) with read and write permissions.
1. Copy your new NPM publish token to the NPM environment as a [secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) named `NPM_PUBLISH`.
1. Profit!

## Security Best Practices
- Ensure that you enable trusted approvers in your GitHub environment. This allows you to reduce the risk of a threat actor making a malicious PR designed to steal your token without trusted person approval.
- Ensure that the GH Environment is only approved to run from the `master` branch for any (`*`) tag. This prevents forks/branches from running the deploy command and only approved code can even attempt to request access.
- Scope the permissions of your granular NPM token to only the two packages `typescript-json` and `typia`, don't grant it any additional permissions.
- Do NOT store the NPM token ANYWHERE else. This could cause a complete breach of your packages. This token is privileged. GH Secrets are one way and won't allow people with repo admin access to read them out of the settings. The only things that can read secrets are GH Actions and as long as you keep an eye on the GH Actions that are being submitted to the project, you should be good.