### PR TITLE
`ImportProgrammer.IOptions` for multiple transformers case.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-7.0.0-dev.20241020.tgz"
+    "typia": "../typia-7.0.0-dev.20241021-2.tgz"
   }
 }

--- a/errors/package.json
+++ b/errors/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "typia": "../typia-7.0.0-dev.20241020.tgz"
+    "typia": "../typia-7.0.0-dev.20241021-2.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.0.0-dev.20241020",
+  "version": "7.0.0-dev.20241021-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.0.0-dev.20241020",
+  "version": "7.0.0-dev.20241021-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.0.0-dev.20241020"
+    "typia": "7.0.0-dev.20241021-2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.7.0"

--- a/src/programmers/ImportProgrammer.ts
+++ b/src/programmers/ImportProgrammer.ts
@@ -4,6 +4,13 @@ import { MapUtil } from "../utils/MapUtil";
 
 export class ImportProgrammer {
   private readonly assets_: Map<string, IAsset> = new Map();
+  private readonly options_: Readonly<ImportProgrammer.IOptions>;
+
+  public constructor(options?: Partial<ImportProgrammer.IOptions>) {
+    this.options_ = {
+      internalPrefix: options?.internalPrefix ?? "",
+    };
+  }
 
   /* -----------------------------------------------------------
     ENROLLMENTS
@@ -56,15 +63,10 @@ export class ImportProgrammer {
    */
   public internal(name: string): ts.PropertyAccessExpression {
     if (name.startsWith("$") === false) name = `$${name}`;
-    this.namespace({
-      file: `typia/lib/internal/${name}.js`,
-      name: alias(name),
-      type: false,
-    });
     return ts.factory.createPropertyAccessExpression(
       this.namespace({
         file: `typia/lib/internal/${name}.js`,
-        name: alias(name),
+        name: this.alias(name),
         type: false,
       }),
       name,
@@ -93,6 +95,10 @@ export class ImportProgrammer {
       namespace: null,
       instances: new Map(),
     }));
+  }
+
+  private alias(name: string): string {
+    return `__${this.options_.internalPrefix}${name}`;
   }
 
   /* -----------------------------------------------------------
@@ -156,6 +162,10 @@ export class ImportProgrammer {
 }
 
 export namespace ImportProgrammer {
+  export interface IOptions {
+    internalPrefix: string;
+  }
+
   export interface IDefault {
     file: string;
     name: string;
@@ -180,5 +190,3 @@ interface IAsset {
   namespace: ImportProgrammer.INamespace | null;
   instances: Map<string, ImportProgrammer.IInstance>;
 }
-
-const alias = (str: string) => `__${str}`;

--- a/src/transformers/FileTransformer.ts
+++ b/src/transformers/FileTransformer.ts
@@ -15,7 +15,9 @@ export namespace FileTransformer {
     (file: ts.SourceFile): ts.SourceFile => {
       if (file.isDeclarationFile) return file;
 
-      const importer: ImportProgrammer = new ImportProgrammer();
+      const importer: ImportProgrammer = new ImportProgrammer({
+        internalPrefix: "typia_transform_",
+      });
       const context: ITypiaContext = {
         ...environments,
         transformer,

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "typia": "../typia-7.0.0-dev.20241020.tgz"
+    "typia": "../typia-7.0.0-dev.20241021-2.tgz"
   }
 }

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -1,8 +1,8 @@
 import typia, { tags } from "typia";
-import * as __$assertGuard from "typia/lib/internal/$assertGuard.js";
-import * as __$jsonStringifyNumber from "typia/lib/internal/$jsonStringifyNumber.js";
-import * as __$jsonStringifyString from "typia/lib/internal/$jsonStringifyString.js";
-import * as __$validateReport from "typia/lib/internal/$validateReport.js";
+import * as __typia_transform_$assertGuard from "typia/lib/internal/$assertGuard.js";
+import * as __typia_transform_$jsonStringifyNumber from "typia/lib/internal/$jsonStringifyNumber.js";
+import * as __typia_transform_$jsonStringifyString from "typia/lib/internal/$jsonStringifyString.js";
+import * as __typia_transform_$validateReport from "typia/lib/internal/$validateReport.js";
 
 interface ICitizen {
   id: string & tags.Format<"uuid">;
@@ -17,7 +17,7 @@ interface ICitizen {
 }
 export const createStringify = (() => {
   const $so0 = (input: any): any =>
-    `{"id":${__$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
+    `{"id":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__typia_transform_$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform_$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
   const $io0 = (input: any): boolean =>
     "string" === typeof input.id &&
     /^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
@@ -76,7 +76,7 @@ export const createIsStringify = (() => {
       (elem: any) => "object" === typeof elem && null !== elem && $io0(elem),
     );
   const $so0 = (input: any): any =>
-    `{"id":${__$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
+    `{"id":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__typia_transform_$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform_$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && $io0(input);
   const __stringify = (input: ICitizen): string => $so0(input);
@@ -120,7 +120,7 @@ export const createAssertStringify = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -130,7 +130,7 @@ export const createAssertStringify = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -142,7 +142,7 @@ export const createAssertStringify = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -152,7 +152,7 @@ export const createAssertStringify = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -166,7 +166,7 @@ export const createAssertStringify = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -176,7 +176,7 @@ export const createAssertStringify = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -190,7 +190,7 @@ export const createAssertStringify = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -201,7 +201,7 @@ export const createAssertStringify = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -211,7 +211,7 @@ export const createAssertStringify = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -222,7 +222,7 @@ export const createAssertStringify = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -233,7 +233,7 @@ export const createAssertStringify = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -245,7 +245,7 @@ export const createAssertStringify = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -257,7 +257,7 @@ export const createAssertStringify = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertStringify",
@@ -268,7 +268,7 @@ export const createAssertStringify = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -279,7 +279,7 @@ export const createAssertStringify = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -292,7 +292,7 @@ export const createAssertStringify = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.json.createAssertStringify",
@@ -307,7 +307,7 @@ export const createAssertStringify = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.json.createAssertStringify",
@@ -318,7 +318,7 @@ export const createAssertStringify = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertStringify",
@@ -329,7 +329,7 @@ export const createAssertStringify = (() => {
         _errorFactory,
       ));
   const $so0 = (input: any): any =>
-    `{"id":${__$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
+    `{"id":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__typia_transform_$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform_$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && $io0(input);
   let _errorFactory: any;
@@ -341,7 +341,7 @@ export const createAssertStringify = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.json.createAssertStringify",
@@ -352,7 +352,7 @@ export const createAssertStringify = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.json.createAssertStringify",
@@ -534,7 +534,7 @@ export const createValidateStringify = (() => {
         }),
     ].every((flag: boolean) => flag);
   const $so0 = (input: any): any =>
-    `{"id":${__$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
+    `{"id":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.id)},"name":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.name)},"email":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.email)},"age":${__typia_transform_$jsonStringifyNumber.$jsonStringifyNumber(input.age)},"motto":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.motto)},"birthdate":${__typia_transform_$jsonStringifyString.$jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform_$jsonStringifyString.$jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? $so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => $so0(elem)).join(",")}]`}}`;
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && $io0(input);
   let errors: any;
@@ -542,7 +542,9 @@ export const createValidateStringify = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -648,7 +650,7 @@ export const createAssertParse = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -658,7 +660,7 @@ export const createAssertParse = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -670,7 +672,7 @@ export const createAssertParse = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -680,7 +682,7 @@ export const createAssertParse = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -694,7 +696,7 @@ export const createAssertParse = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -704,7 +706,7 @@ export const createAssertParse = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -718,7 +720,7 @@ export const createAssertParse = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -729,7 +731,7 @@ export const createAssertParse = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -739,7 +741,7 @@ export const createAssertParse = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -750,7 +752,7 @@ export const createAssertParse = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -761,7 +763,7 @@ export const createAssertParse = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -773,7 +775,7 @@ export const createAssertParse = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -785,7 +787,7 @@ export const createAssertParse = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.json.createAssertParse",
@@ -796,7 +798,7 @@ export const createAssertParse = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -807,7 +809,7 @@ export const createAssertParse = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -820,7 +822,7 @@ export const createAssertParse = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.json.createAssertParse",
@@ -835,7 +837,7 @@ export const createAssertParse = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.json.createAssertParse",
@@ -846,7 +848,7 @@ export const createAssertParse = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.json.createAssertParse",
@@ -867,7 +869,7 @@ export const createAssertParse = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.json.createAssertParse",
@@ -878,7 +880,7 @@ export const createAssertParse = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.json.createAssertParse",
@@ -1063,7 +1065,9 @@ export const createValidateParse = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {

--- a/test/generate/output/generate_misc.ts
+++ b/test/generate/output/generate_misc.ts
@@ -1,6 +1,6 @@
 import typia, { tags } from "typia";
-import * as __$assertGuard from "typia/lib/internal/$assertGuard.js";
-import * as __$validateReport from "typia/lib/internal/$validateReport.js";
+import * as __typia_transform_$assertGuard from "typia/lib/internal/$assertGuard.js";
+import * as __typia_transform_$validateReport from "typia/lib/internal/$validateReport.js";
 
 interface ICitizen {
   id: string & tags.Format<"uuid">;
@@ -94,7 +94,7 @@ export const createAssertClone = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -104,7 +104,7 @@ export const createAssertClone = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -116,7 +116,7 @@ export const createAssertClone = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -126,7 +126,7 @@ export const createAssertClone = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -140,7 +140,7 @@ export const createAssertClone = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -150,7 +150,7 @@ export const createAssertClone = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -164,7 +164,7 @@ export const createAssertClone = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -175,7 +175,7 @@ export const createAssertClone = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -185,7 +185,7 @@ export const createAssertClone = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -196,7 +196,7 @@ export const createAssertClone = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -207,7 +207,7 @@ export const createAssertClone = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -219,7 +219,7 @@ export const createAssertClone = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -231,7 +231,7 @@ export const createAssertClone = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertClone",
@@ -242,7 +242,7 @@ export const createAssertClone = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -253,7 +253,7 @@ export const createAssertClone = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -266,7 +266,7 @@ export const createAssertClone = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.misc.createAssertClone",
@@ -281,7 +281,7 @@ export const createAssertClone = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.misc.createAssertClone",
@@ -292,7 +292,7 @@ export const createAssertClone = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertClone",
@@ -324,7 +324,7 @@ export const createAssertClone = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.misc.createAssertClone",
@@ -335,7 +335,7 @@ export const createAssertClone = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.misc.createAssertClone",
@@ -583,7 +583,9 @@ export const createValidateClone = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -717,7 +719,7 @@ export const createAssertPrune = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -727,7 +729,7 @@ export const createAssertPrune = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -739,7 +741,7 @@ export const createAssertPrune = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -749,7 +751,7 @@ export const createAssertPrune = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -763,7 +765,7 @@ export const createAssertPrune = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -773,7 +775,7 @@ export const createAssertPrune = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -787,7 +789,7 @@ export const createAssertPrune = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -798,7 +800,7 @@ export const createAssertPrune = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -808,7 +810,7 @@ export const createAssertPrune = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -819,7 +821,7 @@ export const createAssertPrune = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -830,7 +832,7 @@ export const createAssertPrune = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -842,7 +844,7 @@ export const createAssertPrune = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -854,7 +856,7 @@ export const createAssertPrune = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.misc.createAssertPrune",
@@ -865,7 +867,7 @@ export const createAssertPrune = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -876,7 +878,7 @@ export const createAssertPrune = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -889,7 +891,7 @@ export const createAssertPrune = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.misc.createAssertPrune",
@@ -904,7 +906,7 @@ export const createAssertPrune = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.misc.createAssertPrune",
@@ -915,7 +917,7 @@ export const createAssertPrune = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.misc.createAssertPrune",
@@ -956,7 +958,7 @@ export const createAssertPrune = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.misc.createAssertPrune",
@@ -967,7 +969,7 @@ export const createAssertPrune = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.misc.createAssertPrune",
@@ -1245,7 +1247,9 @@ export const createValidatePrune = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {

--- a/test/generate/output/generate_notations.ts
+++ b/test/generate/output/generate_notations.ts
@@ -1,6 +1,6 @@
 import typia, { tags } from "typia";
-import * as __$assertGuard from "typia/lib/internal/$assertGuard.js";
-import * as __$validateReport from "typia/lib/internal/$validateReport.js";
+import * as __typia_transform_$assertGuard from "typia/lib/internal/$assertGuard.js";
+import * as __typia_transform_$validateReport from "typia/lib/internal/$validateReport.js";
 
 interface ICitizen {
   id: string & tags.Format<"uuid">;
@@ -67,7 +67,7 @@ export const createAssertCamel = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -77,7 +77,7 @@ export const createAssertCamel = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -89,7 +89,7 @@ export const createAssertCamel = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -99,7 +99,7 @@ export const createAssertCamel = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -113,7 +113,7 @@ export const createAssertCamel = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -123,7 +123,7 @@ export const createAssertCamel = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -137,7 +137,7 @@ export const createAssertCamel = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -148,7 +148,7 @@ export const createAssertCamel = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -158,7 +158,7 @@ export const createAssertCamel = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -169,7 +169,7 @@ export const createAssertCamel = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -180,7 +180,7 @@ export const createAssertCamel = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -192,7 +192,7 @@ export const createAssertCamel = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -204,7 +204,7 @@ export const createAssertCamel = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertCamel",
@@ -215,7 +215,7 @@ export const createAssertCamel = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -226,7 +226,7 @@ export const createAssertCamel = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -239,7 +239,7 @@ export const createAssertCamel = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.notations.createAssertCamel",
@@ -254,7 +254,7 @@ export const createAssertCamel = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.notations.createAssertCamel",
@@ -265,7 +265,7 @@ export const createAssertCamel = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertCamel",
@@ -297,7 +297,7 @@ export const createAssertCamel = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.notations.createAssertCamel",
@@ -308,7 +308,7 @@ export const createAssertCamel = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.notations.createAssertCamel",
@@ -556,7 +556,9 @@ export const createValidateCamel = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -647,7 +649,7 @@ export const createAssertPascal = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -657,7 +659,7 @@ export const createAssertPascal = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -669,7 +671,7 @@ export const createAssertPascal = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -679,7 +681,7 @@ export const createAssertPascal = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -693,7 +695,7 @@ export const createAssertPascal = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -703,7 +705,7 @@ export const createAssertPascal = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -717,7 +719,7 @@ export const createAssertPascal = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -728,7 +730,7 @@ export const createAssertPascal = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -738,7 +740,7 @@ export const createAssertPascal = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -749,7 +751,7 @@ export const createAssertPascal = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -760,7 +762,7 @@ export const createAssertPascal = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -772,7 +774,7 @@ export const createAssertPascal = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -784,7 +786,7 @@ export const createAssertPascal = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertPascal",
@@ -795,7 +797,7 @@ export const createAssertPascal = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -806,7 +808,7 @@ export const createAssertPascal = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -819,7 +821,7 @@ export const createAssertPascal = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.notations.createAssertPascal",
@@ -834,7 +836,7 @@ export const createAssertPascal = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.notations.createAssertPascal",
@@ -845,7 +847,7 @@ export const createAssertPascal = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertPascal",
@@ -877,7 +879,7 @@ export const createAssertPascal = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.notations.createAssertPascal",
@@ -888,7 +890,7 @@ export const createAssertPascal = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.notations.createAssertPascal",
@@ -1136,7 +1138,9 @@ export const createValidatePascal = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -1227,7 +1231,7 @@ export const createAssertSnake = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1237,7 +1241,7 @@ export const createAssertSnake = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1249,7 +1253,7 @@ export const createAssertSnake = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1259,7 +1263,7 @@ export const createAssertSnake = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1273,7 +1277,7 @@ export const createAssertSnake = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1283,7 +1287,7 @@ export const createAssertSnake = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1297,7 +1301,7 @@ export const createAssertSnake = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1308,7 +1312,7 @@ export const createAssertSnake = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1318,7 +1322,7 @@ export const createAssertSnake = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1329,7 +1333,7 @@ export const createAssertSnake = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1340,7 +1344,7 @@ export const createAssertSnake = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1352,7 +1356,7 @@ export const createAssertSnake = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1364,7 +1368,7 @@ export const createAssertSnake = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.notations.createAssertSnake",
@@ -1375,7 +1379,7 @@ export const createAssertSnake = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1386,7 +1390,7 @@ export const createAssertSnake = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1399,7 +1403,7 @@ export const createAssertSnake = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.notations.createAssertSnake",
@@ -1414,7 +1418,7 @@ export const createAssertSnake = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.notations.createAssertSnake",
@@ -1425,7 +1429,7 @@ export const createAssertSnake = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.notations.createAssertSnake",
@@ -1457,7 +1461,7 @@ export const createAssertSnake = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.notations.createAssertSnake",
@@ -1468,7 +1472,7 @@ export const createAssertSnake = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.notations.createAssertSnake",
@@ -1716,7 +1720,9 @@ export const createValidateSnake = (() => {
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1,15 +1,15 @@
 import typia, { tags } from "typia";
-import * as __$accessExpressionAsString from "typia/lib/internal/$accessExpressionAsString.js";
-import * as __$assertGuard from "typia/lib/internal/$assertGuard.js";
-import * as __$randomArray from "typia/lib/internal/$randomArray.js";
-import * as __$randomFormatDatetime from "typia/lib/internal/$randomFormatDatetime.js";
-import * as __$randomFormatEmail from "typia/lib/internal/$randomFormatEmail.js";
-import * as __$randomFormatUuid from "typia/lib/internal/$randomFormatUuid.js";
-import * as __$randomInteger from "typia/lib/internal/$randomInteger.js";
-import * as __$randomPattern from "typia/lib/internal/$randomPattern.js";
-import * as __$randomPick from "typia/lib/internal/$randomPick.js";
-import * as __$randomString from "typia/lib/internal/$randomString.js";
-import * as __$validateReport from "typia/lib/internal/$validateReport.js";
+import * as __typia_transform_$accessExpressionAsString from "typia/lib/internal/$accessExpressionAsString.js";
+import * as __typia_transform_$assertGuard from "typia/lib/internal/$assertGuard.js";
+import * as __typia_transform_$randomArray from "typia/lib/internal/$randomArray.js";
+import * as __typia_transform_$randomFormatDatetime from "typia/lib/internal/$randomFormatDatetime.js";
+import * as __typia_transform_$randomFormatEmail from "typia/lib/internal/$randomFormatEmail.js";
+import * as __typia_transform_$randomFormatUuid from "typia/lib/internal/$randomFormatUuid.js";
+import * as __typia_transform_$randomInteger from "typia/lib/internal/$randomInteger.js";
+import * as __typia_transform_$randomPattern from "typia/lib/internal/$randomPattern.js";
+import * as __typia_transform_$randomPick from "typia/lib/internal/$randomPick.js";
+import * as __typia_transform_$randomString from "typia/lib/internal/$randomString.js";
+import * as __typia_transform_$validateReport from "typia/lib/internal/$validateReport.js";
 
 interface ICitizen {
   id: string & tags.Format<"uuid">;
@@ -144,7 +144,7 @@ export const createAssert = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -154,7 +154,7 @@ export const createAssert = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -166,7 +166,7 @@ export const createAssert = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -176,7 +176,7 @@ export const createAssert = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -190,7 +190,7 @@ export const createAssert = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -200,7 +200,7 @@ export const createAssert = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -214,7 +214,7 @@ export const createAssert = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -225,7 +225,7 @@ export const createAssert = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -235,7 +235,7 @@ export const createAssert = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -246,7 +246,7 @@ export const createAssert = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -257,7 +257,7 @@ export const createAssert = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -269,7 +269,7 @@ export const createAssert = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -281,7 +281,7 @@ export const createAssert = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssert",
@@ -292,7 +292,7 @@ export const createAssert = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -303,7 +303,7 @@ export const createAssert = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -316,7 +316,7 @@ export const createAssert = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.createAssert",
@@ -331,7 +331,7 @@ export const createAssert = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.createAssert",
@@ -342,7 +342,7 @@ export const createAssert = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssert",
@@ -363,7 +363,7 @@ export const createAssert = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.createAssert",
@@ -374,7 +374,7 @@ export const createAssert = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.createAssert",
@@ -448,7 +448,7 @@ export const createAssertEquals = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -458,7 +458,7 @@ export const createAssertEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -470,7 +470,7 @@ export const createAssertEquals = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -480,7 +480,7 @@ export const createAssertEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -494,7 +494,7 @@ export const createAssertEquals = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -504,7 +504,7 @@ export const createAssertEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -518,7 +518,7 @@ export const createAssertEquals = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -529,7 +529,7 @@ export const createAssertEquals = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -539,7 +539,7 @@ export const createAssertEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -550,7 +550,7 @@ export const createAssertEquals = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -561,7 +561,7 @@ export const createAssertEquals = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -573,7 +573,7 @@ export const createAssertEquals = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -585,7 +585,7 @@ export const createAssertEquals = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
@@ -596,7 +596,7 @@ export const createAssertEquals = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -607,7 +607,7 @@ export const createAssertEquals = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -620,7 +620,7 @@ export const createAssertEquals = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.createAssertEquals",
@@ -635,7 +635,7 @@ export const createAssertEquals = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.createAssertEquals",
@@ -646,7 +646,7 @@ export const createAssertEquals = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertEquals",
@@ -675,13 +675,15 @@ export const createAssertEquals = (() => {
           return true;
         const value = input[key];
         if (undefined === value) return true;
-        return __$assertGuard.$assertGuard(
+        return __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertEquals",
             path:
               _path +
-              __$accessExpressionAsString.$accessExpressionAsString(key),
+              __typia_transform_$accessExpressionAsString.$accessExpressionAsString(
+                key,
+              ),
             expected: "undefined",
             value: value,
           },
@@ -702,7 +704,7 @@ export const createAssertEquals = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.createAssertEquals",
@@ -713,7 +715,7 @@ export const createAssertEquals = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.createAssertEquals",
@@ -764,7 +766,7 @@ export const createAssertGuard = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -774,7 +776,7 @@ export const createAssertGuard = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -786,7 +788,7 @@ export const createAssertGuard = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -796,7 +798,7 @@ export const createAssertGuard = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -810,7 +812,7 @@ export const createAssertGuard = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -820,7 +822,7 @@ export const createAssertGuard = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -834,7 +836,7 @@ export const createAssertGuard = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -845,7 +847,7 @@ export const createAssertGuard = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -855,7 +857,7 @@ export const createAssertGuard = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -866,7 +868,7 @@ export const createAssertGuard = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -877,7 +879,7 @@ export const createAssertGuard = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -889,7 +891,7 @@ export const createAssertGuard = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -901,7 +903,7 @@ export const createAssertGuard = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuard",
@@ -912,7 +914,7 @@ export const createAssertGuard = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -923,7 +925,7 @@ export const createAssertGuard = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -936,7 +938,7 @@ export const createAssertGuard = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.createAssertGuard",
@@ -951,7 +953,7 @@ export const createAssertGuard = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.createAssertGuard",
@@ -962,7 +964,7 @@ export const createAssertGuard = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuard",
@@ -983,7 +985,7 @@ export const createAssertGuard = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.createAssertGuard",
@@ -994,7 +996,7 @@ export const createAssertGuard = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.createAssertGuard",
@@ -1067,7 +1069,7 @@ export const createAssertGuardEquals = (() => {
       (/^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(
         input.id,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1077,7 +1079,7 @@ export const createAssertGuardEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1089,7 +1091,7 @@ export const createAssertGuardEquals = (() => {
       )) &&
     (("string" === typeof input.name &&
       (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1099,7 +1101,7 @@ export const createAssertGuardEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1113,7 +1115,7 @@ export const createAssertGuardEquals = (() => {
       (/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(
         input.email,
       ) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1123,7 +1125,7 @@ export const createAssertGuardEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1137,7 +1139,7 @@ export const createAssertGuardEquals = (() => {
       ((Math.floor(input.age) === input.age &&
         0 <= input.age &&
         input.age <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1148,7 +1150,7 @@ export const createAssertGuardEquals = (() => {
           _errorFactory,
         )) &&
       (input.age < 100 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1158,7 +1160,7 @@ export const createAssertGuardEquals = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1169,7 +1171,7 @@ export const createAssertGuardEquals = (() => {
         _errorFactory,
       )) &&
     ("string" === typeof input.motto ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1180,7 +1182,7 @@ export const createAssertGuardEquals = (() => {
         _errorFactory,
       )) &&
     (input.birthdate instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1192,7 +1194,7 @@ export const createAssertGuardEquals = (() => {
       )) &&
     (null === input.died_at ||
       input.died_at instanceof Date ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1204,7 +1206,7 @@ export const createAssertGuardEquals = (() => {
       )) &&
     (null === input.parent ||
       ((("object" === typeof input.parent && null !== input.parent) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
@@ -1215,7 +1217,7 @@ export const createAssertGuardEquals = (() => {
           _errorFactory,
         )) &&
         $ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1226,7 +1228,7 @@ export const createAssertGuardEquals = (() => {
         _errorFactory,
       )) &&
     (((Array.isArray(input.children) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1239,7 +1241,7 @@ export const createAssertGuardEquals = (() => {
       input.children.every(
         (elem: any, _index2: number) =>
           ((("object" === typeof elem && null !== elem) ||
-            __$assertGuard.$assertGuard(
+            __typia_transform_$assertGuard.$assertGuard(
               _exceptionable,
               {
                 method: "typia.createAssertGuardEquals",
@@ -1254,7 +1256,7 @@ export const createAssertGuardEquals = (() => {
               _path + ".children[" + _index2 + "]",
               true && _exceptionable,
             )) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.createAssertGuardEquals",
@@ -1265,7 +1267,7 @@ export const createAssertGuardEquals = (() => {
             _errorFactory,
           ),
       )) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.createAssertGuardEquals",
@@ -1294,13 +1296,15 @@ export const createAssertGuardEquals = (() => {
           return true;
         const value = input[key];
         if (undefined === value) return true;
-        return __$assertGuard.$assertGuard(
+        return __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.createAssertGuardEquals",
             path:
               _path +
-              __$accessExpressionAsString.$accessExpressionAsString(key),
+              __typia_transform_$accessExpressionAsString.$accessExpressionAsString(
+                key,
+              ),
             expected: "undefined",
             value: value,
           },
@@ -1321,7 +1325,7 @@ export const createAssertGuardEquals = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.createAssertGuardEquals",
@@ -1332,7 +1336,7 @@ export const createAssertGuardEquals = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.createAssertGuardEquals",
@@ -1511,7 +1515,9 @@ export const createValidate = (() => {
   return (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -1743,7 +1749,9 @@ export const createValidateEquals = (() => {
             return $report(_exceptionable, {
               path:
                 _path +
-                __$accessExpressionAsString.$accessExpressionAsString(key),
+                __typia_transform_$accessExpressionAsString.$accessExpressionAsString(
+                  key,
+                ),
               expected: "undefined",
               value: value,
             });
@@ -1760,7 +1768,9 @@ export const createValidateEquals = (() => {
   return (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -1790,39 +1800,51 @@ export const createValidateEquals = (() => {
 })();
 export const createRandom = (() => {
   const $ro0 = (_recursive: boolean = true, _depth: number = 0): any => ({
-    id: (_generator?.uuid ?? __$randomFormatUuid.$randomFormatUuid)(),
-    name: (_generator?.pattern ?? __$randomPattern.$randomPattern)(
-      new RegExp("^[A-Z][a-z]+$"),
-    ),
-    email: (_generator?.email ?? __$randomFormatEmail.$randomFormatEmail)(),
-    age: (_generator?.integer ?? __$randomInteger.$randomInteger)({
+    id: (
+      _generator?.uuid ?? __typia_transform_$randomFormatUuid.$randomFormatUuid
+    )(),
+    name: (
+      _generator?.pattern ?? __typia_transform_$randomPattern.$randomPattern
+    )(new RegExp("^[A-Z][a-z]+$")),
+    email: (
+      _generator?.email ??
+      __typia_transform_$randomFormatEmail.$randomFormatEmail
+    )(),
+    age: (
+      _generator?.integer ?? __typia_transform_$randomInteger.$randomInteger
+    )({
       type: "integer",
       exclusiveMaximum: true,
       maximum: 100,
     }),
-    motto: (_generator?.string ?? __$randomString.$randomString)({
+    motto: (
+      _generator?.string ?? __typia_transform_$randomString.$randomString
+    )({
       type: "string",
     }),
     birthdate: new Date(
-      (_generator?.datetime ?? __$randomFormatDatetime.$randomFormatDatetime)(),
+      (
+        _generator?.datetime ??
+        __typia_transform_$randomFormatDatetime.$randomFormatDatetime
+      )(),
     ),
-    died_at: __$randomPick.$randomPick([
+    died_at: __typia_transform_$randomPick.$randomPick([
       () => null,
       () =>
         new Date(
           (
             _generator?.datetime ??
-            __$randomFormatDatetime.$randomFormatDatetime
+            __typia_transform_$randomFormatDatetime.$randomFormatDatetime
           )(),
         ),
     ])(),
-    parent: __$randomPick.$randomPick([
+    parent: __typia_transform_$randomPick.$randomPick([
       () => null,
       () => $ro0(true, _recursive ? 1 + _depth : _depth),
     ])(),
     children:
       5 >= _depth
-        ? (_generator?.array ?? __$randomArray.$randomArray)({
+        ? (_generator?.array ?? __typia_transform_$randomArray.$randomArray)({
             type: "array",
             element: () => $ro0(true, _recursive ? 1 + _depth : _depth),
           })

--- a/test/generate/output/generate_protobuf.ts
+++ b/test/generate/output/generate_protobuf.ts
@@ -1,9 +1,9 @@
 import typia, { tags } from "typia";
-import * as __$ProtobufReader from "typia/lib/internal/$ProtobufReader.js";
-import * as __$ProtobufSizer from "typia/lib/internal/$ProtobufSizer.js";
-import * as __$ProtobufWriter from "typia/lib/internal/$ProtobufWriter.js";
-import * as __$assertGuard from "typia/lib/internal/$assertGuard.js";
-import * as __$validateReport from "typia/lib/internal/$validateReport.js";
+import * as __typia_transform_$ProtobufReader from "typia/lib/internal/$ProtobufReader.js";
+import * as __typia_transform_$ProtobufSizer from "typia/lib/internal/$ProtobufSizer.js";
+import * as __typia_transform_$ProtobufWriter from "typia/lib/internal/$ProtobufWriter.js";
+import * as __typia_transform_$assertGuard from "typia/lib/internal/$assertGuard.js";
+import * as __typia_transform_$validateReport from "typia/lib/internal/$validateReport.js";
 
 interface IFile {
   name: string & tags.MaxLength<8>;
@@ -39,8 +39,14 @@ export const createEncode = (() => {
     return writer;
   };
   return (input: IFile): Uint8Array => {
-    const sizer = encoder(new __$ProtobufSizer.$ProtobufSizer(), input);
-    const writer = encoder(new __$ProtobufWriter.$ProtobufWriter(sizer), input);
+    const sizer = encoder(
+      new __typia_transform_$ProtobufSizer.$ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform_$ProtobufWriter.$ProtobufWriter(sizer),
+      input,
+    );
     return writer.buffer();
   };
 })();
@@ -64,7 +70,7 @@ export const createAssertEncode = (() => {
   ): boolean =>
     (("string" === typeof input.name &&
       (input.name.length <= 8 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.protobuf.createAssertEncode",
@@ -74,7 +80,7 @@ export const createAssertEncode = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertEncode",
@@ -87,7 +93,7 @@ export const createAssertEncode = (() => {
     (null === input.extension ||
       ("string" === typeof input.extension &&
         (1 <= input.extension.length ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.protobuf.createAssertEncode",
@@ -98,7 +104,7 @@ export const createAssertEncode = (() => {
             _errorFactory,
           )) &&
         (input.extension.length <= 3 ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.protobuf.createAssertEncode",
@@ -108,7 +114,7 @@ export const createAssertEncode = (() => {
             },
             _errorFactory,
           ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertEncode",
@@ -122,7 +128,7 @@ export const createAssertEncode = (() => {
       ((Math.floor(input.size) === input.size &&
         0 <= input.size &&
         input.size <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.protobuf.createAssertEncode",
@@ -132,7 +138,7 @@ export const createAssertEncode = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertEncode",
@@ -143,7 +149,7 @@ export const createAssertEncode = (() => {
         _errorFactory,
       )) &&
     (input.data instanceof Uint8Array ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertEncode",
@@ -202,7 +208,7 @@ export const createAssertEncode = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.protobuf.createAssertEncode",
@@ -213,7 +219,7 @@ export const createAssertEncode = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.protobuf.createAssertEncode",
@@ -227,8 +233,14 @@ export const createAssertEncode = (() => {
     return input;
   };
   const __encode = (input: IFile): Uint8Array => {
-    const sizer = encoder(new __$ProtobufSizer.$ProtobufSizer(), input);
-    const writer = encoder(new __$ProtobufWriter.$ProtobufWriter(sizer), input);
+    const sizer = encoder(
+      new __typia_transform_$ProtobufSizer.$ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform_$ProtobufWriter.$ProtobufWriter(sizer),
+      input,
+    );
     return writer.buffer();
   };
   return (
@@ -290,8 +302,14 @@ export const createIsEncode = (() => {
   const __is = (input: any): input is IFile =>
     "object" === typeof input && null !== input && $io0(input);
   const __encode = (input: IFile): Uint8Array => {
-    const sizer = encoder(new __$ProtobufSizer.$ProtobufSizer(), input);
-    const writer = encoder(new __$ProtobufWriter.$ProtobufWriter(sizer), input);
+    const sizer = encoder(
+      new __typia_transform_$ProtobufSizer.$ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform_$ProtobufWriter.$ProtobufWriter(sizer),
+      input,
+    );
     return writer.buffer();
   };
   return (input: any): Uint8Array | null =>
@@ -413,7 +431,9 @@ export const createValidateEncode = (() => {
   const __validate = (input: any): import("typia").IValidation<IFile> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -441,8 +461,14 @@ export const createValidateEncode = (() => {
     } as any;
   };
   const __encode = (input: IFile): Uint8Array => {
-    const sizer = encoder(new __$ProtobufSizer.$ProtobufSizer(), input);
-    const writer = encoder(new __$ProtobufWriter.$ProtobufWriter(sizer), input);
+    const sizer = encoder(
+      new __typia_transform_$ProtobufSizer.$ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform_$ProtobufWriter.$ProtobufWriter(sizer),
+      input,
+    );
     return writer.buffer();
   };
   return (input: any): import("typia").IValidation<Uint8Array> => {
@@ -487,7 +513,7 @@ export const createDecode = (() => {
     return output;
   };
   return (input: Uint8Array): import("typia").Resolved<IFile> => {
-    const reader = new __$ProtobufReader.$ProtobufReader(input);
+    const reader = new __typia_transform_$ProtobufReader.$ProtobufReader(input);
     return $pdo0(reader);
   };
 })();
@@ -511,7 +537,7 @@ export const createAssertDecode = (() => {
   ): boolean =>
     (("string" === typeof input.name &&
       (input.name.length <= 8 ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.protobuf.createAssertDecode",
@@ -521,7 +547,7 @@ export const createAssertDecode = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertDecode",
@@ -534,7 +560,7 @@ export const createAssertDecode = (() => {
     (null === input.extension ||
       ("string" === typeof input.extension &&
         (1 <= input.extension.length ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.protobuf.createAssertDecode",
@@ -545,7 +571,7 @@ export const createAssertDecode = (() => {
             _errorFactory,
           )) &&
         (input.extension.length <= 3 ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             _exceptionable,
             {
               method: "typia.protobuf.createAssertDecode",
@@ -555,7 +581,7 @@ export const createAssertDecode = (() => {
             },
             _errorFactory,
           ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertDecode",
@@ -569,7 +595,7 @@ export const createAssertDecode = (() => {
       ((Math.floor(input.size) === input.size &&
         0 <= input.size &&
         input.size <= 4294967295) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           _exceptionable,
           {
             method: "typia.protobuf.createAssertDecode",
@@ -579,7 +605,7 @@ export const createAssertDecode = (() => {
           },
           _errorFactory,
         ))) ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertDecode",
@@ -590,7 +616,7 @@ export const createAssertDecode = (() => {
         _errorFactory,
       )) &&
     (input.data instanceof Uint8Array ||
-      __$assertGuard.$assertGuard(
+      __typia_transform_$assertGuard.$assertGuard(
         _exceptionable,
         {
           method: "typia.protobuf.createAssertDecode",
@@ -645,7 +671,7 @@ export const createAssertDecode = (() => {
       _errorFactory = errorFactory;
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          __$assertGuard.$assertGuard(
+          __typia_transform_$assertGuard.$assertGuard(
             true,
             {
               method: "typia.protobuf.createAssertDecode",
@@ -656,7 +682,7 @@ export const createAssertDecode = (() => {
             _errorFactory,
           )) &&
           $ao0(input, _path + "", true)) ||
-        __$assertGuard.$assertGuard(
+        __typia_transform_$assertGuard.$assertGuard(
           true,
           {
             method: "typia.protobuf.createAssertDecode",
@@ -670,7 +696,7 @@ export const createAssertDecode = (() => {
     return input;
   };
   const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
-    const reader = new __$ProtobufReader.$ProtobufReader(input);
+    const reader = new __typia_transform_$ProtobufReader.$ProtobufReader(input);
     return $pdo0(reader);
   };
   return (
@@ -728,7 +754,7 @@ export const createIsDecode = (() => {
   const __is = (input: any): input is IFile =>
     "object" === typeof input && null !== input && $io0(input);
   const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
-    const reader = new __$ProtobufReader.$ProtobufReader(input);
+    const reader = new __typia_transform_$ProtobufReader.$ProtobufReader(input);
     return $pdo0(reader);
   };
   return (input: Uint8Array): import("typia").Resolved<IFile> | null => {
@@ -849,7 +875,9 @@ export const createValidateDecode = (() => {
   const __validate = (input: any): import("typia").IValidation<IFile> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__$validateReport.$validateReport as any)(errors);
+      $report = (__typia_transform_$validateReport.$validateReport as any)(
+        errors,
+      );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
           $report(true, {
@@ -877,7 +905,7 @@ export const createValidateDecode = (() => {
     } as any;
   };
   const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
-    const reader = new __$ProtobufReader.$ProtobufReader(input);
+    const reader = new __typia_transform_$ProtobufReader.$ProtobufReader(input);
     return $pdo0(reader);
   };
   return (

--- a/test/package.json
+++ b/test/package.json
@@ -53,6 +53,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-7.0.0-dev.20241020.tgz"
+    "typia": "../typia-7.0.0-dev.20241021-2.tgz"
   }
 }


### PR DESCRIPTION
When `@nestia/core` calls `AssertProgrammer` like functions, the transformed code occurs duplicated importment statement error. To solve this problem, I've decided to add `ImportTransformer.IOptions.internalPrefix` to avoid such situation.

For reference, the `typia`'s transformer will assign the `typia_transform_` prefix to there, and `@nestia/core` will do `nestia_core_transform_`.