### PR TITLE
build: add declaration map

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
 
     /* Emit */
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */


### PR DESCRIPTION
#### Summary
This PR enables `declarationMap: true` in the TypeScript configuration, generating source maps (`.d.ts.map`) alongside the declaration files (`.d.ts`).

#### Purpose
- Allow tracing from type definitions to the original source code, improving debugging and development experience.
