### PR TITLE
Bump up `@samchon/openapi` version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
-    - [A.I. Chatbot](https://typia.io/docs/llm/chat/)
+    - [Super AI Chatbot](https://typia.io/docs/llm/chat/)
     - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
+    - [A.I. Chatbot](https://typia.io/docs/llm/chat/)
     - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -42,7 +42,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": ">=2.4.0 <3.0.0",
+    "@samchon/openapi": "^2.4.2",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -50,7 +50,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=2.4.0 <3.0.0",
+    "@samchon/openapi": ">=2.4.2 <3.0.0",
     "typescript": ">=4.8.0 <5.8.0"
   },
   "devDependencies": {
@@ -121,4 +121,3 @@
   ],
   "private": true
 }
-

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -134,6 +134,8 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
+    - [A.I. Chatbot](https://typia.io/docs/llm/chat/)
+    - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)
     - [`decode()` functions](https://typia.io/docs/protobuf/decode/)

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.5.0-dev.20241218",
+  "version": "7.6.1-dev.20250203",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -17,9 +17,10 @@
     "build": "rimraf lib && tsc && rollup -c",
     "dev": "rimraf lib && tsc --watch",
     "dev:errors": "tsc --project tsconfig.errors.json --watch",
-    "eslint": "eslint ./**/*.ts",
-    "eslint:fix": "eslint ./**/*.ts --fix",
-    "prettier": "prettier src --write",
+    "eslint": "eslint",
+    "eslint:fix": "eslint --fix",
+    "prettier": "prettier src --check",
+    "prettier:fix": "prettier src --write",
     "------------------------------------------------": "",
     "package:latest": "ts-node deploy --tag latest",
     "package:next": "ts-node deploy --tag next",
@@ -37,11 +38,11 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.5.0-dev.20241218"
+    "typia": "7.6.1-dev.20250203"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0 <5.8.0",
-    "@samchon/openapi": ">=2.3.0-dev.20241218 <3.0.0"
+    "@samchon/openapi": ">=2.4.2 <3.0.0",
+    "typescript": ">=4.8.0 <5.8.0"
   },
   "stackblitz": {
     "startCommand": "npm install && npm run test"

--- a/packages/typescript-json/tsconfig.json
+++ b/packages/typescript-json/tsconfig.json
@@ -101,6 +101,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src"],
-  "exclude": ["src/cli"]
+  "include": ["src"]
 }

--- a/test/schemas/json.schemas/v3_0/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_0/UltimateUnion.json
@@ -103,7 +103,7 @@
           }
         ],
         "title": "Type schema info",
-        "description": "Type schema info.\n\n`OpenApi.IJsonSchema` is a type schema info of the OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but a little bit shrinked to remove ambiguous and duplicated\nexpressions of OpenAPI v3.1 for the convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property: {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to {@link OpenApi.IJsonSchema.IReference}"
+        "description": "Type schema info.\n\n`OpenApi.IJsonSchema` is a type schema info of the OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but a little bit shrunk to remove ambiguous and duplicated\nexpressions of OpenAPI v3.1 for the convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property: {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to {@link OpenApi.IJsonSchema.IReference}"
       },
       "OpenApi.IJsonSchema.IString": {
         "type": "object",
@@ -439,7 +439,7 @@
           "minItems": {
             "type": "integer",
             "title": "Minimum items restriction",
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the array."
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the array."
           },
           "maxItems": {
             "type": "integer",
@@ -549,7 +549,7 @@
           "minItems": {
             "type": "integer",
             "title": "Minimum items restriction",
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the tuple."
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the tuple."
           },
           "maxItems": {
             "type": "integer",

--- a/test/schemas/json.schemas/v3_1/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_1/UltimateUnion.json
@@ -100,7 +100,7 @@
           }
         ],
         "title": "Type schema info",
-        "description": "Type schema info.\n\n`OpenApi.IJsonSchema` is a type schema info of the OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but a little bit shrinked to remove ambiguous and duplicated\nexpressions of OpenAPI v3.1 for the convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property: {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to {@link OpenApi.IJsonSchema.IReference}"
+        "description": "Type schema info.\n\n`OpenApi.IJsonSchema` is a type schema info of the OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but a little bit shrunk to remove ambiguous and duplicated\nexpressions of OpenAPI v3.1 for the convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property: {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to {@link OpenApi.IJsonSchema.IReference}"
       },
       "OpenApi.IJsonSchema.IString": {
         "type": "object",
@@ -424,7 +424,7 @@
           "minItems": {
             "type": "integer",
             "title": "Minimum items restriction",
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the array."
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the array."
           },
           "maxItems": {
             "type": "integer",
@@ -531,7 +531,7 @@
           "minItems": {
             "type": "integer",
             "title": "Minimum items restriction",
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the tuple."
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the tuple."
           },
           "maxItems": {
             "type": "integer",

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -3845,7 +3845,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the array.",
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the array.",
             "jsDocTags": [
               {
                 "name": "type",
@@ -4581,7 +4581,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Minimum items restriction.\n\nRestriction of minumum number of items in the tuple.",
+            "description": "Minimum items restriction.\n\nRestriction of minimum number of items in the tuple.",
             "jsDocTags": [
               {
                 "name": "type",

--- a/website/pages/docs/llm/_meta.js
+++ b/website/pages/docs/llm/_meta.js
@@ -2,6 +2,6 @@ export default {
   application: "application() functions",
   parameters: "parameters() function",
   schema: "schema() function",
-  chat: "A.I. Chatbot",
+  chat: "Super A.I. Chatbot",
   strategy: "Documentation Strategy",
 };

--- a/website/pages/docs/llm/chat.mdx
+++ b/website/pages/docs/llm/chat.mdx
@@ -36,7 +36,7 @@ npm create vite@latest bbs -- --template react-ts
 cd bbs
 
 npm install @nestia/agent @nestia/chat @samchon/openapi openai
-npx typia setup
+npx typia setup --project tsconfig.json
 npm install -D @ryoppippi/unplugin-typia
 ```
   </Tabs.Tab>
@@ -46,7 +46,7 @@ pnpm create vite@latest bbs -- --template react-ts
 cd bbs
 
 pnpm install @nestia/agent @nestia/chat @samchon/openapi openai
-pnpm typia setup
+pnpm typia setup --project tsconfig.json
 pnpm install -D @ryoppippi/unplugin-typia
 ```
   </Tabs.Tab>
@@ -56,7 +56,7 @@ yarn create vite@latest bbs --template react-ts
 cd bbs
 
 yarn add @nestia/agent @nestia/chat @samchon/openapi openai
-yarn typia setup
+yarn typia setup --project tsconfig.json
 yarn add -D @ryoppippi/unplugin-typia
 ```
   </Tabs.Tab>


### PR DESCRIPTION
This pull request includes updates to documentation links, dependency versions, and various JSON schema descriptions. The most important changes are summarized below:

### Documentation Updates:
* Added links for the A.I. Chatbot and Documentation Strategy in `README.md` and `packages/typescript-json/README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134) [[2]](diffhunk://#diff-b5a696c23887532ac5268d99c14127b48f7a9696f10815bdec7615809d4a9816R137-R138)

### Dependency Updates:
* Updated the version of `@samchon/openapi` in `package.json` and `packages/typescript-json/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R53) [[2]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L40-R45)

### Version Bumps:
* Bumped the version of `typia` to `7.6.1` in `package.json`.
* Bumped the version of `typescript-json` to `7.6.1-dev.20250203` in `packages/typescript-json/package.json`.

### Script Adjustments:
* Modified `eslint` and `prettier` scripts in `packages/typescript-json/package.json` for better command consistency.

### Typographical Corrections:
* Corrected spelling errors in JSON schema descriptions across multiple files. [[1]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL106-R106) [[2]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL442-R442) [[3]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL103-R103) [[4]](diffhunk://#diff-eff0b888324a2eca3e6f3cc44be773ab08101c02a0806b02a841c9997e2f0858L3848-R3848)