### PR TITLE
Add more gurubase document chatbot links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
 [![Build Status](https://github.com/samchon/typia/workflows/build/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://typia.io/docs/)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Typia%20Guru-006BFF)](https://gurubase.io/g/typia)
+[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
 ```typescript
@@ -131,7 +131,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
-    - [Super AI Chatbot](https://typia.io/docs/llm/chat/)
+    - [AI Chatbot Development](https://typia.io/docs/llm/chat/)
     - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)

--- a/website/pages/_meta.js
+++ b/website/pages/_meta.js
@@ -4,16 +4,19 @@ export default {
     type: "page",
     hidden: true,
     display: "hidden",
-    // theme: {
-    //   layout: "full",
-    // },
   },
   docs: {
     title: "📖 Guide Documents",
     type: "page",
   },
-  playground: {
-    title: "💻 Playground",
+  gurubase: {
     type: "page",
+    title: "💬 Document Chatbot",
+    href: "https://gurubase.io/g/typia",
+    newWindow: true,
   },
+  // playground: {
+  //   title: "💻 Playground",
+  //   type: "page",
+  // },
 };

--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -32,12 +32,12 @@ import Stack from '@mui/material/Stack';
   ],
   [
     "Guide Documents",
-    "https://img.shields.io/badge/guide-documents-forestgreen",
+    "https://img.shields.io/badge/Guide-Documents-forestgreen",
     "https://typia.io/docs/",
   ],
   [
     "Gurubase",
-    "https://img.shields.io/badge/Gurubase-Ask%20Typia%20Guru-006BFF",
+    "https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF",
     "https://gurubase.io/g/typia",
   ],
   [

--- a/website/pages/docs/llm/_meta.js
+++ b/website/pages/docs/llm/_meta.js
@@ -2,6 +2,6 @@ export default {
   application: "application() functions",
   parameters: "parameters() function",
   schema: "schema() function",
-  chat: "Super A.I. Chatbot",
+  chat: "AI Chatbot Development",
   strategy: "Documentation Strategy",
 };

--- a/website/pages/docs/llm/chat.mdx
+++ b/website/pages/docs/llm/chat.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide Documents > Large Language Model > A.I. Chatbot
+title: Guide Documents > Large Language Model > AI Chatbot Development
 ---
 import { Callout, Tabs } from 'nextra/components'
 

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -12,52 +12,8 @@ import HomeStrengthMovie from "../src/movies/home/HomeStrengthMovie";
 ## Transformer
 ![Typia Logo](/logo.png)
 
-{/* <span style={{ display: "flex", flexDirection: "row" }}>
-{[
-  [
-    "MIT License",
-    "https://img.shields.io/badge/license-MIT-blue.svg",
-    "https://github.com/samchon/typia/blob/master/LICENSE",
-  ],
-  [
-    "NPM Version",
-    "https://img.shields.io/npm/v/typia.svg",
-    "https://www.npmjs.com/package/typia",
-  ],
-  [
-    "NPM Downloads",
-    "https://img.shields.io/npm/dm/typia.svg",
-    "https://www.npmjs.com/package/typia",
-  ],
-  [
-    "Build Status",
-    "https://github.com/samchon/typia/workflows/build/badge.svg",
-    "https://github.com/samchon/typia/actions?query=workflow%3Abuild",
-  ],
-  [
-    "Guide Documents",
-    "https://img.shields.io/badge/guide-documents-forestgreen",
-    "https://typia.io/docs/",
-  ],
-  [
-    "Gurubase",
-    "https://img.shields.io/badge/Gurubase-Ask%20Typia%20Guru-006BFF",
-    "https://gurubase.io/g/typia",
-  ],
-  [
-    "Discord",
-    "https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ",
-    "https://discord.gg/E94XhzrUCZ",
-  ]
-].map(([alt, image, url]) => (
-  <a href={url} style={{ marginTop: "30px", marginRight: "6px" }}>
-      <img src={image} alt={alt} />
-  </a>
-))}
-</span> */}
-
 <center>
-[Guide Documents](/docs) · [Playground (Online IDE)](/playground) · [Github Repository](https://github.com/samchon/typia)
+[Guide Documents](/docs) ([Document Chatbot](https://gurubase.io/g/typia)) · [Playground (Online IDE)](/playground) · [Github Repository](https://github.com/samchon/typia)
 </center>
 
 `typia` is a transformer library converting TypeScript types to runtime function. 


### PR DESCRIPTION
This pull request includes several updates to the documentation and website for the `typia` project. The most important changes focus on rebranding and updating terminology related to the AI chatbot and guide documents.

Rebranding and terminology updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R9): Updated badge labels and links to reflect the new terminology for the guide documents and AI chatbot. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R134)
* [`website/pages/_meta.js`](diffhunk://#diff-54bc2d530749150030c3c846b56e6da49ed548e3523d5462ad8bd32ca608958dL7-R21): Changed the `playground` section to `gurubase` with updated title and link for the document chatbot.
* [`website/pages/docs/index.mdx`](diffhunk://#diff-40599ca0c014adddd03e121c88203066eb27b33d4722f580769ceb026a3ac6d5L35-R40): Updated badge labels and links for the guide documents and AI chatbot.
* [`website/pages/docs/llm/_meta.js`](diffhunk://#diff-a217a071f8fd936d5630ca3a06c4ab03c6f7514683918b6a98ce96e624142e5bL5-R5): Updated the title for the AI chatbot section.
* [`website/pages/docs/llm/chat.mdx`](diffhunk://#diff-32e2198139f141d4524b1e0538d0d9595321b55d78846ade27e6c797b12d679cL2-R2): Updated the title to reflect the new terminology for AI chatbot development.

Additional changes:

* [`website/pages/index.mdx`](diffhunk://#diff-70ee476cc5c68fd7eccd52bb228fb294c7df548d7ae5d935f503c47421b55be6L15-R16): Updated the guide documents link to include the document chatbot.