### PR TITLE
Fix samchon/nestia#1043: object literal shorthand property problem.

### DIFF
--- a/debug/package.json
+++ b/debug/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "tstl": "^3.0.0",
-    "typia": "../typia-6.10.4-dev.20240925.tgz",
+    "typia": "../typia-6.11.0.tgz",
     "uuid": "^10.0.0"
   }
 }

--- a/debug/src/shorthand.ts
+++ b/debug/src/shorthand.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+const x: number = 3;
+const rest = {
+  y: 4,
+  z: 5,
+};
+typia.is({ x, ...rest });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -177,7 +177,8 @@ const significant = (functional: boolean) =>
         ts.isPropertyDeclaration(node) ||
         ts.isPropertyAssignment(node) ||
         ts.isPropertySignature(node) ||
-        ts.isTypeLiteralNode(node);
+        ts.isTypeLiteralNode(node) ||
+        ts.isShorthandPropertyAssignment(node);
 
 const iterate_optional_coalesce = (meta: Metadata, type: ts.Type): void => {
   if (type.isUnionOrIntersection())


### PR DESCRIPTION
```typescript
import typia from "typia";

const x: number = 3;
typia.is({ x }); // didn't know x property's existance
typia.is({ x: x }); // catch exact type
```

`typia` could not catch exact type iformation from the shorthand property assigned object literal expression.

This PR solves the problem.
