### PR TITLE
Fix samchon/nestia#1063: no `@default` comment tag support.

### DIFF
--- a/website/pages/docs/json/schema.mdx
+++ b/website/pages/docs/json/schema.mdx
@@ -139,7 +139,6 @@ If you write any comment on a property, it would fill the `IJsonSchema.descripti
   - `@hidden`
   - `@internal`
   - `@title {string}`
-  - `@default {value}`
 
 Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
 
@@ -183,7 +182,6 @@ interface Special {
    *
    * @exclusiveMinimum 19
    * @maximum 100
-   * @default 30
    */
   number?: number;
 

--- a/website/pages/docs/llm/schema.mdx
+++ b/website/pages/docs/llm/schema.mdx
@@ -452,7 +452,6 @@ If you write any comment on a property, it would fill the `IJsonSchema.descripti
   - `@hidden`
   - `@internal`
   - `@title {string}`
-  - `@default {value}`
 
 Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
 
@@ -496,7 +495,6 @@ interface Special {
    *
    * @exclusiveMinimum 19
    * @maximum 100
-   * @default 30
    */
   number?: number;
 

--- a/website/pages/docs/llm/strategy.mdx
+++ b/website/pages/docs/llm/strategy.mdx
@@ -1042,7 +1042,6 @@ interface Special {
    *
    * @exclusiveMinimum 19
    * @maximum 100
-   * @default 30
    */
   number?: number;
 
@@ -1160,7 +1159,6 @@ If you write any comment on a property, it would fill the `IJsonSchema.descripti
   - `@hidden`
   - `@internal`
   - `@title {string}`
-  - `@default {value}`
 
 Let's see how those [type tags](../validators/tags/#type-tags), comment tags and description comments are working with example code.
 


### PR DESCRIPTION
This pull request includes changes to the documentation files to remove the `@default` tag from various schema examples. The changes affect three different documentation files.

Changes to documentation:

* [`website/pages/docs/json/schema.mdx`](diffhunk://#diff-5ba46879958e93b711e4f8b8a9b0c8f15cf01fe2f10eb15bb3e4b18094725cebL142): Removed the `@default` tag from the example code in two places. [[1]](diffhunk://#diff-5ba46879958e93b711e4f8b8a9b0c8f15cf01fe2f10eb15bb3e4b18094725cebL142) [[2]](diffhunk://#diff-5ba46879958e93b711e4f8b8a9b0c8f15cf01fe2f10eb15bb3e4b18094725cebL186)
* [`website/pages/docs/llm/schema.mdx`](diffhunk://#diff-984efefe2098bace28f142e1040640c58dc2516e23bc5da1a7f744de9fce8e77L455): Removed the `@default` tag from the example code in two places. [[1]](diffhunk://#diff-984efefe2098bace28f142e1040640c58dc2516e23bc5da1a7f744de9fce8e77L455) [[2]](diffhunk://#diff-984efefe2098bace28f142e1040640c58dc2516e23bc5da1a7f744de9fce8e77L499)
* [`website/pages/docs/llm/strategy.mdx`](diffhunk://#diff-515fd128a8b0c460e51df13a06a7f44e012c8bfe8b887b07ea12ccd5abd18ad6L1045): Removed the `@default` tag from the example code in two places. [[1]](diffhunk://#diff-515fd128a8b0c460e51df13a06a7f44e012c8bfe8b887b07ea12ccd5abd18ad6L1045) [[2]](diffhunk://#diff-515fd128a8b0c460e51df13a06a7f44e012c8bfe8b887b07ea12ccd5abd18ad6L1163)