### PR TITLE
Fix wrong file typo

### DIFF
--- a/website/pages/docs/llm/application.mdx
+++ b/website/pages/docs/llm/application.mdx
@@ -235,107 +235,74 @@ export namespace ILlmFunction {
   </Tab>
   <Tab>
 ```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
+import { IChatGptSchema } from "./IChatGptSchema";
+import { IClaudeSchema } from "./IClaudeSchema";
+import { IGeminiSchema } from "./IGeminiSchema";
+import { ILlamaSchema } from "./ILlamaSchema";
+import { ILlmSchemaV3 } from "./ILlmSchemaV3";
+import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
 
 /**
- * LLM function metadata.
+ * The schemas for the LLM function calling.
  *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
+ * `ILlmSchema` is an union type collecting every the schemas for the
+ * LLM function calling.
  *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
+ * Select a proper schema type according to the LLM provider you're using.
  *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
+ * @template Model Name of the target LLM model
  * @reference https://platform.openai.com/docs/guides/function-calling
+ * @reference https://platform.openai.com/docs/guides/structured-outputs
  * @author Jeongho Nam - https://github.com/samchon
  */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
+export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+  ILlmSchema.ModelSchema[Model];
 
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<ILlmSchema.ModelParameters[Model]>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priroity, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Parameters extends ILlmSchema.IParameters> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: Parameters | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: Parameters | null;
+export namespace ILlmSchema {
+  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
+  export interface ModelConfig {
+    chatgpt: IChatGptSchema.IConfig;
+    claude: IClaudeSchema.IConfig;
+    gemini: IGeminiSchema.IConfig;
+    llama: ILlamaSchema.IConfig;
+    "3.0": ILlmSchemaV3.IConfig;
+    "3.1": ILlmSchemaV3_1.IConfig;
   }
+  export interface ModelParameters {
+    chatgpt: IChatGptSchema.IParameters;
+    claude: IClaudeSchema.IParameters;
+    gemini: IGeminiSchema.IParameters;
+    llama: ILlamaSchema.IParameters;
+    "3.0": ILlmSchemaV3.IParameters;
+    "3.1": ILlmSchemaV3_1.IParameters;
+  }
+  export interface ModelSchema {
+    chatgpt: IChatGptSchema;
+    claude: IClaudeSchema;
+    gemini: IGeminiSchema;
+    llama: ILlamaSchema;
+    "3.0": ILlmSchemaV3;
+    "3.1": ILlmSchemaV3_1;
+  }
+
+  /**
+   * Type of function parameters.
+   *
+   * `ILlmSchema.IParameters` is a type defining a function's pamameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelParameters[Model];
+
+  /**
+   * Configuration for the LLM schema composition.
+   */
+  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelConfig[Model];
 }
 ```
   </Tab>

--- a/website/pages/docs/llm/parameters.mdx
+++ b/website/pages/docs/llm/parameters.mdx
@@ -235,107 +235,74 @@ export namespace ILlmFunction {
   </Tab>
   <Tab>
 ```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
+import { IChatGptSchema } from "./IChatGptSchema";
+import { IClaudeSchema } from "./IClaudeSchema";
+import { IGeminiSchema } from "./IGeminiSchema";
+import { ILlamaSchema } from "./ILlamaSchema";
+import { ILlmSchemaV3 } from "./ILlmSchemaV3";
+import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
 
 /**
- * LLM function metadata.
+ * The schemas for the LLM function calling.
  *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
+ * `ILlmSchema` is an union type collecting every the schemas for the
+ * LLM function calling.
  *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
+ * Select a proper schema type according to the LLM provider you're using.
  *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
+ * @template Model Name of the target LLM model
  * @reference https://platform.openai.com/docs/guides/function-calling
+ * @reference https://platform.openai.com/docs/guides/structured-outputs
  * @author Jeongho Nam - https://github.com/samchon
  */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
+export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+  ILlmSchema.ModelSchema[Model];
 
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<ILlmSchema.ModelParameters[Model]>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priroity, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Parameters extends ILlmSchema.IParameters> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: Parameters | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: Parameters | null;
+export namespace ILlmSchema {
+  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
+  export interface ModelConfig {
+    chatgpt: IChatGptSchema.IConfig;
+    claude: IClaudeSchema.IConfig;
+    gemini: IGeminiSchema.IConfig;
+    llama: ILlamaSchema.IConfig;
+    "3.0": ILlmSchemaV3.IConfig;
+    "3.1": ILlmSchemaV3_1.IConfig;
   }
+  export interface ModelParameters {
+    chatgpt: IChatGptSchema.IParameters;
+    claude: IClaudeSchema.IParameters;
+    gemini: IGeminiSchema.IParameters;
+    llama: ILlamaSchema.IParameters;
+    "3.0": ILlmSchemaV3.IParameters;
+    "3.1": ILlmSchemaV3_1.IParameters;
+  }
+  export interface ModelSchema {
+    chatgpt: IChatGptSchema;
+    claude: IClaudeSchema;
+    gemini: IGeminiSchema;
+    llama: ILlamaSchema;
+    "3.0": ILlmSchemaV3;
+    "3.1": ILlmSchemaV3_1;
+  }
+
+  /**
+   * Type of function parameters.
+   *
+   * `ILlmSchema.IParameters` is a type defining a function's pamameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelParameters[Model];
+
+  /**
+   * Configuration for the LLM schema composition.
+   */
+  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelConfig[Model];
 }
 ```
   </Tab>

--- a/website/pages/docs/llm/schema.mdx
+++ b/website/pages/docs/llm/schema.mdx
@@ -235,107 +235,74 @@ export namespace ILlmFunction {
   </Tab>
   <Tab>
 ```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
+import { IChatGptSchema } from "./IChatGptSchema";
+import { IClaudeSchema } from "./IClaudeSchema";
+import { IGeminiSchema } from "./IGeminiSchema";
+import { ILlamaSchema } from "./ILlamaSchema";
+import { ILlmSchemaV3 } from "./ILlmSchemaV3";
+import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
 
 /**
- * LLM function metadata.
+ * The schemas for the LLM function calling.
  *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
+ * `ILlmSchema` is an union type collecting every the schemas for the
+ * LLM function calling.
  *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
+ * Select a proper schema type according to the LLM provider you're using.
  *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
+ * @template Model Name of the target LLM model
  * @reference https://platform.openai.com/docs/guides/function-calling
+ * @reference https://platform.openai.com/docs/guides/structured-outputs
  * @author Jeongho Nam - https://github.com/samchon
  */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
+export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+  ILlmSchema.ModelSchema[Model];
 
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<ILlmSchema.ModelParameters[Model]>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priroity, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Parameters extends ILlmSchema.IParameters> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: Parameters | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: Parameters | null;
+export namespace ILlmSchema {
+  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
+  export interface ModelConfig {
+    chatgpt: IChatGptSchema.IConfig;
+    claude: IClaudeSchema.IConfig;
+    gemini: IGeminiSchema.IConfig;
+    llama: ILlamaSchema.IConfig;
+    "3.0": ILlmSchemaV3.IConfig;
+    "3.1": ILlmSchemaV3_1.IConfig;
   }
+  export interface ModelParameters {
+    chatgpt: IChatGptSchema.IParameters;
+    claude: IClaudeSchema.IParameters;
+    gemini: IGeminiSchema.IParameters;
+    llama: ILlamaSchema.IParameters;
+    "3.0": ILlmSchemaV3.IParameters;
+    "3.1": ILlmSchemaV3_1.IParameters;
+  }
+  export interface ModelSchema {
+    chatgpt: IChatGptSchema;
+    claude: IClaudeSchema;
+    gemini: IGeminiSchema;
+    llama: ILlamaSchema;
+    "3.0": ILlmSchemaV3;
+    "3.1": ILlmSchemaV3_1;
+  }
+
+  /**
+   * Type of function parameters.
+   *
+   * `ILlmSchema.IParameters` is a type defining a function's pamameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelParameters[Model];
+
+  /**
+   * Configuration for the LLM schema composition.
+   */
+  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelConfig[Model];
 }
 ```
   </Tab>


### PR DESCRIPTION
This pull request includes significant changes to the LLM function schema definitions across multiple files. The changes primarily involve updating the schema imports and restructuring the `ILlmSchema` type to accommodate various LLM models.

Schema updates and restructuring:

* [`website/pages/docs/llm/application.mdx`](diffhunk://#diff-2cd7acc5989dca887f9c80e0ecc50d9473ecf9d0b42f28664039235fe6e97339L238-R305): Replaced `ILlmSchema` import with individual schema imports for different LLM models and redefined `ILlmSchema` as a union type. Removed the `ILlmFunction` interface and replaced it with type definitions for model configurations, parameters, and schemas.
* [`website/pages/docs/llm/parameters.mdx`](diffhunk://#diff-685aa2b52f8394e7f9914c616b152fd5a37345e483bf0577206d2d839105f6d1L238-R305): Similar updates as in `application.mdx`, including replacing `ILlmSchema` import, redefining `ILlmSchema` as a union type, and removing the `ILlmFunction` interface.
* [`website/pages/docs/llm/schema.mdx`](diffhunk://#diff-984efefe2098bace28f142e1040640c58dc2516e23bc5da1a7f744de9fce8e77L238-R305): Applied the same schema import replacements and type redefinitions as in the other files, ensuring consistency across documentation.