### PR TITLE
Upgrade `@samchon/openapi`, maybe the last update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.0.0-dev.20241130",
+  "version": "7.0.0-dev.20241201",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^2.0.0-dev.20241130",
+    "@samchon/openapi": "^2.0.0-dev.20241201-2",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",

--- a/src/internal/_llmApplicationFinalize.ts
+++ b/src/internal/_llmApplicationFinalize.ts
@@ -1,21 +1,20 @@
-import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
-import { HttpLlmConverter } from "@samchon/openapi/lib/converters/HttpLlmConverter";
-import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import { ILlmApplication, ILlmFunction, ILlmSchema } from "@samchon/openapi";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 
 export const _llmApplicationFinalize = <Model extends ILlmSchema.Model>(
   app: ILlmApplication<Model>,
   options?: Partial<Pick<ILlmApplication.IOptions<Model>, "separate">>,
 ): void => {
   app.options = {
-    ...LlmSchemaConverter.defaultConfig(app.model),
+    ...LlmSchemaComposer.defaultConfig(app.model),
     separate: options?.separate ?? null,
   };
   if (app.options.separate === null) return;
   for (const func of app.functions)
-    func.separated = HttpLlmConverter.separate({
-      model: app.model,
-      parameters: func.parameters,
+    func.separated = LlmSchemaComposer.separateParameters(app.model)({
+      parameters:
+        func.parameters satisfies ILlmSchema.IParameters<Model> as any,
       predicate: app.options
         .separate as ILlmApplication.IOptions<Model>["separate"] as any,
-    });
+    }) as ILlmFunction.ISeparated<Model>;
 };

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -1,5 +1,5 @@
 import { ILlmApplication, ILlmSchema, OpenApi } from "@samchon/openapi";
-import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import { ILlmFunction } from "@samchon/openapi/lib/structures/ILlmFunction";
 
 import { MetadataFactory } from "../../factories/MetadataFactory";
@@ -151,7 +151,7 @@ export namespace LlmApplicationProgrammer {
     return {
       model: props.model,
       options: {
-        ...LlmSchemaConverter.defaultConfig(props.model),
+        ...LlmSchemaComposer.defaultConfig(props.model),
         ...props.config,
         separate: null,
       },
@@ -221,8 +221,8 @@ export namespace LlmApplicationProgrammer {
   }): ILlmSchema.ModelParameters[Model] | null => {
     const schema = props.function.parameters[0]?.schema;
     if (!schema) return null;
-    return LlmSchemaConverter.parameters(props.model)({
-      config: LlmSchemaConverter.defaultConfig(props.model) as any,
+    return LlmSchemaComposer.parameters(props.model)({
+      config: LlmSchemaComposer.defaultConfig(props.model) as any,
       components: props.components,
       schema: schema as
         | OpenApi.IJsonSchema.IObject
@@ -241,8 +241,8 @@ export namespace LlmApplicationProgrammer {
     accessor: string;
   }): ILlmSchema.ModelSchema[Model] | null | undefined => {
     if (props.schema === null) return undefined;
-    return LlmSchemaConverter.schema(props.model)({
-      config: LlmSchemaConverter.defaultConfig(props.model) as any,
+    return LlmSchemaComposer.schema(props.model)({
+      config: LlmSchemaComposer.defaultConfig(props.model) as any,
       components: props.components,
       schema: props.schema,
       $defs: (props.parameters as any).$defs,

--- a/src/programmers/llm/LlmModelPredicator.ts
+++ b/src/programmers/llm/LlmModelPredicator.ts
@@ -1,5 +1,5 @@
 import { ILlmSchema } from "@samchon/openapi";
-import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 import ts from "typescript";
 
 import { MetadataCollection } from "../../factories/MetadataCollection";
@@ -116,7 +116,7 @@ export namespace LlmModelPredicator {
       : props.checker.typeToString(type);
     if (
       typeof value !== "string" ||
-      LlmSchemaConverter.defaultConfig(value as "3.0") === undefined
+      LlmSchemaComposer.defaultConfig(value as "3.0") === undefined
     )
       throw new TransformerError({
         code: "typia.llm.schema",

--- a/src/programmers/llm/LlmParametersProgrammer.ts
+++ b/src/programmers/llm/LlmParametersProgrammer.ts
@@ -1,5 +1,5 @@
 import { ILlmSchema, OpenApi, OpenApiTypeChecker } from "@samchon/openapi";
-import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 
 import { MetadataFactory } from "../../factories/MetadataFactory";
 
@@ -35,9 +35,9 @@ export namespace LlmParametersProgrammer {
 
     const errors: string[] = [];
     const parameters: ILlmSchema.ModelParameters[Model] | null =
-      LlmSchemaConverter.parameters(props.model)({
+      LlmSchemaComposer.parameters(props.model)({
         config: {
-          ...LlmSchemaConverter.defaultConfig(props.model),
+          ...LlmSchemaComposer.defaultConfig(props.model),
           ...props.config,
         } as any,
         components: collection.components,

--- a/src/programmers/llm/LlmSchemaProgrammer.ts
+++ b/src/programmers/llm/LlmSchemaProgrammer.ts
@@ -1,5 +1,5 @@
 import { ILlmSchema } from "@samchon/openapi";
-import { LlmSchemaConverter } from "@samchon/openapi/lib/converters/LlmSchemaConverter";
+import { LlmSchemaComposer } from "@samchon/openapi/lib/composers/LlmSchemaComposer";
 
 import { IJsonSchemaCollection } from "../../schemas/json/IJsonSchemaCollection";
 import { Metadata } from "../../schemas/metadata/Metadata";
@@ -35,9 +35,9 @@ export namespace LlmSchemaProgrammer {
     const $defs: Record<string, ILlmSchema.ModelSchema[Model]> = {};
     const errors: string[] = [];
     const schema: ILlmSchema.ModelSchema[Model] | null =
-      LlmSchemaConverter.schema(props.model)({
+      LlmSchemaComposer.schema(props.model)({
         config: {
-          ...LlmSchemaConverter.defaultConfig(props.model),
+          ...LlmSchemaComposer.defaultConfig(props.model),
           ...props.config,
         } as any,
         components: collection.components,


### PR DESCRIPTION
This pull request includes several updates to the `typia` package, primarily focusing on updating dependencies and refactoring code to use a different module from the `@samchon/openapi` library. The most important changes are detailed below:

### Dependency Updates:
* Updated the `version` in `package.json` to `7.0.0-dev.20241201`.
* Updated the `@samchon/openapi` dependency version in `package.json` to `^2.0.0-dev.20241201-2`.

### Code Refactoring:
* Replaced imports from `LlmSchemaConverter` to `LlmSchemaComposer` in multiple files, including:
  - `src/internal/_llmApplicationFinalize.ts`
  - `src/programmers/llm/LlmApplicationProgrammer.ts` [[1]](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920L2-R2) [[2]](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920L154-R154) [[3]](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920L224-R225) [[4]](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920L244-R245)
  - `src/programmers/llm/LlmModelPredicator.ts` [[1]](diffhunk://#diff-80d5da70dbedc1dc527a11e64f96e9476b2f18e4bdaab396890830eeeddeb3e7L2-R2) [[2]](diffhunk://#diff-80d5da70dbedc1dc527a11e64f96e9476b2f18e4bdaab396890830eeeddeb3e7L119-R119)
  - `src/programmers/llm/LlmParametersProgrammer.ts` [[1]](diffhunk://#diff-77606f8a3051d299481cee74278c10fd4b2645c8d6585dd59c45d26ebe29e557L2-R2) [[2]](diffhunk://#diff-77606f8a3051d299481cee74278c10fd4b2645c8d6585dd59c45d26ebe29e557L38-R40)
  - `src/programmers/llm/LlmSchemaProgrammer.ts` [[1]](diffhunk://#diff-937ecaf1c09e422b1f10d05d9f98c101ea9497a9b9ec4d9b68195a5c3a41c113L2-R2) [[2]](diffhunk://#diff-937ecaf1c09e422b1f10d05d9f98c101ea9497a9b9ec4d9b68195a5c3a41c113L38-R40)