### PR TITLE
Prepare `@samchon/openapi` v3 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "7.6.4",
+  "version": "8.0.0-dev.20250222",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -42,7 +42,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^2.4.2",
+    "@samchon/openapi": "^3.0.0-dev.20250222",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -50,7 +50,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=2.4.2 <3.0.0",
+    "@samchon/openapi": ">=3.0.0 <4.0.0",
     "typescript": ">=4.8.0 <5.8.0"
   },
   "devDependencies": {

--- a/packages/typescript-json/README.md
+++ b/packages/typescript-json/README.md
@@ -8,8 +8,8 @@
 [![NPM Version](https://img.shields.io/npm/v/typia.svg)](https://www.npmjs.com/package/typia)
 [![NPM Downloads](https://img.shields.io/npm/dm/typia.svg)](https://www.npmjs.com/package/typia)
 [![Build Status](https://github.com/samchon/typia/workflows/build/badge.svg)](https://github.com/samchon/typia/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/guide-documents-forestgreen)](https://typia.io/docs/)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Typia%20Guru-006BFF)](https://gurubase.io/g/typia)
+[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://typia.io/docs/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Document%20Chatbot-006BFF)](https://gurubase.io/g/typia)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
 ```typescript
@@ -134,7 +134,7 @@ Check out the document in the [website](https://typia.io/docs/):
     - [`application()` function](https://typia.io/docs/llm/application/)
     - [`parameters()` function](https://typia.io/docs/llm/parameters/)
     - [`schema()` function](https://typia.io/docs/llm/schema/)
-    - [Super AI Chatbot](https://typia.io/docs/llm/chat/)
+    - [AI Chatbot Development](https://typia.io/docs/llm/chat/)
     - [Documentation Strategy](https://typia.io/docs/llm/strategy/)
   - Protocol Buffer
     - [Message Schema](https://typia.io/docs/protobuf/message)

--- a/packages/typescript-json/package.json
+++ b/packages/typescript-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json",
-  "version": "7.6.2-dev.20250205",
+  "version": "8.0.0-dev.20250221",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -38,10 +38,10 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "typia": "7.6.2-dev.20250205"
+    "typia": "8.0.0-dev.20250221"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=2.4.2 <3.0.0",
+    "@samchon/openapi": ">=3.0.0 <4.0.0",
     "typescript": ">=4.8.0 <5.8.0"
   },
   "stackblitz": {

--- a/test/schemas/json.schemas/v3_0/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_0/UltimateUnion.json
@@ -165,8 +165,8 @@
         "properties": {
           "default": {
             "type": "boolean",
-            "title": "The default value",
-            "description": "The default value."
+            "title": "The default value of the boolean type",
+            "description": "The default value of the boolean type."
           },
           "type": {
             "type": "string",
@@ -211,8 +211,8 @@
         "properties": {
           "default": {
             "type": "integer",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the integer type",
+            "description": "Default value of the integer type."
           },
           "minimum": {
             "type": "integer",
@@ -284,8 +284,8 @@
         "properties": {
           "default": {
             "type": "number",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the number type",
+            "description": "Default value of the number type."
           },
           "minimum": {
             "type": "number",
@@ -357,8 +357,8 @@
         "properties": {
           "default": {
             "type": "string",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the string type",
+            "description": "Default value of the string type."
           },
           "format": {
             "type": "string",
@@ -488,6 +488,14 @@
       "OpenApi.IJsonSchema.ITuple": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "array"
+            ],
+            "title": "Discriminator value of the type",
+            "description": "Discriminator value of the type.\n\nNote that, the tuple type cannot be distinguished with\n{@link IArray} type just by this `discriminator` property.\n\nTo check whether the type is tuple or array, you have to check\nthe existence of {@link IArray.items} or {@link ITuple.prefixItems}\nproperties."
+          },
           "prefixItems": {
             "type": "array",
             "items": {
@@ -532,10 +540,10 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ],
             "title": "Additional items",
@@ -555,14 +563,6 @@
             "type": "integer",
             "title": "Maximum items restriction",
             "description": "Maximum items restriction.\n\nRestriction of maximum number of items in the tuple."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "array"
-            ],
-            "title": "Discriminator value of the type",
-            "description": "Discriminator value of the type."
           },
           "title": {
             "type": "string",
@@ -590,8 +590,8 @@
           }
         },
         "required": [
-          "prefixItems",
-          "type"
+          "type",
+          "prefixItems"
         ],
         "description": "Tuple type info."
       },
@@ -639,10 +639,10 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ],
             "title": "Additional properties' info",
@@ -767,10 +767,10 @@
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IReferencestring"
                 },
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
                 },
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
                 }
               ]
             },
@@ -812,13 +812,48 @@
         ],
         "description": "Union type.\n\nIOneOf` represents an union type of the TypeScript (`A | B | C`).\n\nFor reference, even though your Swagger (or OpenAPI) document has\ndefined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly\nconverts it to `oneOf` type."
       },
+      "OpenApi.IJsonSchema.IUnknown": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "title": "Default value of the `any` type",
+            "description": "Default value of the `any` type."
+          },
+          "title": {
+            "type": "string",
+            "title": "Title of the schema",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "title": "Detailed description of the schema",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "title": "Whether the type is deprecated or not",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "title": "Example value",
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "title": "List of example values as key-value pairs",
+            "description": "List of example values as key-value pairs."
+          }
+        },
+        "required": [],
+        "description": "Unknown, the `any` type."
+      },
       "OpenApi.IJsonSchema.INull": {
         "type": "object",
         "properties": {
           "default": {
             "type": "null",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the `null` type",
+            "description": "Default value of the `null` type."
           },
           "type": {
             "type": "string",
@@ -857,37 +892,6 @@
           "type"
         ],
         "description": "Null type."
-      },
-      "OpenApi.IJsonSchema.IUnknown": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title of the schema",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "title": "Detailed description of the schema",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "title": "Whether the type is deprecated or not",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "title": "Example value",
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "title": "List of example values as key-value pairs",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [],
-        "description": "Unknown, the `any` type."
       },
       "OpenApi.IJsonSchema.IOneOf.IDiscriminator": {
         "type": "object",

--- a/test/schemas/json.schemas/v3_1/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_1/UltimateUnion.json
@@ -162,8 +162,8 @@
         "properties": {
           "default": {
             "type": "boolean",
-            "title": "The default value",
-            "description": "The default value."
+            "title": "The default value of the boolean type",
+            "description": "The default value of the boolean type."
           },
           "type": {
             "const": "boolean",
@@ -205,8 +205,8 @@
         "properties": {
           "default": {
             "type": "integer",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the integer type",
+            "description": "Default value of the integer type."
           },
           "minimum": {
             "type": "integer",
@@ -275,8 +275,8 @@
         "properties": {
           "default": {
             "type": "number",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the number type",
+            "description": "Default value of the number type."
           },
           "minimum": {
             "type": "number",
@@ -345,8 +345,8 @@
         "properties": {
           "default": {
             "type": "string",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the string type",
+            "description": "Default value of the string type."
           },
           "format": {
             "type": "string",
@@ -470,6 +470,11 @@
       "OpenApi.IJsonSchema.ITuple": {
         "type": "object",
         "properties": {
+          "type": {
+            "const": "array",
+            "title": "Discriminator value of the type",
+            "description": "Discriminator value of the type.\n\nNote that, the tuple type cannot be distinguished with\n{@link IArray} type just by this `discriminator` property.\n\nTo check whether the type is tuple or array, you have to check\nthe existence of {@link IArray.items} or {@link ITuple.prefixItems}\nproperties."
+          },
           "prefixItems": {
             "type": "array",
             "items": {
@@ -514,10 +519,10 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ],
             "title": "Additional items",
@@ -537,11 +542,6 @@
             "type": "integer",
             "title": "Maximum items restriction",
             "description": "Maximum items restriction.\n\nRestriction of maximum number of items in the tuple."
-          },
-          "type": {
-            "const": "array",
-            "title": "Discriminator value of the type",
-            "description": "Discriminator value of the type."
           },
           "title": {
             "type": "string",
@@ -569,8 +569,8 @@
           }
         },
         "required": [
-          "prefixItems",
-          "type"
+          "type",
+          "prefixItems"
         ],
         "description": "Tuple type info."
       },
@@ -618,10 +618,10 @@
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IOneOf"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
               }
             ],
             "title": "Additional properties' info",
@@ -743,10 +743,10 @@
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IReferencestring"
                 },
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
                 },
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IUnknown"
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INull"
                 }
               ]
             },
@@ -788,13 +788,48 @@
         ],
         "description": "Union type.\n\nIOneOf` represents an union type of the TypeScript (`A | B | C`).\n\nFor reference, even though your Swagger (or OpenAPI) document has\ndefined `anyOf` instead of the `oneOf`, {@link OpenApi} forcibly\nconverts it to `oneOf` type."
       },
+      "OpenApi.IJsonSchema.IUnknown": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "title": "Default value of the `any` type",
+            "description": "Default value of the `any` type."
+          },
+          "title": {
+            "type": "string",
+            "title": "Title of the schema",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "title": "Detailed description of the schema",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "title": "Whether the type is deprecated or not",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "title": "Example value",
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "title": "List of example values as key-value pairs",
+            "description": "List of example values as key-value pairs."
+          }
+        },
+        "required": [],
+        "description": "Unknown, the `any` type."
+      },
       "OpenApi.IJsonSchema.INull": {
         "type": "object",
         "properties": {
           "default": {
             "type": "null",
-            "title": "Default value",
-            "description": "Default value."
+            "title": "Default value of the `null` type",
+            "description": "Default value of the `null` type."
           },
           "type": {
             "const": "null",
@@ -830,37 +865,6 @@
           "type"
         ],
         "description": "Null type."
-      },
-      "OpenApi.IJsonSchema.IUnknown": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title of the schema",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "title": "Detailed description of the schema",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "title": "Whether the type is deprecated or not",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "title": "Example value",
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "title": "List of example values as key-value pairs",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [],
-        "description": "Unknown, the `any` type."
       },
       "OpenApi.IJsonSchema.IOneOf.IDiscriminator": {
         "type": "object",

--- a/test/schemas/llm.application/chatgpt/CommentTagRange.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagRange.json
@@ -20,7 +20,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -28,7 +28,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -36,15 +36,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
@@ -96,7 +96,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -104,7 +104,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -112,15 +112,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
@@ -164,7 +164,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -172,7 +172,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -180,15 +180,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -237,7 +237,7 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal": {
@@ -245,7 +245,7 @@
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "less_equal": {
@@ -253,15 +253,15 @@
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@maximum 7\n@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {
@@ -311,7 +311,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -319,7 +319,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -327,15 +327,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -381,7 +381,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -389,7 +389,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -397,15 +397,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -451,7 +451,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -459,7 +459,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -467,15 +467,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -529,7 +529,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -537,7 +537,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -545,15 +545,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicAbsorbed.json
@@ -19,7 +19,6 @@
                 "type": "string"
               },
               "age": {
-                "description": "@default 20",
                 "type": "number"
               }
             },
@@ -49,7 +48,6 @@
                 "type": "string"
               },
               "age": {
-                "description": "@default 20",
                 "type": "number"
               }
             },
@@ -71,7 +69,6 @@
                     "type": "string"
                   },
                   "age": {
-                    "description": "@default 20",
                     "type": "number"
                   }
                 },
@@ -98,7 +95,6 @@
             "type": "string"
           },
           "age": {
-            "description": "@default 20",
             "type": "number"
           }
         },
@@ -126,7 +122,6 @@
                     "type": "string"
                   },
                   "age": {
-                    "description": "@default 20",
                     "type": "number"
                   }
                 },
@@ -150,7 +145,6 @@
                     "type": "string"
                   },
                   "age": {
-                    "description": "@default 20",
                     "type": "number"
                   }
                 },
@@ -174,7 +168,6 @@
                     "type": "string"
                   },
                   "age": {
-                    "description": "@default 20",
                     "type": "number"
                   }
                 },
@@ -206,7 +199,6 @@
                 "type": "string"
               },
               "age": {
-                "description": "@default 20",
                 "type": "number"
               }
             },

--- a/test/schemas/llm.application/chatgpt/TypeTagDefault.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagDefault.json
@@ -18,7 +18,6 @@
                 "type": "boolean"
               },
               "number": {
-                "description": "@default 1",
                 "type": "number"
               },
               "string": {
@@ -32,8 +31,7 @@
               "boolean_and_number_and_string": {
                 "anyOf": [
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "string",
@@ -63,8 +61,7 @@
                     "type": "string"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"
@@ -92,8 +89,7 @@
                     "description": "@pattern ^(prefix_(.*))"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 2"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"
@@ -133,7 +129,6 @@
                 "type": "boolean"
               },
               "number": {
-                "description": "@default 1",
                 "type": "number"
               },
               "string": {
@@ -147,8 +142,7 @@
               "boolean_and_number_and_string": {
                 "anyOf": [
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "string",
@@ -178,8 +172,7 @@
                     "type": "string"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"
@@ -207,8 +200,7 @@
                     "description": "@pattern ^(prefix_(.*))"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 2"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"
@@ -240,7 +232,6 @@
                     "type": "boolean"
                   },
                   "number": {
-                    "description": "@default 1",
                     "type": "number"
                   },
                   "string": {
@@ -254,8 +245,7 @@
                   "boolean_and_number_and_string": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "string",
@@ -285,8 +275,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -314,8 +303,7 @@
                         "description": "@pattern ^(prefix_(.*))"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 2"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -352,7 +340,6 @@
             "type": "boolean"
           },
           "number": {
-            "description": "@default 1",
             "type": "number"
           },
           "string": {
@@ -366,8 +353,7 @@
           "boolean_and_number_and_string": {
             "anyOf": [
               {
-                "type": "number",
-                "description": "@default 1"
+                "type": "number"
               },
               {
                 "type": "string",
@@ -397,8 +383,7 @@
                 "type": "string"
               },
               {
-                "type": "number",
-                "description": "@default 1"
+                "type": "number"
               },
               {
                 "type": "boolean"
@@ -426,8 +411,7 @@
                 "description": "@pattern ^(prefix_(.*))"
               },
               {
-                "type": "number",
-                "description": "@default 2"
+                "type": "number"
               },
               {
                 "type": "boolean"
@@ -465,7 +449,6 @@
                     "type": "boolean"
                   },
                   "number": {
-                    "description": "@default 1",
                     "type": "number"
                   },
                   "string": {
@@ -479,8 +462,7 @@
                   "boolean_and_number_and_string": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "string",
@@ -510,8 +492,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -539,8 +520,7 @@
                         "description": "@pattern ^(prefix_(.*))"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 2"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -574,7 +554,6 @@
                     "type": "boolean"
                   },
                   "number": {
-                    "description": "@default 1",
                     "type": "number"
                   },
                   "string": {
@@ -588,8 +567,7 @@
                   "boolean_and_number_and_string": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "string",
@@ -619,8 +597,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -648,8 +625,7 @@
                         "description": "@pattern ^(prefix_(.*))"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 2"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -683,7 +659,6 @@
                     "type": "boolean"
                   },
                   "number": {
-                    "description": "@default 1",
                     "type": "number"
                   },
                   "string": {
@@ -697,8 +672,7 @@
                   "boolean_and_number_and_string": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "string",
@@ -728,8 +702,7 @@
                         "type": "string"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 1"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -757,8 +730,7 @@
                         "description": "@pattern ^(prefix_(.*))"
                       },
                       {
-                        "type": "number",
-                        "description": "@default 2"
+                        "type": "number"
                       },
                       {
                         "type": "boolean"
@@ -800,7 +772,6 @@
                 "type": "boolean"
               },
               "number": {
-                "description": "@default 1",
                 "type": "number"
               },
               "string": {
@@ -814,8 +785,7 @@
               "boolean_and_number_and_string": {
                 "anyOf": [
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "string",
@@ -845,8 +815,7 @@
                     "type": "string"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 1"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"
@@ -874,8 +843,7 @@
                     "description": "@pattern ^(prefix_(.*))"
                   },
                   {
-                    "type": "number",
-                    "description": "@default 2"
+                    "type": "number"
                   },
                   {
                     "type": "boolean"

--- a/test/schemas/llm.application/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagRange.json
@@ -20,7 +20,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -28,7 +28,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -36,15 +36,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
@@ -96,7 +96,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -104,7 +104,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -112,15 +112,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {
@@ -164,7 +164,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -172,7 +172,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -180,15 +180,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -237,7 +237,7 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal": {
@@ -245,7 +245,7 @@
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "less_equal": {
@@ -253,15 +253,15 @@
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@maximum 7\n@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {
@@ -311,7 +311,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -319,7 +319,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -327,15 +327,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -381,7 +381,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -389,7 +389,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -397,15 +397,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -451,7 +451,7 @@
                       "type": "object",
                       "properties": {
                         "greater": {
-                          "description": "@minimum 3\n@exclusiveMinimum true",
+                          "description": "@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal": {
@@ -459,7 +459,7 @@
                           "type": "integer"
                         },
                         "less": {
-                          "description": "@maximum 7\n@exclusiveMaximum true",
+                          "description": "@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "less_equal": {
@@ -467,15 +467,15 @@
                           "type": "integer"
                         },
                         "greater_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                          "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_equal_less": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                          "description": "@minimum 3\n@exclusiveMaximum 7",
                           "type": "integer"
                         },
                         "greater_less_equal": {
-                          "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                          "description": "@maximum 7\n@exclusiveMinimum 3",
                           "type": "integer"
                         },
                         "greater_equal_less_equal": {
@@ -529,7 +529,7 @@
                   "type": "object",
                   "properties": {
                     "greater": {
-                      "description": "@minimum 3\n@exclusiveMinimum true",
+                      "description": "@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal": {
@@ -537,7 +537,7 @@
                       "type": "integer"
                     },
                     "less": {
-                      "description": "@maximum 7\n@exclusiveMaximum true",
+                      "description": "@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "less_equal": {
@@ -545,15 +545,15 @@
                       "type": "integer"
                     },
                     "greater_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_equal_less": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                      "description": "@minimum 3\n@exclusiveMaximum 7",
                       "type": "integer"
                     },
                     "greater_less_equal": {
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                      "description": "@maximum 7\n@exclusiveMinimum 3",
                       "type": "integer"
                     },
                     "greater_equal_less_equal": {

--- a/test/schemas/llm.application/gemini/CommentTagRange.json
+++ b/test/schemas/llm.application/gemini/CommentTagRange.json
@@ -20,7 +20,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -28,7 +28,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -36,15 +36,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -94,7 +94,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -102,7 +102,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -110,15 +110,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -157,7 +157,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -165,7 +165,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -173,15 +173,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -227,7 +227,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -235,7 +235,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -243,15 +243,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
@@ -296,7 +296,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -304,7 +304,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -312,15 +312,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -360,7 +360,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -368,7 +368,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -376,15 +376,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -424,7 +424,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -432,7 +432,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -440,15 +440,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -494,7 +494,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -502,7 +502,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -510,15 +510,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",

--- a/test/schemas/llm.application/gemini/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.application/gemini/ConstantAtomicAbsorbed.json
@@ -18,8 +18,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -46,8 +45,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -63,8 +61,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -87,8 +84,7 @@
             "description": "@default something"
           },
           "age": {
-            "type": "number",
-            "description": "@default 20"
+            "type": "number"
           }
         },
         "required": [
@@ -110,8 +106,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -128,8 +123,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -146,8 +140,7 @@
                 "description": "@default something"
               },
               "age": {
-                "type": "number",
-                "description": "@default 20"
+                "type": "number"
               }
             },
             "required": [
@@ -170,8 +163,7 @@
             "description": "@default something"
           },
           "age": {
-            "type": "number",
-            "description": "@default 20"
+            "type": "number"
           }
         },
         "required": [

--- a/test/schemas/llm.application/gemini/TypeTagRange.json
+++ b/test/schemas/llm.application/gemini/TypeTagRange.json
@@ -20,7 +20,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -28,7 +28,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -36,15 +36,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -94,7 +94,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -102,7 +102,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -110,15 +110,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -157,7 +157,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -165,7 +165,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -173,15 +173,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -227,7 +227,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -235,7 +235,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -243,15 +243,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",
@@ -296,7 +296,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -304,7 +304,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -312,15 +312,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -360,7 +360,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -368,7 +368,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -376,15 +376,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -424,7 +424,7 @@
                   "properties": {
                     "greater": {
                       "type": "integer",
-                      "description": "@minimum 3\n@exclusiveMinimum true"
+                      "description": "@exclusiveMinimum 3"
                     },
                     "greater_equal": {
                       "type": "integer",
@@ -432,7 +432,7 @@
                     },
                     "less": {
                       "type": "integer",
-                      "description": "@maximum 7\n@exclusiveMaximum true"
+                      "description": "@exclusiveMaximum 7"
                     },
                     "less_equal": {
                       "type": "integer",
@@ -440,15 +440,15 @@
                     },
                     "greater_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                      "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_equal_less": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                      "description": "@minimum 3\n@exclusiveMaximum 7"
                     },
                     "greater_less_equal": {
                       "type": "integer",
-                      "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                      "description": "@maximum 7\n@exclusiveMinimum 3"
                     },
                     "greater_equal_less_equal": {
                       "type": "integer",
@@ -494,7 +494,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -502,7 +502,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -510,15 +510,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",

--- a/test/schemas/llm.parameters/chatgpt/CommentTagRange.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagRange.json
@@ -10,7 +10,7 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal": {
@@ -18,7 +18,7 @@
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@exclusiveMaximum 7",
                 "type": "integer"
               },
               "less_equal": {
@@ -26,15 +26,15 @@
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@maximum 7\n@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
@@ -78,7 +78,7 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal": {
@@ -86,7 +86,7 @@
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "less_equal": {
@@ -94,15 +94,15 @@
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@maximum 7\n@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
@@ -143,7 +143,7 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal": {
@@ -151,7 +151,7 @@
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@exclusiveMaximum 7",
                 "type": "integer"
               },
               "less_equal": {
@@ -159,15 +159,15 @@
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@maximum 7\n@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
@@ -211,7 +211,7 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal": {
@@ -219,7 +219,7 @@
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "less_equal": {
@@ -227,15 +227,15 @@
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@maximum 7\n@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
@@ -278,7 +278,7 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal": {
@@ -286,7 +286,7 @@
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "less_equal": {
@@ -294,15 +294,15 @@
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@maximum 7\n@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicAbsorbed.json
@@ -9,7 +9,6 @@
           "type": "string"
         },
         "age": {
-          "description": "@default 20",
           "type": "number"
         }
       },
@@ -31,7 +30,6 @@
               "type": "string"
             },
             "age": {
-              "description": "@default 20",
               "type": "number"
             }
           },
@@ -50,7 +48,6 @@
           "type": "string"
         },
         "age": {
-          "description": "@default 20",
           "type": "number"
         }
       },
@@ -72,7 +69,6 @@
               "type": "string"
             },
             "age": {
-              "description": "@default 20",
               "type": "number"
             }
           },
@@ -93,7 +89,6 @@
             "type": "string"
           },
           "age": {
-            "description": "@default 20",
             "type": "number"
           }
         },

--- a/test/schemas/llm.parameters/chatgpt/TypeTagDefault.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagDefault.json
@@ -8,7 +8,6 @@
           "type": "boolean"
         },
         "number": {
-          "description": "@default 1",
           "type": "number"
         },
         "string": {
@@ -22,8 +21,7 @@
         "boolean_and_number_and_string": {
           "anyOf": [
             {
-              "type": "number",
-              "description": "@default 1"
+              "type": "number"
             },
             {
               "type": "string",
@@ -53,8 +51,7 @@
               "type": "string"
             },
             {
-              "type": "number",
-              "description": "@default 1"
+              "type": "number"
             },
             {
               "type": "boolean"
@@ -82,8 +79,7 @@
               "description": "@pattern ^(prefix_(.*))"
             },
             {
-              "type": "number",
-              "description": "@default 2"
+              "type": "number"
             },
             {
               "type": "boolean"
@@ -115,7 +111,6 @@
               "type": "boolean"
             },
             "number": {
-              "description": "@default 1",
               "type": "number"
             },
             "string": {
@@ -129,8 +124,7 @@
             "boolean_and_number_and_string": {
               "anyOf": [
                 {
-                  "type": "number",
-                  "description": "@default 1"
+                  "type": "number"
                 },
                 {
                   "type": "string",
@@ -160,8 +154,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "number",
-                  "description": "@default 1"
+                  "type": "number"
                 },
                 {
                   "type": "boolean"
@@ -189,8 +182,7 @@
                   "description": "@pattern ^(prefix_(.*))"
                 },
                 {
-                  "type": "number",
-                  "description": "@default 2"
+                  "type": "number"
                 },
                 {
                   "type": "boolean"
@@ -219,7 +211,6 @@
           "type": "boolean"
         },
         "number": {
-          "description": "@default 1",
           "type": "number"
         },
         "string": {
@@ -233,8 +224,7 @@
         "boolean_and_number_and_string": {
           "anyOf": [
             {
-              "type": "number",
-              "description": "@default 1"
+              "type": "number"
             },
             {
               "type": "string",
@@ -264,8 +254,7 @@
               "type": "string"
             },
             {
-              "type": "number",
-              "description": "@default 1"
+              "type": "number"
             },
             {
               "type": "boolean"
@@ -293,8 +282,7 @@
               "description": "@pattern ^(prefix_(.*))"
             },
             {
-              "type": "number",
-              "description": "@default 2"
+              "type": "number"
             },
             {
               "type": "boolean"
@@ -326,7 +314,6 @@
               "type": "boolean"
             },
             "number": {
-              "description": "@default 1",
               "type": "number"
             },
             "string": {
@@ -340,8 +327,7 @@
             "boolean_and_number_and_string": {
               "anyOf": [
                 {
-                  "type": "number",
-                  "description": "@default 1"
+                  "type": "number"
                 },
                 {
                   "type": "string",
@@ -371,8 +357,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "number",
-                  "description": "@default 1"
+                  "type": "number"
                 },
                 {
                   "type": "boolean"
@@ -400,8 +385,7 @@
                   "description": "@pattern ^(prefix_(.*))"
                 },
                 {
-                  "type": "number",
-                  "description": "@default 2"
+                  "type": "number"
                 },
                 {
                   "type": "boolean"
@@ -432,7 +416,6 @@
             "type": "boolean"
           },
           "number": {
-            "description": "@default 1",
             "type": "number"
           },
           "string": {
@@ -446,8 +429,7 @@
           "boolean_and_number_and_string": {
             "anyOf": [
               {
-                "type": "number",
-                "description": "@default 1"
+                "type": "number"
               },
               {
                 "type": "string",
@@ -477,8 +459,7 @@
                 "type": "string"
               },
               {
-                "type": "number",
-                "description": "@default 1"
+                "type": "number"
               },
               {
                 "type": "boolean"
@@ -506,8 +487,7 @@
                 "description": "@pattern ^(prefix_(.*))"
               },
               {
-                "type": "number",
-                "description": "@default 2"
+                "type": "number"
               },
               {
                 "type": "boolean"

--- a/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
@@ -10,7 +10,7 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal": {
@@ -18,7 +18,7 @@
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@exclusiveMaximum 7",
                 "type": "integer"
               },
               "less_equal": {
@@ -26,15 +26,15 @@
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@maximum 7\n@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
@@ -78,7 +78,7 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal": {
@@ -86,7 +86,7 @@
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "less_equal": {
@@ -94,15 +94,15 @@
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@maximum 7\n@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
@@ -143,7 +143,7 @@
             "type": "object",
             "properties": {
               "greater": {
-                "description": "@minimum 3\n@exclusiveMinimum true",
+                "description": "@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal": {
@@ -151,7 +151,7 @@
                 "type": "integer"
               },
               "less": {
-                "description": "@maximum 7\n@exclusiveMaximum true",
+                "description": "@exclusiveMaximum 7",
                 "type": "integer"
               },
               "less_equal": {
@@ -159,15 +159,15 @@
                 "type": "integer"
               },
               "greater_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_equal_less": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                "description": "@minimum 3\n@exclusiveMaximum 7",
                 "type": "integer"
               },
               "greater_less_equal": {
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                "description": "@maximum 7\n@exclusiveMinimum 3",
                 "type": "integer"
               },
               "greater_equal_less_equal": {
@@ -211,7 +211,7 @@
                 "type": "object",
                 "properties": {
                   "greater": {
-                    "description": "@minimum 3\n@exclusiveMinimum true",
+                    "description": "@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal": {
@@ -219,7 +219,7 @@
                     "type": "integer"
                   },
                   "less": {
-                    "description": "@maximum 7\n@exclusiveMaximum true",
+                    "description": "@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "less_equal": {
@@ -227,15 +227,15 @@
                     "type": "integer"
                   },
                   "greater_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                    "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_equal_less": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                    "description": "@minimum 3\n@exclusiveMaximum 7",
                     "type": "integer"
                   },
                   "greater_less_equal": {
-                    "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                    "description": "@maximum 7\n@exclusiveMinimum 3",
                     "type": "integer"
                   },
                   "greater_equal_less_equal": {
@@ -278,7 +278,7 @@
               "type": "object",
               "properties": {
                 "greater": {
-                  "description": "@minimum 3\n@exclusiveMinimum true",
+                  "description": "@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal": {
@@ -286,7 +286,7 @@
                   "type": "integer"
                 },
                 "less": {
-                  "description": "@maximum 7\n@exclusiveMaximum true",
+                  "description": "@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "less_equal": {
@@ -294,15 +294,15 @@
                   "type": "integer"
                 },
                 "greater_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_equal_less": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+                  "description": "@minimum 3\n@exclusiveMaximum 7",
                   "type": "integer"
                 },
                 "greater_less_equal": {
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+                  "description": "@maximum 7\n@exclusiveMinimum 3",
                   "type": "integer"
                 },
                 "greater_equal_less_equal": {

--- a/test/schemas/llm.parameters/gemini/CommentTagRange.json
+++ b/test/schemas/llm.parameters/gemini/CommentTagRange.json
@@ -11,7 +11,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -19,7 +19,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -27,15 +27,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -74,7 +74,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -82,7 +82,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -90,15 +90,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -138,7 +138,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -146,7 +146,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -154,15 +154,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -201,7 +201,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -209,7 +209,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -217,15 +217,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -267,7 +267,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -275,7 +275,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -283,15 +283,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",

--- a/test/schemas/llm.parameters/gemini/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.parameters/gemini/ConstantAtomicAbsorbed.json
@@ -9,8 +9,7 @@
           "description": "@default something"
         },
         "age": {
-          "type": "number",
-          "description": "@default 20"
+          "type": "number"
         }
       },
       "required": [
@@ -26,8 +25,7 @@
           "description": "@default something"
         },
         "age": {
-          "type": "number",
-          "description": "@default 20"
+          "type": "number"
         }
       },
       "required": [
@@ -44,8 +42,7 @@
           "description": "@default something"
         },
         "age": {
-          "type": "number",
-          "description": "@default 20"
+          "type": "number"
         }
       },
       "required": [
@@ -61,8 +58,7 @@
           "description": "@default something"
         },
         "age": {
-          "type": "number",
-          "description": "@default 20"
+          "type": "number"
         }
       },
       "required": [
@@ -81,8 +77,7 @@
             "description": "@default something"
           },
           "age": {
-            "type": "number",
-            "description": "@default 20"
+            "type": "number"
           }
         },
         "required": [

--- a/test/schemas/llm.parameters/gemini/TypeTagRange.json
+++ b/test/schemas/llm.parameters/gemini/TypeTagRange.json
@@ -11,7 +11,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -19,7 +19,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -27,15 +27,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -74,7 +74,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -82,7 +82,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -90,15 +90,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -138,7 +138,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -146,7 +146,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -154,15 +154,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -201,7 +201,7 @@
             "properties": {
               "greater": {
                 "type": "integer",
-                "description": "@minimum 3\n@exclusiveMinimum true"
+                "description": "@exclusiveMinimum 3"
               },
               "greater_equal": {
                 "type": "integer",
@@ -209,7 +209,7 @@
               },
               "less": {
                 "type": "integer",
-                "description": "@maximum 7\n@exclusiveMaximum true"
+                "description": "@exclusiveMaximum 7"
               },
               "less_equal": {
                 "type": "integer",
@@ -217,15 +217,15 @@
               },
               "greater_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
               },
               "greater_equal_less": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                "description": "@minimum 3\n@exclusiveMaximum 7"
               },
               "greater_less_equal": {
                 "type": "integer",
-                "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                "description": "@maximum 7\n@exclusiveMinimum 3"
               },
               "greater_equal_less_equal": {
                 "type": "integer",
@@ -267,7 +267,7 @@
               "properties": {
                 "greater": {
                   "type": "integer",
-                  "description": "@minimum 3\n@exclusiveMinimum true"
+                  "description": "@exclusiveMinimum 3"
                 },
                 "greater_equal": {
                   "type": "integer",
@@ -275,7 +275,7 @@
                 },
                 "less": {
                   "type": "integer",
-                  "description": "@maximum 7\n@exclusiveMaximum true"
+                  "description": "@exclusiveMaximum 7"
                 },
                 "less_equal": {
                   "type": "integer",
@@ -283,15 +283,15 @@
                 },
                 "greater_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+                  "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_equal_less": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+                  "description": "@minimum 3\n@exclusiveMaximum 7"
                 },
                 "greater_less_equal": {
                   "type": "integer",
-                  "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+                  "description": "@maximum 7\n@exclusiveMinimum 3"
                 },
                 "greater_equal_less_equal": {
                   "type": "integer",

--- a/test/schemas/llm.schema/chatgpt/CommentTagRange.json
+++ b/test/schemas/llm.schema/chatgpt/CommentTagRange.json
@@ -7,7 +7,7 @@
         "type": "object",
         "properties": {
           "greater": {
-            "description": "@minimum 3\n@exclusiveMinimum true",
+            "description": "@exclusiveMinimum 3",
             "type": "integer"
           },
           "greater_equal": {
@@ -15,7 +15,7 @@
             "type": "integer"
           },
           "less": {
-            "description": "@maximum 7\n@exclusiveMaximum true",
+            "description": "@exclusiveMaximum 7",
             "type": "integer"
           },
           "less_equal": {
@@ -23,15 +23,15 @@
             "type": "integer"
           },
           "greater_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+            "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
             "type": "integer"
           },
           "greater_equal_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+            "description": "@minimum 3\n@exclusiveMaximum 7",
             "type": "integer"
           },
           "greater_less_equal": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+            "description": "@maximum 7\n@exclusiveMinimum 3",
             "type": "integer"
           },
           "greater_equal_less_equal": {

--- a/test/schemas/llm.schema/chatgpt/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.schema/chatgpt/ConstantAtomicAbsorbed.json
@@ -6,7 +6,6 @@
       "type": "string"
     },
     "age": {
-      "description": "@default 20",
       "type": "number"
     }
   },

--- a/test/schemas/llm.schema/chatgpt/TypeTagDefault.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagDefault.json
@@ -5,7 +5,6 @@
       "type": "boolean"
     },
     "number": {
-      "description": "@default 1",
       "type": "number"
     },
     "string": {
@@ -19,8 +18,7 @@
     "boolean_and_number_and_string": {
       "anyOf": [
         {
-          "type": "number",
-          "description": "@default 1"
+          "type": "number"
         },
         {
           "type": "string",
@@ -50,8 +48,7 @@
           "type": "string"
         },
         {
-          "type": "number",
-          "description": "@default 1"
+          "type": "number"
         },
         {
           "type": "boolean"
@@ -79,8 +76,7 @@
           "description": "@pattern ^(prefix_(.*))"
         },
         {
-          "type": "number",
-          "description": "@default 2"
+          "type": "number"
         },
         {
           "type": "boolean"

--- a/test/schemas/llm.schema/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagRange.json
@@ -7,7 +7,7 @@
         "type": "object",
         "properties": {
           "greater": {
-            "description": "@minimum 3\n@exclusiveMinimum true",
+            "description": "@exclusiveMinimum 3",
             "type": "integer"
           },
           "greater_equal": {
@@ -15,7 +15,7 @@
             "type": "integer"
           },
           "less": {
-            "description": "@maximum 7\n@exclusiveMaximum true",
+            "description": "@exclusiveMaximum 7",
             "type": "integer"
           },
           "less_equal": {
@@ -23,15 +23,15 @@
             "type": "integer"
           },
           "greater_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true",
+            "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7",
             "type": "integer"
           },
           "greater_equal_less": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true",
+            "description": "@minimum 3\n@exclusiveMaximum 7",
             "type": "integer"
           },
           "greater_less_equal": {
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true",
+            "description": "@maximum 7\n@exclusiveMinimum 3",
             "type": "integer"
           },
           "greater_equal_less_equal": {

--- a/test/schemas/llm.schema/gemini/CommentTagRange.json
+++ b/test/schemas/llm.schema/gemini/CommentTagRange.json
@@ -8,7 +8,7 @@
         "properties": {
           "greater": {
             "type": "integer",
-            "description": "@minimum 3\n@exclusiveMinimum true"
+            "description": "@exclusiveMinimum 3"
           },
           "greater_equal": {
             "type": "integer",
@@ -16,7 +16,7 @@
           },
           "less": {
             "type": "integer",
-            "description": "@maximum 7\n@exclusiveMaximum true"
+            "description": "@exclusiveMaximum 7"
           },
           "less_equal": {
             "type": "integer",
@@ -24,15 +24,15 @@
           },
           "greater_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+            "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
           },
           "greater_equal_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+            "description": "@minimum 3\n@exclusiveMaximum 7"
           },
           "greater_less_equal": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+            "description": "@maximum 7\n@exclusiveMinimum 3"
           },
           "greater_equal_less_equal": {
             "type": "integer",

--- a/test/schemas/llm.schema/gemini/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.schema/gemini/ConstantAtomicAbsorbed.json
@@ -6,8 +6,7 @@
       "description": "@default something"
     },
     "age": {
-      "type": "number",
-      "description": "@default 20"
+      "type": "number"
     }
   },
   "required": [

--- a/test/schemas/llm.schema/gemini/TypeTagRange.json
+++ b/test/schemas/llm.schema/gemini/TypeTagRange.json
@@ -8,7 +8,7 @@
         "properties": {
           "greater": {
             "type": "integer",
-            "description": "@minimum 3\n@exclusiveMinimum true"
+            "description": "@exclusiveMinimum 3"
           },
           "greater_equal": {
             "type": "integer",
@@ -16,7 +16,7 @@
           },
           "less": {
             "type": "integer",
-            "description": "@maximum 7\n@exclusiveMaximum true"
+            "description": "@exclusiveMaximum 7"
           },
           "less_equal": {
             "type": "integer",
@@ -24,15 +24,15 @@
           },
           "greater_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true\n@exclusiveMaximum true"
+            "description": "@exclusiveMinimum 3\n@exclusiveMaximum 7"
           },
           "greater_equal_less": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMaximum true"
+            "description": "@minimum 3\n@exclusiveMaximum 7"
           },
           "greater_less_equal": {
             "type": "integer",
-            "description": "@minimum 3\n@maximum 7\n@exclusiveMinimum true"
+            "description": "@maximum 7\n@exclusiveMinimum 3"
           },
           "greater_equal_less_equal": {
             "type": "integer",

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -480,11 +480,11 @@
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.INull",
+                  "name": "OpenApi.IJsonSchema.IUnknown",
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.IUnknown",
+                  "name": "OpenApi.IJsonSchema.INull",
                   "tags": []
                 }
               ],
@@ -978,7 +978,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "The default value.",
+            "description": "The default value of the boolean type.",
             "jsDocTags": []
           },
           {
@@ -1403,7 +1403,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Default value.",
+            "description": "Default value of the integer type.",
             "jsDocTags": [
               {
                 "name": "type",
@@ -2205,7 +2205,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Default value.",
+            "description": "Default value of the number type.",
             "jsDocTags": []
           },
           {
@@ -2929,7 +2929,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Default value.",
+            "description": "Default value of the string type.",
             "jsDocTags": []
           },
           {
@@ -3704,11 +3704,11 @@
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.INull",
+                  "name": "OpenApi.IJsonSchema.IUnknown",
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.IUnknown",
+                  "name": "OpenApi.IJsonSchema.INull",
                   "tags": []
                 }
               ],
@@ -4306,6 +4306,68 @@
                   "type": "string",
                   "values": [
                     {
+                      "value": "type",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "array",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Discriminator value of the type.\n\nNote that, the tuple type cannot be distinguished with\n{@link IArray} type just by this `discriminator` property.\n\nTo check whether the type is tuple or array, you have to check\nthe existence of {@link IArray.items} or {@link ITuple.prefixItems}\nproperties.",
+            "jsDocTags": []
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
                       "value": "prefixItems",
                       "tags": []
                     }
@@ -4440,11 +4502,11 @@
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.INull",
+                  "name": "OpenApi.IJsonSchema.IUnknown",
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.IUnknown",
+                  "name": "OpenApi.IJsonSchema.INull",
                   "tags": []
                 }
               ],
@@ -4674,68 +4736,6 @@
                 ]
               }
             ]
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "type",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "array",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Discriminator value of the type.",
-            "jsDocTags": []
           },
           {
             "key": {
@@ -5176,11 +5176,11 @@
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.INull",
+                  "name": "OpenApi.IJsonSchema.IUnknown",
                   "tags": []
                 },
                 {
-                  "name": "OpenApi.IJsonSchema.IUnknown",
+                  "name": "OpenApi.IJsonSchema.INull",
                   "tags": []
                 }
               ],
@@ -6407,7 +6407,7 @@
               "sets": [],
               "maps": []
             },
-            "description": "Default value.",
+            "description": "Default value of the `null` type.",
             "jsDocTags": []
           },
           {
@@ -6764,6 +6764,58 @@
       {
         "name": "OpenApi.IJsonSchema.IUnknown",
         "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "default",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": true,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Default value of the `any` type.",
+            "jsDocTags": []
+          },
           {
             "key": {
               "any": false,
@@ -9387,11 +9439,11 @@
               "tags": []
             },
             {
-              "name": "OpenApi.IJsonSchema.INull",
+              "name": "OpenApi.IJsonSchema.IUnknown",
               "tags": []
             },
             {
-              "name": "OpenApi.IJsonSchema.IUnknown",
+              "name": "OpenApi.IJsonSchema.INull",
               "tags": []
             }
           ],
@@ -9459,11 +9511,11 @@
               "tags": []
             },
             {
-              "name": "OpenApi.IJsonSchema.INull",
+              "name": "OpenApi.IJsonSchema.IUnknown",
               "tags": []
             },
             {
-              "name": "OpenApi.IJsonSchema.IUnknown",
+              "name": "OpenApi.IJsonSchema.INull",
               "tags": []
             }
           ],


### PR DESCRIPTION
This pull request includes version updates and documentation improvements, as well as schema adjustments to enhance clarity and accuracy. The most important changes are summarized below:

### Version Updates:
* Updated the `typia` package version to `8.0.0-dev.20250222` and the `@samchon/openapi` dependency to `^3.0.0-dev.20250222` in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R53)
* Updated the `typescript-json` package version to `8.0.0-dev.20250221` and its `typia` dependency to `8.0.0-dev.20250221` in `packages/typescript-json/package.json`. [[1]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L3-R3) [[2]](diffhunk://#diff-8080f74be0f746f6fc5487d0e6930fbe0e86764a33cdb8588f50a0a0bc18af69L41-R44)

### Documentation Improvements:
* Improved badge labels and descriptions in `packages/typescript-json/README.md`. [[1]](diffhunk://#diff-b5a696c23887532ac5268d99c14127b48f7a9696f10815bdec7615809d4a9816L11-R12) [[2]](diffhunk://#diff-b5a696c23887532ac5268d99c14127b48f7a9696f10815bdec7615809d4a9816L137-R137)

### Schema Adjustments:
* Enhanced property descriptions in `test/schemas/json.schemas/v3_0/UltimateUnion.json` and `test/schemas/json.schemas/v3_1/UltimateUnion.json` to specify types more clearly. [[1]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL168-R169) [[2]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL214-R215) [[3]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL287-R288) [[4]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL360-R361) [[5]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL165-R166) [[6]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL208-R209) [[7]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL278-R279) [[8]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL348-R349)
* Added and reordered required properties in `test/schemas/json.schemas/v3_0/UltimateUnion.json` and `test/schemas/json.schemas/v3_1/UltimateUnion.json` to ensure consistency. [[1]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeR491-R498) [[2]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL535-R546) [[3]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL559-L566) [[4]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL593-R594) [[5]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacR473-R477) [[6]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL517-R525) [[7]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL541-L545) [[8]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL572-R573)
* Corrected schema references from `INull` to `IUnknown` and vice versa in `test/schemas/json.schemas/v3_0/UltimateUnion.json` and `test/schemas/json.schemas/v3_1/UltimateUnion.json`. [[1]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL535-R546) [[2]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL642-R645) [[3]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL770-R773) [[4]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL815-R820) [[5]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL856-R865) [[6]](diffhunk://#diff-e53771bddd8d5c6424d188d3acc24fda58591a18d626dd60cf9037c773d8d4aeL889-R894) [[7]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL517-R525) [[8]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL621-R624) [[9]](diffhunk://#diff-320b98451fc761fe625fe48524f31eab1256437537b9075bed8e4f94f96aaaacL746-R749)