### PR TITLE
feat(ci): update node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
       - uses: actions/cache@v4
         with:
           path: ~/.npm
@@ -50,11 +50,14 @@ jobs:
 
   NodeJS:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, lts/*]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v4
         with:
           path: ~/.npm
@@ -72,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: lts/*
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest


### PR DESCRIPTION
In this patch

- use 'lts' version for pkg-pr-new & bun action
- added multiple node version matrix for Node action

for now, `lts/*` means `22.x`, so if you think 
`node-version: [20.x, 22.x, lts/*]`
is redundant, you can fix that part
