### PR TITLE
Adapt `@samchon/openapi@2.3.0`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.4.2",
+  "version": "7.5.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^2.2.1",
+    "@samchon/openapi": "^2.3.0",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.2.1 <3.0.0"
+    "@samchon/openapi": ">=2.3.0 <3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.4.2-dev.20241217",
+  "version": "7.5.0-dev.20241218",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,11 +37,11 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.4.2-dev.20241217"
+    "typia": "7.5.0-dev.20241218"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.2.1 <3.0.0"
+    "@samchon/openapi": ">=2.3.0-dev.20241218 <3.0.0"
   },
   "stackblitz": {
     "startCommand": "npm install && npm run test"

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -95,6 +95,10 @@ export namespace LlmApplicationProgrammer {
       output.push(
         `${prefix}'s return type must not be union type with undefined.`,
       );
+    if (/^[0-9]/.test(name[0] ?? "") === true)
+      output.push(`name must not start with a number`);
+    if (/^[a-zA-Z0-9_-]+$/.test(name) === false)
+      output.push(`name must be alphanumeric with underscore`);
     if (func.parameters.length !== 1)
       output.push(`${prefix} must have a single parameter.`);
     if (func.parameters.length !== 0) {

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -96,9 +96,9 @@ export namespace LlmApplicationProgrammer {
         `${prefix}'s return type must not be union type with undefined.`,
       );
     if (/^[0-9]/.test(name[0] ?? "") === true)
-      output.push(`name must not start with a number`);
+      output.push(`name must not start with a number.`);
     if (/^[a-zA-Z0-9_-]+$/.test(name) === false)
-      output.push(`name must be alphanumeric with underscore`);
+      output.push(`name must be alphanumeric with underscore or hypen.`);
     if (func.parameters.length !== 1)
       output.push(`${prefix} must have a single parameter.`);
     if (func.parameters.length !== 0) {

--- a/test-error/src/llm/llm.application.name.ts
+++ b/test-error/src/llm/llm.application.name.ts
@@ -1,0 +1,41 @@
+import typia from "typia";
+
+// APPLICATION FUNCTION
+typia.llm.application<
+  {
+    "0create"(p: {}): void;
+  },
+  "chatgpt"
+>();
+typia.llm.application<
+  {
+    "a.b.c"(p: {}): void;
+  },
+  "chatgpt"
+>();
+typia.llm.application<
+  {
+    "&x"(p: {}): void;
+  },
+  "chatgpt"
+>();
+
+// APPLICATION-OF-VALIDATE
+typia.llm.applicationOfValidate<
+  {
+    "0create"(p: {}): void;
+  },
+  "chatgpt"
+>();
+typia.llm.applicationOfValidate<
+  {
+    "a.b.c"(p: {}): void;
+  },
+  "chatgpt"
+>();
+typia.llm.applicationOfValidate<
+  {
+    "&x"(p: {}): void;
+  },
+  "chatgpt"
+>();


### PR DESCRIPTION
Bump up `@samchon/openapi` version, and adapt its function name prohibition rule in the compilation level.

-------------------

This pull request includes several updates to version dependencies and validation logic improvements. The most important changes include version bumps for dependencies and enhancements to the `LlmApplicationProgrammer` validation checks.

### Version Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated version from `7.4.2` to `7.5.0` and bumped `@samchon/openapi` dependency from `^2.2.1` to `^2.3.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R44) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L53-R53)
* [`packages/typescript-json/package.json`](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L3-R3): Updated version from `7.4.2-dev.20241217` to `7.5.0-dev.20241218` and updated `typia` dependency accordingly. [[1]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L3-R3) [[2]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L40-R44)

### Validation Logic Enhancements:
* [`src/programmers/llm/LlmApplicationProgrammer.ts`](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920R98-R101): Added new validation checks to ensure names do not start with a number and are alphanumeric with underscores.

### Test Cases:
* [`test-error/src/llm/llm.application.name.ts`](diffhunk://#diff-a89d4932dc8afc8d53618dc2804ffa850124acfa8a107a3df7794d182f0588f5R1-R41): Added test cases to validate the new name constraints in the `LlmApplicationProgrammer`.