### PR TITLE
Develop #1447: format int32 like feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.5.1",
+  "version": "7.6.0-dev.20241229",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^2.3.1",
+    "@samchon/openapi": "^2.4.0-dev.20241229",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -49,8 +49,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.3.0 <3.0.0"
+    "typescript": ">=4.8.0 <5.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -134,6 +134,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
+    - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)
     - [`decode()` functions](https://typia.io/docs/protobuf/decode/)

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.5.0-dev.20241218",
+  "version": "7.6.0-dev.20241229",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -37,11 +37,10 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.5.0-dev.20241218"
+    "typia": "7.6.0-dev.20241229"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.3.0-dev.20241218 <3.0.0"
+    "typescript": ">=4.8.0 <5.8.0"
   },
   "stackblitz": {
     "startCommand": "npm install && npm run test"

--- a/src/tags/Type.ts
+++ b/src/tags/Type.ts
@@ -28,5 +28,6 @@ export type Type<
     type: Value extends "int32" | "uint32" | "int64" | "uint64"
       ? "integer"
       : "number";
+    format: Value;
   };
 }>;

--- a/test/generate/output/generate_index.ts
+++ b/test/generate/output/generate_index.ts
@@ -1741,6 +1741,7 @@ export const random = (() => {
       _generator?.integer ?? __typia_transform__randomInteger._randomInteger
     )({
       type: "integer",
+      format: "uint32",
       exclusiveMaximum: true,
       maximum: 100,
     }),

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -39,6 +39,7 @@ export const collection = {
           },
           age: {
             type: "integer",
+            format: "uint32",
             exclusiveMaximum: true,
             maximum: 100,
           },

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1741,6 +1741,7 @@ export const createRandom = (() => {
       _generator?.integer ?? __typia_transform__randomInteger._randomInteger
     )({
       type: "integer",
+      format: "uint32",
       exclusiveMaximum: true,
       maximum: 100,
     }),

--- a/test/schemas/json.schemas/v3_0/ConstantAtomicTagged.json
+++ b/test/schemas/json.schemas/v3_0/ConstantAtomicTagged.json
@@ -16,6 +16,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               },
               {

--- a/test/schemas/json.schemas/v3_0/TypeTagRange.json
+++ b/test/schemas/json.schemas/v3_0/TypeTagRange.json
@@ -21,24 +21,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -46,23 +51,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/json.schemas/v3_0/TypeTagType.json
+++ b/test/schemas/json.schemas/v3_0/TypeTagType.json
@@ -20,25 +20,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_0/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_0/UltimateUnion.json
@@ -191,6 +191,11 @@
             "title": "Default value",
             "description": "Default value."
           },
+          "format": {
+            "type": "string",
+            "title": "Format restriction",
+            "description": "Format restriction."
+          },
           "minimum": {
             "type": "number",
             "title": "Minimum value restriction",
@@ -357,6 +362,11 @@
             "type": "integer",
             "title": "Default value",
             "description": "Default value."
+          },
+          "format": {
+            "type": "string",
+            "title": "Format restriction",
+            "description": "Format restriction."
           },
           "minimum": {
             "type": "integer",

--- a/test/schemas/json.schemas/v3_1/ConstantAtomicTagged.json
+++ b/test/schemas/json.schemas/v3_1/ConstantAtomicTagged.json
@@ -23,6 +23,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]

--- a/test/schemas/json.schemas/v3_1/TypeTagRange.json
+++ b/test/schemas/json.schemas/v3_1/TypeTagRange.json
@@ -21,24 +21,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -46,23 +51,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/json.schemas/v3_1/TypeTagType.json
+++ b/test/schemas/json.schemas/v3_1/TypeTagType.json
@@ -20,25 +20,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_1/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_1/UltimateUnion.json
@@ -185,6 +185,11 @@
             "title": "Default value",
             "description": "Default value."
           },
+          "format": {
+            "type": "string",
+            "title": "Format restriction",
+            "description": "Format restriction."
+          },
           "minimum": {
             "type": "number",
             "title": "Minimum value restriction",
@@ -345,6 +350,11 @@
             "type": "integer",
             "title": "Default value",
             "description": "Default value."
+          },
+          "format": {
+            "type": "string",
+            "title": "Format restriction",
+            "description": "Format restriction."
           },
           "minimum": {
             "type": "integer",

--- a/test/schemas/llm.application/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/3.0/ConstantAtomicTagged.json
@@ -25,6 +25,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -68,6 +69,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -99,6 +101,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -138,6 +141,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               },
               {
@@ -175,6 +179,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -207,6 +212,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -239,6 +245,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   },
                   {
@@ -278,6 +285,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               },
               {

--- a/test/schemas/llm.application/3.0/TypeTagRange.json
+++ b/test/schemas/llm.application/3.0/TypeTagRange.json
@@ -21,24 +21,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -46,23 +51,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -109,24 +118,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -134,23 +148,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -185,24 +203,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -210,23 +233,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -269,24 +296,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -294,23 +326,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }
@@ -351,24 +387,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -376,23 +417,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -428,24 +473,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -453,23 +503,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -505,24 +559,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -530,23 +589,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -589,24 +652,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -614,23 +682,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }

--- a/test/schemas/llm.application/3.0/TypeTagType.json
+++ b/test/schemas/llm.application/3.0/TypeTagType.json
@@ -20,25 +20,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -80,25 +87,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -128,25 +142,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -184,25 +205,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [
@@ -238,25 +266,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -287,25 +322,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -336,25 +378,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -392,25 +441,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [

--- a/test/schemas/llm.application/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/3.1/ConstantAtomicTagged.json
@@ -32,6 +32,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -76,6 +77,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -112,6 +114,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -153,6 +156,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]
@@ -195,6 +199,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -233,6 +238,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -271,6 +277,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -317,6 +324,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/3.1/TypeTagRange.json
+++ b/test/schemas/llm.application/3.1/TypeTagRange.json
@@ -21,24 +21,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -46,23 +51,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -108,24 +117,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -133,23 +147,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -187,24 +205,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -212,23 +235,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -271,24 +298,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -296,23 +328,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }
@@ -356,24 +392,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -381,23 +422,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -437,24 +482,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -462,23 +512,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -518,24 +572,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -543,23 +602,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -607,24 +670,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -632,23 +700,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }

--- a/test/schemas/llm.application/3.1/TypeTagType.json
+++ b/test/schemas/llm.application/3.1/TypeTagType.json
@@ -20,25 +20,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -79,25 +86,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -130,25 +144,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -186,25 +207,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [
@@ -243,25 +271,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -296,25 +331,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -349,25 +391,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -410,25 +459,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
@@ -25,7 +25,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@maximum 100\n@format uint32"
                   },
                   {
                     "type": "number",
@@ -68,7 +68,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@maximum 100\n@format uint32"
                   },
                   {
                     "type": "number",
@@ -103,7 +103,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@maximum 100\n@format uint32"
                       },
                       {
                         "type": "number",
@@ -143,7 +143,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "description": "@maximum 100"
+                "description": "@maximum 100\n@format uint32"
               },
               {
                 "type": "number",
@@ -184,7 +184,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@maximum 100\n@format uint32"
                       },
                       {
                         "type": "number",
@@ -221,7 +221,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@maximum 100\n@format uint32"
                       },
                       {
                         "type": "number",
@@ -258,7 +258,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@maximum 100\n@format uint32"
                       },
                       {
                         "type": "number",
@@ -303,7 +303,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@maximum 100\n@format uint32"
                   },
                   {
                     "type": "number",

--- a/test/schemas/llm.application/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagRange.json
@@ -20,39 +20,39 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal": {
-                      "description": "@minimum 3",
+                      "description": "@minimum 3\n@format int32",
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "less_equal": {
-                      "description": "@maximum 7",
+                      "description": "@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
-                      "description": "@minimum 3\n@maximum 7",
+                      "description": "@minimum 3\n@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "equal": {
-                      "description": "@minimum 10\n@maximum 10",
+                      "description": "@minimum 10\n@maximum 10\n@format int32",
                       "type": "integer"
                     }
                   },
@@ -96,39 +96,39 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal": {
-                      "description": "@minimum 3",
+                      "description": "@minimum 3\n@format int32",
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "less_equal": {
-                      "description": "@maximum 7",
+                      "description": "@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
-                      "description": "@minimum 3\n@maximum 7",
+                      "description": "@minimum 3\n@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "equal": {
-                      "description": "@minimum 10\n@maximum 10",
+                      "description": "@minimum 10\n@maximum 10\n@format int32",
                       "type": "integer"
                     }
                   },
@@ -164,39 +164,39 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal": {
-                          "description": "@minimum 3",
+                          "description": "@minimum 3\n@format int32",
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "less_equal": {
-                          "description": "@maximum 7",
+                          "description": "@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
-                          "description": "@minimum 3\n@maximum 7",
+                          "description": "@minimum 3\n@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "equal": {
-                          "description": "@minimum 10\n@maximum 10",
+                          "description": "@minimum 10\n@maximum 10\n@format int32",
                           "type": "integer"
                         }
                       },
@@ -237,39 +237,39 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal": {
-                  "description": "@minimum 3",
+                  "description": "@minimum 3\n@format int32",
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "less_equal": {
-                  "description": "@maximum 7",
+                  "description": "@maximum 7\n@format int32",
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {
-                  "description": "@minimum 3\n@maximum 7",
+                  "description": "@minimum 3\n@maximum 7\n@format int32",
                   "type": "integer"
                 },
                 "equal": {
-                  "description": "@minimum 10\n@maximum 10",
+                  "description": "@minimum 10\n@maximum 10\n@format int32",
                   "type": "integer"
                 }
               },
@@ -311,39 +311,39 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal": {
-                          "description": "@minimum 3",
+                          "description": "@minimum 3\n@format int32",
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "less_equal": {
-                          "description": "@maximum 7",
+                          "description": "@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
-                          "description": "@minimum 3\n@maximum 7",
+                          "description": "@minimum 3\n@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "equal": {
-                          "description": "@minimum 10\n@maximum 10",
+                          "description": "@minimum 10\n@maximum 10\n@format int32",
                           "type": "integer"
                         }
                       },
@@ -381,39 +381,39 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal": {
-                          "description": "@minimum 3",
+                          "description": "@minimum 3\n@format int32",
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "less_equal": {
-                          "description": "@maximum 7",
+                          "description": "@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
-                          "description": "@minimum 3\n@maximum 7",
+                          "description": "@minimum 3\n@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "equal": {
-                          "description": "@minimum 10\n@maximum 10",
+                          "description": "@minimum 10\n@maximum 10\n@format int32",
                           "type": "integer"
                         }
                       },
@@ -451,39 +451,39 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal": {
-                          "description": "@minimum 3",
+                          "description": "@minimum 3\n@format int32",
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "less_equal": {
-                          "description": "@maximum 7",
+                          "description": "@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
-                          "description": "@minimum 3\n@maximum 7",
+                          "description": "@minimum 3\n@maximum 7\n@format int32",
                           "type": "integer"
                         },
                         "equal": {
-                          "description": "@minimum 10\n@maximum 10",
+                          "description": "@minimum 10\n@maximum 10\n@format int32",
                           "type": "integer"
                         }
                       },
@@ -529,39 +529,39 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal": {
-                      "description": "@minimum 3",
+                      "description": "@minimum 3\n@format int32",
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "less_equal": {
-                      "description": "@maximum 7",
+                      "description": "@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
-                      "description": "@minimum 3\n@maximum 7",
+                      "description": "@minimum 3\n@maximum 7\n@format int32",
                       "type": "integer"
                     },
                     "equal": {
-                      "description": "@minimum 10\n@maximum 10",
+                      "description": "@minimum 10\n@maximum 10\n@format int32",
                       "type": "integer"
                     }
                   },

--- a/test/schemas/llm.application/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagType.json
@@ -20,24 +20,31 @@
                   "type": "object",
                   "properties": {
                     "int": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int32": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int64": {
+                      "description": "@format int64",
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@format uint64",
                       "type": "integer"
                     },
                     "float": {
+                      "description": "@format float",
                       "type": "number"
                     }
                   },
@@ -79,24 +86,31 @@
                   "type": "object",
                   "properties": {
                     "int": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int32": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int64": {
+                      "description": "@format int64",
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@format uint64",
                       "type": "integer"
                     },
                     "float": {
+                      "description": "@format float",
                       "type": "number"
                     }
                   },
@@ -130,24 +144,31 @@
                       "type": "object",
                       "properties": {
                         "int": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int32": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int64": {
+                          "description": "@format int64",
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@format uint64",
                           "type": "integer"
                         },
                         "float": {
+                          "description": "@format float",
                           "type": "number"
                         }
                       },
@@ -186,24 +207,31 @@
               "type": "object",
               "properties": {
                 "int": {
+                  "description": "@format int32",
                   "type": "integer"
                 },
                 "uint": {
+                  "description": "@format uint32",
                   "type": "integer"
                 },
                 "int32": {
+                  "description": "@format int32",
                   "type": "integer"
                 },
                 "uint32": {
+                  "description": "@format uint32",
                   "type": "integer"
                 },
                 "int64": {
+                  "description": "@format int64",
                   "type": "integer"
                 },
                 "uint64": {
+                  "description": "@format uint64",
                   "type": "integer"
                 },
                 "float": {
+                  "description": "@format float",
                   "type": "number"
                 }
               },
@@ -243,24 +271,31 @@
                       "type": "object",
                       "properties": {
                         "int": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int32": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int64": {
+                          "description": "@format int64",
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@format uint64",
                           "type": "integer"
                         },
                         "float": {
+                          "description": "@format float",
                           "type": "number"
                         }
                       },
@@ -296,24 +331,31 @@
                       "type": "object",
                       "properties": {
                         "int": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int32": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int64": {
+                          "description": "@format int64",
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@format uint64",
                           "type": "integer"
                         },
                         "float": {
+                          "description": "@format float",
                           "type": "number"
                         }
                       },
@@ -349,24 +391,31 @@
                       "type": "object",
                       "properties": {
                         "int": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int32": {
+                          "description": "@format int32",
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@format uint32",
                           "type": "integer"
                         },
                         "int64": {
+                          "description": "@format int64",
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@format uint64",
                           "type": "integer"
                         },
                         "float": {
+                          "description": "@format float",
                           "type": "number"
                         }
                       },
@@ -410,24 +459,31 @@
                   "type": "object",
                   "properties": {
                     "int": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int32": {
+                      "description": "@format int32",
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@format uint32",
                       "type": "integer"
                     },
                     "int64": {
+                      "description": "@format int64",
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@format uint64",
                       "type": "integer"
                     },
                     "float": {
+                      "description": "@format float",
                       "type": "number"
                     }
                   },

--- a/test/schemas/llm.application/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/claude/ConstantAtomicTagged.json
@@ -31,6 +31,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -75,6 +76,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -111,6 +113,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -152,6 +155,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]
@@ -194,6 +198,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -232,6 +237,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -270,6 +276,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -316,6 +323,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/claude/TypeTagRange.json
+++ b/test/schemas/llm.application/claude/TypeTagRange.json
@@ -20,24 +20,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -45,23 +50,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -107,24 +116,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -132,23 +146,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -186,24 +204,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -211,23 +234,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -270,24 +297,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -295,23 +327,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }
@@ -355,24 +391,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -380,23 +421,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -436,24 +481,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -461,23 +511,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -517,24 +571,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -542,23 +601,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -606,24 +669,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -631,23 +699,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }

--- a/test/schemas/llm.application/claude/TypeTagType.json
+++ b/test/schemas/llm.application/claude/TypeTagType.json
@@ -19,25 +19,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -78,25 +85,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -129,25 +143,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -185,25 +206,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [
@@ -242,25 +270,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -295,25 +330,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -348,25 +390,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -409,25 +458,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [

--- a/test/schemas/llm.application/gemini/TypeTagRange.json
+++ b/test/schemas/llm.application/gemini/TypeTagRange.json
@@ -20,39 +20,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -94,39 +94,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -157,39 +157,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -227,39 +227,39 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal": {
                   "type": "integer",
-                  "description": "@minimum 3"
+                  "description": "@minimum 3\n@format int32"
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "less_equal": {
                   "type": "integer",
-                  "description": "@maximum 7"
+                  "description": "@maximum 7\n@format int32"
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7"
+                  "description": "@minimum 3\n@maximum 7\n@format int32"
                 },
                 "equal": {
                   "type": "integer",
-                  "description": "@minimum 10\n@maximum 10"
+                  "description": "@minimum 10\n@maximum 10\n@format int32"
                 }
               },
               "required": [
@@ -296,39 +296,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -360,39 +360,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -424,39 +424,39 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal": {
                       "type": "integer",
-                      "description": "@minimum 3"
+                      "description": "@minimum 3\n@format int32"
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "less_equal": {
                       "type": "integer",
-                      "description": "@maximum 7"
+                      "description": "@maximum 7\n@format int32"
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7"
+                      "description": "@minimum 3\n@maximum 7\n@format int32"
                     },
                     "equal": {
                       "type": "integer",
-                      "description": "@minimum 10\n@maximum 10"
+                      "description": "@minimum 10\n@maximum 10\n@format int32"
                     }
                   },
                   "required": [
@@ -494,39 +494,39 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal": {
                   "type": "integer",
-                  "description": "@minimum 3"
+                  "description": "@minimum 3\n@format int32"
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "less_equal": {
                   "type": "integer",
-                  "description": "@maximum 7"
+                  "description": "@maximum 7\n@format int32"
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7"
+                  "description": "@minimum 3\n@maximum 7\n@format int32"
                 },
                 "equal": {
                   "type": "integer",
-                  "description": "@minimum 10\n@maximum 10"
+                  "description": "@minimum 10\n@maximum 10\n@format int32"
                 }
               },
               "required": [

--- a/test/schemas/llm.application/gemini/TypeTagType.json
+++ b/test/schemas/llm.application/gemini/TypeTagType.json
@@ -19,25 +19,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -76,25 +83,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -122,25 +136,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -175,25 +196,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "@format float"
                 }
               },
               "required": [
@@ -227,25 +255,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -274,25 +309,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -321,25 +363,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@format uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "@format float"
                     }
                   },
                   "required": [
@@ -374,25 +423,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "@format float"
                 }
               },
               "required": [

--- a/test/schemas/llm.application/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/llama/ConstantAtomicTagged.json
@@ -31,6 +31,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -75,6 +76,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]
@@ -111,6 +113,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -152,6 +155,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]
@@ -194,6 +198,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -232,6 +237,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -270,6 +276,7 @@
                       },
                       {
                         "type": "integer",
+                        "format": "uint32",
                         "maximum": 100
                       }
                     ]
@@ -316,6 +323,7 @@
                   },
                   {
                     "type": "integer",
+                    "format": "uint32",
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/llama/TypeTagRange.json
+++ b/test/schemas/llm.application/llama/TypeTagRange.json
@@ -20,24 +20,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -45,23 +50,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -107,24 +116,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -132,23 +146,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }
@@ -186,24 +204,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -211,23 +234,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -270,24 +297,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -295,23 +327,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }
@@ -355,24 +391,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -380,23 +421,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -436,24 +481,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -461,23 +511,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -517,24 +571,29 @@
                       "properties": {
                         "greater": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3
                         },
                         "greater_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3
                         },
                         "less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "maximum": 7
                         },
                         "greater_less": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "exclusiveMaximum": true,
@@ -542,23 +601,27 @@
                         },
                         "greater_equal_less": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "exclusiveMaximum": true,
                           "maximum": 7
                         },
                         "greater_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "exclusiveMinimum": true,
                           "minimum": 3,
                           "maximum": 7
                         },
                         "greater_equal_less_equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 3,
                           "maximum": 7
                         },
                         "equal": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": 10,
                           "maximum": 10
                         }
@@ -606,24 +669,29 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3
                     },
                     "greater_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3
                     },
                     "less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "maximum": 7
                     },
                     "greater_less": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "exclusiveMaximum": true,
@@ -631,23 +699,27 @@
                     },
                     "greater_equal_less": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "exclusiveMaximum": true,
                       "maximum": 7
                     },
                     "greater_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "exclusiveMinimum": true,
                       "minimum": 3,
                       "maximum": 7
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 3,
                       "maximum": 7
                     },
                     "equal": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 10,
                       "maximum": 10
                     }

--- a/test/schemas/llm.application/llama/TypeTagType.json
+++ b/test/schemas/llm.application/llama/TypeTagType.json
@@ -19,25 +19,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -78,25 +85,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [
@@ -129,25 +143,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -185,25 +206,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [
@@ -242,25 +270,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -295,25 +330,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -348,25 +390,32 @@
                       "type": "object",
                       "properties": {
                         "int": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         },
                         "int64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         },
                         "float": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       },
                       "required": [
@@ -409,25 +458,32 @@
                   "type": "object",
                   "properties": {
                     "int": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "int64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     },
                     "float": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   },
                   "required": [

--- a/test/schemas/llm.parameters/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/3.0/ConstantAtomicTagged.json
@@ -15,6 +15,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             },
             {
@@ -46,6 +47,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             },
             {
@@ -78,6 +80,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             },
             {
@@ -109,6 +112,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             },
             {
@@ -143,6 +147,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               },
               {

--- a/test/schemas/llm.parameters/3.0/TypeTagRange.json
+++ b/test/schemas/llm.parameters/3.0/TypeTagRange.json
@@ -11,24 +11,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -36,23 +41,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -87,24 +96,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -112,23 +126,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -164,24 +182,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -189,23 +212,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -240,24 +267,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -265,23 +297,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -319,24 +355,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -344,23 +385,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }

--- a/test/schemas/llm.parameters/3.0/TypeTagType.json
+++ b/test/schemas/llm.parameters/3.0/TypeTagType.json
@@ -10,25 +10,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -58,25 +65,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -107,25 +121,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -155,25 +176,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -206,25 +234,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [

--- a/test/schemas/llm.parameters/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/3.1/ConstantAtomicTagged.json
@@ -22,6 +22,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -58,6 +59,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -91,6 +93,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -127,6 +130,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -162,6 +166,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/3.1/TypeTagRange.json
+++ b/test/schemas/llm.parameters/3.1/TypeTagRange.json
@@ -11,24 +11,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -36,23 +41,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -90,24 +99,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -115,23 +129,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -166,24 +184,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -191,23 +214,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -245,24 +272,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -270,23 +302,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -323,24 +359,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -348,23 +389,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }

--- a/test/schemas/llm.parameters/3.1/TypeTagType.json
+++ b/test/schemas/llm.parameters/3.1/TypeTagType.json
@@ -10,25 +10,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -61,25 +68,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -109,25 +123,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -160,25 +181,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -210,25 +238,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
@@ -15,7 +15,7 @@
           "anyOf": [
             {
               "type": "integer",
-              "description": "@maximum 100"
+              "description": "@maximum 100\n@format uint32"
             },
             {
               "type": "number",
@@ -50,7 +50,7 @@
               "anyOf": [
                 {
                   "type": "integer",
-                  "description": "@maximum 100"
+                  "description": "@maximum 100\n@format uint32"
                 },
                 {
                   "type": "number",
@@ -82,7 +82,7 @@
           "anyOf": [
             {
               "type": "integer",
-              "description": "@maximum 100"
+              "description": "@maximum 100\n@format uint32"
             },
             {
               "type": "number",
@@ -117,7 +117,7 @@
               "anyOf": [
                 {
                   "type": "integer",
-                  "description": "@maximum 100"
+                  "description": "@maximum 100\n@format uint32"
                 },
                 {
                   "type": "number",
@@ -151,7 +151,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "description": "@maximum 100"
+                "description": "@maximum 100\n@format uint32"
               },
               {
                 "type": "number",

--- a/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
@@ -10,39 +10,39 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal": {
-                "description": "@minimum 3",
+                "description": "@minimum 3\n@format int32",
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "less_equal": {
-                "description": "@maximum 7",
+                "description": "@maximum 7\n@format int32",
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
-                "description": "@minimum 3\n@maximum 7",
+                "description": "@minimum 3\n@maximum 7\n@format int32",
                 "type": "integer"
               },
               "equal": {
-                "description": "@minimum 10\n@maximum 10",
+                "description": "@minimum 10\n@maximum 10\n@format int32",
                 "type": "integer"
               }
             },
@@ -78,39 +78,39 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal": {
-                    "description": "@minimum 3",
+                    "description": "@minimum 3\n@format int32",
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "less_equal": {
-                    "description": "@maximum 7",
+                    "description": "@maximum 7\n@format int32",
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
-                    "description": "@minimum 3\n@maximum 7",
+                    "description": "@minimum 3\n@maximum 7\n@format int32",
                     "type": "integer"
                   },
                   "equal": {
-                    "description": "@minimum 10\n@maximum 10",
+                    "description": "@minimum 10\n@maximum 10\n@format int32",
                     "type": "integer"
                   }
                 },
@@ -143,39 +143,39 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal": {
-                "description": "@minimum 3",
+                "description": "@minimum 3\n@format int32",
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "less_equal": {
-                "description": "@maximum 7",
+                "description": "@maximum 7\n@format int32",
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
-                "description": "@minimum 3\n@maximum 7",
+                "description": "@minimum 3\n@maximum 7\n@format int32",
                 "type": "integer"
               },
               "equal": {
-                "description": "@minimum 10\n@maximum 10",
+                "description": "@minimum 10\n@maximum 10\n@format int32",
                 "type": "integer"
               }
             },
@@ -211,39 +211,39 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal": {
-                    "description": "@minimum 3",
+                    "description": "@minimum 3\n@format int32",
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "less_equal": {
-                    "description": "@maximum 7",
+                    "description": "@maximum 7\n@format int32",
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
-                    "description": "@minimum 3\n@maximum 7",
+                    "description": "@minimum 3\n@maximum 7\n@format int32",
                     "type": "integer"
                   },
                   "equal": {
-                    "description": "@minimum 10\n@maximum 10",
+                    "description": "@minimum 10\n@maximum 10\n@format int32",
                     "type": "integer"
                   }
                 },
@@ -278,39 +278,39 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal": {
-                  "description": "@minimum 3",
+                  "description": "@minimum 3\n@format int32",
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "less_equal": {
-                  "description": "@maximum 7",
+                  "description": "@maximum 7\n@format int32",
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {
-                  "description": "@minimum 3\n@maximum 7",
+                  "description": "@minimum 3\n@maximum 7\n@format int32",
                   "type": "integer"
                 },
                 "equal": {
-                  "description": "@minimum 10\n@maximum 10",
+                  "description": "@minimum 10\n@maximum 10\n@format int32",
                   "type": "integer"
                 }
               },

--- a/test/schemas/llm.parameters/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagType.json
@@ -10,24 +10,31 @@
             "type": "object",
             "properties": {
               "int": {
+                "description": "@format int32",
                 "type": "integer"
               },
               "uint": {
+                "description": "@format uint32",
                 "type": "integer"
               },
               "int32": {
+                "description": "@format int32",
                 "type": "integer"
               },
               "uint32": {
+                "description": "@format uint32",
                 "type": "integer"
               },
               "int64": {
+                "description": "@format int64",
                 "type": "integer"
               },
               "uint64": {
+                "description": "@format uint64",
                 "type": "integer"
               },
               "float": {
+                "description": "@format float",
                 "type": "number"
               }
             },
@@ -61,24 +68,31 @@
                 "type": "object",
                 "properties": {
                   "int": {
+                    "description": "@format int32",
                     "type": "integer"
                   },
                   "uint": {
+                    "description": "@format uint32",
                     "type": "integer"
                   },
                   "int32": {
+                    "description": "@format int32",
                     "type": "integer"
                   },
                   "uint32": {
+                    "description": "@format uint32",
                     "type": "integer"
                   },
                   "int64": {
+                    "description": "@format int64",
                     "type": "integer"
                   },
                   "uint64": {
+                    "description": "@format uint64",
                     "type": "integer"
                   },
                   "float": {
+                    "description": "@format float",
                     "type": "number"
                   }
                 },
@@ -109,24 +123,31 @@
             "type": "object",
             "properties": {
               "int": {
+                "description": "@format int32",
                 "type": "integer"
               },
               "uint": {
+                "description": "@format uint32",
                 "type": "integer"
               },
               "int32": {
+                "description": "@format int32",
                 "type": "integer"
               },
               "uint32": {
+                "description": "@format uint32",
                 "type": "integer"
               },
               "int64": {
+                "description": "@format int64",
                 "type": "integer"
               },
               "uint64": {
+                "description": "@format uint64",
                 "type": "integer"
               },
               "float": {
+                "description": "@format float",
                 "type": "number"
               }
             },
@@ -160,24 +181,31 @@
                 "type": "object",
                 "properties": {
                   "int": {
+                    "description": "@format int32",
                     "type": "integer"
                   },
                   "uint": {
+                    "description": "@format uint32",
                     "type": "integer"
                   },
                   "int32": {
+                    "description": "@format int32",
                     "type": "integer"
                   },
                   "uint32": {
+                    "description": "@format uint32",
                     "type": "integer"
                   },
                   "int64": {
+                    "description": "@format int64",
                     "type": "integer"
                   },
                   "uint64": {
+                    "description": "@format uint64",
                     "type": "integer"
                   },
                   "float": {
+                    "description": "@format float",
                     "type": "number"
                   }
                 },
@@ -210,24 +238,31 @@
               "type": "object",
               "properties": {
                 "int": {
+                  "description": "@format int32",
                   "type": "integer"
                 },
                 "uint": {
+                  "description": "@format uint32",
                   "type": "integer"
                 },
                 "int32": {
+                  "description": "@format int32",
                   "type": "integer"
                 },
                 "uint32": {
+                  "description": "@format uint32",
                   "type": "integer"
                 },
                 "int64": {
+                  "description": "@format int64",
                   "type": "integer"
                 },
                 "uint64": {
+                  "description": "@format uint64",
                   "type": "integer"
                 },
                 "float": {
+                  "description": "@format float",
                   "type": "number"
                 }
               },

--- a/test/schemas/llm.parameters/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/claude/ConstantAtomicTagged.json
@@ -22,6 +22,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -58,6 +59,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -91,6 +93,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -127,6 +130,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -162,6 +166,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/claude/TypeTagRange.json
+++ b/test/schemas/llm.parameters/claude/TypeTagRange.json
@@ -11,24 +11,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -36,23 +41,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -90,24 +99,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -115,23 +129,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -166,24 +184,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -191,23 +214,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -245,24 +272,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -270,23 +302,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -323,24 +359,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -348,23 +389,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }

--- a/test/schemas/llm.parameters/claude/TypeTagType.json
+++ b/test/schemas/llm.parameters/claude/TypeTagType.json
@@ -10,25 +10,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -61,25 +68,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -109,25 +123,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -160,25 +181,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -210,25 +238,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [

--- a/test/schemas/llm.parameters/gemini/TypeTagRange.json
+++ b/test/schemas/llm.parameters/gemini/TypeTagRange.json
@@ -11,39 +11,39 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal": {
                 "type": "integer",
-                "description": "@minimum 3"
+                "description": "@minimum 3\n@format int32"
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "less_equal": {
                 "type": "integer",
-                "description": "@maximum 7"
+                "description": "@maximum 7\n@format int32"
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7"
+                "description": "@minimum 3\n@maximum 7\n@format int32"
               },
               "equal": {
                 "type": "integer",
-                "description": "@minimum 10\n@maximum 10"
+                "description": "@minimum 10\n@maximum 10\n@format int32"
               }
             },
             "required": [
@@ -74,39 +74,39 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal": {
                 "type": "integer",
-                "description": "@minimum 3"
+                "description": "@minimum 3\n@format int32"
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "less_equal": {
                 "type": "integer",
-                "description": "@maximum 7"
+                "description": "@maximum 7\n@format int32"
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7"
+                "description": "@minimum 3\n@maximum 7\n@format int32"
               },
               "equal": {
                 "type": "integer",
-                "description": "@minimum 10\n@maximum 10"
+                "description": "@minimum 10\n@maximum 10\n@format int32"
               }
             },
             "required": [
@@ -138,39 +138,39 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal": {
                 "type": "integer",
-                "description": "@minimum 3"
+                "description": "@minimum 3\n@format int32"
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "less_equal": {
                 "type": "integer",
-                "description": "@maximum 7"
+                "description": "@maximum 7\n@format int32"
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7"
+                "description": "@minimum 3\n@maximum 7\n@format int32"
               },
               "equal": {
                 "type": "integer",
-                "description": "@minimum 10\n@maximum 10"
+                "description": "@minimum 10\n@maximum 10\n@format int32"
               }
             },
             "required": [
@@ -201,39 +201,39 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal": {
                 "type": "integer",
-                "description": "@minimum 3"
+                "description": "@minimum 3\n@format int32"
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "less_equal": {
                 "type": "integer",
-                "description": "@maximum 7"
+                "description": "@maximum 7\n@format int32"
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7"
+                "description": "@minimum 3\n@maximum 7\n@format int32"
               },
               "equal": {
                 "type": "integer",
-                "description": "@minimum 10\n@maximum 10"
+                "description": "@minimum 10\n@maximum 10\n@format int32"
               }
             },
             "required": [
@@ -267,39 +267,39 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal": {
                   "type": "integer",
-                  "description": "@minimum 3"
+                  "description": "@minimum 3\n@format int32"
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "less_equal": {
                   "type": "integer",
-                  "description": "@maximum 7"
+                  "description": "@maximum 7\n@format int32"
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7"
+                  "description": "@minimum 3\n@maximum 7\n@format int32"
                 },
                 "equal": {
                   "type": "integer",
-                  "description": "@minimum 10\n@maximum 10"
+                  "description": "@minimum 10\n@maximum 10\n@format int32"
                 }
               },
               "required": [

--- a/test/schemas/llm.parameters/gemini/TypeTagType.json
+++ b/test/schemas/llm.parameters/gemini/TypeTagType.json
@@ -10,25 +10,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "description": "@format float"
               }
             },
             "required": [
@@ -56,25 +63,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "description": "@format float"
               }
             },
             "required": [
@@ -103,25 +117,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "description": "@format float"
               }
             },
             "required": [
@@ -149,25 +170,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@format uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "description": "@format float"
               }
             },
             "required": [
@@ -198,25 +226,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@format uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "@format float"
                 }
               },
               "required": [

--- a/test/schemas/llm.parameters/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/llama/ConstantAtomicTagged.json
@@ -22,6 +22,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -58,6 +59,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -91,6 +93,7 @@
             },
             {
               "type": "integer",
+              "format": "uint32",
               "maximum": 100
             }
           ]
@@ -127,6 +130,7 @@
                 },
                 {
                   "type": "integer",
+                  "format": "uint32",
                   "maximum": 100
                 }
               ]
@@ -162,6 +166,7 @@
               },
               {
                 "type": "integer",
+                "format": "uint32",
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/llama/TypeTagRange.json
+++ b/test/schemas/llm.parameters/llama/TypeTagRange.json
@@ -11,24 +11,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -36,23 +41,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -90,24 +99,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -115,23 +129,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -166,24 +184,29 @@
             "properties": {
               "greater": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3
               },
               "greater_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3
               },
               "less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "maximum": 7
               },
               "greater_less": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "exclusiveMaximum": true,
@@ -191,23 +214,27 @@
               },
               "greater_equal_less": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "exclusiveMaximum": true,
                 "maximum": 7
               },
               "greater_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "exclusiveMinimum": true,
                 "minimum": 3,
                 "maximum": 7
               },
               "greater_equal_less_equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 3,
                 "maximum": 7
               },
               "equal": {
                 "type": "integer",
+                "format": "int32",
                 "minimum": 10,
                 "maximum": 10
               }
@@ -245,24 +272,29 @@
                 "properties": {
                   "greater": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3
                   },
                   "greater_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3
                   },
                   "less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "maximum": 7
                   },
                   "greater_less": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "exclusiveMaximum": true,
@@ -270,23 +302,27 @@
                   },
                   "greater_equal_less": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "exclusiveMaximum": true,
                     "maximum": 7
                   },
                   "greater_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "exclusiveMinimum": true,
                     "minimum": 3,
                     "maximum": 7
                   },
                   "greater_equal_less_equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 3,
                     "maximum": 7
                   },
                   "equal": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 10,
                     "maximum": 10
                   }
@@ -323,24 +359,29 @@
               "properties": {
                 "greater": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3
                 },
                 "greater_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3
                 },
                 "less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "maximum": 7
                 },
                 "greater_less": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "exclusiveMaximum": true,
@@ -348,23 +389,27 @@
                 },
                 "greater_equal_less": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "exclusiveMaximum": true,
                   "maximum": 7
                 },
                 "greater_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "exclusiveMinimum": true,
                   "minimum": 3,
                   "maximum": 7
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 3,
                   "maximum": 7
                 },
                 "equal": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 10,
                   "maximum": 10
                 }

--- a/test/schemas/llm.parameters/llama/TypeTagType.json
+++ b/test/schemas/llm.parameters/llama/TypeTagType.json
@@ -10,25 +10,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -61,25 +68,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -109,25 +123,32 @@
             "type": "object",
             "properties": {
               "int": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int32"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint32"
               },
               "int64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "format": "uint64"
               },
               "float": {
-                "type": "number"
+                "type": "number",
+                "format": "float"
               }
             },
             "required": [
@@ -160,25 +181,32 @@
                 "type": "object",
                 "properties": {
                   "int": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint32"
                   },
                   "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "float": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float"
                   }
                 },
                 "required": [
@@ -210,25 +238,32 @@
               "type": "object",
               "properties": {
                 "int": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint32"
                 },
                 "int64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "int64"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "format": "uint64"
                 },
                 "float": {
-                  "type": "number"
+                  "type": "number",
+                  "format": "float"
                 }
               },
               "required": [

--- a/test/schemas/llm.schema/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/3.0/ConstantAtomicTagged.json
@@ -12,6 +12,7 @@
       "oneOf": [
         {
           "type": "integer",
+          "format": "uint32",
           "maximum": 100
         },
         {

--- a/test/schemas/llm.schema/3.0/TypeTagRange.json
+++ b/test/schemas/llm.schema/3.0/TypeTagRange.json
@@ -8,24 +8,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -33,23 +38,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/llm.schema/3.0/TypeTagType.json
+++ b/test/schemas/llm.schema/3.0/TypeTagType.json
@@ -7,25 +7,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/llm.schema/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/3.1/ConstantAtomicTagged.json
@@ -19,6 +19,7 @@
         },
         {
           "type": "integer",
+          "format": "uint32",
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/3.1/TypeTagRange.json
+++ b/test/schemas/llm.schema/3.1/TypeTagRange.json
@@ -8,24 +8,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -33,23 +38,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/llm.schema/3.1/TypeTagType.json
+++ b/test/schemas/llm.schema/3.1/TypeTagType.json
@@ -7,25 +7,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/llm.schema/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/chatgpt/ConstantAtomicTagged.json
@@ -12,7 +12,7 @@
       "anyOf": [
         {
           "type": "integer",
-          "description": "@maximum 100"
+          "description": "@maximum 100\n@format uint32"
         },
         {
           "type": "number",

--- a/test/schemas/llm.schema/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagRange.json
@@ -7,39 +7,39 @@
         "type": "object",
         "properties": {
           "greater": {
-            "description": "@minimum 3\n@exclusiveMinimum true",
+            "description": "@minimum 3\n@exclusiveMinimum true\n@format int32",
             "type": "integer"
           },
           "greater_equal": {
-            "description": "@minimum 3",
+            "description": "@minimum 3\n@format int32",
             "type": "integer"
           },
           "less": {
-            "description": "@maximum 7\n@exclusiveMaximum true",
+            "description": "@maximum 7\n@exclusiveMaximum true\n@format int32",
             "type": "integer"
           },
           "less_equal": {
-            "description": "@maximum 7",
+            "description": "@maximum 7\n@format int32",
             "type": "integer"
           },
           "greater_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32",
             "type": "integer"
           },
           "greater_equal_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32",
             "type": "integer"
           },
           "greater_less_equal": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32",
             "type": "integer"
           },
           "greater_equal_less_equal": {
-            "description": "@minimum 3\n@maximum 7",
+            "description": "@minimum 3\n@maximum 7\n@format int32",
             "type": "integer"
           },
           "equal": {
-            "description": "@minimum 10\n@maximum 10",
+            "description": "@minimum 10\n@maximum 10\n@format int32",
             "type": "integer"
           }
         },

--- a/test/schemas/llm.schema/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagType.json
@@ -7,24 +7,31 @@
         "type": "object",
         "properties": {
           "int": {
+            "description": "@format int32",
             "type": "integer"
           },
           "uint": {
+            "description": "@format uint32",
             "type": "integer"
           },
           "int32": {
+            "description": "@format int32",
             "type": "integer"
           },
           "uint32": {
+            "description": "@format uint32",
             "type": "integer"
           },
           "int64": {
+            "description": "@format int64",
             "type": "integer"
           },
           "uint64": {
+            "description": "@format uint64",
             "type": "integer"
           },
           "float": {
+            "description": "@format float",
             "type": "number"
           }
         },

--- a/test/schemas/llm.schema/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/claude/ConstantAtomicTagged.json
@@ -19,6 +19,7 @@
         },
         {
           "type": "integer",
+          "format": "uint32",
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/claude/TypeTagRange.json
+++ b/test/schemas/llm.schema/claude/TypeTagRange.json
@@ -8,24 +8,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -33,23 +38,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/llm.schema/claude/TypeTagType.json
+++ b/test/schemas/llm.schema/claude/TypeTagType.json
@@ -7,25 +7,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/llm.schema/gemini/TypeTagRange.json
+++ b/test/schemas/llm.schema/gemini/TypeTagRange.json
@@ -8,39 +8,39 @@
         "properties": {
           "greater": {
             "type": "integer",
-            "description": "@minimum 3\n@exclusiveMinimum true"
+            "description": "@minimum 3\n@exclusiveMinimum true\n@format int32"
           },
           "greater_equal": {
             "type": "integer",
-            "description": "@minimum 3"
+            "description": "@minimum 3\n@format int32"
           },
           "less": {
             "type": "integer",
-            "description": "@maximum 7\n@exclusiveMaximum true"
+            "description": "@maximum 7\n@exclusiveMaximum true\n@format int32"
           },
           "less_equal": {
             "type": "integer",
-            "description": "@maximum 7"
+            "description": "@maximum 7\n@format int32"
           },
           "greater_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true\n@format int32"
           },
           "greater_equal_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true\n@format int32"
           },
           "greater_less_equal": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@format int32"
           },
           "greater_equal_less_equal": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7"
+            "description": "@minimum 3\n@maximum 7\n@format int32"
           },
           "equal": {
             "type": "integer",
-            "description": "@minimum 10\n@maximum 10"
+            "description": "@minimum 10\n@maximum 10\n@format int32"
           }
         },
         "required": [

--- a/test/schemas/llm.schema/gemini/TypeTagType.json
+++ b/test/schemas/llm.schema/gemini/TypeTagType.json
@@ -7,25 +7,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@format uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "description": "@format float"
           }
         },
         "required": [

--- a/test/schemas/llm.schema/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/llama/ConstantAtomicTagged.json
@@ -19,6 +19,7 @@
         },
         {
           "type": "integer",
+          "format": "uint32",
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/llama/TypeTagRange.json
+++ b/test/schemas/llm.schema/llama/TypeTagRange.json
@@ -8,24 +8,29 @@
         "properties": {
           "greater": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3
           },
           "greater_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3
           },
           "less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "less_equal": {
             "type": "integer",
+            "format": "int32",
             "maximum": 7
           },
           "greater_less": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "exclusiveMaximum": true,
@@ -33,23 +38,27 @@
           },
           "greater_equal_less": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "exclusiveMaximum": true,
             "maximum": 7
           },
           "greater_less_equal": {
             "type": "integer",
+            "format": "int32",
             "exclusiveMinimum": true,
             "minimum": 3,
             "maximum": 7
           },
           "greater_equal_less_equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 3,
             "maximum": 7
           },
           "equal": {
             "type": "integer",
+            "format": "int32",
             "minimum": 10,
             "maximum": 10
           }

--- a/test/schemas/llm.schema/llama/TypeTagType.json
+++ b/test/schemas/llm.schema/llama/TypeTagType.json
@@ -7,25 +7,32 @@
         "type": "object",
         "properties": {
           "int": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int32"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint32"
           },
           "int64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "float": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           }
         },
         "required": [

--- a/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
@@ -664,7 +664,8 @@
                     "validate": "$importInternal(\"isTypeInt32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 ]
@@ -710,7 +711,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     }
                   }
                 ]
@@ -756,7 +758,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     }
                   }
                 ]
@@ -802,7 +805,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     }
                   }
                 ]
@@ -848,7 +852,8 @@
                     "validate": "$importInternal(\"isTypeFloat\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   }
                 ]
@@ -894,7 +899,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "double"
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
@@ -664,7 +664,8 @@
                     "validate": "$importInternal(\"isTypeInt32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 ]
@@ -710,7 +711,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     }
                   }
                 ]
@@ -756,7 +758,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     }
                   }
                 ]
@@ -802,7 +805,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     }
                   }
                 ]
@@ -848,7 +852,8 @@
                     "validate": "$importInternal(\"isTypeFloat\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   }
                 ]
@@ -894,7 +899,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "double"
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
@@ -664,7 +664,8 @@
                     "validate": "$importInternal(\"isTypeInt32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 ]
@@ -710,7 +711,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     }
                   }
                 ]
@@ -756,7 +758,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int64"
                     }
                   }
                 ]
@@ -802,7 +805,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint64"
                     }
                   }
                 ]
@@ -848,7 +852,8 @@
                     "validate": "$importInternal(\"isTypeFloat\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "float"
                     }
                   }
                 ]
@@ -894,7 +899,8 @@
                     "validate": "true",
                     "exclusive": true,
                     "schema": {
-                      "type": "number"
+                      "type": "number",
+                      "format": "double"
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ConstantAtomicTagged.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicTagged.json
@@ -163,7 +163,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       },
                       {

--- a/test/schemas/reflect/metadata/DynamicTag.json
+++ b/test/schemas/reflect/metadata/DynamicTag.json
@@ -106,7 +106,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/MapSimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobuf.json
@@ -226,7 +226,8 @@
                               "validate": "$importInternal(\"isTypeInt32\")($input)",
                               "exclusive": true,
                               "schema": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int32"
                               }
                             }
                           ]

--- a/test/schemas/reflect/metadata/MapSimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobufNullable.json
@@ -226,7 +226,8 @@
                               "validate": "$importInternal(\"isTypeInt32\")($input)",
                               "exclusive": true,
                               "schema": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int32"
                               }
                             }
                           ]

--- a/test/schemas/reflect/metadata/MapSimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobufOptional.json
@@ -226,7 +226,8 @@
                               "validate": "$importInternal(\"isTypeInt32\")($input)",
                               "exclusive": true,
                               "schema": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int32"
                               }
                             }
                           ]

--- a/test/schemas/reflect/metadata/ObjectHttpFormData.json
+++ b/test/schemas/reflect/metadata/ObjectHttpFormData.json
@@ -478,7 +478,8 @@
                     "validate": "$importInternal(\"isTypeInt32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
+++ b/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
@@ -79,7 +79,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -150,7 +151,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
@@ -165,7 +165,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       },
                       {

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
@@ -136,7 +136,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -207,7 +208,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -335,7 +337,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -406,7 +409,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ]
@@ -477,7 +481,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
@@ -136,7 +136,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -207,7 +208,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -335,7 +337,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -406,7 +409,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ]
@@ -477,7 +481,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
@@ -136,7 +136,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -207,7 +208,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -335,7 +337,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -406,7 +409,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ]
@@ -477,7 +481,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagInfinite.json
+++ b/test/schemas/reflect/metadata/TypeTagInfinite.json
@@ -443,7 +443,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagNaN.json
+++ b/test/schemas/reflect/metadata/TypeTagNaN.json
@@ -443,7 +443,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagRange.json
+++ b/test/schemas/reflect/metadata/TypeTagRange.json
@@ -147,7 +147,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -233,7 +234,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -318,7 +320,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -404,7 +407,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -489,7 +493,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -590,7 +595,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -690,7 +696,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -790,7 +797,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {
@@ -889,7 +897,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       },
                       {

--- a/test/schemas/reflect/metadata/TypeTagType.json
+++ b/test/schemas/reflect/metadata/TypeTagType.json
@@ -147,7 +147,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -218,7 +219,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -289,7 +291,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ]
@@ -360,7 +363,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -431,7 +435,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ]
@@ -502,7 +507,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -573,7 +579,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
@@ -136,7 +136,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagTypeUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeUnion.json
@@ -79,7 +79,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -92,7 +93,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ]
@@ -163,7 +165,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -176,7 +179,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ]
@@ -247,7 +251,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -260,7 +265,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -331,7 +337,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -344,7 +351,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ]
@@ -415,7 +423,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -428,7 +437,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ]
@@ -499,7 +509,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ],
@@ -512,7 +523,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]
@@ -583,7 +595,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ],
@@ -596,7 +609,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ]
@@ -667,7 +681,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ],
@@ -680,7 +695,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ]
@@ -751,7 +767,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ],
@@ -764,7 +781,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ]
@@ -835,7 +853,8 @@
                         "validate": "$importInternal(\"isTypeInt32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int32"
                         }
                       }
                     ],
@@ -848,7 +867,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint32"
                         }
                       }
                     ],
@@ -861,7 +881,8 @@
                         "validate": "$importInternal(\"isTypeFloat\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "float"
                         }
                       }
                     ],
@@ -874,7 +895,8 @@
                         "validate": "true",
                         "exclusive": true,
                         "schema": {
-                          "type": "number"
+                          "type": "number",
+                          "format": "double"
                         }
                       }
                     ],
@@ -887,7 +909,8 @@
                         "validate": "$importInternal(\"isTypeInt64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "int64"
                         }
                       }
                     ],
@@ -900,7 +923,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint64"
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -1381,6 +1381,63 @@
                   "type": "string",
                   "values": [
                     {
+                      "value": "format",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Format restriction.",
+            "jsDocTags": []
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
                       "value": "minimum",
                       "tags": []
                     }
@@ -2883,6 +2940,63 @@
                 ]
               }
             ]
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "format",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Format restriction.",
+            "jsDocTags": []
           },
           {
             "key": {


### PR DESCRIPTION
This pull request includes several updates to the `typia` package, focusing on version upgrades and the addition of a `format` property to various JSON schema definitions. The most important changes are summarized below:

### Version Upgrades:
* Updated the `typia` package version to `7.6.0-dev.20241229` and the `@samchon/openapi` dependency to `^2.4.0-dev.20241229` in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R52)
* Updated the `typescript-json` package version to `7.6.0-dev.20241229` and the `typia` dependency to `7.6.0-dev.20241229` in `packages/typescript-json/package.json`. [[1]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L3-R3) [[2]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L40-R43)

### JSON Schema Enhancements:
* Added the `format` property to the `Type` type definition in `src/tags/Type.ts`.
* Added the `format` property to various JSON schema definitions in the `test/schemas/json.schemas` directory. [[1]](diffhunk://#diff-f33ba44ed8649fde416e034ff5284af6c06bd6e5d05f0579d94b1a2124240da0R19) [[2]](diffhunk://#diff-c3cbd9fe9cae7c687a85627c2a653d7a7c5ace4bc30c573c671eca6d591cdfb8R24-R74) [[3]](diffhunk://#diff-19a00b7cb04538d06f2a76d66e0857bfae8b4a8605a6ec5b255853ae2474e09aL23-R48) [[4]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeR194-R198) [[5]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeR366-R370) [[6]](diffhunk://#diff-8c787f89ccad740689641b23f233c2ed23161b2329a90291730e3b0457b1feeeR26) [[7]](diffhunk://#diff-96531d5ecaf5fe89927edd067388ed7bac6bca8c4cade84d35ddbef6e11686d9R24-R74) [[8]](diffhunk://#diff-4dc6555198459aae14a98b5f99b9e344f98ceffceee476485f6f4211e50b27d6L23-R48) [[9]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacR188-R192) [[10]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacR354-R358) [[11]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R28) [[12]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R72) [[13]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R104) [[14]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R144) [[15]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R182) [[16]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R215) [[17]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R248) [[18]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R288) [[19]](diffhunk://#diff-6e8d05a0734f1348392f2bc775567bc49d1e6ea1fffeeed01451915657204945R24-R74)

### Test Updates:
* Updated the test generation files to include the `format` property in the generated output. [[1]](diffhunk://#diff-bf75082abce30e0838cd4655af8d29451d6796f29df6bf0a6f76f0ac7374239fR1744) [[2]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4R42) [[3]](diffhunk://#diff-e1dfd187f1fd4410862cb916a63887d44058f338f6fb9d76ec85a1af90ae4bbdR1744)

### Documentation Updates:
* Added a link to the "Documentation Strategy" in the `packages/typescript-json/README.md`.