### PR TITLE
feat: disable additionalProperties for llm schema

### DIFF
--- a/src/programmers/internal/llm_schema_object.ts
+++ b/src/programmers/internal/llm_schema_object.ts
@@ -98,7 +98,7 @@ export const llm_schema_object = (props: {
 /**
  * @internal
  */
-const join = (extra: ISuperfluous): ILlmSchema | undefined => {
+const join = (extra: ISuperfluous): ILlmSchema | false => {
   // LIST UP METADATA
   const elements: [Metadata, ILlmSchema][] = Object.values(
     extra.patternProperties || {},
@@ -106,7 +106,7 @@ const join = (extra: ISuperfluous): ILlmSchema | undefined => {
   if (extra.additionalProperties) elements.push(extra.additionalProperties);
 
   // SHORT RETURN
-  if (elements.length === 0) return undefined;
+  if (elements.length === 0) return false;
   else if (elements.length === 1) return elements[0]![1]!;
 
   // MERGE METADATA AND GENERATE VULNERABLE SCHEMA


### PR DESCRIPTION
This is a first pass at disabling `additionalProperties` for `typia.llm.schema`. I think in general LLMs are stochastic enough that for most use cases we would probably want to disable generating additional properties (e.g. to lower the output tokens count).

However, I think we should provide a way to enable additional properties back, although I wasn't sure how to do it with the current types. I was looking at the `Metadata` type but couldn't find useful properties that would let us decide for example if the type inherit from Record-like types.

I was thinking maybe we can control the behavior via a flag, but @samchon already proposed to separate schema generate based on LLM provider like: `typia.openai.application<App>(): ILlmApplication<IOpenAiSchema>`, so probably we could offload the decision there.

We know from OpenAI docs that `additionalProperties` is not supported and will raise an error if we passed it to their API, but it's still unclear if other providers fully support OpenAPI 3.1 or just a subset.

For example, OSS solutions like guidance [supports](https://github.com/guidance-ai/guidance/pull/1029) this feature.
Outlines [supports](https://github.com/dottxt-ai/outlines/pull/907) it as well (with some hidden limitations - 2-level depth max). llm-schema-enforcer has [some issues](https://github.com/noamgat/lm-format-enforcer/issues/129) with additionalProperties.

