### PR TITLE
Fix #1409 and Fix #1410: `"use server"` case, and `$` starting variable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/internal/_miscCloneAny.ts
+++ b/src/internal/_miscCloneAny.ts
@@ -1,13 +1,13 @@
 import { Resolved } from "../Resolved";
 
 export const _miscCloneAny = <T>(value: T): Resolved<T> =>
-  $cloneMain(value) as Resolved<T>;
+  cloneMain(value) as Resolved<T>;
 
-const $cloneMain = (value: any): any => {
+const cloneMain = (value: any): any => {
   if (value === undefined) return undefined;
   else if (typeof value === "object")
     if (value === null) return null;
-    else if (Array.isArray(value)) return value.map($cloneMain);
+    else if (Array.isArray(value)) return value.map(cloneMain);
     else if (value instanceof Date) return new Date(value);
     else if (value instanceof Uint8Array) return new Uint8Array(value);
     else if (value instanceof Uint8ClampedArray)
@@ -29,18 +29,16 @@ const $cloneMain = (value: any): any => {
       return new File([value], value.name, { type: value.type });
     else if (typeof Blob !== "undefined" && value instanceof Blob)
       return new Blob([value], { type: value.type });
-    else if (value instanceof Set) return new Set([...value].map($cloneMain));
+    else if (value instanceof Set) return new Set([...value].map(cloneMain));
     else if (value instanceof Map)
-      return new Map(
-        [...value].map(([k, v]) => [$cloneMain(k), $cloneMain(v)]),
-      );
+      return new Map([...value].map(([k, v]) => [cloneMain(k), cloneMain(v)]));
     else if (value instanceof WeakSet || value instanceof WeakMap)
       throw new Error("WeakSet and WeakMap are not supported");
-    else if (value.valueOf() !== value) return $cloneMain(value.valueOf());
+    else if (value.valueOf() !== value) return cloneMain(value.valueOf());
     else
       return Object.fromEntries(
         Object.entries(value)
-          .map(([k, v]) => [k, $cloneMain(v)])
+          .map(([k, v]) => [k, cloneMain(v)])
           .filter(([, v]) => v !== undefined),
       );
   else if (typeof value === "function") return undefined;

--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -139,7 +139,7 @@ export namespace ValidateProgrammer {
               ),
               ts.factory.createExpressionStatement(
                 ts.factory.createBinaryExpression(
-                  ts.factory.createIdentifier("$report"),
+                  ts.factory.createIdentifier("_report"),
                   ts.factory.createToken(ts.SyntaxKind.EqualsToken),
                   ts.factory.createCallExpression(
                     ts.factory.createAsExpression(
@@ -223,7 +223,7 @@ export namespace ValidateProgrammer {
           value: is.arrow,
         }),
         StatementFactory.mut({ name: "errors" }),
-        StatementFactory.mut({ name: "$report" }),
+        StatementFactory.mut({ name: "_report" }),
       ],
       arrow,
     };
@@ -415,7 +415,7 @@ const create_report_call = (props: {
   input: ts.Expression;
 }): ts.Expression =>
   ts.factory.createCallExpression(
-    ts.factory.createIdentifier("$report"),
+    ts.factory.createIdentifier("_report"),
     undefined,
     [
       props.exceptionable ?? ts.factory.createIdentifier("_exceptionable"),

--- a/test/build/validate-generate.ts
+++ b/test/build/validate-generate.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+
+const directory: string[] = fs.readdirSync(`${__dirname}/../generate/output`);
+for (const file of directory) {
+  const content: string = fs.readFileSync(
+    `${__dirname}/../generate/output/${file}`,
+    "utf8",
+  );
+  if (content.includes("const $"))
+    throw new Error(`$ is not allowed in Svelte5`);
+}

--- a/test/generate/input/generate_index.ts
+++ b/test/generate/input/generate_index.ts
@@ -1,0 +1,25 @@
+import typia, { tags } from "typia";
+
+interface ICitizen {
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
+}
+
+export const is = typia.createIs<ICitizen>();
+export const assert = typia.createAssert<ICitizen>();
+export const assertGuard = typia.createAssertGuard<ICitizen>();
+export const validate = typia.createValidate<ICitizen>();
+
+export const equals = typia.createEquals<ICitizen>();
+export const assertEquals = typia.createAssertEquals<ICitizen>();
+export const assertGuardEquals = typia.createAssertGuardEquals<ICitizen>();
+export const validateEquals = typia.createValidateEquals<ICitizen>();
+
+export const random = typia.createRandom<ICitizen>();

--- a/test/generate/input/generate_use.ts
+++ b/test/generate/input/generate_use.ts
@@ -1,0 +1,7 @@
+"use strict";
+
+'use server';
+
+import typia, { tags } from "typia";
+
+typia.createIs<string & tags.Format<"uuid">>();

--- a/test/generate/output/generate_http.ts
+++ b/test/generate/output/generate_http.ts
@@ -239,18 +239,18 @@ export const validateQuery = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ((Array.isArray(input.beta) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".beta",
           expected: "Array<number>",
           value: input.beta,
@@ -259,20 +259,20 @@ export const validateQuery = (() => {
           .map(
             (elem: any, _index2: number) =>
               ("number" === typeof elem && Number.isFinite(elem)) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".beta[" + _index2 + "]",
                 expected: "number",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".beta",
           expected: "Array<number>",
           value: input.beta,
         }),
       "bigint" === typeof input.gamma ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".gamma",
           expected: "bigint",
           value: input.gamma,
@@ -281,22 +281,22 @@ export const validateQuery = (() => {
   const __is = (input: any): input is ISomething =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ISomething> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ISomething",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ISomething",
           value: input,

--- a/test/generate/output/generate_index.ts
+++ b/test/generate/output/generate_index.ts
@@ -1,8 +1,17 @@
 import typia, { tags } from "typia";
+import * as __typia_transform__accessExpressionAsString from "typia/lib/internal/_accessExpressionAsString.js";
 import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
 import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
 import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
 import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__randomArray from "typia/lib/internal/_randomArray.js";
+import * as __typia_transform__randomFormatDatetime from "typia/lib/internal/_randomFormatDatetime.js";
+import * as __typia_transform__randomFormatEmail from "typia/lib/internal/_randomFormatEmail.js";
+import * as __typia_transform__randomFormatUuid from "typia/lib/internal/_randomFormatUuid.js";
+import * as __typia_transform__randomInteger from "typia/lib/internal/_randomInteger.js";
+import * as __typia_transform__randomPattern from "typia/lib/internal/_randomPattern.js";
+import * as __typia_transform__randomPick from "typia/lib/internal/_randomPick.js";
+import * as __typia_transform__randomString from "typia/lib/internal/_randomString.js";
 import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
 
 interface ICitizen {
@@ -16,19 +25,7 @@ interface ICitizen {
   parent: ICitizen | null;
   children: ICitizen[];
 }
-export const createClone = (() => {
-  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
-  const _co0 = (input: any): any => ({
-    id: input.id,
-    name: input.name,
-    email: input.email,
-    age: input.age,
-    motto: input.motto,
-    birthdate: new Date(input.birthdate) as any,
-    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
-    parent: input.parent ? _co0(input.parent) : (input.parent as any),
-    children: _cp0(input.children) as any,
-  });
+export const is = (() => {
   const _io0 = (input: any): boolean =>
     "string" === typeof input.id &&
     __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
@@ -50,11 +47,10 @@ export const createClone = (() => {
     input.children.every(
       (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
     );
-  return (input: ICitizen): import("typia").Resolved<ICitizen> =>
-    _co0(input) as any;
+  return (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
 })();
-export const createAssertClone = (() => {
-  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+export const assert = (() => {
   const _io0 = (input: any): boolean =>
     "string" === typeof input.id &&
     __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
@@ -86,7 +82,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
@@ -96,7 +92,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
@@ -108,7 +104,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
@@ -118,7 +114,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
@@ -130,7 +126,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
@@ -140,7 +136,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
@@ -152,7 +148,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
@@ -163,7 +159,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
@@ -173,7 +169,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
@@ -184,7 +180,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
@@ -195,7 +191,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
@@ -207,7 +203,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
@@ -219,7 +215,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           _exceptionable,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
@@ -230,7 +226,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
@@ -241,7 +237,7 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -254,7 +250,7 @@ export const createAssertClone = (() => {
             __typia_transform__assertGuard._assertGuard(
               _exceptionable,
               {
-                method: "typia.misc.createAssertClone",
+                method: "typia.createAssert",
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
@@ -269,7 +265,7 @@ export const createAssertClone = (() => {
           __typia_transform__assertGuard._assertGuard(
             _exceptionable,
             {
-              method: "typia.misc.createAssertClone",
+              method: "typia.createAssert",
               path: _path + ".children[" + _index2 + "]",
               expected: "ICitizen",
               value: elem,
@@ -280,28 +276,17 @@ export const createAssertClone = (() => {
       __typia_transform__assertGuard._assertGuard(
         _exceptionable,
         {
-          method: "typia.misc.createAssertClone",
+          method: "typia.createAssert",
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
         },
         _errorFactory,
       ));
-  const _co0 = (input: any): any => ({
-    id: input.id,
-    name: input.name,
-    email: input.email,
-    age: input.age,
-    motto: input.motto,
-    birthdate: new Date(input.birthdate) as any,
-    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
-    parent: input.parent ? _co0(input.parent) : (input.parent as any),
-    children: _cp0(input.children) as any,
-  });
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let _errorFactory: any;
-  const __assert = (
+  return (
     input: any,
     errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
   ): ICitizen => {
@@ -312,7 +297,7 @@ export const createAssertClone = (() => {
           __typia_transform__assertGuard._assertGuard(
             true,
             {
-              method: "typia.misc.createAssertClone",
+              method: "typia.createAssert",
               path: _path + "",
               expected: "ICitizen",
               value: input,
@@ -323,7 +308,7 @@ export const createAssertClone = (() => {
         __typia_transform__assertGuard._assertGuard(
           true,
           {
-            method: "typia.misc.createAssertClone",
+            method: "typia.createAssert",
             path: _path + "",
             expected: "ICitizen",
             value: input,
@@ -333,16 +318,8 @@ export const createAssertClone = (() => {
     }
     return input;
   };
-  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
-    _co0(input) as any;
-  return (
-    input: any,
-    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
-  ): import("typia").Resolved<ICitizen> =>
-    __clone(__assert(input, errorFactory));
 })();
-export const createIsClone = (() => {
-  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+export const assertGuard = (() => {
   const _io0 = (input: any): boolean =>
     "string" === typeof input.id &&
     __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
@@ -364,28 +341,253 @@ export const createIsClone = (() => {
     input.children.every(
       (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
     );
-  const _co0 = (input: any): any => ({
-    id: input.id,
-    name: input.name,
-    email: input.email,
-    age: input.age,
-    motto: input.motto,
-    birthdate: new Date(input.birthdate) as any,
-    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
-    parent: input.parent ? _co0(input.parent) : (input.parent as any),
-    children: _cp0(input.children) as any,
-  });
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuard",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
-  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
-    _co0(input) as any;
-  return (input: any): import("typia").Resolved<ICitizen> | null => {
-    if (!__is(input)) return null;
-    return __clone(input);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
   };
 })();
-export const createValidateClone = (() => {
-  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+export const validate = (() => {
   const _io0 = (input: any): boolean =>
     "string" === typeof input.id &&
     __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
@@ -532,688 +734,1046 @@ export const createValidateClone = (() => {
           value: input.children,
         }),
     ].every((flag: boolean) => flag);
-  const _co0 = (input: any): any => ({
-    id: input.id,
-    name: input.name,
-    email: input.email,
-    age: input.age,
-    motto: input.motto,
-    birthdate: new Date(input.birthdate) as any,
-    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
-    parent: input.parent ? _co0(input.parent) : (input.parent as any),
-    children: _cp0(input.children) as any,
-  });
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
   let _report: any;
-  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
-    if (false === __is(input)) {
-      errors = [];
-      _report = (__typia_transform__validateReport._validateReport as any)(
-        errors,
-      );
-      ((input: any, _path: string, _exceptionable: boolean = true) =>
-        ((("object" === typeof input && null !== input) ||
-          _report(true, {
-            path: _path + "",
-            expected: "ICitizen",
-            value: input,
-          })) &&
-          _vo0(input, _path + "", true)) ||
-        _report(true, {
-          path: _path + "",
-          expected: "ICitizen",
-          value: input,
-        }))(input, "$input", true);
-      const success = 0 === errors.length;
-      return {
-        success,
-        errors,
-        data: success ? input : undefined,
-      } as any;
-    }
-    return {
-      success: true,
-      errors: [],
-      data: input,
-    } as any;
-  };
-  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
-    _co0(input) as any;
-  return (
-    input: any,
-  ): import("typia").IValidation<import("typia").Resolved<ICitizen>> => {
-    const result = __validate(input) as any;
-    if (result.success) result.data = __clone(input);
-    return result;
-  };
-})();
-export const createPrune = (() => {
-  const _pp0 = (input: any) =>
-    input.forEach((elem: any) => {
-      if ("object" === typeof elem && null !== elem) _po0(elem);
-    });
-  const _po0 = (input: any): any => {
-    if ("object" === typeof input.parent && null !== input.parent)
-      _po0(input.parent);
-    if (Array.isArray(input.children)) _pp0(input.children);
-    for (const key of Object.keys(input)) {
-      if (
-        "id" === key ||
-        "name" === key ||
-        "email" === key ||
-        "age" === key ||
-        "motto" === key ||
-        "birthdate" === key ||
-        "died_at" === key ||
-        "parent" === key ||
-        "children" === key
-      )
-        continue;
-      delete input[key];
-    }
-  };
-  const _io0 = (input: any): boolean =>
-    "string" === typeof input.id &&
-    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
-    "string" === typeof input.name &&
-    RegExp("^[A-Z][a-z]+$").test(input.name) &&
-    "string" === typeof input.email &&
-    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
-    "number" === typeof input.age &&
-    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
-    input.age < 100 &&
-    "string" === typeof input.motto &&
-    input.birthdate instanceof Date &&
-    (null === input.died_at || input.died_at instanceof Date) &&
-    (null === input.parent ||
-      ("object" === typeof input.parent &&
-        null !== input.parent &&
-        _io0(input.parent))) &&
-    Array.isArray(input.children) &&
-    input.children.every(
-      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
-    );
-  return (input: ICitizen): void => {
-    if ("object" === typeof input && null !== input) _po0(input);
-  };
-})();
-export const createAssertPrune = (() => {
-  const _pp0 = (input: any) =>
-    input.forEach((elem: any) => {
-      if ("object" === typeof elem && null !== elem) _po0(elem);
-    });
-  const _io0 = (input: any): boolean =>
-    "string" === typeof input.id &&
-    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
-    "string" === typeof input.name &&
-    RegExp("^[A-Z][a-z]+$").test(input.name) &&
-    "string" === typeof input.email &&
-    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
-    "number" === typeof input.age &&
-    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
-    input.age < 100 &&
-    "string" === typeof input.motto &&
-    input.birthdate instanceof Date &&
-    (null === input.died_at || input.died_at instanceof Date) &&
-    (null === input.parent ||
-      ("object" === typeof input.parent &&
-        null !== input.parent &&
-        _io0(input.parent))) &&
-    Array.isArray(input.children) &&
-    input.children.every(
-      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
-    );
-  const _ao0 = (
-    input: any,
-    _path: string,
-    _exceptionable: boolean = true,
-  ): boolean =>
-    (("string" === typeof input.id &&
-      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".id",
-            expected: 'string & Format<"uuid">',
-            value: input.id,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".id",
-          expected: '(string & Format<"uuid">)',
-          value: input.id,
-        },
-        _errorFactory,
-      )) &&
-    (("string" === typeof input.name &&
-      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".name",
-            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
-            value: input.name,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".name",
-          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
-          value: input.name,
-        },
-        _errorFactory,
-      )) &&
-    (("string" === typeof input.email &&
-      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".email",
-            expected: 'string & Format<"email">',
-            value: input.email,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".email",
-          expected: '(string & Format<"email">)',
-          value: input.email,
-        },
-        _errorFactory,
-      )) &&
-    (("number" === typeof input.age &&
-      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".age",
-            expected: 'number & Type<"uint32">',
-            value: input.age,
-          },
-          _errorFactory,
-        )) &&
-      (input.age < 100 ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".age",
-            expected: "number & ExclusiveMaximum<100>",
-            value: input.age,
-          },
-          _errorFactory,
-        ))) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".age",
-          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
-          value: input.age,
-        },
-        _errorFactory,
-      )) &&
-    ("string" === typeof input.motto ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".motto",
-          expected: "string",
-          value: input.motto,
-        },
-        _errorFactory,
-      )) &&
-    (input.birthdate instanceof Date ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".birthdate",
-          expected: "Date",
-          value: input.birthdate,
-        },
-        _errorFactory,
-      )) &&
-    (null === input.died_at ||
-      input.died_at instanceof Date ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".died_at",
-          expected: "(Date | null)",
-          value: input.died_at,
-        },
-        _errorFactory,
-      )) &&
-    (null === input.parent ||
-      ((("object" === typeof input.parent && null !== input.parent) ||
-        __typia_transform__assertGuard._assertGuard(
-          _exceptionable,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + ".parent",
-            expected: "(ICitizen | null)",
-            value: input.parent,
-          },
-          _errorFactory,
-        )) &&
-        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".parent",
-          expected: "(ICitizen | null)",
-          value: input.parent,
-        },
-        _errorFactory,
-      )) &&
-    (((Array.isArray(input.children) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".children",
-          expected: "Array<ICitizen>",
-          value: input.children,
-        },
-        _errorFactory,
-      )) &&
-      input.children.every(
-        (elem: any, _index2: number) =>
-          ((("object" === typeof elem && null !== elem) ||
-            __typia_transform__assertGuard._assertGuard(
-              _exceptionable,
-              {
-                method: "typia.misc.createAssertPrune",
-                path: _path + ".children[" + _index2 + "]",
-                expected: "ICitizen",
-                value: elem,
-              },
-              _errorFactory,
-            )) &&
-            _ao0(
-              elem,
-              _path + ".children[" + _index2 + "]",
-              true && _exceptionable,
-            )) ||
-          __typia_transform__assertGuard._assertGuard(
-            _exceptionable,
-            {
-              method: "typia.misc.createAssertPrune",
-              path: _path + ".children[" + _index2 + "]",
-              expected: "ICitizen",
-              value: elem,
-            },
-            _errorFactory,
-          ),
-      )) ||
-      __typia_transform__assertGuard._assertGuard(
-        _exceptionable,
-        {
-          method: "typia.misc.createAssertPrune",
-          path: _path + ".children",
-          expected: "Array<ICitizen>",
-          value: input.children,
-        },
-        _errorFactory,
-      ));
-  const _po0 = (input: any): any => {
-    if ("object" === typeof input.parent && null !== input.parent)
-      _po0(input.parent);
-    if (Array.isArray(input.children)) _pp0(input.children);
-    for (const key of Object.keys(input)) {
-      if (
-        "id" === key ||
-        "name" === key ||
-        "email" === key ||
-        "age" === key ||
-        "motto" === key ||
-        "birthdate" === key ||
-        "died_at" === key ||
-        "parent" === key ||
-        "children" === key
-      )
-        continue;
-      delete input[key];
-    }
-  };
-  const __is = (input: any): input is ICitizen =>
-    "object" === typeof input && null !== input && _io0(input);
-  let _errorFactory: any;
-  const __assert = (
-    input: any,
-    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
-  ): ICitizen => {
-    if (false === __is(input)) {
-      _errorFactory = errorFactory;
-      ((input: any, _path: string, _exceptionable: boolean = true) =>
-        ((("object" === typeof input && null !== input) ||
-          __typia_transform__assertGuard._assertGuard(
-            true,
-            {
-              method: "typia.misc.createAssertPrune",
-              path: _path + "",
-              expected: "ICitizen",
-              value: input,
-            },
-            _errorFactory,
-          )) &&
-          _ao0(input, _path + "", true)) ||
-        __typia_transform__assertGuard._assertGuard(
-          true,
-          {
-            method: "typia.misc.createAssertPrune",
-            path: _path + "",
-            expected: "ICitizen",
-            value: input,
-          },
-          _errorFactory,
-        ))(input, "$input", true);
-    }
-    return input;
-  };
-  const __prune = (input: ICitizen): void => {
-    if ("object" === typeof input && null !== input) _po0(input);
-  };
-  return (
-    input: any,
-    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
-  ): ICitizen => {
-    input = __assert(input, errorFactory);
-    __prune(input);
-    return input;
-  };
-})();
-export const createIsPrune = (() => {
-  const _pp0 = (input: any) =>
-    input.forEach((elem: any) => {
-      if ("object" === typeof elem && null !== elem) _po0(elem);
-    });
-  const _io0 = (input: any): boolean =>
-    "string" === typeof input.id &&
-    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
-    "string" === typeof input.name &&
-    RegExp("^[A-Z][a-z]+$").test(input.name) &&
-    "string" === typeof input.email &&
-    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
-    "number" === typeof input.age &&
-    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
-    input.age < 100 &&
-    "string" === typeof input.motto &&
-    input.birthdate instanceof Date &&
-    (null === input.died_at || input.died_at instanceof Date) &&
-    (null === input.parent ||
-      ("object" === typeof input.parent &&
-        null !== input.parent &&
-        _io0(input.parent))) &&
-    Array.isArray(input.children) &&
-    input.children.every(
-      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
-    );
-  const _po0 = (input: any): any => {
-    if ("object" === typeof input.parent && null !== input.parent)
-      _po0(input.parent);
-    if (Array.isArray(input.children)) _pp0(input.children);
-    for (const key of Object.keys(input)) {
-      if (
-        "id" === key ||
-        "name" === key ||
-        "email" === key ||
-        "age" === key ||
-        "motto" === key ||
-        "birthdate" === key ||
-        "died_at" === key ||
-        "parent" === key ||
-        "children" === key
-      )
-        continue;
-      delete input[key];
-    }
-  };
-  const __is = (input: any): input is ICitizen =>
-    "object" === typeof input && null !== input && _io0(input);
-  const __prune = (input: ICitizen): void => {
-    if ("object" === typeof input && null !== input) _po0(input);
-  };
-  return (input: any): input is ICitizen => {
-    if (false == __is(input)) return false;
-    __prune(input);
-    return true;
-  };
-})();
-export const createValidatePrune = (() => {
-  const _pp0 = (input: any) =>
-    input.forEach((elem: any) => {
-      if ("object" === typeof elem && null !== elem) _po0(elem);
-    });
-  const _io0 = (input: any): boolean =>
-    "string" === typeof input.id &&
-    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
-    "string" === typeof input.name &&
-    RegExp("^[A-Z][a-z]+$").test(input.name) &&
-    "string" === typeof input.email &&
-    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
-    "number" === typeof input.age &&
-    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
-    input.age < 100 &&
-    "string" === typeof input.motto &&
-    input.birthdate instanceof Date &&
-    (null === input.died_at || input.died_at instanceof Date) &&
-    (null === input.parent ||
-      ("object" === typeof input.parent &&
-        null !== input.parent &&
-        _io0(input.parent))) &&
-    Array.isArray(input.children) &&
-    input.children.every(
-      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
-    );
-  const _vo0 = (
-    input: any,
-    _path: string,
-    _exceptionable: boolean = true,
-  ): boolean =>
-    [
-      ("string" === typeof input.id &&
-        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          _report(_exceptionable, {
-            path: _path + ".id",
-            expected: 'string & Format<"uuid">',
-            value: input.id,
-          }))) ||
-        _report(_exceptionable, {
-          path: _path + ".id",
-          expected: '(string & Format<"uuid">)',
-          value: input.id,
-        }),
-      ("string" === typeof input.name &&
-        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          _report(_exceptionable, {
-            path: _path + ".name",
-            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
-            value: input.name,
-          }))) ||
-        _report(_exceptionable, {
-          path: _path + ".name",
-          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
-          value: input.name,
-        }),
-      ("string" === typeof input.email &&
-        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          _report(_exceptionable, {
-            path: _path + ".email",
-            expected: 'string & Format<"email">',
-            value: input.email,
-          }))) ||
-        _report(_exceptionable, {
-          path: _path + ".email",
-          expected: '(string & Format<"email">)',
-          value: input.email,
-        }),
-      ("number" === typeof input.age &&
-        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          _report(_exceptionable, {
-            path: _path + ".age",
-            expected: 'number & Type<"uint32">',
-            value: input.age,
-          })) &&
-        (input.age < 100 ||
-          _report(_exceptionable, {
-            path: _path + ".age",
-            expected: "number & ExclusiveMaximum<100>",
-            value: input.age,
-          }))) ||
-        _report(_exceptionable, {
-          path: _path + ".age",
-          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
-          value: input.age,
-        }),
-      "string" === typeof input.motto ||
-        _report(_exceptionable, {
-          path: _path + ".motto",
-          expected: "string",
-          value: input.motto,
-        }),
-      input.birthdate instanceof Date ||
-        _report(_exceptionable, {
-          path: _path + ".birthdate",
-          expected: "Date",
-          value: input.birthdate,
-        }),
-      null === input.died_at ||
-        input.died_at instanceof Date ||
-        _report(_exceptionable, {
-          path: _path + ".died_at",
-          expected: "(Date | null)",
-          value: input.died_at,
-        }),
-      null === input.parent ||
-        ((("object" === typeof input.parent && null !== input.parent) ||
-          _report(_exceptionable, {
-            path: _path + ".parent",
-            expected: "(ICitizen | null)",
-            value: input.parent,
-          })) &&
-          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        _report(_exceptionable, {
-          path: _path + ".parent",
-          expected: "(ICitizen | null)",
-          value: input.parent,
-        }),
-      ((Array.isArray(input.children) ||
-        _report(_exceptionable, {
-          path: _path + ".children",
-          expected: "Array<ICitizen>",
-          value: input.children,
-        })) &&
-        input.children
-          .map(
-            (elem: any, _index2: number) =>
-              ((("object" === typeof elem && null !== elem) ||
-                _report(_exceptionable, {
-                  path: _path + ".children[" + _index2 + "]",
-                  expected: "ICitizen",
-                  value: elem,
-                })) &&
-                _vo0(
-                  elem,
-                  _path + ".children[" + _index2 + "]",
-                  true && _exceptionable,
-                )) ||
-              _report(_exceptionable, {
-                path: _path + ".children[" + _index2 + "]",
-                expected: "ICitizen",
-                value: elem,
-              }),
-          )
-          .every((flag: boolean) => flag)) ||
-        _report(_exceptionable, {
-          path: _path + ".children",
-          expected: "Array<ICitizen>",
-          value: input.children,
-        }),
-    ].every((flag: boolean) => flag);
-  const _po0 = (input: any): any => {
-    if ("object" === typeof input.parent && null !== input.parent)
-      _po0(input.parent);
-    if (Array.isArray(input.children)) _pp0(input.children);
-    for (const key of Object.keys(input)) {
-      if (
-        "id" === key ||
-        "name" === key ||
-        "email" === key ||
-        "age" === key ||
-        "motto" === key ||
-        "birthdate" === key ||
-        "died_at" === key ||
-        "parent" === key ||
-        "children" === key
-      )
-        continue;
-      delete input[key];
-    }
-  };
-  const __is = (input: any): input is ICitizen =>
-    "object" === typeof input && null !== input && _io0(input);
-  let errors: any;
-  let _report: any;
-  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
-    if (false === __is(input)) {
-      errors = [];
-      _report = (__typia_transform__validateReport._validateReport as any)(
-        errors,
-      );
-      ((input: any, _path: string, _exceptionable: boolean = true) =>
-        ((("object" === typeof input && null !== input) ||
-          _report(true, {
-            path: _path + "",
-            expected: "ICitizen",
-            value: input,
-          })) &&
-          _vo0(input, _path + "", true)) ||
-        _report(true, {
-          path: _path + "",
-          expected: "ICitizen",
-          value: input,
-        }))(input, "$input", true);
-      const success = 0 === errors.length;
-      return {
-        success,
-        errors,
-        data: success ? input : undefined,
-      } as any;
-    }
-    return {
-      success: true,
-      errors: [],
-      data: input,
-    } as any;
-  };
-  const __prune = (input: ICitizen): void => {
-    if ("object" === typeof input && null !== input) _po0(input);
-  };
   return (input: any): import("typia").IValidation<ICitizen> => {
-    const result = __validate(input);
-    if (result.success) __prune(input);
-    return result;
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return {
+        success,
+        errors,
+        data: success ? input : undefined,
+      } as any;
+    }
+    return {
+      success: true,
+      errors: [],
+      data: input,
+    } as any;
   };
 })();
-export const literals = [false, 1, "two"] as const;
+export const equals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  return (input: any, _exceptionable: boolean = true): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+})();
+export const assertEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+})();
+export const assertGuardEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuardEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+  };
+})();
+export const validateEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+      9 === Object.keys(input).length ||
+        false === _exceptionable ||
+        Object.keys(input)
+          .map((key: any) => {
+            if (
+              [
+                "id",
+                "name",
+                "email",
+                "age",
+                "motto",
+                "birthdate",
+                "died_at",
+                "parent",
+                "children",
+              ].some((prop: any) => key === prop)
+            )
+              return true;
+            const value = input[key];
+            if (undefined === value) return true;
+            return _report(_exceptionable, {
+              path:
+                _path +
+                __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                  key,
+                ),
+              expected: "undefined",
+              value: value,
+            });
+          })
+          .every((flag: boolean) => flag),
+    ].every((flag: boolean) => flag);
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let errors: any;
+  let _report: any;
+  return (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return {
+        success,
+        errors,
+        data: success ? input : undefined,
+      } as any;
+    }
+    return {
+      success: true,
+      errors: [],
+      data: input,
+    } as any;
+  };
+})();
+export const random = (() => {
+  const _ro0 = (_recursive: boolean = true, _depth: number = 0): any => ({
+    id: (
+      _generator?.uuid ?? __typia_transform__randomFormatUuid._randomFormatUuid
+    )(),
+    name: (
+      _generator?.pattern ?? __typia_transform__randomPattern._randomPattern
+    )(new RegExp("^[A-Z][a-z]+$")),
+    email: (
+      _generator?.email ??
+      __typia_transform__randomFormatEmail._randomFormatEmail
+    )(),
+    age: (
+      _generator?.integer ?? __typia_transform__randomInteger._randomInteger
+    )({
+      type: "integer",
+      exclusiveMaximum: true,
+      maximum: 100,
+    }),
+    motto: (
+      _generator?.string ?? __typia_transform__randomString._randomString
+    )({
+      type: "string",
+    }),
+    birthdate: new Date(
+      (
+        _generator?.datetime ??
+        __typia_transform__randomFormatDatetime._randomFormatDatetime
+      )(),
+    ),
+    died_at: __typia_transform__randomPick._randomPick([
+      () => null,
+      () =>
+        new Date(
+          (
+            _generator?.datetime ??
+            __typia_transform__randomFormatDatetime._randomFormatDatetime
+          )(),
+        ),
+    ])(),
+    parent: __typia_transform__randomPick._randomPick([
+      () => null,
+      () => _ro0(true, _recursive ? 1 + _depth : _depth),
+    ])(),
+    children:
+      5 >= _depth
+        ? (_generator?.array ?? __typia_transform__randomArray._randomArray)({
+            type: "array",
+            element: () => _ro0(true, _recursive ? 1 + _depth : _depth),
+          })
+        : [],
+  });
+  let _generator: Partial<import("typia").IRandomGenerator> | undefined;
+  return (
+    generator?: Partial<import("typia").IRandomGenerator>,
+  ): import("typia").Resolved<ICitizen> => {
+    _generator = generator;
+    return _ro0();
+  };
+})();

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -462,92 +462,92 @@ export const createValidateStringify = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -556,7 +556,7 @@ export const createValidateStringify = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -566,14 +566,14 @@ export const createValidateStringify = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -584,22 +584,22 @@ export const createValidateStringify = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,
@@ -957,92 +957,92 @@ export const createValidateParse = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1051,7 +1051,7 @@ export const createValidateParse = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -1061,14 +1061,14 @@ export const createValidateParse = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1077,22 +1077,22 @@ export const createValidateParse = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,

--- a/test/generate/output/generate_notations.ts
+++ b/test/generate/output/generate_notations.ts
@@ -394,92 +394,92 @@ export const createValidateCamel = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -488,7 +488,7 @@ export const createValidateCamel = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -498,14 +498,14 @@ export const createValidateCamel = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -525,22 +525,22 @@ export const createValidateCamel = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,
@@ -946,92 +946,92 @@ export const createValidatePascal = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1040,7 +1040,7 @@ export const createValidatePascal = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -1050,14 +1050,14 @@ export const createValidatePascal = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1077,22 +1077,22 @@ export const createValidatePascal = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,
@@ -1498,92 +1498,92 @@ export const createValidateSnake = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1592,7 +1592,7 @@ export const createValidateSnake = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -1602,14 +1602,14 @@ export const createValidateSnake = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1629,22 +1629,22 @@ export const createValidateSnake = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1322,92 +1322,92 @@ export const createValidate = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1416,7 +1416,7 @@ export const createValidate = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -1426,14 +1426,14 @@ export const createValidate = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1442,22 +1442,22 @@ export const createValidate = (() => {
   const __is = (input: any): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   return (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,
@@ -1529,92 +1529,92 @@ export const createValidateEquals = (() => {
     [
       ("string" === typeof input.id &&
         (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".id",
             expected: 'string & Format<"uuid">',
             value: input.id,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".id",
           expected: '(string & Format<"uuid">)',
           value: input.id,
         }),
       ("string" === typeof input.name &&
         (RegExp("^[A-Z][a-z]+$").test(input.name) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: 'string & Pattern<"^[A-Z][a-z]+$">',
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
           value: input.name,
         }),
       ("string" === typeof input.email &&
         (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".email",
             expected: 'string & Format<"email">',
             value: input.email,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".email",
           expected: '(string & Format<"email">)',
           value: input.email,
         }),
       ("number" === typeof input.age &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: 'number & Type<"uint32">',
             value: input.age,
           })) &&
         (input.age < 100 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".age",
             expected: "number & ExclusiveMaximum<100>",
             value: input.age,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".age",
           expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
           value: input.age,
         }),
       "string" === typeof input.motto ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".motto",
           expected: "string",
           value: input.motto,
         }),
       input.birthdate instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".birthdate",
           expected: "Date",
           value: input.birthdate,
         }),
       null === input.died_at ||
         input.died_at instanceof Date ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".died_at",
           expected: "(Date | null)",
           value: input.died_at,
         }),
       null === input.parent ||
         ((("object" === typeof input.parent && null !== input.parent) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".parent",
             expected: "(ICitizen | null)",
             value: input.parent,
           })) &&
           _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".parent",
           expected: "(ICitizen | null)",
           value: input.parent,
         }),
       ((Array.isArray(input.children) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1623,7 +1623,7 @@ export const createValidateEquals = (() => {
           .map(
             (elem: any, _index2: number) =>
               ((("object" === typeof elem && null !== elem) ||
-                $report(_exceptionable, {
+                _report(_exceptionable, {
                   path: _path + ".children[" + _index2 + "]",
                   expected: "ICitizen",
                   value: elem,
@@ -1633,14 +1633,14 @@ export const createValidateEquals = (() => {
                   _path + ".children[" + _index2 + "]",
                   true && _exceptionable,
                 )) ||
-              $report(_exceptionable, {
+              _report(_exceptionable, {
                 path: _path + ".children[" + _index2 + "]",
                 expected: "ICitizen",
                 value: elem,
               }),
           )
           .every((flag: boolean) => flag)) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".children",
           expected: "Array<ICitizen>",
           value: input.children,
@@ -1665,7 +1665,7 @@ export const createValidateEquals = (() => {
               return true;
             const value = input[key];
             if (undefined === value) return true;
-            return $report(_exceptionable, {
+            return _report(_exceptionable, {
               path:
                 _path +
                 __typia_transform__accessExpressionAsString._accessExpressionAsString(
@@ -1683,22 +1683,22 @@ export const createValidateEquals = (() => {
   ): input is ICitizen =>
     "object" === typeof input && null !== input && _io0(input, true);
   let errors: any;
-  let $report: any;
+  let _report: any;
   return (input: any): import("typia").IValidation<ICitizen> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "ICitizen",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "ICitizen",
           value: input,

--- a/test/generate/output/generate_protobuf.ts
+++ b/test/generate/output/generate_protobuf.ts
@@ -325,12 +325,12 @@ export const createValidateEncode = (() => {
     [
       ("string" === typeof input.name &&
         (input.name.length <= 8 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: "string & MaxLength<8>",
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: "(string & MaxLength<8>)",
           value: input.name,
@@ -338,36 +338,36 @@ export const createValidateEncode = (() => {
       null === input.extension ||
         ("string" === typeof input.extension &&
           (1 <= input.extension.length ||
-            $report(_exceptionable, {
+            _report(_exceptionable, {
               path: _path + ".extension",
               expected: "string & MinLength<1>",
               value: input.extension,
             })) &&
           (input.extension.length <= 3 ||
-            $report(_exceptionable, {
+            _report(_exceptionable, {
               path: _path + ".extension",
               expected: "string & MaxLength<3>",
               value: input.extension,
             }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".extension",
           expected: "((string & MinLength<1> & MaxLength<3>) | null)",
           value: input.extension,
         }),
       ("number" === typeof input.size &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".size",
             expected: 'number & Type<"uint32">',
             value: input.size,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".size",
           expected: '(number & Type<"uint32">)',
           value: input.size,
         }),
       input.data instanceof Uint8Array ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".data",
           expected: "Uint8Array",
           value: input.data,
@@ -412,22 +412,22 @@ export const createValidateEncode = (() => {
   const __is = (input: any): input is IFile =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<IFile> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "IFile",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "IFile",
           value: input,
@@ -761,12 +761,12 @@ export const createValidateDecode = (() => {
     [
       ("string" === typeof input.name &&
         (input.name.length <= 8 ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".name",
             expected: "string & MaxLength<8>",
             value: input.name,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".name",
           expected: "(string & MaxLength<8>)",
           value: input.name,
@@ -774,36 +774,36 @@ export const createValidateDecode = (() => {
       null === input.extension ||
         ("string" === typeof input.extension &&
           (1 <= input.extension.length ||
-            $report(_exceptionable, {
+            _report(_exceptionable, {
               path: _path + ".extension",
               expected: "string & MinLength<1>",
               value: input.extension,
             })) &&
           (input.extension.length <= 3 ||
-            $report(_exceptionable, {
+            _report(_exceptionable, {
               path: _path + ".extension",
               expected: "string & MaxLength<3>",
               value: input.extension,
             }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".extension",
           expected: "((string & MinLength<1> & MaxLength<3>) | null)",
           value: input.extension,
         }),
       ("number" === typeof input.size &&
         (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
-          $report(_exceptionable, {
+          _report(_exceptionable, {
             path: _path + ".size",
             expected: 'number & Type<"uint32">',
             value: input.size,
           }))) ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".size",
           expected: '(number & Type<"uint32">)',
           value: input.size,
         }),
       input.data instanceof Uint8Array ||
-        $report(_exceptionable, {
+        _report(_exceptionable, {
           path: _path + ".data",
           expected: "Uint8Array",
           value: input.data,
@@ -846,22 +846,22 @@ export const createValidateDecode = (() => {
   const __is = (input: any): input is IFile =>
     "object" === typeof input && null !== input && _io0(input);
   let errors: any;
-  let $report: any;
+  let _report: any;
   const __validate = (input: any): import("typia").IValidation<IFile> => {
     if (false === __is(input)) {
       errors = [];
-      $report = (__typia_transform__validateReport._validateReport as any)(
+      _report = (__typia_transform__validateReport._validateReport as any)(
         errors,
       );
       ((input: any, _path: string, _exceptionable: boolean = true) =>
         ((("object" === typeof input && null !== input) ||
-          $report(true, {
+          _report(true, {
             path: _path + "",
             expected: "IFile",
             value: input,
           })) &&
           _vo0(input, _path + "", true)) ||
-        $report(true, {
+        _report(true, {
           path: _path + "",
           expected: "IFile",
           value: input,

--- a/test/generate/output/generate_use.ts
+++ b/test/generate/output/generate_use.ts
@@ -1,0 +1,11 @@
+"use strict";
+"use server";
+
+import typia, { tags } from "typia";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+
+(() => {
+  return (input: any): input is string & tags.Format<"uuid"> =>
+    "string" === typeof input &&
+    __typia_transform__isFormatUuid._isFormatUuid(input);
+})();

--- a/test/package.json
+++ b/test/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rimraf bin && tsc",
     "build_run": "npm run build",
-    "generate": "typia generate --input generate/input --output generate/output --project tsconfig.generate.json && tsc --project tsconfig.generate.json && prettier generate/**/*.ts --write",
+    "generate": "typia generate --input generate/input --output generate/output --project tsconfig.generate.json && tsc --project tsconfig.generate.json && prettier generate/output/*.ts --write && ts-node build/validate-generate.ts",
     "prepare": "ts-patch install",
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",


### PR DESCRIPTION
Emergent update for #1409 and #1410.

---------------

This pull request includes several updates across multiple files to improve consistency and functionality. The most important changes involve renaming identifiers for clarity, updating functions, and adding new validation and testing capabilities.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `7.0.0` to `7.0.1`.

### Function and Identifier Renaming:
* [`src/internal/_miscCloneAny.ts`](diffhunk://#diff-aedcb182c3903ce614043e32c181d3d9c70dc7fed5fc6857c3de3846a6a44362L4-R10): Renamed the `$cloneMain` function to `cloneMain` throughout the file for consistency. [[1]](diffhunk://#diff-aedcb182c3903ce614043e32c181d3d9c70dc7fed5fc6857c3de3846a6a44362L4-R10) [[2]](diffhunk://#diff-aedcb182c3903ce614043e32c181d3d9c70dc7fed5fc6857c3de3846a6a44362L32-R41)
* [`src/programmers/ValidateProgrammer.ts`](diffhunk://#diff-989189c9a3595d5f3d151752d9bca901231505cab2c6cbfa3b54f6c47eaddf0dL142-R142): Renamed the `$report` identifier to `_report` for better readability and consistency. [[1]](diffhunk://#diff-989189c9a3595d5f3d151752d9bca901231505cab2c6cbfa3b54f6c47eaddf0dL142-R142) [[2]](diffhunk://#diff-989189c9a3595d5f3d151752d9bca901231505cab2c6cbfa3b54f6c47eaddf0dL226-R226) [[3]](diffhunk://#diff-989189c9a3595d5f3d151752d9bca901231505cab2c6cbfa3b54f6c47eaddf0dL418-R418)
* [`test/generate/output/generate_http.ts`](diffhunk://#diff-2edc83c903fc2cb4c20e7fc139eb9cc74bf4e7ad8191a709efd987e1612ab123L242-R253): Renamed `$report` to `_report` in multiple locations for consistency. [[1]](diffhunk://#diff-2edc83c903fc2cb4c20e7fc139eb9cc74bf4e7ad8191a709efd987e1612ab123L242-R253) [[2]](diffhunk://#diff-2edc83c903fc2cb4c20e7fc139eb9cc74bf4e7ad8191a709efd987e1612ab123L262-R275) [[3]](diffhunk://#diff-2edc83c903fc2cb4c20e7fc139eb9cc74bf4e7ad8191a709efd987e1612ab123L284-R299)
* [`test/generate/output/generate_json.ts`](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L465-R550): Renamed `$report` to `_report` in multiple locations for consistency. [[1]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L465-R550) [[2]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L559-R559) [[3]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L569-R576) [[4]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L587-R602) [[5]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L960-R1045) [[6]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4L1054-R1054)

### New Functions and Enhancements:
* [`src/transformers/FileTransformer.ts`](diffhunk://#diff-f503bf0fc6bea085e2bded282119a3e521ded8ed85467e482683f61cb8a7c167R37-R44): Added the `find_import_injection_index` function to determine the correct index for import injection, improving the file transformation process. [[1]](diffhunk://#diff-f503bf0fc6bea085e2bded282119a3e521ded8ed85467e482683f61cb8a7c167R37-R44) [[2]](diffhunk://#diff-f503bf0fc6bea085e2bded282119a3e521ded8ed85467e482683f61cb8a7c167R88-R102)

### Testing and Validation:
* [`test/build/validate-generate.ts`](diffhunk://#diff-aed508f3dc67fdd47416bdc7c1a9b461ca9d5233444aa56e28eac291f2239cd9R1-R11): Added a new test to ensure that files do not contain the ` character, which is not allowed in Svelte5.
* [`test/generate/input/generate_index.ts`](diffhunk://#diff-0965b1681364c7a88addea4aa19ad5da35c43142926727b15a096b7b3c3f5532R1-R25): Added a new test file with multiple validation functions for the `ICitizen` interface.
* [`test/generate/input/generate_use.ts`](diffhunk://#diff-17e4189c34aea8a791517fa91cbd9d7d3b2ba735763a847602d2c66ded74cd13R1-R7): Added a new test file with strict mode and server usage declarations.