### PR TITLE
Fix LLM schema recursive type detector.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.4.0",
+  "version": "7.4.1-dev.20241216-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^2.2.0",
+    "@samchon/openapi": "^2.2.1",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.2.0 <3.0.0"
+    "@samchon/openapi": ">=2.2.1 <3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.4.1-dev.20241216-2",
+  "version": "7.4.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.4.0-dev.20241215",
+  "version": "7.4.1-dev.20241216-2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,11 +37,11 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.4.0-dev.20241215"
+    "typia": "7.4.1-dev.20241216-2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.2.0 <3.0.0"
+    "@samchon/openapi": ">=2.2.1 <3.0.0"
   },
   "stackblitz": {
     "startCommand": "npm install && npm run test"

--- a/src/factories/JsonMetadataFactory.ts
+++ b/src/factories/JsonMetadataFactory.ts
@@ -17,6 +17,7 @@ export namespace JsonMetadataFactory {
     checker: ts.TypeChecker;
     transformer?: ts.TransformationContext;
     type: ts.Type;
+    validate?: MetadataFactory.Validator;
   }
   export interface IOutput {
     collection: MetadataCollection;
@@ -33,7 +34,13 @@ export namespace JsonMetadataFactory {
           escape: true,
           constant: true,
           absorb: true,
-          validate,
+          validate: props.validate
+            ? (meta, explore) => {
+                const errors: string[] = validate(meta);
+                errors.push(...props.validate!(meta, explore));
+                return errors;
+              }
+            : validate,
         },
         collection,
         type: props.type,

--- a/src/programmers/llm/LlmSchemaProgrammer.ts
+++ b/src/programmers/llm/LlmSchemaProgrammer.ts
@@ -1,6 +1,8 @@
 import {
   IChatGptSchema,
+  IGeminiSchema,
   ILlmSchema,
+  ILlmSchemaV3,
   IOpenApiSchemaError,
   IResult,
 } from "@samchon/openapi";
@@ -104,6 +106,23 @@ export namespace LlmSchemaProgrammer {
       // Gemini does not support the union type
       if (props.model === "gemini" && size(metadata) > 1)
         output.push("Gemini model does not support the union type.");
+
+      // no recursive rule of Gemini and V3
+      if (
+        (props.model === "gemini" || props.model === "3.0") &&
+        ((props.config as IGeminiSchema.IConfig | undefined)?.recursive ===
+          false ||
+          (props.config as ILlmSchemaV3.IConfig | undefined)?.recursive === 0)
+      ) {
+        if (metadata.objects.some((o) => o.type.recursive))
+          output.push(
+            `LLM schema of "${props.model}" does not support recursive object.`,
+          );
+        if (metadata.arrays.some((a) => a.type.recursive))
+          output.push(
+            `LLM schema of "${props.model}" does not support recursive array.`,
+          );
+      }
 
       // just JSON rule
       if (

--- a/test-error/src/llm/llm.gemini.recursive.ts
+++ b/test-error/src/llm/llm.gemini.recursive.ts
@@ -1,0 +1,114 @@
+import typia from "typia";
+
+interface IHierarchical {
+  children: IHierarchical[];
+}
+interface IReference {
+  parent: IReference | null;
+}
+
+// SCHEMA
+typia.llm.schema<
+  IHierarchical,
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.schema<
+  IReference,
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.schema<
+  IHierarchical,
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.schema<
+  IReference,
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();
+
+// PARAMETERS
+typia.llm.parameters<
+  {
+    x: IHierarchical;
+  },
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IReference;
+  },
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IHierarchical;
+  },
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IReference;
+  },
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();
+
+// APPLICATION
+typia.llm.application<
+  {
+    insert(props: { x: IHierarchical }): void;
+  },
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IReference }): void;
+  },
+  "gemini",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IHierarchical }): void;
+  },
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IReference }): void;
+  },
+  "gemini",
+  {
+    recursive: 0;
+  }
+>();

--- a/test-error/src/llm/llm.v30.recursive.ts
+++ b/test-error/src/llm/llm.v30.recursive.ts
@@ -1,0 +1,114 @@
+import typia from "typia";
+
+interface IHierarchical {
+  children: IHierarchical[];
+}
+interface IReference {
+  parent: IReference | null;
+}
+
+// SCHEMA
+typia.llm.schema<
+  IHierarchical,
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.schema<
+  IReference,
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.schema<
+  IHierarchical,
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.schema<
+  IReference,
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();
+
+// PARAMETERS
+typia.llm.parameters<
+  {
+    x: IHierarchical;
+  },
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IReference;
+  },
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IHierarchical;
+  },
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.parameters<
+  {
+    x: IReference;
+  },
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();
+
+// APPLICATION
+typia.llm.application<
+  {
+    insert(props: { x: IHierarchical }): void;
+  },
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IReference }): void;
+  },
+  "3.0",
+  {
+    recursive: false;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IHierarchical }): void;
+  },
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();
+typia.llm.application<
+  {
+    insert(props: { x: IReference }): void;
+  },
+  "3.0",
+  {
+    recursive: 0;
+  }
+>();


### PR DESCRIPTION
This pull request includes several updates to version numbers, dependencies, and functionality related to LLM schema validation. The most important changes include updating package versions, adding support for new schema types, and implementing new validation rules for recursive objects and arrays.

### Version and Dependency Updates:
* Updated the `typia` package version to `7.4.1-dev.20241216-2` and the `@samchon/openapi` dependency to `^2.2.1` in `package.json` and `packages/typescript-json/package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R44) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L53-R53) [[4]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L3-R3) [[5]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L40-R44).

### Functionality Enhancements:
* Added an optional `validate` property to the `JsonMetadataFactory` namespace and implemented logic to handle this new property in `src/factories/JsonMetadataFactory.ts` [[1]](diffhunk://#diff-9de9e49475d4802977ea31ab4fa0d57b1c16cf528b3bdd31e522e8b204fed3d7R20) [[2]](diffhunk://#diff-9de9e49475d4802977ea31ab4fa0d57b1c16cf528b3bdd31e522e8b204fed3d7L36-R43).
* Introduced new schema types `IGeminiSchema` and `ILlmSchemaV3` and added validation rules for non-recursive objects and arrays in `src/programmers/llm/LlmSchemaProgrammer.ts` [[1]](diffhunk://#diff-937ecaf1c09e422b1f10d05d9f98c101ea9497a9b9ec4d9b68195a5c3a41c113R3-R5) [[2]](diffhunk://#diff-937ecaf1c09e422b1f10d05d9f98c101ea9497a9b9ec4d9b68195a5c3a41c113R110-R126).

### Test Cases:
* Added new test cases for validating non-recursive objects and arrays for the "gemini" model in `test-error/src/llm/llm.gemini.recursive.ts`.
* Added new test cases for validating non-recursive objects and arrays for the "3.0" model in `test-error/src/llm/llm.v30.recursive.ts`.