### PR TITLE
API document combined by `@samchon/openapi`

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -7,5 +7,6 @@ public/api/
 public/compilers/
 public/robots.txt
 public/sitemap*.xml
+typedoc-json/
 
 package-lock.json

--- a/website/build/typedoc.js
+++ b/website/build/typedoc.js
@@ -1,0 +1,36 @@
+const cp = require("child_process");
+const fs = require("fs");
+
+const main = async () => {
+  if (fs.existsSync(`${__dirname}/../typedoc-json`) === false)
+    await fs.promises.mkdir(`${__dirname}/../typedoc-json`);
+  await fs.promises.writeFile(
+    `${__dirname}/../typedoc-json/openapi.json`,
+    await fetch("https://samchon.github.io/openapi/api/openapi.json").then(
+      (r) => r.text(),
+    ),
+    "utf8",
+  );
+
+  const execute = (str) =>
+    cp.execSync(str, {
+      cwd: `${__dirname}/..`,
+      stdio: "inherit",
+    });
+  execute("npx typedoc --json typedoc-json/typia.json");
+  execute(
+    `npx typedoc --entryPointStrategy merge "typedoc-json/*.json" --plugin typedoc-github-theme --theme typedoc-github-theme`,
+  );
+  await fs.promises.writeFile(
+    `${__dirname}/../public/api/typia.json`,
+    await fs.promises.readFile(
+      `${__dirname}/../typedoc-json/typia.json`,
+      "utf8",
+    ),
+    "utf8",
+  );
+};
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rimraf .next && rimraf out && npm run build:typedoc && next build && node build/sitemap",
-    "build:typedoc": "typedoc --plugin typedoc-github-theme --theme typedoc-github-theme",
+    "build:typedoc": "node build/typedoc",
     "deploy": "node build/deploy",
     "dev": "next dev",
     "prepare": "node build/raw && rspack && npm run build:typedoc"


### PR DESCRIPTION
This pull request includes several changes to improve the handling of TypeDoc JSON files and update the build process for the website. The most important changes include adding a new script to generate TypeDoc JSON files, updating the `.gitignore` file, and modifying the build script in `package.json`.

Improvements to TypeDoc JSON handling:

* [`website/build/typedoc.js`](diffhunk://#diff-e42f4d8ceb8336889101cafff758774867fa98cc2b66b2f5f5c202171b3b0638R1-R36): Added a new script to generate TypeDoc JSON files, fetch OpenAPI JSON, and merge them using the TypeDoc GitHub theme.

Updates to build process:

* [`website/package.json`](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L8-R8): Updated the `build:typedoc` script to use the new `build/typedoc.js` script instead of directly calling TypeDoc.

Updates to `.gitignore`:

* [`website/.gitignore`](diffhunk://#diff-d8ae2e4bc862e6c28c03d8a661735180ccdc3b81d7fab3f1ddb88a941d28f030R10): Added `typedoc-json/` to the `.gitignore` file to exclude generated TypeDoc JSON files from version control.