### PR TITLE
Introducing Typia Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
 [![Build Status](https://github.com/samchon/typia/workflows/build/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Abuild)
 [![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://typia.io/docs/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Typia%20Guru-006BFF)](https://gurubase.io/g/typia)
 
 ```typescript
 // RUNTIME VALIDATORS


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Typia Guru](https://gurubase.io/g/typia) to Gurubase. Typia Guru uses the data from this repo and data from the [docs](https://typia.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Typia Guru", which highlights that Typia now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Typia Guru in Gurubase, just let me know that's totally fine.
