### PR TITLE
Fix #1357: use relative path instead of `tgz` setup.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -62,7 +62,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^3.2.0",
     "tstl": "^3.0.0",
-    "typescript": "^5.3.2",
+    "typescript": "5.6.3",
     "uuid": "^8.3.2",
     "zod": "^3.19.1"
   },
@@ -72,6 +72,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-7.0.0-dev.20241125-2.tgz"
+    "typia": "../"
   }
 }

--- a/deploy/bun.ts
+++ b/deploy/bun.ts
@@ -26,7 +26,7 @@ const main = async (): Promise<void> => {
   });
   if (skipSetup === undefined) throw new Error("skipSetup is undefined");
   await DeployRunner.main({
-    tag: "tgz",
+    tag: "test",
     publish: false,
     setup: !skipSetup,
     testExecutors: [

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -19,13 +19,13 @@ const main = async (): Promise<void> => {
   }
   await DeployRunner.main({
     tag,
-    publish: tag !== "tgz",
+    publish: tag !== "test",
     setup: true,
     testExecutors: [
       {
         name: "test",
         commands:
-          tag === "tgz" && template === true
+          tag === "test" && template === true
             ? [
                 "npm run template",
                 "npm run build",

--- a/deploy/internal/DeployRunner.ts
+++ b/deploy/internal/DeployRunner.ts
@@ -23,7 +23,7 @@ export namespace DeployRunner {
       });
     }
     const version: string = props.setup
-      ? await publish("tgz")
+      ? await publish("test")
       : JSON.parse(
           await fs.promises.readFile(`${__dirname}/../../package.json`, "utf8"),
         ).version;
@@ -68,8 +68,7 @@ export namespace DeployRunner {
       JSON.stringify(pack, null, 2),
       "utf8",
     );
-    if (tag === "tgz") cp.execSync("npm pack");
-    else
+    if (tag !== "test")
       cp.execSync(
         `npm publish --tag ${tag}${tag === "latest" ? " --provenance" : ""}`,
         { stdio: "inherit" },
@@ -100,7 +99,7 @@ export namespace DeployRunner {
         await fs.promises.readFile("package.json", "utf8"),
       );
       pack.dependencies ??= {};
-      pack.dependencies.typia = `../typia-${props.version}.tgz`;
+      pack.dependencies.typia = `../`;
       await fs.promises.writeFile(
         "package.json",
         JSON.stringify(pack, null, 2),

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     }
   },
   "scripts": {
-    "test": "npm run package:tgz",
+    "test": "ts-node deploy --tag test",
     "test:bun": "bun run deploy/bun.ts",
     "test:template": "npm run --tag test --template",
     "-------------------------------------------------": "",
     "build": "rimraf lib && tsc && rollup -c",
-    "dev": "tsc --project tsconfig.test.json --watch",
+    "dev": "rimraf lib && tsc --watch",
     "dev:errors": "tsc --project tsconfig.errors.json --watch",
     "eslint": "eslint ./**/*.ts",
     "eslint:fix": "eslint ./**/*.ts --fix",
@@ -28,7 +28,6 @@
     "package:latest": "ts-node deploy --tag latest",
     "package:next": "ts-node deploy --tag next",
     "package:patch": "ts-node deploy --tag patch",
-    "package:tgz": "ts-node deploy --tag tgz",
     "package:deprecate": "npm deprecate typescript-json \"Renamed to typia\""
   },
   "repository": {

--- a/test-error/package.json
+++ b/test-error/package.json
@@ -29,9 +29,9 @@
   "devDependencies": {
     "rimraf": "^5.0.5",
     "ts-patch": "^3.2.0",
-    "typescript": "^5.3.2"
+    "typescript": "5.6.3"
   },
   "dependencies": {
-    "typia": "../typia-7.0.0-dev.20241125-2.tgz"
+    "typia": "../"
   }
 }

--- a/test-esm/package.json
+++ b/test-esm/package.json
@@ -33,9 +33,9 @@
     "@types/cli": "^0.11.25",
     "@types/node": "^20.9.4",
     "ts-patch": "^3.2.0",
-    "typescript": "^5.4.5"
+    "typescript": "5.6.3"
   },
   "dependencies": {
-    "typia": "../typia-7.0.0-dev.20241125-2.tgz"
+    "typia": "../"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^5.0.5",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.2.1",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   },
   "dependencies": {
     "cli": "^1.0.1",
@@ -53,6 +53,6 @@
     "suppress-warnings": "^1.0.2",
     "tstl": "^3.0.0",
     "uuid": "^9.0.1",
-    "typia": "../typia-7.0.0-dev.20241125-2.tgz"
+    "typia": "../"
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./test/node_modules/typia/lib",
-  },
-}


### PR DESCRIPTION
This pull request includes several updates and refactoring across multiple files, primarily focusing on changing the tag used for deployment and updating dependencies. The most important changes include updating the TypeScript version, modifying deployment tags, and removing specific package references.

### Dependency Updates:
* Updated `typescript` version to `5.6.3` in `benchmark/package.json`, `test-error/package.json`, `test-esm/package.json`, and `test/package.json`. [[1]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL65-R65) [[2]](diffhunk://#diff-a9248c7305590b65154000dd626459d77420568f0e860cc5e0ee911187778045L32-R35) [[3]](diffhunk://#diff-d8b4b436525d33ed2192dcb4bbe45cbd6ce389f74a31939c5f592c6c41653c84L36-R39) [[4]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL46-R46)

### Deployment Tag Changes:
* Changed deployment tag from `"tgz"` to `"test"` in `deploy/bun.ts`, `deploy/index.ts`, and `deploy/internal/DeployRunner.ts`. [[1]](diffhunk://#diff-ecaabaf7ff823215793ee711f585f19cced8db2503a295899e6147393c9e8262L29-R29) [[2]](diffhunk://#diff-60f1a44570700c9642d322559d1ca2f15aa6713de159b8d70f04ba296722a6c2L22-R28) [[3]](diffhunk://#diff-2fd5f412e6a946856efe334e36a5a3d3fcbb9d9937bf8b7f5d0cc4775be20badL26-R26) [[4]](diffhunk://#diff-2fd5f412e6a946856efe334e36a5a3d3fcbb9d9937bf8b7f5d0cc4775be20badL71-R71)

### Package Reference Updates:
* Updated `typia` package reference from a specific version to a relative path in `benchmark/package.json`, `test-error/package.json`, `test-esm/package.json`, and `test/package.json`. [[1]](diffhunk://#diff-ebd18337ce8dc8b96a8403d2731d05bbb7502293037672a62faa622e36d2821aL75-R75) [[2]](diffhunk://#diff-a9248c7305590b65154000dd626459d77420568f0e860cc5e0ee911187778045L32-R35) [[3]](diffhunk://#diff-d8b4b436525d33ed2192dcb4bbe45cbd6ce389f74a31939c5f592c6c41653c84L36-R39) [[4]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL56-R56)

### Script and Configuration Changes:
* Updated `test` script to use the `test` tag and modified the `dev` script to include `rimraf` in `package.json`. Also removed the `package:tgz` script. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R22) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31)
* Removed `tsconfig.test.json` configuration file.