### PR TITLE
No more `typia patch` command required

### DIFF
--- a/src/executable/TypiaSetupWizard.ts
+++ b/src/executable/TypiaSetupWizard.ts
@@ -40,22 +40,18 @@ export namespace TypiaSetupWizard {
       data.scripts ??= {};
       if (
         typeof data.scripts.prepare === "string" &&
-        data.scripts.prepare.trim().length
+        data.scripts.prepare.trim().length !== 0
       ) {
-        if (
-          data.scripts.prepare.indexOf("ts-patch install") === -1 &&
-          data.scripts.prepare.indexOf("typia patch") === -1
-        )
-          data.scripts.prepare =
-            "ts-patch install && typia patch && " + data.scripts.prepare;
-        else if (data.scripts.prepare.indexOf("ts-patch install") === -1)
+        if (data.scripts.prepare.includes("ts-patch install") === false)
           data.scripts.prepare = "ts-patch install && " + data.scripts.prepare;
-        else if (data.scripts.prepare.indexOf("typia patch") === -1)
-          data.scripts.prepare = data.scripts.prepare.replace(
-            "ts-patch install",
-            "ts-patch install && typia patch",
-          );
-      } else data.scripts.prepare = "ts-patch install && typia patch";
+      } else data.scripts.prepare = "ts-patch install";
+
+      // NO MORE "typia patch" REQUIRED
+      data.scripts.prepare = data.scripts.prepare
+        .split("&&")
+        .map((str) => str.trim())
+        .filter((str) => str !== "typia patch")
+        .join(" && ");
 
       // FOR OLDER VERSIONS
       if (typeof data.scripts.postinstall === "string") {
@@ -100,11 +96,7 @@ export namespace TypiaSetupWizard {
             name: name,
             message: message,
             choices: choices,
-            ...(filter
-              ? {
-                  filter,
-                }
-              : {}),
+            ...(filter ? { filter } : {}),
           })
         )[name];
       };


### PR DESCRIPTION
This pull request includes changes to the `TypiaSetupWizard` to improve the handling of the `prepare` script and simplify the code structure. The most important changes include updating the logic for script preparation and refining the object spread syntax.

Improvements to script preparation:

* [`src/executable/TypiaSetupWizard.ts`](diffhunk://#diff-3d2b1c3e47dbe88c2672e6642534147569d90250465f3bf5c9d466ff98e722d1L43-R54): Modified the `prepare` script logic to use `includes` instead of `indexOf` for checking the presence of "ts-patch install". Removed the need for "typia patch" in the `prepare` script and added a filter to exclude it if present.

Code structure simplification:

* [`src/executable/TypiaSetupWizard.ts`](diffhunk://#diff-3d2b1c3e47dbe88c2672e6642534147569d90250465f3bf5c9d466ff98e722d1L103-R99): Simplified the object spread syntax by condensing the conditional spread of the `filter` property.