### PR TITLE
Add `IValidation.IError.data` property.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,5 @@
 name: build
 on: 
-  push:
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'test-error/**'
-      - 'test-esm/**'
-      - 'package.json'
-      - '.github/workflows/build.yml'
   pull_request:
     paths:
       - 'src/**'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/IValidation.ts
+++ b/src/IValidation.ts
@@ -9,6 +9,7 @@ export namespace IValidation {
 
   export interface IFailure {
     success: false;
+    data: unknown;
     errors: IError[];
   }
 

--- a/src/IValidation.ts
+++ b/src/IValidation.ts
@@ -9,8 +9,8 @@ export namespace IValidation {
 
   export interface IFailure {
     success: false;
-    data: unknown;
     errors: IError[];
+    data: unknown;
   }
 
   export interface IError {

--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -193,10 +193,6 @@ export namespace ValidateProgrammer {
                     ts.factory.createTrue(),
                   ),
                   ts.factory.createPropertyAssignment(
-                    "errors",
-                    ts.factory.createArrayLiteralExpression([]),
-                  ),
-                  ts.factory.createPropertyAssignment(
                     "data",
                     ts.factory.createIdentifier("input"),
                   ),
@@ -390,16 +386,31 @@ const joiner = (props: {
 });
 
 const create_output = () =>
-  ts.factory.createObjectLiteralExpression(
-    [
-      ts.factory.createShorthandPropertyAssignment("success"),
-      ts.factory.createShorthandPropertyAssignment("errors"),
-      ts.factory.createPropertyAssignment(
-        "data",
-        ts.factory.createIdentifier("input"),
-      ),
-    ],
-    true,
+  ts.factory.createConditionalExpression(
+    ts.factory.createIdentifier("success"),
+    undefined,
+    ts.factory.createObjectLiteralExpression(
+      [
+        ts.factory.createShorthandPropertyAssignment("success"),
+        ts.factory.createPropertyAssignment(
+          "data",
+          ts.factory.createIdentifier("input"),
+        ),
+      ],
+      true,
+    ),
+    undefined,
+    ts.factory.createObjectLiteralExpression(
+      [
+        ts.factory.createShorthandPropertyAssignment("success"),
+        ts.factory.createShorthandPropertyAssignment("errors"),
+        ts.factory.createPropertyAssignment(
+          "data",
+          ts.factory.createIdentifier("input"),
+        ),
+      ],
+      true,
+    ),
   );
 
 const create_report_call = (props: {

--- a/src/programmers/ValidateProgrammer.ts
+++ b/src/programmers/ValidateProgrammer.ts
@@ -396,13 +396,7 @@ const create_output = () =>
       ts.factory.createShorthandPropertyAssignment("errors"),
       ts.factory.createPropertyAssignment(
         "data",
-        ts.factory.createConditionalExpression(
-          ts.factory.createIdentifier("success"),
-          undefined,
-          ts.factory.createIdentifier("input"),
-          undefined,
-          ts.factory.createIdentifier("undefined"),
-        ),
+        ts.factory.createIdentifier("input"),
       ),
     ],
     true,

--- a/test/generate/output/generate_http.ts
+++ b/test/generate/output/generate_http.ts
@@ -305,7 +305,7 @@ export const validateQuery = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_index.ts
+++ b/test/generate/output/generate_index.ts
@@ -761,7 +761,7 @@ export const validate = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1707,7 +1707,7 @@ export const validateEquals = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -608,7 +608,7 @@ export const createValidateStringify = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1101,7 +1101,7 @@ export const createValidateParse = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_misc.ts
+++ b/test/generate/output/generate_misc.ts
@@ -570,7 +570,7 @@ export const createValidateClone = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1198,7 +1198,7 @@ export const createValidatePrune = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_notations.ts
+++ b/test/generate/output/generate_notations.ts
@@ -549,7 +549,7 @@ export const createValidateCamel = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1101,7 +1101,7 @@ export const createValidatePascal = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1653,7 +1653,7 @@ export const createValidateSnake = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1466,7 +1466,7 @@ export const createValidate = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -1707,7 +1707,7 @@ export const createValidateEquals = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/generate/output/generate_protobuf.ts
+++ b/test/generate/output/generate_protobuf.ts
@@ -436,7 +436,7 @@ export const createValidateEncode = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {
@@ -870,7 +870,7 @@ export const createValidateDecode = (() => {
       return {
         success,
         errors,
-        data: success ? input : undefined,
+        data: input,
       } as any;
     }
     return {

--- a/test/src/debug/validate.ts
+++ b/test/src/debug/validate.ts
@@ -1,0 +1,9 @@
+import typia from "typia";
+
+console.log(
+  typia.validate<number>("one"),
+  typia.json.validateStringify<string>(2),
+  typia.protobuf.validateEncode<{
+    id: string;
+  }>({ id: 3 }),
+);

--- a/test/src/internal/_test_functional_validateFunction.ts
+++ b/test/src/internal/_test_functional_validateFunction.ts
@@ -26,7 +26,7 @@ export const _test_functional_validateFunction =
           throw new Error(
             `Bug on typia.functional.validateFunction(): failed to detect error on the ${name} type.`,
           );
-        typia.assert(valid);
+        typia.assertEquals(valid);
         valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 
         if (

--- a/test/src/internal/_test_functional_validateFunctionAsync.ts
+++ b/test/src/internal/_test_functional_validateFunctionAsync.ts
@@ -31,7 +31,7 @@ export const _test_functional_validateFunctionAsync =
             throw new Error(
               `Bug on await typia.functional.validateFunction(): failed to detect error on the ${name} type.`,
             );
-          typia.assert(valid);
+          typia.assertEquals(valid);
           valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 
           if (

--- a/test/src/internal/_test_functional_validateParameters.ts
+++ b/test/src/internal/_test_functional_validateParameters.ts
@@ -26,7 +26,7 @@ export const _test_functional_validateParameters =
           throw new Error(
             `Bug on typia.functional.validateFunction(): failed to detect error on the ${name} type.`,
           );
-        typia.assert(valid);
+        typia.assertEquals(valid);
         valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 
         if (

--- a/test/src/internal/_test_functional_validateParametersAsync.ts
+++ b/test/src/internal/_test_functional_validateParametersAsync.ts
@@ -31,7 +31,7 @@ export const _test_functional_validateParametersAsync =
             throw new Error(
               `Bug on await typia.functional.validateFunction(): failed to detect error on the ${name} type.`,
             );
-          typia.assert(valid);
+          typia.assertEquals(valid);
           valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 
           if (

--- a/test/src/internal/_test_functional_validateReturn.ts
+++ b/test/src/internal/_test_functional_validateReturn.ts
@@ -26,7 +26,7 @@ export const _test_functional_validateReturn =
           throw new Error(
             `Bug on typia.functional.validateFunction(): failed to detect error on the ${name} type.`,
           );
-        typia.assert(valid);
+        typia.assertEquals(valid);
         valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 
         if (

--- a/test/src/internal/_test_http_validateFormData.ts
+++ b/test/src/internal/_test_http_validateFormData.ts
@@ -17,6 +17,7 @@ export const _test_http_validateFormData =
       throw new Error(
         `Bug on typia.http.validateFormData(): failed to understand ${name} type.`,
       );
+    typia.assertEquals<typia.IValidation.ISuccess<unknown>>(result);
 
     const equal: boolean =
       result !== null && resolved_equal_to(name)(data, result.data);
@@ -38,7 +39,7 @@ export const _test_http_validateFormData =
           `Bug on typia.http.validateFormData(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_http_validateHeaders.ts
+++ b/test/src/internal/_test_http_validateHeaders.ts
@@ -22,6 +22,7 @@ export const _test_http_validateHeaders =
       throw new Error(
         `Bug on typia.http.validateHeaders(): failed to understand ${name} type.`,
       );
+    typia.assertEquals<typia.IValidation.ISuccess<unknown>>(result);
 
     const equal: boolean =
       result !== null && resolved_equal_to(name)(data, result.data);
@@ -43,7 +44,7 @@ export const _test_http_validateHeaders =
           `Bug on typia.http.validateHeaders(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_http_validateQuery.ts
+++ b/test/src/internal/_test_http_validateQuery.ts
@@ -17,6 +17,7 @@ export const _test_http_validateQuery =
       throw new Error(
         `Bug on typia.http.validateQuery(): failed to understand ${name} type.`,
       );
+    typia.assertEquals<typia.IValidation.ISuccess<unknown>>(result);
 
     const equal: boolean =
       result !== null && resolved_equal_to(name)(data, result.data);
@@ -38,7 +39,7 @@ export const _test_http_validateQuery =
           `Bug on typia.http.validateQuery(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_json_validateParse.ts
+++ b/test/src/internal/_test_json_validateParse.ts
@@ -23,6 +23,7 @@ export const _test_json_validateParse =
         `Bug on typia.json.validateParse(): failed to understand the ${name} type.`,
       );
     }
+    typia.assertEquals<IValidation.ISuccess<unknown>>(valid);
 
     const wrong: ISpoiled[] = [];
     for (const spoil of factory.SPOILERS ?? []) {

--- a/test/src/internal/_test_json_validateStringify.ts
+++ b/test/src/internal/_test_json_validateStringify.ts
@@ -15,6 +15,7 @@ export const _test_json_validateStringify =
         `Bug on typia.json.validateStringify(): failed to understand the ${name} type.`,
       );
 
+    typia.assertEquals(valid);
     if (predicate(input, valid.data) === false) {
       throw new Error(
         `Bug on typia.json.validateStringify(): failed to understand the ${name} type.`,
@@ -32,7 +33,7 @@ export const _test_json_validateStringify =
           `Bug on typia.json.validateStringify(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_misc_validateClone.ts
+++ b/test/src/internal/_test_misc_validateClone.ts
@@ -15,6 +15,7 @@ export const _test_misc_validateClone =
         `Bug on typia.misc.validateClone(): failed to understand the ${name} type.`,
       );
 
+    typia.assertEquals<typia.IValidation.ISuccess<unknown>>(valid);
     if (resolved_equal_to(name)(input, valid.data) === false) {
       throw new Error(
         `Bug on typia.misc.validateClone(): failed to understand the ${name} type.`,
@@ -32,7 +33,7 @@ export const _test_misc_validateClone =
           `Bug on typia.misc.validateClone(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_misc_validatePrune.ts
+++ b/test/src/internal/_test_misc_validatePrune.ts
@@ -1,4 +1,4 @@
-import { IValidation, assert } from "typia";
+import { IValidation, assertEquals } from "typia";
 
 import { TestStructure } from "../helpers/TestStructure";
 
@@ -45,7 +45,7 @@ export const _test_misc_validatePrune =
           `Bug on typia.misc.validatePrune(): failed to detect error on the ${name} type.`,
         );
 
-      assert(valid);
+      assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_notation_validateGeneral.ts
+++ b/test/src/internal/_test_notation_validateGeneral.ts
@@ -1,4 +1,4 @@
-import { IValidation } from "typia";
+import typia, { IValidation } from "typia";
 
 import { TestStructure } from "../helpers/TestStructure";
 import { _test_notation_general } from "./_test_notation_general";
@@ -19,6 +19,7 @@ export const _test_notation_validateGeneral =
           throw new Error(
             `Bug on typia.notations.validateX(): failed to understand the ${name} type.`,
           );
+        typia.assertEquals<IValidation.ISuccess<unknown>>(res);
         return res.data;
       },
     })();
@@ -34,6 +35,7 @@ export const _test_notation_validateGeneral =
           `Bug on typia.notations.validateX(): failed to detect error on the ${name} type.`,
         );
 
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_protobuf_validateDecode.ts
+++ b/test/src/internal/_test_protobuf_validateDecode.ts
@@ -1,4 +1,4 @@
-import typia from "typia";
+import typia, { IValidation } from "typia";
 
 import { _test_protobuf_decode } from "./_test_protobuf_decode";
 
@@ -14,6 +14,7 @@ export const _test_protobuf_validateDecode =
       decode: (input) => {
         const result = functor.decode(input);
         if (!result.success) throw new Error();
+        typia.assertEquals<IValidation.ISuccess<unknown>>(result);
         return result.data;
       },
       encode: functor.encode,

--- a/test/src/internal/_test_protobuf_validateEncode.ts
+++ b/test/src/internal/_test_protobuf_validateEncode.ts
@@ -18,6 +18,7 @@ export const _test_protobuf_validateEncode =
       encode: (input: T) => {
         const result: typia.IValidation<Uint8Array> = functor.encode(input);
         if (!result.success) throw new Error();
+        typia.assertEquals(result);
         return result.data;
       },
     })();
@@ -33,7 +34,7 @@ export const _test_protobuf_validateEncode =
           `Bug on typia.json.validateEncode(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_validate.ts
+++ b/test/src/internal/_test_validate.ts
@@ -17,7 +17,7 @@ export const _test_validate =
       throw new Error(
         "Bug on typia.validate(): failed to archive the input value.",
       );
-    typia.assert(valid);
+    typia.assertEquals(valid);
 
     const wrong: ISpoiled[] = [];
     for (const spoil of factory.SPOILERS ?? []) {
@@ -30,7 +30,7 @@ export const _test_validate =
           `Bug on typia.validate(): failed to detect error on the ${name} type.`,
         );
 
-      typia.assert(valid);
+      typia.assertEquals(valid);
       expected.sort();
       valid.errors.sort((x, y) => (x.path < y.path ? -1 : 1));
 

--- a/test/src/internal/_test_validateEquals.ts
+++ b/test/src/internal/_test_validateEquals.ts
@@ -21,7 +21,7 @@ export const _test_validateEquals =
       throw new Error(
         "Bug on typia.validateEquals(): failed to archive the input value.",
       );
-    typia.assert(valid);
+    typia.assertEquals(valid);
     if (factory.ADDABLE === false) return;
 
     // EXPECTED

--- a/website/pages/docs/json/parse.mdx
+++ b/website/pages/docs/json/parse.mdx
@@ -37,6 +37,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -576,6 +577,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;

--- a/website/pages/docs/json/stringify.mdx
+++ b/website/pages/docs/json/stringify.mdx
@@ -39,6 +39,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -240,6 +241,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;

--- a/website/pages/docs/misc.mdx
+++ b/website/pages/docs/misc.mdx
@@ -50,6 +50,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -611,11 +612,11 @@ export namespace IValidation {
   export interface ISuccess<T = unknown> {
     success: true;
     data: T;
-    errors: [];
   }
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -1115,6 +1116,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -1338,6 +1340,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -1559,6 +1562,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -1840,6 +1844,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -2107,6 +2112,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;

--- a/website/pages/docs/protobuf/decode.mdx
+++ b/website/pages/docs/protobuf/decode.mdx
@@ -42,6 +42,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -683,6 +684,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;

--- a/website/pages/docs/protobuf/encode.mdx
+++ b/website/pages/docs/protobuf/encode.mdx
@@ -40,6 +40,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -550,6 +551,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;

--- a/website/pages/docs/validators/validate.mdx
+++ b/website/pages/docs/validators/validate.mdx
@@ -24,6 +24,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -226,6 +227,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -442,6 +444,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;
@@ -668,6 +671,7 @@ export namespace IValidation {
   export interface IFailure {
     success: false;
     errors: IError[];
+    data: unknown;
   }
   export interface IError {
     path: string;


### PR DESCRIPTION
Even when the validation is failed, its origin data should be filled. 

This PR fills the input data in the `IValidation.IError.data` property.

```typescript
export type IValidation<T = unknown> =
  | IValidation.ISuccess<T>
  | IValidation.IFailure;
export namespace IValidation {
  export interface ISuccess<T = unknown> {
    success: true;
    data: T;
  }
  export interface IFailure {
    success: false;
    data: unknown;
    errors: IError[];
  }
  export interface IError {
    path: string;
    expected: string;
    value: any;
  }
}
```