### PR TITLE
Emend #1349: publish `IReadableURLSearchParams` in v7 major update.

### DIFF
--- a/src/IReadableURLSearchParams.ts
+++ b/src/IReadableURLSearchParams.ts
@@ -1,4 +1,9 @@
 /**
- * Interface for a readable URLSearchParams object
+ * Interface for a readable URLSearchParams object.
+ *
+ * This interface is a subset of the URLSearchParams interface,
+ * designed especially for the [Hono.JS](https://hono.dev/) libray.
+ *
+ * @author https://github.com/miyaji255
  */
 export type IReadableURLSearchParams = Pick<URLSearchParams, "get" | "getAll">;

--- a/src/IReadableURLSearchParams.ts
+++ b/src/IReadableURLSearchParams.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for a readable URLSearchParams object.
  *
- * This interface is a subset of the URLSearchParams interface,
+ * This interface is a subset of the {@link URLSearchParams} interface,
  * designed especially for the [Hono.JS](https://hono.dev/) libray.
  *
  * @author https://github.com/miyaji255

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import { Atomic } from "./typings/Atomic";
 
-import type { IReadableURLSearchParams } from "./IReadableURLSearchParams";
+import { IReadableURLSearchParams } from "./IReadableURLSearchParams";
 import { IValidation } from "./IValidation";
 import { Resolved } from "./Resolved";
 import { TypeGuardError } from "./TypeGuardError";
@@ -204,7 +204,7 @@ export function validateFormData(): never {
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function query<T extends object>(
+export function query<T extends object>(
   input: string | IReadableURLSearchParams,
 ): Resolved<T>;
 
@@ -244,8 +244,8 @@ export function query(): never {
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function assertQuery<T extends object>(
-  input: string | IReadableURLSearchParams,hParams,
+export function assertQuery<T extends object>(
+  input: string | IReadableURLSearchParams,
   errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
 ): Resolved<T>;
 
@@ -283,7 +283,7 @@ export function assertQuery(): never {
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function isQuery<T extends object>(
+export function isQuery<T extends object>(
   input: string | IReadableURLSearchParams,
 ): Resolved<T> | null;
 
@@ -322,7 +322,7 @@ export function isQuery(): never {
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function validateQuery<T extends object>(
+export function validateQuery<T extends object>(
   input: string | IReadableURLSearchParams,
 ): IValidation<Resolved<T>>;
 
@@ -760,14 +760,16 @@ export function createQuery(): never;
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function createQuery<T extends object>(): (
+export function createQuery<T extends object>(): (
   input: string | IReadableURLSearchParams,
 ) => T;
 
 /**
  * @internal
  */
-function createQuery<T>(): (input: string | IReadableURLSearchParams) => T {
+export function createQuery<T>(): (
+  input: string | IReadableURLSearchParams,
+) => T {
   halt("createQuery");
 }
 
@@ -801,7 +803,7 @@ export function createAssertQuery<T extends object>(
 /**
  * @internal
  */
-function createAssertQuery<T>(): (
+export function createAssertQuery<T>(): (
   input: string | IReadableURLSearchParams,
 ) => T {
   halt("createAssertQuery");
@@ -826,14 +828,14 @@ export function createIsQuery(): never;
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function createIsQuery<T extends object>(): (
+export function createIsQuery<T extends object>(): (
   input: string | IReadableURLSearchParams,
 ) => T | null;
 
 /**
  * @internal
  */
-function createIsQuery<T>(): (
+export function createIsQuery<T>(): (
   input: string | IReadableURLSearchParams,
 ) => T | null {
   halt("createIsQuery");
@@ -858,14 +860,14 @@ export function createValidateQuery(): never;
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-function createValidateQuery<T extends object>(): (
+export function createValidateQuery<T extends object>(): (
   input: string | IReadableURLSearchParams,
 ) => IValidation<Resolved<T>>;
 
 /**
  * @internal
  */
-function createValidateQuery<T>(): (
+export function createValidateQuery<T>(): (
   input: string | IReadableURLSearchParams,
 ) => IValidation<Resolved<T>> {
   halt("createValidateQuery");

--- a/src/internal/_httpQueryParseURLSearchParams.ts
+++ b/src/internal/_httpQueryParseURLSearchParams.ts
@@ -1,6 +1,8 @@
+import { IReadableURLSearchParams } from "../IReadableURLSearchParams";
+
 export const _httpQueryParseURLSearchParams = (
-  input: string | URLSearchParams,
-) => {
+  input: string | IReadableURLSearchParams,
+): IReadableURLSearchParams => {
   if (typeof input === "string") {
     const index: number = input.indexOf("?");
     input = index === -1 ? "" : input.substring(index + 1);

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,6 +27,7 @@ export * from "./Resolved";
 export * from "./CamelCase";
 export * from "./PascalCase";
 export * from "./SnakeCase";
+export * from "./IReadableURLSearchParams";
 
 /* -----------------------------------------------------------
     BASIC VALIDATORS

--- a/src/programmers/http/HttpQueryProgrammer.ts
+++ b/src/programmers/http/HttpQueryProgrammer.ts
@@ -25,8 +25,6 @@ import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
 import { HttpMetadataUtil } from "../helpers/HttpMetadataUtil";
 
 export namespace HttpQueryProgrammer {
-  export const INPUT_TYPE = "string | URLSearchParams";
-
   export interface IProps extends IProgrammerProps {
     allowOptional?: boolean;
   }
@@ -74,7 +72,13 @@ export namespace HttpQueryProgrammer {
         [
           IdentifierFactory.parameter(
             "input",
-            ts.factory.createTypeReferenceNode(INPUT_TYPE),
+            ts.factory.createUnionTypeNode([
+              ts.factory.createTypeReferenceNode("string"),
+              props.context.importer.type({
+                file: "typia",
+                name: "IReadableURLSearchParams",
+              }),
+            ]),
           ),
         ],
         props.context.importer.type({
@@ -195,7 +199,10 @@ export namespace HttpQueryProgrammer {
               undefined,
               [input],
             ),
-            ts.factory.createTypeReferenceNode("URLSearchParams"),
+            props.context.importer.type({
+              file: "typia",
+              name: "IReadableURLSearchParams",
+            }),
           ),
         ),
       ),

--- a/test/generate/input/generate_http.ts
+++ b/test/generate/input/generate_http.ts
@@ -1,0 +1,12 @@
+import typia, { tags } from "typia";
+
+interface ISomething {
+  id: string & tags.Format<"uuid">;
+  beta: number[];
+  gamma: bigint;
+}
+
+export const query = typia.http.createQuery<ISomething>();
+export const isQuery = typia.http.createIsQuery<ISomething>();
+export const assertQuery = typia.http.createAssertQuery<ISomething>();
+export const validateQuery = typia.http.createValidateQuery<ISomething>();

--- a/test/generate/output/generate_http.ts
+++ b/test/generate/output/generate_http.ts
@@ -1,0 +1,343 @@
+import typia, { tags } from "typia";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__httpQueryParseURLSearchParams from "typia/lib/internal/_httpQueryParseURLSearchParams.js";
+import * as __typia_transform__httpQueryReadBigint from "typia/lib/internal/_httpQueryReadBigint.js";
+import * as __typia_transform__httpQueryReadNumber from "typia/lib/internal/_httpQueryReadNumber.js";
+import * as __typia_transform__httpQueryReadString from "typia/lib/internal/_httpQueryReadString.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
+interface ISomething {
+  id: string & tags.Format<"uuid">;
+  beta: number[];
+  gamma: bigint;
+}
+export const query = (() => {
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+})();
+export const isQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> | null => {
+    const value = __decode(input);
+    if (!__is(value)) return null;
+    return value;
+  };
+})();
+export const assertQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.http.createAssertQuery",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.beta) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        },
+        _errorFactory,
+      )) &&
+      input.beta.every(
+        (elem: any, _index2: number) =>
+          ("number" === typeof elem && Number.isFinite(elem)) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.http.createAssertQuery",
+              path: _path + ".beta[" + _index2 + "]",
+              expected: "number",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        },
+        _errorFactory,
+      )) &&
+    ("bigint" === typeof input.gamma ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".gamma",
+          expected: "bigint",
+          value: input.gamma,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ISomething => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.http.createAssertQuery",
+              path: _path + "",
+              expected: "ISomething",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.http.createAssertQuery",
+            path: _path + "",
+            expected: "ISomething",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").Resolved<ISomething> =>
+    __assert(__decode(input), errorFactory);
+})();
+export const validateQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          $report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        $report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ((Array.isArray(input.beta) ||
+        $report(_exceptionable, {
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        })) &&
+        input.beta
+          .map(
+            (elem: any, _index2: number) =>
+              ("number" === typeof elem && Number.isFinite(elem)) ||
+              $report(_exceptionable, {
+                path: _path + ".beta[" + _index2 + "]",
+                expected: "number",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        $report(_exceptionable, {
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        }),
+      "bigint" === typeof input.gamma ||
+        $report(_exceptionable, {
+          path: _path + ".gamma",
+          expected: "bigint",
+          value: input.gamma,
+        }),
+    ].every((flag: boolean) => flag);
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let $report: any;
+  const __validate = (input: any): import("typia").IValidation<ISomething> => {
+    if (false === __is(input)) {
+      errors = [];
+      $report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          $report(true, {
+            path: _path + "",
+            expected: "ISomething",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        $report(true, {
+          path: _path + "",
+          expected: "ISomething",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return {
+        success,
+        errors,
+        data: success ? input : undefined,
+      } as any;
+    }
+    return {
+      success: true,
+      errors: [],
+      data: input,
+    } as any;
+  };
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").IValidation<import("typia").Resolved<ISomething>> =>
+    __validate(__decode(input));
+})();


### PR DESCRIPTION
This pull request includes several changes to enhance the handling of URL search parameters and improve the query validation functions. The primary focus is on introducing the `IReadableURLSearchParams` type and updating various query-related functions to use this new type.

### Introduction of `IReadableURLSearchParams`:

* [`src/IReadableURLSearchParams.ts`](diffhunk://#diff-8ef107c3fd62e0cd891175a2cf801032eca6697040d3d57d265bd8ce2417317bL2-R7): Added comments and documentation to define `IReadableURLSearchParams` as a subset of the `URLSearchParams` interface, specifically for the Hono.JS library.

### Updates to Query Functions:

* [`src/http.ts`](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL3-R3): Modified various query-related functions (`query`, `assertQuery`, `isQuery`, `validateQuery`, `createQuery`, `createAssertQuery`, `createIsQuery`, `createValidateQuery`) to use `IReadableURLSearchParams` instead of `URLSearchParams`. [[1]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL3-R3) [[2]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL207-R207) [[3]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL247-R248) [[4]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL286-R286) [[5]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL325-R325) [[6]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL763-R772) [[7]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL804-R806) [[8]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL829-R838) [[9]](diffhunk://#diff-d12299d8c4ec4ce4401d0a4ca90f330520ad90714c71841b145d069010e06e5cL861-R870)

### Internal Function Updates:

* [`src/internal/_httpQueryParseURLSearchParams.ts`](diffhunk://#diff-65523234098831b5190032b32c7eaf0ea8f2d956d6af8150436d9970143e97b9R1-R5): Updated the internal function `_httpQueryParseURLSearchParams` to use `IReadableURLSearchParams`.

### Exports and Imports Adjustments:

* [`src/module.ts`](diffhunk://#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70R30): Exported `IReadableURLSearchParams` to make it available for other modules.
* [`src/programmers/http/HttpQueryProgrammer.ts`](diffhunk://#diff-43deb0f726e0a3a4205114c66da4bd23662f7c2d27b727a4e64fe030a2f6212dL28-L29): Adjusted imports and type references to use `IReadableURLSearchParams` instead of `URLSearchParams`. [[1]](diffhunk://#diff-43deb0f726e0a3a4205114c66da4bd23662f7c2d27b727a4e64fe030a2f6212dL28-L29) [[2]](diffhunk://#diff-43deb0f726e0a3a4205114c66da4bd23662f7c2d27b727a4e64fe030a2f6212dL77-R81) [[3]](diffhunk://#diff-43deb0f726e0a3a4205114c66da4bd23662f7c2d27b727a4e64fe030a2f6212dL198-R205)

### Test Updates:

* [`test/generate/input/generate_http.ts`](diffhunk://#diff-9f94512b7534a14d74e4ce03762deb2a2fca8c9f559b3da068e65f7d0742ac54R1-R12): Added tests to generate HTTP queries using the new `IReadableURLSearchParams` type.
* [`test/generate/output/generate_http.ts`](diffhunk://#diff-2edc83c903fc2cb4c20e7fc139eb9cc74bf4e7ad8191a709efd987e1612ab123R1-R343): Updated generated output tests to reflect changes in query handling and validation functions.