### PR TITLE
fix: Prevent type name numbering like ".o1"

### DIFF
--- a/src/factories/MetadataCollection.ts
+++ b/src/factories/MetadataCollection.ts
@@ -83,7 +83,7 @@ export class MetadataCollection {
       const str: string = TypeFactory.getFullName(checker)(type);
       return this.options?.replace ? this.options.replace(str) : str;
     })();
-
+    if (name !== "__type") return name;
     const duplicates: Map<ts.Type, string> = MapUtil.take(this.names_)(
       name,
       () => new Map(),

--- a/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicitPointer.json
+++ b/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicitPointer.json
@@ -372,7 +372,7 @@
               "rest": null,
               "arrays": [
                 {
-                  "name": "Array<ArrayRecursiveUnionExplicitPointer.IBucket>.o1",
+                  "name": "Array<ArrayRecursiveUnionExplicitPointer.IBucket>",
                   "tags": []
                 }
               ],
@@ -2191,9 +2191,8 @@
         ],
         "recursive": false,
         "index": null
-      },
-      {
-        "name": "Array<ArrayRecursiveUnionExplicitPointer.IBucket>.o1",
+      },  {
+        "name": "Array<ArrayRecursiveUnionExplicitPointer.IBucket>",
         "value": {
           "any": false,
           "required": true,


### PR DESCRIPTION
I prevented values like “.o1” from being appended if they have the same name, except when the typename is “__type”.
This keeps the `ts.type` objects internally distinct enough to use as keys, but I suspect they will be represented as one type when converted to openapi, etc.

However, there are cases where separate ts.Type objects are created for the same ts type, and i didn't prevent this, so this change may need further review.

And I didn't really get to see if the results were what I wanted in the nestia environment. Because I couldn't find a way to test it.

related with [nestia/1016](https://github.com/samchon/nestia/issues/1016)