### PR TITLE
Report `TransformError` in website playground.

### DIFF
--- a/website/src/components/playground/OutputViewer.tsx
+++ b/website/src/components/playground/OutputViewer.tsx
@@ -1,13 +1,5 @@
 import Editor from "@monaco-editor/react";
 
-import { Singleton } from "tstl";
-
-import { typia_packageJson } from "../../../raw/typia/packageJson";
-
-const version = new Singleton(
-  () => typia_packageJson.split(`"version": "`)[1].split(`"`)[0],
-);
-
 const OutputViewer = (props: {
   language: "typescript" | "javascript";
   content: string;

--- a/website/src/pages/Playground.tsx
+++ b/website/src/pages/Playground.tsx
@@ -244,7 +244,7 @@ const Playground = () => {
                           })
                           .join("\n\n")
                       : output.content
-                    : output.error.message
+                    : JSON.stringify(output.error, null, 2)
               }
             />
             <div


### PR DESCRIPTION
This pull request includes changes to improve error handling and diagnostics in the TypeScript compiler and simplify the codebase in the playground components. The most important changes include adding a failure return function, modifying how errors are returned, and simplifying the `OutputViewer` component.

Improvements to error handling and diagnostics:

* [`website/src/compilers/TypeScriptCompiler.ts`](diffhunk://#diff-c1b0c1cdbc9b17cd72acee52b9bc6315d7e2a1c4fd993e52f8b5264d0daf4a8dR43-R54): Added a `returnFailure` function to standardize the error output when TypeScript compilation fails.
* [`website/src/compilers/TypeScriptCompiler.ts`](diffhunk://#diff-c1b0c1cdbc9b17cd72acee52b9bc6315d7e2a1c4fd993e52f8b5264d0daf4a8dR95): Included a check to return failure if diagnostics are present after transformation. [[1]](diffhunk://#diff-c1b0c1cdbc9b17cd72acee52b9bc6315d7e2a1c4fd993e52f8b5264d0daf4a8dR95) [[2]](diffhunk://#diff-c1b0c1cdbc9b17cd72acee52b9bc6315d7e2a1c4fd993e52f8b5264d0daf4a8dL94-R117)
* [`website/src/compilers/TypeScriptCompiler.ts`](diffhunk://#diff-c1b0c1cdbc9b17cd72acee52b9bc6315d7e2a1c4fd993e52f8b5264d0daf4a8dL110-R139): Enhanced the error return object to include `message` and `name` properties when an error is caught.

Codebase simplification:

* [`website/src/components/playground/OutputViewer.tsx`](diffhunk://#diff-41a7258590eda8addec4deeab575e690eca43f40877f2981c4cfe629712bdf89L3-L10): Removed the `Singleton` import and related code to simplify the `OutputViewer` component.
* [`website/src/pages/Playground.tsx`](diffhunk://#diff-9168ead9aa964e9b83075bf6998d53b1592fdd5a474c2708aca2b0f0d39d258fL247-R247): Changed the error display to use `JSON.stringify` for better readability of error messages.