### PR TITLE
`typia` setup strategy change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -67,7 +67,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^1.2.2",
+    "@samchon/openapi": "^1.2.4",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.7.0",
-    "@samchon/openapi": ">=1.2.2 <2.0.0"
+    "@samchon/openapi": ">=1.2.4 <2.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rollup": "^4.18.0",
     "suppress-warnings": "^1.0.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.2"
+    "typescript": "~5.6.3"
   },
   "stackblitz": {
     "startCommand": "npm install && npm run test"


### PR DESCRIPTION
As `typescript` has broken `ts-patch` too much a lot by every minor updates, I've changed setup strategy of the `npx typia setup` clli command.