### PR TITLE
Fix `typia.llm.application<App>()` for asynchronous methods.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.10.1-dev.20240913.tgz"
+    "typia": "../typia-6.10.1-dev.20240919.tgz"
   }
 }

--- a/debug/package.json
+++ b/debug/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "tstl": "^3.0.0",
-    "typia": "../typia-6.10.0-dev.20240910-2.tgz",
+    "typia": "../typia-6.10.1-dev.20240919.tgz",
     "uuid": "^10.0.0"
   }
 }

--- a/debug/src/llm.schema.recursive.ts
+++ b/debug/src/llm.schema.recursive.ts
@@ -1,5 +1,0 @@
-import { ILlmSchema } from "@samchon/openapi";
-import typia from "typia";
-
-const schema: ILlmSchema = typia.llm.schema<Date>();
-console.log(schema);

--- a/debug/src/llm.ts
+++ b/debug/src/llm.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+interface Something<T> {
+  add(x: number, y: number): Promise<number>;
+  plus(x: T, y: T): T;
+  asyncPlus(x: T, y: T): Promise<T>;
+}
+
+typia.llm.application<Something<number>>();

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-6.10.1-dev.20240913.tgz"
+    "typia": "../typia-6.10.1-dev.20240919.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.10.1-dev.20240913",
+  "version": "6.10.1-dev.20240919",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "6.10.0",
+  "version": "6.10.1-dev.20240919",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "6.10.0"
+    "typia": "6.10.1-dev.20240919"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.7.0"

--- a/src/factories/internal/metadata/iterate_metadata_function.ts
+++ b/src/factories/internal/metadata/iterate_metadata_function.ts
@@ -70,7 +70,9 @@ export const iterate_metadata_function =
               functional: false,
             })(collection)(errors)(
               async
-                ? (signature.getReturnType().aliasTypeArguments?.[0] ??
+                ? (checker.getTypeArguments(
+                    signature.getReturnType() as ts.TypeReference,
+                  )?.[0] ??
                     checker.getTypeFromTypeNode(TypeFactory.keyword("any")))
                 : signature.getReturnType(),
               {

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-6.10.1-dev.20240913.tgz"
+    "typia": "../typia-6.10.1-dev.20240919.tgz"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -52,6 +52,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-6.10.1-dev.20240913.tgz"
+    "typia": "../typia-6.10.1-dev.20240919.tgz"
   }
 }

--- a/test/src/features/llm.application/test_llm_application.ts
+++ b/test/src/features/llm.application/test_llm_application.ts
@@ -106,7 +106,7 @@ class SomeClass {
   /**
    * Get performance.
    */
-  getPerformance(): IPerformance {
+  async getPerformance(): Promise<IPerformance> {
     return { level: 3 };
   }
 


### PR DESCRIPTION
When asynchrounouse member method comes, `typia.llm.application<App>()` had composed the `ILlmFunction.output` as `any` type.

This PR fixes the problem. As such reason, you should upgrade to `6.10.1` @ryoppippi.

## TypeScript Source File
```typescript
import typia from "typia";

interface Something<T> {
  add(x: number, y: number): Promise<number>;
  plus(x: T, y: T): T;
  asyncPlus(x: T, y: T): Promise<T>;
}

typia.llm.application<Something<number>>();
```

## JavaScript Compiled File
```javascript
({
  functions: [
    {
      name: "add",
      parameters: [
        {
          type: "number",
        },
        {
          type: "number",
        },
      ],
      output: {},
    },
    {
      name: "plus",
      parameters: [
        {
          type: "number",
        },
        {
          type: "number",
        },
      ],
      output: {
        type: "number",
      },
    },
    {
      name: "asyncPlus",
      parameters: [
        {
          type: "number",
        },
        {
          type: "number",
        },
      ],
      output: {},
    },
  ],
  options: {
    separate: null,
  },
});
```