### PR TITLE
fix build for esm

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,8 +29,8 @@ module.exports = {
       }
       return `[name].${ext}`;
     },
-    // preserveModules: true,
-    // preserveModulesRoot: "src",
+    preserveModules: true,
+    preserveModulesRoot: "src",
     external: ["randexp"],
   },
   plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ module.exports = {
     },
     // preserveModules: true,
     // preserveModulesRoot: "src",
+    external: ["randexp"],
   },
   plugins: [
     nodeResolve(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,6 +101,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src"],
-  "exclude": ["src/cli"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Hi @samchon 
finally I fixed the rollup script.
I found that we don't have to include cjs conversion in build anymore because bun solved this problem
