### PR TITLE
fix(ci): use `npm pkg delete` to remove `private` instead of `jq`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,7 @@ jobs:
       - run: npm run build
       - name: remove `private=true` from package.json
         run: |
-          jq 'del(.private)' package.json > package.json.tmp
-          mv package.json.tmp package.json
+          npm pkg delete private
       - name: upload to pkg.pr.now
         run: npx pkg-pr-new publish --compact
       - name: Upload tgz for Artifactory


### PR DESCRIPTION
just a small change
This pull request includes a change to the `.github/workflows/build.yml` file to simplify the process of removing the `private` field from `package.json`.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L32-R32): Replaced the `jq` command with `npm pkg delete private` to remove the `private` field from `package.json`.