### PR TITLE
Fixing #1227: documentation of `UniqueItems`

### DIFF
--- a/website/pages/docs/validators/tags.mdx
+++ b/website/pages/docs/validators/tags.mdx
@@ -189,6 +189,10 @@ For reference, when you take a mistake that choosing different target type, Type
       - `duration`
       - `json-pointer`
       - `relative-json-pointer`
+  - array
+    - `Array<T> & MinItems<{number}>`
+    - `Array<T> & MaxItems<{number}>`
+    - `Array<T> & UniqueItems`
 
 Also, if you need custom validation logic, just make it by yourself referencing [Customization](#customization) section. It is easy to define. For such type safety and generous use case reasons even customization supporting, I recommend you to use type tags instead of [comment tags](#comment-tags), unless you are maintaining a legacy JSDoc styled project.
 
@@ -341,6 +345,7 @@ Here is the entire list of comment tags that `typia` supports.
   - array
     - `@minItems {number}`
     - `@maxItems {number}`
+    - `@uniqueItems`
 
 By the way, I do not recommend this way, because it can't perform union numeric types, and can be used for only object property type. It can't be used standalone, and cannot be used for element type of `Array` and `Map` even when they're declared on object property. Also, When you declare `@type int32` statement, target `number` type be fixed as `int32` type, and never can have another numeric type by declaring union statements.
 


### PR DESCRIPTION
This pull request includes updates to the documentation for the `typia` validation library. The changes primarily involve adding new array validation tags to the documentation.

Documentation updates:

* [`website/pages/docs/validators/tags.mdx`](diffhunk://#diff-7b44985dfe86f40a02a67154e51b871db5268751409c090de1b86d64e4ac33b0R192-R195): Added new array validation tags `Array<T> & MinItems<{number}>`, `Array<T> & MaxItems<{number}>`, and `Array<T> & UniqueItems` to the list of supported type tags.
* [`website/pages/docs/validators/tags.mdx`](diffhunk://#diff-7b44985dfe86f40a02a67154e51b871db5268751409c090de1b86d64e4ac33b0R348): Added the `@uniqueItems` tag to the list of supported comment tags.