### PR TITLE
Add tutorial video on docs/index.mdx

### DIFF
--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -111,6 +111,15 @@ export function random<T>(g?: Partial<IRandomGenerator>): T;
 
 
 ## Transformation
+<br/>
+<iframe src="https://www.youtube.com/embed/WM6LGy2UU6s?si=lZrqbILxHI22QwEE" 
+        title="Typia Tutorial Video" 
+        width="100%" 
+        height="500"
+        frameborder="0" 
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" 
+        allowfullscreen></iframe>
+
 If you call `typia` function, it would be compiled like below.
 
 This is the key concept of `typia`, transforming TypeScript type to a runtime function. The `typia.is<T>()` function is transformed to a dedicated type checker by analyzing the target type `T` in the compilation level.


### PR DESCRIPTION
This pull request includes an enhancement to the documentation on the website by embedding a tutorial video. The most important change is the addition of an iframe to display the video.

Documentation enhancement:

* [`website/pages/docs/index.mdx`](diffhunk://#diff-40599ca0c014adddd03e121c88203066eb27b33d4722f580769ceb026a3ac6d5R114-R122): Added an iframe to embed a YouTube video tutorial on the Typia transformation process.