### PR TITLE
Optimize `typia.llm.application<App>()` function for bundling.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.10.0.tgz"
+    "typia": "../typia-6.10.1-dev.20240913.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.10.0.tgz"
+    "typia": "../typia-6.10.1-dev.20240913.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.10.0",
+  "version": "6.10.1-dev.20240913",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/transformers/features/llm/LlmApplicationTransformer.ts
+++ b/src/transformers/features/llm/LlmApplicationTransformer.ts
@@ -56,7 +56,8 @@ export namespace LlmApplicationTransformer {
       const schema: ILlmApplication = LlmApplicationProgrammer.write(
         result.data,
       );
-
+      const literal: ts.Expression = LiteralFactory.generate(schema);
+      if (!expression.arguments?.[0]) return literal;
       return ExpressionFactory.selfCall(
         ts.factory.createBlock(
           [
@@ -68,12 +69,7 @@ export namespace LlmApplicationTransformer {
                   TypeFactory.keyword("any"),
                 ),
                 undefined,
-                [
-                  ts.factory.createIdentifier("app"),
-                  ...(expression.arguments?.[0]
-                    ? [expression.arguments[0]]
-                    : []),
-                ],
+                [ts.factory.createIdentifier("app"), expression.arguments[0]],
               ),
             ),
             ts.factory.createReturnStatement(

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.10.0.tgz"
+    "typia": "../typia-6.10.1-dev.20240913.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -52,6 +52,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.10.0.tgz"
+    "typia": "../typia-6.10.1-dev.20240913.tgz"
   }
 }


### PR DESCRIPTION
Do not import `typia.llm.application<App>()` embeded function when no parameter argument assigned to reduce bundling size in the frontend application.
