### PR TITLE
Compare feature

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,0 +1,19 @@
+/**
+ * Comapre in deep A and B
+ */
+export function equals<T extends object>(a: T, b: T): boolean;
+/**
+ * @internal
+ */
+export function equals<T extends object>(_a: T, _b: T): boolean {
+  halt("equals");
+}
+
+/**
+ * @internal
+ */
+function halt(name: string): never {
+  throw new Error(
+    `Error on typia.compare.${name}(): no transform has been configured. Read and follow https://typia.io/docs/setup please.`,
+  );
+}

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,11 +1,11 @@
 /**
  * Comapre in deep A and B
  */
-export function equals<T extends object>(a: T, b: T): boolean;
+export function equals<T>(a: T, b: T): boolean;
 /**
  * @internal
  */
-export function equals<T extends object>(_a: T, _b: T): boolean {
+export function equals<T>(_a: T, _b: T): boolean {
   halt("equals");
 }
 

--- a/src/factories/MetadataCollection.ts
+++ b/src/factories/MetadataCollection.ts
@@ -76,6 +76,16 @@ export class MetadataCollection {
     return [...this.tuples_.values()];
   }
 
+  public findObjectType(target: MetadataObjectType) {
+    // Add weakmap to index it and avoid finding O(n)
+    for (const [key, object] of this.objects_.entries()) {
+      if (object === target) {
+        return key;
+      }
+    }
+    return undefined;
+  }
+
   private getName(checker: ts.TypeChecker, type: ts.Type): string {
     const name: string = (() => {
       const str: string = TypeFactory.getFullName({

--- a/src/factories/internal/metadata/iterate_metadata.ts
+++ b/src/factories/internal/metadata/iterate_metadata.ts
@@ -30,6 +30,9 @@ export const iterate_metadata = (props: IMetadataIteratorProps): void => {
     });
     return;
   }
+  if (props.type.isClass()) {
+    props.metadata.class = true;
+  }
   // CHECK SPECIAL CASES
   if (
     (props.explore.aliased !== true && iterate_metadata_alias(props)) ||

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,7 @@ export * as notations from "./notations";
 export * as protobuf from "./protobuf";
 export * as reflect from "./reflect";
 export * as tags from "./tags";
+export * as compare from "./compare";
 
 export * from "./schemas/metadata/IJsDocTagInfo";
 export * from "./schemas/json/IJsonApplication";

--- a/src/programmers/compare/CompareEqualsProgrammer.ts
+++ b/src/programmers/compare/CompareEqualsProgrammer.ts
@@ -1,0 +1,89 @@
+import ts from "typescript";
+
+import { MetadataCollection } from "../../factories/MetadataCollection";
+import { MetadataFactory } from "../../factories/MetadataFactory";
+import { TypeFactory } from "../../factories/TypeFactory";
+
+import { IProgrammerProps } from "../../transformers/IProgrammerProps";
+import { ITypiaContext } from "../../transformers/ITypiaContext";
+import { TransformerError } from "../../transformers/TransformerError";
+
+import { FeatureProgrammer } from "../FeatureProgrammer";
+import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
+
+export namespace CompareEqualsProgrammer {
+  export const decompose = (props: {
+    context: ITypiaContext;
+    functor: FunctionProgrammer;
+    type: ts.Type;
+    name: string | undefined;
+  }): FeatureProgrammer.IDecomposed => {
+    // ANALYZE TYPE
+    const collection: MetadataCollection = new MetadataCollection();
+    const result = MetadataFactory.analyze({
+      checker: props.context.checker,
+      transformer: props.context.transformer,
+      options: {
+        escape: false,
+        constant: true,
+        absorb: true,
+      },
+      collection,
+      type: props.type,
+    });
+    if (result.success === false) {
+      throw TransformerError.from({
+        code: props.functor.method,
+        errors: result.errors,
+      });
+    }
+
+    console.log(result.data);
+    // DO TRANSFORM
+    // const object = result.data.objects?.[0]!.type;
+    // console.log(object.description);
+
+    return {
+      functions: {},
+      statements: [],
+      arrow: ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        props.context.importer.type({
+          file: "typia",
+          name: "Resolved",
+          arguments: [
+            ts.factory.createTypeReferenceNode(
+              props.name ??
+                TypeFactory.getFullName({
+                  checker: props.context.checker,
+                  type: props.type,
+                }),
+            ),
+          ],
+        }),
+        undefined,
+        ts.factory.createBlock([], true),
+      ),
+    };
+  };
+
+  export const write = (props: IProgrammerProps) => {
+    const functor = new FunctionProgrammer(props.modulo.getText());
+    const result: FeatureProgrammer.IDecomposed = decompose({
+      ...props,
+      functor,
+    });
+    console.log("-----------------------------------------------------");
+    console.log(result);
+    console.log("-----------------------------------------------------");
+    console.log(props.modulo);
+    console.log("-----------------------------------------------------");
+    return FeatureProgrammer.writeDecomposed({
+      modulo: props.modulo,
+      functor,
+      result,
+    });
+  };
+}

--- a/src/programmers/compare/CompareEqualsProgrammer.ts
+++ b/src/programmers/compare/CompareEqualsProgrammer.ts
@@ -1,12 +1,9 @@
 import ts from "typescript";
 
-import { MetadataCollection } from "../../factories/MetadataCollection";
-import { MetadataFactory } from "../../factories/MetadataFactory";
-import { TypeFactory } from "../../factories/TypeFactory";
+import { IdentifierFactory } from "../../factories/IdentifierFactory";
 
 import { IProgrammerProps } from "../../transformers/IProgrammerProps";
 import { ITypiaContext } from "../../transformers/ITypiaContext";
-import { TransformerError } from "../../transformers/TransformerError";
 
 import { FeatureProgrammer } from "../FeatureProgrammer";
 import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
@@ -19,29 +16,37 @@ export namespace CompareEqualsProgrammer {
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
     // ANALYZE TYPE
-    const collection: MetadataCollection = new MetadataCollection();
-    const result = MetadataFactory.analyze({
-      checker: props.context.checker,
-      transformer: props.context.transformer,
-      options: {
-        escape: false,
-        constant: true,
-        absorb: true,
-      },
-      collection,
-      type: props.type,
-    });
-    if (result.success === false) {
-      throw TransformerError.from({
-        code: props.functor.method,
-        errors: result.errors,
-      });
-    }
+    // const collection: MetadataCollection = new MetadataCollection();
+    // const result = MetadataFactory.analyze({
+    //   checker: props.context.checker,
+    //   transformer: props.context.transformer,
+    //   options: {
+    //     escape: false,
+    //     constant: true,
+    //     absorb: true,
+    //   },
+    //   collection,
+    //   type: props.type,
+    // });
+    // if (result.success === false) {
+    //   throw TransformerError.from({
+    //     code: props.functor.method,
+    //     errors: result.errors,
+    //   });
+    // }
 
-    console.log(result.data);
     // DO TRANSFORM
-    // const object = result.data.objects?.[0]!.type;
-    // console.log(object.description);
+    const a = ts.factory.createIdentifier("a");
+    const b = ts.factory.createIdentifier("b");
+    // console.log(props.type);
+
+    // const statements = transform(a, b, result.data, props);
+    const expression = transform(a, b, props.context, props.type);
+    const argType = props.context.checker.typeToTypeNode(
+      props.type,
+      undefined,
+      ts.NodeBuilderFlags.NoTruncation,
+    );
 
     return {
       functions: {},
@@ -49,22 +54,16 @@ export namespace CompareEqualsProgrammer {
       arrow: ts.factory.createArrowFunction(
         undefined,
         undefined,
-        [],
-        props.context.importer.type({
-          file: "typia",
-          name: "Resolved",
-          arguments: [
-            ts.factory.createTypeReferenceNode(
-              props.name ??
-                TypeFactory.getFullName({
-                  checker: props.context.checker,
-                  type: props.type,
-                }),
-            ),
-          ],
-        }),
+        [
+          IdentifierFactory.parameter("a", argType),
+          IdentifierFactory.parameter("b", argType),
+        ],
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
         undefined,
-        ts.factory.createBlock([], true),
+        ts.factory.createBlock(
+          [ts.factory.createExpressionStatement(expression)],
+          true,
+        ),
       ),
     };
   };
@@ -75,15 +74,155 @@ export namespace CompareEqualsProgrammer {
       ...props,
       functor,
     });
-    console.log("-----------------------------------------------------");
-    console.log(result);
-    console.log("-----------------------------------------------------");
-    console.log(props.modulo);
-    console.log("-----------------------------------------------------");
+
+    // console.log("-----------------------------------------------------");
+    // console.log(props.context);
+    // console.log("-----------------------------------------------------");
+    // console.log(props.modulo);
+    // console.log("-----------------------------------------------------");
     return FeatureProgrammer.writeDecomposed({
       modulo: props.modulo,
       functor,
       result,
     });
   };
+  function isPrimitiveType(type: ts.Type): boolean {
+    const primitiveFlags =
+      ts.TypeFlags.String |
+      ts.TypeFlags.Number |
+      ts.TypeFlags.Boolean |
+      ts.TypeFlags.BigInt |
+      ts.TypeFlags.ESSymbol |
+      ts.TypeFlags.Null |
+      ts.TypeFlags.Undefined |
+      ts.TypeFlags.StringLiteral |
+      ts.TypeFlags.NumberLiteral |
+      ts.TypeFlags.BooleanLiteral |
+      ts.TypeFlags.BigIntLiteral;
+    return (type.flags & primitiveFlags) !== 0;
+  }
+  function eqeqeq(a: ts.Identifier, b: ts.Identifier) {
+    return ts.factory.createExpressionStatement(
+      ts.factory.createBinaryExpression(
+        a,
+        ts.factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+        b,
+      ),
+    );
+  }
+
+  function eqeqeqReturn(a: ts.Identifier, b: ts.Identifier) {
+    return ts.factory.createIfStatement(
+      eqeqeq(a, b).expression,
+      ts.factory.createReturnStatement(
+        ts.factory.createToken(ts.SyntaxKind.TrueKeyword),
+      ),
+    );
+  }
+
+  function mergeWithAmp(expressions: ts.Expression[]) {
+    if (expressions.length === 0) {
+      return ts.factory.createTrue();
+    }
+
+    return expressions.reduce((acc, current) =>
+      ts.factory.createBinaryExpression(
+        acc,
+        ts.factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+        current,
+      ),
+    );
+  }
+
+  function transform(
+    a: ts.Identifier,
+    b: ts.Identifier,
+    context: ITypiaContext,
+    type: ts.Type,
+  ): ts.Expression {
+    if (isPrimitiveType(type)) {
+      return eqeqeqReturn(a, b).expression;
+    }
+
+    if (context.checker.isArrayType(type)) {
+      return eqeqeqReturn(a, b).expression;
+    }
+    if (context.checker.isTupleType(type)) {
+      return eqeqeqReturn(a, b).expression;
+    }
+
+    if ((type.flags & ts.TypeFlags.Object) !== 0) {
+      const properties = type.getProperties();
+      const statements = properties.flatMap((prop) => {
+        return transform(
+          ts.factory.createIdentifier(`${a.escapedText}.${prop.escapedName}`),
+          ts.factory.createIdentifier(`${b.escapedText}.${prop.escapedName}`),
+          context,
+          context.checker.getTypeOfSymbolAtLocation(
+            prop,
+            prop.declarations![0]!,
+          ),
+        );
+      });
+      return ts.factory.createBinaryExpression(
+        eqeqeq(a, b).expression,
+        ts.factory.createToken(ts.SyntaxKind.BarBarToken),
+        mergeWithAmp(statements),
+      );
+    }
+
+    throw new Error("Unsupported type");
+  }
+
+  // function transform_(
+  //   a: ts.Identifier,
+  //   b: ts.Identifier,
+  //   metadata: Metadata,
+  //   props: {
+  //     context: ITypiaContext;
+  //     type: ts.Type;
+  //   },
+  // ) {
+  //   if (metadata.atomics[0]) {
+  //     // DO:
+  //     return [
+  //       ts.factory.createExpressionStatement(
+  //         ts.factory.createBinaryExpression(
+  //           a,
+  //           ts.factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+  //           b,
+  //         ),
+  //       ),
+  //     ];
+  //   }
+  //   // if (props.metadata.tuples[0]) {
+  //   //   const tuple = props.metadata.tuples[0]!.type;
+  //   //   console.log(tuple.elements.at(0));
+  //   //   return [
+  //   //     ts.factory.createExpressionStatement(
+  //   //       ts.factory.createBinaryExpression(
+  //   //         eqeqeq(a, b).expression,
+  //   //         ts.factory.createToken(ts.SyntaxKind.AmpersandAmpersandEqualsToken),
+  //   //         b,
+  //   //       ),
+  //   //     ),
+  //   //   ];
+  //   // }
+  //   if (metadata.objects[0]) {
+  //     // const tuple = props.metadata.tuples[0]!.type;
+  //     // console.log(tuple.elements.at(0));
+  //     // props.type.isTypeParameter
+  //     return [eqeqeqReturn(a, b), ...transform_meta(a, b, metadata.objects)];
+  //   }
+  //
+  //   return [
+  //     ts.factory.createExpressionStatement(
+  //       ts.factory.createBinaryExpression(
+  //         a,
+  //         ts.factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+  //         b,
+  //       ),
+  //     ),
+  //   ];
+  // }
 }

--- a/src/programmers/compare/CompareEqualsProgrammer.ts
+++ b/src/programmers/compare/CompareEqualsProgrammer.ts
@@ -5,6 +5,9 @@ import { MetadataCollection } from "../../factories/MetadataCollection";
 import { MetadataFactory } from "../../factories/MetadataFactory";
 
 import { Metadata } from "../../schemas/metadata/Metadata";
+import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataObject } from "../../schemas/metadata/MetadataObject";
+import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 
 import { IProgrammerProps } from "../../transformers/IProgrammerProps";
 import { ITypiaContext } from "../../transformers/ITypiaContext";
@@ -119,20 +122,20 @@ export namespace CompareEqualsProgrammer {
     return result;
   }
 
-  // function mergeWithBar(
-  //   expressions: ts.Expression[],
-  //   withParenthesized = false,
-  // ) {
-  //   if (expressions.length === 0) {
-  //     return ts.factory.createTrue();
-  //   }
-  //
-  //   const result = expressions.reduce((acc, current) => or(acc, current));
-  //   if (withParenthesized) {
-  //     return ts.factory.createParenthesizedExpression(result);
-  //   }
-  //   return result;
-  // }
+  function mergeWithBar(
+    expressions: ts.Expression[],
+    withParenthesized = false,
+  ) {
+    if (expressions.length === 0) {
+      return ts.factory.createTrue();
+    }
+
+    const result = expressions.reduce((acc, current) => or(acc, current));
+    if (withParenthesized) {
+      return ts.factory.createParenthesizedExpression(result);
+    }
+    return result;
+  }
 
   function or(a: ts.Expression, b: ts.Expression) {
     return ts.factory.createBinaryExpression(
@@ -152,18 +155,23 @@ export namespace CompareEqualsProgrammer {
 
   const params = {
     item: IdentifierFactory.parameter("item"),
-    index: IdentifierFactory.parameter("index"),
+    index: IdentifierFactory.parameter,
   };
   const ids = {
+    Map: ts.factory.createIdentifier("Map"),
+    Set: ts.factory.createIdentifier("Set"),
     Array: ts.factory.createIdentifier("Array"),
 
     item: ts.factory.createIdentifier("item"),
     size: ts.factory.createIdentifier("size"),
     from: ts.factory.createIdentifier("from"),
-    index: ts.factory.createIdentifier("index"),
     every: ts.factory.createIdentifier("every"),
+    object: ts.factory.createIdentifier("object"),
     values: ts.factory.createIdentifier("values"),
     length: ts.factory.createIdentifier("length"),
+    isArray: ts.factory.createIdentifier("isArray"),
+
+    index: () => ts.factory.createUniqueName("index"),
   };
 
   function indexAccess(
@@ -194,151 +202,262 @@ export namespace CompareEqualsProgrammer {
     );
   }
 
+  function transformObject(
+    a: ts.Expression,
+    b: ts.Expression,
+    props: Props,
+    metadata: Metadata,
+    object: MetadataObject,
+  ) {
+    if (object.type.recursive) {
+      throw new TransformerError({
+        code: `typia.compare.equals()`,
+        message: `Detected recusion type ${props.type.getSymbol()?.getName()} -> ${object.type.name}.`,
+      });
+    }
+
+    if (metadata.class) {
+      throw new TransformerError({
+        code: `typia.compare.equals()`,
+        message: `Can't compare classes as static ${props.type.getSymbol()?.getName()} -> ${object.type.name}.`,
+      });
+    }
+
+    const statements = object.type.properties.map((prop) => {
+      if (!prop.key.getSoleLiteral()) {
+        throw new TransformerError({
+          code: `typia.compare.equals()`,
+          message: `Detected unknown property name ${props.type.getSymbol()?.getName()} -> ${object.type.name}. If it's dynamic it's doesn't support.`,
+        });
+      }
+
+      return transform(
+        access(
+          a,
+          ts.factory.createIdentifier(prop.key.getSoleLiteral()!),
+          prop.value.optional,
+        ),
+        access(
+          b,
+          ts.factory.createIdentifier(prop.key.getSoleLiteral()!),
+          prop.value.optional,
+        ),
+        props,
+        prop.value,
+      );
+    });
+    return or(eqeqeq(a, b).expression, mergeWithAmp(statements, true));
+  }
+
+  function compareItem(b: ts.Expression, props: Props, metadata: Metadata) {
+    const index = ids.index();
+    return ts.factory.createArrowFunction(
+      undefined,
+      undefined,
+      [params.item, params.index(index)],
+      undefined,
+      undefined,
+      ts.factory.createBlock([
+        ts.factory.createReturnStatement(
+          transform(
+            ids.item,
+            indexAccess(
+              ts.factory.createAsExpression(
+                b,
+                ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+              ),
+              index,
+              true,
+            ),
+            props,
+            metadata,
+          ),
+        ),
+      ]),
+    );
+  }
+
+  function transformIterable(
+    a: ts.Expression,
+    b: ts.Expression,
+    props: Props,
+    metadata: Metadata,
+  ) {
+    return or(
+      eqeqeq(a, b).expression,
+      ts.factory.createParenthesizedExpression(
+        and(
+          eqeqeq(access(a, ids.size), access(b, ids.size)).expression,
+
+          ts.factory.createCallExpression(
+            access(
+              ts.factory.createCallExpression(
+                access(ids.Array, ids.from),
+                undefined,
+                [
+                  ts.factory.createCallExpression(
+                    access(a, ids.values),
+                    undefined,
+                    undefined,
+                  ),
+                ],
+              ),
+              ids.every,
+            ),
+            undefined,
+            [compareItem(b, props, metadata)],
+          ),
+        ),
+      ),
+    );
+  }
+
+  function transformTuple(
+    a: ts.Expression,
+    b: ts.Expression,
+    props: Props,
+    _metadata: Metadata,
+    tuple: MetadataTuple,
+  ) {
+    const compares = tuple.type.elements.map((type, index) =>
+      transform(
+        indexAccess(a, ts.factory.createIdentifier(index.toString())),
+        indexAccess(b, ts.factory.createIdentifier(index.toString())),
+        props,
+        type,
+      ),
+    );
+    return or(eqeqeq(a, b).expression, mergeWithAmp(compares, true));
+  }
+
+  function transformArray(
+    a: ts.Expression,
+    b: ts.Expression,
+    props: Props,
+    _metadata: Metadata,
+    array: MetadataArray,
+  ) {
+    if (array.type.recursive) {
+      throw new TransformerError({
+        code: `typia.compare.equals()`,
+        message: `Detected recusion type ${props.type.getSymbol()?.getName()} -> ${array.type.name}.`,
+      });
+    }
+    return or(
+      eqeqeq(a, b).expression,
+      ts.factory.createParenthesizedExpression(
+        and(
+          eqeqeq(access(a, ids.length), access(b, ids.length)).expression,
+          ts.factory.createCallExpression(access(a, ids.every), undefined, [
+            compareItem(b, props, array.type.value),
+          ]),
+        ),
+      ),
+    );
+  }
+
+  function instaceof(a: ts.Expression, b: ts.Expression) {
+    return ts.factory.createBinaryExpression(
+      a,
+      ts.factory.createToken(ts.SyntaxKind.InstanceOfKeyword),
+      b,
+    );
+  }
+
+  function typeOf(a: ts.Expression, b: ts.Expression) {
+    return eqeqeq(ts.factory.createTypeOfExpression(a), b).expression;
+  }
+
+  function isArray(a: ts.Expression) {
+    return ts.factory.createCallExpression(
+      access(ids.Array, ids.isArray),
+      undefined,
+      [a],
+    );
+  }
+
   function transform(
     a: ts.Expression,
     b: ts.Expression,
     props: Props,
     metadata: Metadata,
   ): ts.Expression {
-    if (metadata.atomics[0]) {
+    if (metadata.isUnionBucket()) {
+      const compares: ts.Expression[] = [];
+
+      if (metadata.constants.length > 0 || metadata.atomics.length > 0) {
+        compares.push(eqeqeq(a, b).expression);
+      }
+      if (metadata.maps.length > 0) {
+        compares.push(
+          and(
+            instaceof(a, ids.Map),
+            mergeWithBar(
+              metadata.maps.map((element) =>
+                transformIterable(a, b, props, element.value),
+              ),
+            ),
+          ),
+        );
+      }
+      if (metadata.sets.length > 0) {
+        compares.push(
+          and(
+            instaceof(a, ids.Map),
+            mergeWithBar(
+              metadata.sets.map((element) =>
+                transformIterable(a, b, props, element.value),
+              ),
+            ),
+          ),
+        );
+      }
+      if (metadata.objects.length > 0) {
+        compares.push(
+          and(
+            typeOf(a, ids.object),
+            mergeWithBar(
+              metadata.objects.map((element) =>
+                transformObject(a, b, props, metadata, element),
+              ),
+            ),
+          ),
+        );
+      }
+      if (metadata.arrays.length > 0) {
+        compares.push(
+          and(
+            isArray(a),
+            mergeWithBar(
+              metadata.arrays.map((element) =>
+                transformArray(a, b, props, metadata, element),
+              ),
+            ),
+          ),
+        );
+      }
+
+      return mergeWithBar(compares);
+    }
+
+    if (metadata.atomics[0] || metadata.constants[0]) {
       return eqeqeq(a, b).expression;
     }
 
     if (metadata.objects[0]) {
-      const object = metadata.objects[0];
-      const name = object.getName();
-
-      if (object.type.recursive) {
-        throw new TransformerError({
-          code: `typia.compare.equals()`,
-          message: `Detected recusion type ${props.type.getSymbol()?.getName()} -> ${object.type.name}.`,
-        });
-      }
-
-      if (metadata.class) {
-        throw new TransformerError({
-          code: `typia.compare.equals()`,
-          message: `Can't compare classes as static ${props.type.getSymbol()?.getName()} -> ${object.type.name}.`,
-        });
-      }
-
-      if (name === "__type" || name.startsWith("__type.")) {
-        return eqeqeq(a, b).expression;
-      }
-
-      const statements = object.type.properties.map((prop) => {
-        if (!prop.key.getSoleLiteral()) {
-          throw new TransformerError({
-            code: `typia.compare.equals()`,
-            message: `Detected unknown property name ${props.type.getSymbol()?.getName()} -> ${object.type.name}. If it's dynamic it's doesn't support.`,
-          });
-        }
-
-        return transform(
-          access(
-            a,
-            ts.factory.createIdentifier(prop.key.getSoleLiteral()!),
-            prop.value.optional,
-          ),
-          access(
-            b,
-            ts.factory.createIdentifier(prop.key.getSoleLiteral()!),
-            prop.value.optional,
-          ),
-          props,
-          prop.value,
-        );
-      });
-      return or(eqeqeq(a, b).expression, mergeWithAmp(statements, true));
+      return transformObject(a, b, props, metadata, metadata.objects[0]);
     }
 
     if (metadata.tuples[0]) {
-      const tuple = metadata.tuples[0];
-
-      const compares = tuple.type.elements.map((type, index) =>
-        transform(
-          indexAccess(a, ts.factory.createIdentifier(index.toString())),
-          indexAccess(b, ts.factory.createIdentifier(index.toString())),
-          props,
-          type,
-        ),
-      );
-      return or(eqeqeq(a, b).expression, mergeWithAmp(compares, true));
-    }
-
-    function compaeItem(meta: Metadata) {
-      return ts.factory.createArrowFunction(
-        undefined,
-        undefined,
-        [params.item, params.index],
-        undefined,
-        undefined,
-        ts.factory.createBlock([
-          ts.factory.createReturnStatement(
-            transform(
-              ids.item,
-              indexAccess(
-                ts.factory.createAsExpression(
-                  b,
-                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                ),
-                ids.index,
-                true,
-              ),
-              props,
-              meta,
-            ),
-          ),
-        ]),
-      );
-    }
-
-    function compareIterable(meta: Metadata) {
-      return or(
-        eqeqeq(a, b).expression,
-        ts.factory.createParenthesizedExpression(
-          and(
-            eqeqeq(access(a, ids.size), access(b, ids.size)).expression,
-
-            ts.factory.createCallExpression(
-              access(
-                ts.factory.createCallExpression(
-                  access(ids.Array, ids.from),
-                  undefined,
-                  [
-                    ts.factory.createCallExpression(
-                      access(a, ids.values),
-                      undefined,
-                      undefined,
-                    ),
-                  ],
-                ),
-                ids.every,
-              ),
-              undefined,
-              [compaeItem(meta)],
-            ),
-          ),
-        ),
-      );
+      return transformTuple(a, b, props, metadata, metadata.tuples[0]);
     }
 
     if (metadata.arrays[0]) {
-      return or(
-        eqeqeq(a, b).expression,
-        ts.factory.createParenthesizedExpression(
-          and(
-            eqeqeq(access(a, ids.length), access(b, ids.length)).expression,
-            ts.factory.createCallExpression(access(a, ids.every), undefined, [
-              compaeItem(metadata.arrays[0].type.value),
-            ]),
-          ),
-        ),
-      );
+      return transformArray(a, b, props, metadata, metadata.arrays[0]);
     } else if (metadata.sets[0]) {
-      return compareIterable(metadata.sets[0].value);
+      return transformIterable(a, b, props, metadata.sets[0].value);
     } else if (metadata.maps[0]) {
-      return compareIterable(metadata.maps[0].value);
+      return transformIterable(a, b, props, metadata.maps[0].value);
     }
 
     return eqeqeq(a, b).expression;

--- a/src/programmers/compare/CompareEqualsProgrammer.ts
+++ b/src/programmers/compare/CompareEqualsProgrammer.ts
@@ -83,15 +83,6 @@ export namespace CompareEqualsProgrammer {
     );
   }
 
-  // function eqeqeqReturn(a: ts.Identifier, b: ts.Identifier) {
-  //   return ts.factory.createIfStatement(
-  //     eqeqeq(a, b).expression,
-  //     ts.factory.createReturnStatement(
-  //       ts.factory.createToken(ts.SyntaxKind.TrueKeyword),
-  //     ),
-  //   );
-  // }
-
   function mergeWithAmp(
     expressions: ts.Expression[],
     withParenthesized = false,
@@ -296,6 +287,6 @@ export namespace CompareEqualsProgrammer {
       return or(eqeqeq(a, b).expression, mergeWithAmp(statements, true));
     }
 
-    throw new Error("Unsupported type");
+    return eqeqeq(a, b).expression;
   }
 }

--- a/src/schemas/metadata/IMetadata.ts
+++ b/src/schemas/metadata/IMetadata.ts
@@ -16,6 +16,7 @@ export interface IMetadata {
   required: boolean;
   optional: boolean;
   nullable: boolean;
+  class: boolean;
   functions: IMetadataFunction[];
 
   atomics: IMetadataAtomic[];

--- a/src/schemas/metadata/Metadata.ts
+++ b/src/schemas/metadata/Metadata.ts
@@ -24,6 +24,7 @@ export class Metadata {
   public required: boolean;
   public optional: boolean;
   public nullable: boolean;
+  public class: boolean;
 
   public escaped: MetadataEscaped | null;
   public atomics: MetadataAtomic[];
@@ -60,6 +61,7 @@ export class Metadata {
     this.optional = props.optional;
     this.nullable = props.nullable;
     this.functions = props.functions;
+    this.class = props.class;
 
     this.escaped = props.escaped;
     this.atomics = props.atomics;
@@ -93,6 +95,7 @@ export class Metadata {
       nullable: false,
       required: true,
       optional: false,
+      class: false,
 
       escaped: null,
       constants: [],
@@ -119,6 +122,7 @@ export class Metadata {
       required: this.required,
       optional: this.optional,
       nullable: this.nullable,
+      class: this.class,
       functions: this.functions.map((f) => f.toJSON()),
 
       atomics: this.atomics.map((a) => a.toJSON()),
@@ -144,6 +148,7 @@ export class Metadata {
       required: meta.required,
       optional: meta.optional,
       nullable: meta.nullable,
+      class: meta.class,
       functions: meta.functions.map((f) => MetadataFunction.from(f, dict)),
 
       constants: meta.constants.map(MetadataConstant.from),
@@ -522,6 +527,7 @@ export namespace Metadata {
       nullable: x.nullable || y.nullable,
       required: x.required && y.required,
       optional: x.optional || y.optional,
+      class: x.class || y.class,
       functions: x.functions.length ? x.functions : y.functions, // @todo
       escaped:
         x.escaped !== null && y.escaped !== null

--- a/src/transformers/CallExpressionTransformer.ts
+++ b/src/transformers/CallExpressionTransformer.ts
@@ -24,6 +24,7 @@ import { CreateValidateTransformer } from "./features/CreateValidateTransformer"
 import { IsTransformer } from "./features/IsTransformer";
 import { RandomTransformer } from "./features/RandomTransformer";
 import { ValidateTransformer } from "./features/ValidateTransformer";
+import { CompareEqualsTransformer } from "./features/compare/CompareEqualsTransformer";
 import { CreateHttpAssertFormDataTransformer } from "./features/http/CreateHttpAssertFormDataTransformer";
 import { CreateHttpAssertHeadersTransformer } from "./features/http/CreateHttpAssertHeadersTransformer";
 import { CreateHttpAssertQueryTransformer } from "./features/http/CreateHttpAssertQueryTransformer";
@@ -426,6 +427,9 @@ const FUNCTORS: Record<string, Record<string, () => Task>> = {
     createIsStringify: () => JsonCreateIsStringifyTransformer.transform,
     createValidateStringify: () =>
       JsonCreateValidateStringifyTransformer.transform,
+  },
+  compare: {
+    equals: () => CompareEqualsTransformer.transform,
   },
   protobuf: {
     // SCHEMA

--- a/src/transformers/features/compare/CompareEqualsTransformer.ts
+++ b/src/transformers/features/compare/CompareEqualsTransformer.ts
@@ -1,0 +1,13 @@
+import { CompareEqualsProgrammer } from "../../../programmers/compare/CompareEqualsProgrammer";
+
+import { ITransformProps } from "../../ITransformProps";
+import { GenericTransformer } from "../../internal/GenericTransformer";
+
+export namespace CompareEqualsTransformer {
+  export const transform = (props: ITransformProps) =>
+    GenericTransformer.scalar({
+      ...props,
+      method: "json.isStringify",
+      write: CompareEqualsProgrammer.write,
+    });
+}

--- a/src/transformers/features/compare/CompareEqualsTransformer.ts
+++ b/src/transformers/features/compare/CompareEqualsTransformer.ts
@@ -7,7 +7,7 @@ export namespace CompareEqualsTransformer {
   export const transform = (props: ITransformProps) =>
     GenericTransformer.scalar({
       ...props,
-      method: "json.isStringify",
+      method: "compare.equals",
       write: CompareEqualsProgrammer.write,
     });
 }

--- a/test/build/internal/TestFeature.ts
+++ b/test/build/internal/TestFeature.ts
@@ -1,3 +1,4 @@
+import { write_compare } from "../writers/write_compare";
 import { write_functional } from "../writers/write_functional";
 import { write_functionalAsync } from "../writers/write_functionalAsync";
 import { write_notation } from "../writers/write_notation";
@@ -410,6 +411,22 @@ export namespace TestFeature {
       )
       .flat(),
 
+    //----
+    // COMPARES
+    //----
+    ...["equals"]
+      .map((method) => [
+        {
+          module: "compare",
+          method,
+          creatable: false,
+          spoilable: true,
+          programmer() {
+            return write_compare(this)(false);
+          },
+        },
+      ])
+      .flat(),
     //----
     // MISCELLANEOUS
     //----

--- a/test/build/template.ts
+++ b/test/build/template.ts
@@ -143,6 +143,10 @@ function script(
 async function main(): Promise<void> {
   process.chdir(__dirname + "/..");
 
+  const featureFilter = process.argv
+    .find((a) => a.startsWith("--features"))
+    ?.split("=")[1];
+
   // NORMAL FEATURES
   const structures: TestStructure<any>[] = await load();
   const featureList: TestFeature[] = [
@@ -154,7 +158,10 @@ async function main(): Promise<void> {
       custom: true as const,
     })),
   ];
-  for (const feature of featureList) {
+  for await (const feature of featureList) {
+    if (featureFilter && feature.module !== featureFilter) {
+      continue;
+    }
     await generate(feature, structures, false);
     if (feature.creatable) await generate(feature, structures, true);
   }

--- a/test/build/writers/write_compare.ts
+++ b/test/build/writers/write_compare.ts
@@ -1,0 +1,54 @@
+import { StringUtil } from "../utils/StringUtil";
+
+// import typia from "typia";
+//
+// import { _test_compare_equals } from "../../internal/_test_compare_equals";
+// import { AtomicSimple } from "../../structures/AtomicSimple";
+//
+// export const test_compare_equals_AtomicSimple = _test_compare_equals(
+//   "AtomicSimple",
+// )<AtomicSimple>(AtomicSimple)((a, b) =>
+//   typia.compare.equals<AtomicSimple>(a, b),
+// );
+
+export const write_compare =
+  (p: IProps) => (create: boolean) => (structure: string) =>
+    `import typia from "typia";
+
+import { _${file({
+      ...p,
+      method: p.method.startsWith("create")
+        ? StringUtil.localize(p.method.replace("create", ""))
+        : p.method,
+    })} } from "../../internal/_${file({
+      ...p,
+      method: p.method.startsWith("create")
+        ? StringUtil.localize(p.method.replace("create", ""))
+        : p.method,
+    })}";
+import { ${structure} } from "../../structures/${structure}";
+
+export const ${file(p)}_${structure} = _${file({
+      ...p,
+      method: p.method.startsWith("create")
+        ? StringUtil.localize(p.method.replace("create", ""))
+        : p.method,
+    })}(
+    "${structure}",
+)<${structure}>(
+    ${structure}
+)(${functor(p)(create)(structure)});
+`;
+
+const file = (p: IProps) => "test_" + method(p).replace(".", "_");
+const method = (p: IProps) =>
+  [p.module, p.method].filter((str) => !!str).join(".");
+const functor = (p: IProps) => (create: boolean) => (structure: string) =>
+  create
+    ? `typia.${method(p)}<${structure}>()`
+    : `(a, b) => typia.${method(p)}<${structure}>(a, b)`;
+
+interface IProps {
+  module: string | null;
+  method: string;
+}

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -5,12 +5,12 @@ interface ISomething {
   age: number;
 }
 
-// export const objects = typia.compare.equals<ISomething>(
-//   { id: "1", age: 2 },
-//   { id: "1", age: 2 },
-// );
+export const objects = typia.compare.equals<ISomething>(
+  { id: "1", age: 2 },
+  { id: "1", age: 2 },
+);
 
-// export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
+export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
 
 export const tuple = typia.compare.equals<
   [number, string, { foo: string; bar?: string }]
@@ -19,7 +19,12 @@ export const tuple = typia.compare.equals<
   [1, "foo", { foo: "bar", bar: "baz" }],
 );
 
-// export const nested = typia.compare.equals<{
-//   id: number;
-//   items: Array<{ name: string }>;
-// }>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+export const nested = typia.compare.equals<{
+  id: number;
+  items: Array<{ name: string }>;
+}>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+
+export const union = typia.compare.equals<Array<string | number>>([1], [1]);
+export const unionNested = typia.compare.equals<
+  Array<{ foo: string } | { bar: number }>
+>([{ foo: "1" }], [{ foo: "1" }]);

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -1,3 +1,4 @@
+import { assert } from "console";
 import typia from "typia";
 
 interface ISomething {
@@ -9,10 +10,15 @@ export const objects = typia.compare.equals<ISomething>(
   { id: "1", age: 2 },
   { id: "1", age: 2 },
 );
-//
+
 // export const matrix = typia.compare.equals<number[][][]>(
 //   [[[1, 2, 3]]],
 //   [[[1, 2, 3]]],
+// );
+
+// export const matrix = typia.compare.equals<number[][]>(
+//   [[1, 2, 3]],
+//   [[1, 2, 3]],
 // );
 
 // interface ICategory {
@@ -42,6 +48,48 @@ export const objects = typia.compare.equals<ISomething>(
 //   Array<{ foo: string } | { bar: number }>
 // >([{ foo: "1" }], [{ foo: "1" }]);
 
+// export type Union = false | 1 | 2 | "three" | "four" | { key: "key" };
+// export function union(): Union[] {
+//   return [false, 1, 2, "three", "four", { key: "key" }];
+// }
+// export const arrayUnioun = typia.compare.equals(union(), union());
+// console.assert(arrayUnioun, union.name);
+//
+// typia.compare.equals([{ a: 1 }], [{ a: 1 }]);
+
+console.assert(
+  typia.compare.equals(new Set([1]), new Set([1])),
+  "Set compares should be equal",
+);
+
+export type MegaUnion =
+  | number
+  | Uint8Array
+  | Set<boolean>
+  | Map<any, any>
+  | [string, string]
+  | [boolean, number, number]
+  | number[]
+  | boolean[]
+  | [];
+
+export function megaUnion(): MegaUnion[] {
+  return [
+    3,
+    // new Uint8Array(),
+    new Set([false, true]),
+    // new Map(),
+    // ["one", "two"],
+    // [false, 1, 2],
+    // [1, 2, 3],
+    // [true, false],
+    // [],
+  ];
+}
+
+export const arrayMegaUnioun = typia.compare.equals(megaUnion(), megaUnion());
+console.assert(arrayMegaUnioun, megaUnion.name);
+
 // type SpecificKeys = {
 //   "foo-bar-baz": number;
 // };
@@ -62,7 +110,26 @@ export const objects = typia.compare.equals<ISomething>(
 //   { foo: new FooClass() },
 // );
 
-export const sets = typia.compare.equals(
-  new Set([{ foo: 1 }]),
-  new Set([{ foo: 1 }]),
-);
+// export const sets = typia.compare.equals(
+//   new Set([{ foo: 1 }]),
+//   new Set([{ foo: 1 }]),
+// );
+//
+// export enum LanguageCode {
+//   Arabic = "ar",
+//   ChineseSimp = "zh-Hans",
+//   ChineseTrad = "zh-Hant",
+//   English = "en",
+//   French = "fr",
+//   German = "de",
+//   Japanese = "ja",
+//   Korean = "ko", // <-- this line
+//   Portuguese = "pt",
+//   Russian = "ru",
+// }
+//
+// export type DynamicEnumeration = {
+//   [P in LanguageCode]?: string;
+// };
+//
+// export const dyn = typia.compare.equals<DynamicEnumeration>({}, {});

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -1,0 +1,13 @@
+import typia from "typia";
+
+interface ISomething {
+  id: string;
+  age: number;
+}
+
+// export const objects = typia.compare.equals<ISomething>(
+//   { id: "1", age: 2 },
+//   { id: "1", age: 2 },
+// );
+
+export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -1,30 +1,43 @@
 import typia from "typia";
 
-interface ISomething {
-  id: string;
-  age: number;
-}
+// interface ISomething {
+//   id: string;
+//   age: number;
+// }
+//
+// export const objects = typia.compare.equals<ISomething>(
+//   { id: "1", age: 2 },
+//   { id: "1", age: 2 },
+// );
+//
+// export const matrix = typia.compare.equals<number[][][]>(
+//   [[[1, 2, 3]]],
+//   [[[1, 2, 3]]],
+// );
 
-export const objects = typia.compare.equals<ISomething>(
-  { id: "1", age: 2 },
-  { id: "1", age: 2 },
-);
-
-export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
-
-export const tuple = typia.compare.equals<
-  [number, string, { foo: string; bar?: string }]
->(
-  [1, "foo", { foo: "bar", bar: "baz" }],
-  [1, "foo", { foo: "bar", bar: "baz" }],
-);
-
-export const nested = typia.compare.equals<{
+interface ICategory {
+  children: ICategory[];
   id: number;
-  items: Array<{ name: string }>;
-}>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+  code: string;
+  sequence: number;
+}
+export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
 
-export const union = typia.compare.equals<Array<string | number>>([1], [1]);
-export const unionNested = typia.compare.equals<
-  Array<{ foo: string } | { bar: number }>
->([{ foo: "1" }], [{ foo: "1" }]);
+// export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
+//
+// export const tuple = typia.compare.equals<
+//   [number, string, { foo: string; bar?: string }]
+// >(
+//   [1, "foo", { foo: "bar", bar: "baz" }],
+//   [1, "foo", { foo: "bar", bar: "baz" }],
+// );
+//
+// export const nested = typia.compare.equals<{
+//   id: number;
+//   items: Array<{ name: string }>;
+// }>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+//
+// export const union = typia.compare.equals<Array<string | number>>([1], [1]);
+// export const unionNested = typia.compare.equals<
+//   Array<{ foo: string } | { bar: number }>
+// >([{ foo: "1" }], [{ foo: "1" }]);

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -10,4 +10,16 @@ interface ISomething {
 //   { id: "1", age: 2 },
 // );
 
-export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
+// export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
+
+export const tuple = typia.compare.equals<
+  [number, string, { foo: string; bar?: string }]
+>(
+  [1, "foo", { foo: "bar", bar: "baz" }],
+  [1, "foo", { foo: "bar", bar: "baz" }],
+);
+
+// export const nested = typia.compare.equals<{
+//   id: number;
+//   items: Array<{ name: string }>;
+// }>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -1,30 +1,30 @@
 import typia from "typia";
 
-// interface ISomething {
-//   id: string;
-//   age: number;
-// }
-//
-// export const objects = typia.compare.equals<ISomething>(
-//   { id: "1", age: 2 },
-//   { id: "1", age: 2 },
-// );
+interface ISomething {
+  id: string;
+  age: number;
+}
+
+export const objects = typia.compare.equals<ISomething>(
+  { id: "1", age: 2 },
+  { id: "1", age: 2 },
+);
 //
 // export const matrix = typia.compare.equals<number[][][]>(
 //   [[[1, 2, 3]]],
 //   [[[1, 2, 3]]],
 // );
 
-interface ICategory {
-  children: ICategory[];
-  id: number;
-  code: string;
-  sequence: number;
-}
-export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
+// interface ICategory {
+//   children: ICategory[];
+//   id: number;
+//   code: string;
+//   sequence: number;
+// }
+// export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
 
 // export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
-//
+
 // export const tuple = typia.compare.equals<
 //   [number, string, { foo: string; bar?: string }]
 // >(
@@ -41,3 +41,28 @@ export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
 // export const unionNested = typia.compare.equals<
 //   Array<{ foo: string } | { bar: number }>
 // >([{ foo: "1" }], [{ foo: "1" }]);
+
+// type SpecificKeys = {
+//   "foo-bar-baz": number;
+// };
+// export const specificKeys = typia.compare.equals<SpecificKeys>(
+//   { "foo-bar-baz": 1 },
+//   { "foo-bar-baz": 2 },
+// );
+
+// class FooClass {
+//   foo: string = "";
+//   method() {}
+// }
+//
+// export const fooClass = typia.compare.equals(new FooClass(), new FooClass());
+//
+// export const fooNestedClass = typia.compare.equals(
+//   { foo: new FooClass() },
+//   { foo: new FooClass() },
+// );
+
+export const sets = typia.compare.equals(
+  new Set([{ foo: 1 }]),
+  new Set([{ foo: 1 }]),
+);

--- a/test/generate/input/generate_comare.ts
+++ b/test/generate/input/generate_comare.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import typia from "typia";
 
 interface ISomething {
@@ -9,6 +8,15 @@ interface ISomething {
 export const objects = typia.compare.equals<ISomething>(
   { id: "1", age: 2 },
   { id: "1", age: 2 },
+);
+
+console.assert(
+  typia.compare.equals(new Map([["foo", 1]]), new Map([["foo", 1]])),
+  "Map compares should be equal",
+);
+console.assert(
+  typia.compare.equals(new Set([["foo", 1]]), new Set([["foo", 1]])),
+  "Set compares should be equal",
 );
 
 // export const matrix = typia.compare.equals<number[][][]>(
@@ -57,38 +65,31 @@ export const objects = typia.compare.equals<ISomething>(
 //
 // typia.compare.equals([{ a: 1 }], [{ a: 1 }]);
 
-console.assert(
-  typia.compare.equals(new Set([1]), new Set([1])),
-  "Set compares should be equal",
-);
-
-export type MegaUnion =
-  | number
-  | Uint8Array
-  | Set<boolean>
-  | Map<any, any>
-  | [string, string]
-  | [boolean, number, number]
-  | number[]
-  | boolean[]
-  | [];
-
-export function megaUnion(): MegaUnion[] {
-  return [
-    3,
-    // new Uint8Array(),
-    new Set([false, true]),
-    // new Map(),
-    // ["one", "two"],
-    // [false, 1, 2],
-    // [1, 2, 3],
-    // [true, false],
-    // [],
-  ];
-}
-
-export const arrayMegaUnioun = typia.compare.equals(megaUnion(), megaUnion());
-console.assert(arrayMegaUnioun, megaUnion.name);
+// export type MegaUnion =
+//   | number
+//   | Uint8Array
+//   | Map<string, number>
+//   | [string, string]
+//   | [boolean, number, number]
+//   | number[]
+//   | boolean[]
+//   | [];
+//
+// export function megaUnion(): MegaUnion[] {
+//   return [
+//     3,
+//     // new Uint8Array(),
+//     new Map([["foo", 1]]),
+//     // ["one", "two"],
+//     // [false, 1, 2],
+//     // [1, 2, 3],
+//     // [true, false],
+//     // [],
+//   ];
+// }
+//
+// export const arrayMegaUnioun = typia.compare.equals(megaUnion(), megaUnion());
+// console.assert(arrayMegaUnioun, megaUnion.name);
 
 // type SpecificKeys = {
 //   "foo-bar-baz": number;

--- a/test/generate/output/generate_comare.ts
+++ b/test/generate/output/generate_comare.ts
@@ -1,0 +1,88 @@
+import typia from "typia";
+
+interface ISomething {
+  id: string;
+  age: number;
+}
+export const objects = (() => {
+  return (a: ISomething, b: ISomething): boolean => {
+    return a === b || (a.id === b.id && a.age === b.age);
+  };
+})()({ id: "1", age: 2 }, { id: "1", age: 2 });
+export const arrays = (() => {
+  return (a: number[], b: number[]): boolean => {
+    return (
+      a === b ||
+      (a.length === b.length &&
+        a.every((item: any, index: any) => {
+          return item === (b as any)[index]!;
+        }))
+    );
+  };
+})()([1, 2, 3], [1, 2, 3]);
+export const tuple = (() => {
+  return (
+    a: [number, string, { foo: string; bar?: string }],
+    b: [number, string, { foo: string; bar?: string }],
+  ): boolean => {
+    return (
+      a === b ||
+      (a[0] === b[0] &&
+        a[1] === b[1] &&
+        (a[2] === b[2] || (a[2].foo === b[2].foo && a[2]?.bar === b[2]?.bar)))
+    );
+  };
+})()(
+  [1, "foo", { foo: "bar", bar: "baz" }],
+  [1, "foo", { foo: "bar", bar: "baz" }],
+);
+export const nested = (() => {
+  return (
+    a: { id: number; items: { name: string }[] },
+    b: { id: number; items: { name: string }[] },
+  ): boolean => {
+    return (
+      a === b ||
+      (a.id === b.id &&
+        (a.items === b.items ||
+          (a.items.length === b.items.length &&
+            a.items.every((item: any, index: any) => {
+              return (
+                item === (b.items as any)[index]! ||
+                item.name === (b.items as any)[index]!.name
+              );
+            }))))
+    );
+  };
+})()({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+export const union = (() => {
+  return (a: (string | number)[], b: (string | number)[]): boolean => {
+    return (
+      a === b ||
+      (a.length === b.length &&
+        a.every((item: any, index: any) => {
+          return item === (b as any)[index]! || item === (b as any)[index]!;
+        }))
+    );
+  };
+})()([1], [1]);
+export const unionNested = (() => {
+  return (
+    a: ({ foo: string } | { bar: number })[],
+    b: ({ foo: string } | { bar: number })[],
+  ): boolean => {
+    return (
+      a === b ||
+      (a.length === b.length &&
+        a.every((item: any, index: any) => {
+          return (
+            item === (b as any)[index]! ||
+            item === (b as any)[index]! ||
+            item.foo === (b as any)[index]!.foo ||
+            item === (b as any)[index]! ||
+            item.bar === (b as any)[index]!.bar
+          );
+        }))
+    );
+  };
+})()([{ foo: "1" }], [{ foo: "1" }]);

--- a/test/generate/output/generate_comare.ts
+++ b/test/generate/output/generate_comare.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import typia from "typia";
 
 interface ISomething {
@@ -10,117 +9,58 @@ export const objects = (() => {
     return a === b || (a.id === b.id && a.age === b.age);
   };
 })()({ id: "1", age: 2 }, { id: "1", age: 2 });
-// export const matrix = typia.compare.equals<number[][][]>(
-//   [[[1, 2, 3]]],
-//   [[[1, 2, 3]]],
-// );
-// export const matrix = typia.compare.equals<number[][]>(
-//   [[1, 2, 3]],
-//   [[1, 2, 3]],
-// );
-// interface ICategory {
-//   children: ICategory[];
-//   id: number;
-//   code: string;
-//   sequence: number;
-// }
-// export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
-// export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
-// export const tuple = typia.compare.equals<
-//   [number, string, { foo: string; bar?: string }]
-// >(
-//   [1, "foo", { foo: "bar", bar: "baz" }],
-//   [1, "foo", { foo: "bar", bar: "baz" }],
-// );
-//
-// export const nested = typia.compare.equals<{
-//   id: number;
-//   items: Array<{ name: string }>;
-// }>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
-//
-// export const union = typia.compare.equals<Array<string | number>>([1], [1]);
-// export const unionNested = typia.compare.equals<
-//   Array<{ foo: string } | { bar: number }>
-// >([{ foo: "1" }], [{ foo: "1" }]);
-// export type Union = false | 1 | 2 | "three" | "four" | { key: "key" };
-// export function union(): Union[] {
-//   return [false, 1, 2, "three", "four", { key: "key" }];
-// }
-// export const arrayUnioun = typia.compare.equals(union(), union());
-// console.assert(arrayUnioun, union.name);
-//
-// typia.compare.equals([{ a: 1 }], [{ a: 1 }]);
 console.assert(
   (() => {
-    return (a: Set<number>, b: Set<number>): boolean => {
+    return (a: Map<string, number>, b: Map<string, number>): boolean => {
       return (
         a === b ||
         (a.size === b.size &&
-          Array.from(a.values()).every((item: any, index_1: any) => {
-            return item === (b as any)[index_1]!;
-          }))
+          (() => {
+            const a1 = Array.from(a.values());
+            const b1 = Array.from(b.values());
+            return (
+              a1 === b1 ||
+              (a1.length === b1.length &&
+                a1.every((item: any, index_1: any) => {
+                  return item === (b1 as any)[index_1]!;
+                }))
+            );
+          })())
       );
     };
-  })()(new Set([1]), new Set([1])),
+  })()(new Map([["foo", 1]]), new Map([["foo", 1]])),
+  "Map compares should be equal",
+);
+console.assert(
+  (() => {
+    return (
+      a: Set<(string | number)[]>,
+      b: Set<(string | number)[]>,
+    ): boolean => {
+      return (
+        a === b ||
+        (a.size === b.size &&
+          (() => {
+            const a1 = Array.from(a.values());
+            const b1 = Array.from(b.values());
+            return (
+              a1 === b1 ||
+              (a1.length === b1.length &&
+                a1.every((item: any, index_2: any) => {
+                  return (
+                    item === (b1 as any)[index_2]! ||
+                    (item.length === (b1 as any)[index_2]!.length &&
+                      item.every((item: any, index_3: any) => {
+                        return (
+                          item === ((b1 as any)[index_2]! as any)[index_3]!
+                        );
+                      }))
+                  );
+                }))
+            );
+          })())
+      );
+    };
+  })()(new Set([["foo", 1]]), new Set([["foo", 1]])),
   "Set compares should be equal",
 );
-export type MegaUnion =
-  | number
-  | Uint8Array
-  | Set<boolean>
-  | Map<any, any>
-  | [string, string]
-  | [boolean, number, number]
-  | number[]
-  | boolean[]
-  | [];
-export function megaUnion(): MegaUnion[] {
-  return [
-    3,
-    // new Uint8Array(),
-    new Set([false, true]),
-    // new Map(),
-    // ["one", "two"],
-    // [false, 1, 2],
-    // [1, 2, 3],
-    // [true, false],
-    // [],
-  ];
-}
-export const arrayMegaUnioun = (() => {
-  return (a: MegaUnion[], b: MegaUnion[]): boolean => {
-    return (
-      a === b ||
-      (a.length === b.length &&
-        a.every((item: any, index_2: any) => {
-          return (
-            item === (b as any)[index_2]! ||
-            (item instanceof Map &&
-              (item === (b as any)[index_2]! ||
-                (item.size === (b as any)[index_2]!.size &&
-                  Array.from(item.values()).every((item: any, index_3: any) => {
-                    return item === ((b as any)[index_2]! as any)[index_3]!;
-                  })))) ||
-            (item instanceof Map &&
-              (item === (b as any)[index_2]! ||
-                (item.size === (b as any)[index_2]!.size &&
-                  Array.from(item.values()).every((item: any, index_4: any) => {
-                    return item === ((b as any)[index_2]! as any)[index_4]!;
-                  })))) ||
-            (Array.isArray(item) &&
-              (item === (b as any)[index_2]! ||
-                (item.length === (b as any)[index_2]!.length &&
-                  item.every((item: any, index_5: any) => {
-                    return item === ((b as any)[index_2]! as any)[index_5]!;
-                  })) ||
-                item === (b as any)[index_2]! ||
-                (item.length === (b as any)[index_2]!.length &&
-                  item.every((item: any, index_6: any) => {
-                    return item === ((b as any)[index_2]! as any)[index_6]!;
-                  }))))
-          );
-        }))
-    );
-  };
-})()(megaUnion(), megaUnion());
-console.assert(arrayMegaUnioun, megaUnion.name);

--- a/test/generate/output/generate_comare.ts
+++ b/test/generate/output/generate_comare.ts
@@ -1,38 +1,71 @@
 import typia from "typia";
 
-// interface ISomething {
-//   id: string;
-//   age: number;
-// }
+interface ISomething {
+  id: string;
+  age: number;
+}
+export const objects = (() => {
+  return (a: ISomething, b: ISomething): boolean => {
+    return a === b || (a.id === b.id && a.age === b.age);
+  };
+})()({ id: "1", age: 2 }, { id: "1", age: 2 });
 //
-// export const objects = typia.compare.equals<ISomething>(
-//   { id: "1", age: 2 },
-//   { id: "1", age: 2 },
+// export const matrix = typia.compare.equals<number[][][]>(
+//   [[[1, 2, 3]]],
+//   [[[1, 2, 3]]],
+// );
+// interface ICategory {
+//   children: ICategory[];
+//   id: number;
+//   code: string;
+//   sequence: number;
+// }
+// export const recurcive = typia.compare.equals<ICategory>(1 as any, 1 as any);
+// export const arrays = typia.compare.equals<number[]>([1, 2, 3], [1, 2, 3]);
+// export const tuple = typia.compare.equals<
+//   [number, string, { foo: string; bar?: string }]
+// >(
+//   [1, "foo", { foo: "bar", bar: "baz" }],
+//   [1, "foo", { foo: "bar", bar: "baz" }],
 // );
 //
-export const matrix = (() => {
-  return (a: number[][][], b: number[][][]): boolean => {
+// export const nested = typia.compare.equals<{
+//   id: number;
+//   items: Array<{ name: string }>;
+// }>({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
+//
+// export const union = typia.compare.equals<Array<string | number>>([1], [1]);
+// export const unionNested = typia.compare.equals<
+//   Array<{ foo: string } | { bar: number }>
+// >([{ foo: "1" }], [{ foo: "1" }]);
+// type SpecificKeys = {
+//   "foo-bar-baz": number;
+// };
+// export const specificKeys = typia.compare.equals<SpecificKeys>(
+//   { "foo-bar-baz": 1 },
+//   { "foo-bar-baz": 2 },
+// );
+// class FooClass {
+//   foo: string = "";
+//   method() {}
+// }
+//
+// export const fooClass = typia.compare.equals(new FooClass(), new FooClass());
+//
+// export const fooNestedClass = typia.compare.equals(
+//   { foo: new FooClass() },
+//   { foo: new FooClass() },
+// );
+export const sets = (() => {
+  return (a: Set<{ foo: number }>, b: Set<{ foo: number }>): boolean => {
     return (
       a === b ||
-      (a.length === b.length &&
-        a.every((item: any, index: any) => {
+      (a.size === b.size &&
+        Array.from(a.values()).every((item: any, index: any) => {
           return (
-            item === (b as any)[index]! ||
-            (item.length === (b as any)[index]!.length &&
-              item.every((item: any, index: any) => {
-                return (
-                  item === ((b as any)[index]! as any)[index]! ||
-                  (item.length === ((b as any)[index]! as any)[index]!.length &&
-                    item.every((item: any, index: any) => {
-                      return (
-                        item ===
-                        (((b as any)[index]! as any)[index]! as any)[index]!
-                      );
-                    }))
-                );
-              }))
+            item === (b as any)[index]! || item.foo === (b as any)[index]!.foo
           );
         }))
     );
   };
-})()([[[1, 2, 3]]], [[[1, 2, 3]]]);
+})()(new Set([{ foo: 1 }]), new Set([{ foo: 1 }]));

--- a/test/generate/output/generate_comare.ts
+++ b/test/generate/output/generate_comare.ts
@@ -1,88 +1,38 @@
 import typia from "typia";
 
-interface ISomething {
-  id: string;
-  age: number;
-}
-export const objects = (() => {
-  return (a: ISomething, b: ISomething): boolean => {
-    return a === b || (a.id === b.id && a.age === b.age);
-  };
-})()({ id: "1", age: 2 }, { id: "1", age: 2 });
-export const arrays = (() => {
-  return (a: number[], b: number[]): boolean => {
-    return (
-      a === b ||
-      (a.length === b.length &&
-        a.every((item: any, index: any) => {
-          return item === (b as any)[index]!;
-        }))
-    );
-  };
-})()([1, 2, 3], [1, 2, 3]);
-export const tuple = (() => {
-  return (
-    a: [number, string, { foo: string; bar?: string }],
-    b: [number, string, { foo: string; bar?: string }],
-  ): boolean => {
-    return (
-      a === b ||
-      (a[0] === b[0] &&
-        a[1] === b[1] &&
-        (a[2] === b[2] || (a[2].foo === b[2].foo && a[2]?.bar === b[2]?.bar)))
-    );
-  };
-})()(
-  [1, "foo", { foo: "bar", bar: "baz" }],
-  [1, "foo", { foo: "bar", bar: "baz" }],
-);
-export const nested = (() => {
-  return (
-    a: { id: number; items: { name: string }[] },
-    b: { id: number; items: { name: string }[] },
-  ): boolean => {
-    return (
-      a === b ||
-      (a.id === b.id &&
-        (a.items === b.items ||
-          (a.items.length === b.items.length &&
-            a.items.every((item: any, index: any) => {
-              return (
-                item === (b.items as any)[index]! ||
-                item.name === (b.items as any)[index]!.name
-              );
-            }))))
-    );
-  };
-})()({ id: 1, items: [{ name: "foo" }] }, { id: 1, items: [{ name: "foo" }] });
-export const union = (() => {
-  return (a: (string | number)[], b: (string | number)[]): boolean => {
-    return (
-      a === b ||
-      (a.length === b.length &&
-        a.every((item: any, index: any) => {
-          return item === (b as any)[index]! || item === (b as any)[index]!;
-        }))
-    );
-  };
-})()([1], [1]);
-export const unionNested = (() => {
-  return (
-    a: ({ foo: string } | { bar: number })[],
-    b: ({ foo: string } | { bar: number })[],
-  ): boolean => {
+// interface ISomething {
+//   id: string;
+//   age: number;
+// }
+//
+// export const objects = typia.compare.equals<ISomething>(
+//   { id: "1", age: 2 },
+//   { id: "1", age: 2 },
+// );
+//
+export const matrix = (() => {
+  return (a: number[][][], b: number[][][]): boolean => {
     return (
       a === b ||
       (a.length === b.length &&
         a.every((item: any, index: any) => {
           return (
             item === (b as any)[index]! ||
-            item === (b as any)[index]! ||
-            item.foo === (b as any)[index]!.foo ||
-            item === (b as any)[index]! ||
-            item.bar === (b as any)[index]!.bar
+            (item.length === (b as any)[index]!.length &&
+              item.every((item: any, index: any) => {
+                return (
+                  item === ((b as any)[index]! as any)[index]! ||
+                  (item.length === ((b as any)[index]! as any)[index]!.length &&
+                    item.every((item: any, index: any) => {
+                      return (
+                        item ===
+                        (((b as any)[index]! as any)[index]! as any)[index]!
+                      );
+                    }))
+                );
+              }))
           );
         }))
     );
   };
-})()([{ foo: "1" }], [{ foo: "1" }]);
+})()([[[1, 2, 3]]], [[[1, 2, 3]]]);

--- a/test/generate/output/generate_comare.ts
+++ b/test/generate/output/generate_comare.ts
@@ -1,3 +1,4 @@
+import { assert } from "console";
 import typia from "typia";
 
 interface ISomething {
@@ -9,10 +10,13 @@ export const objects = (() => {
     return a === b || (a.id === b.id && a.age === b.age);
   };
 })()({ id: "1", age: 2 }, { id: "1", age: 2 });
-//
 // export const matrix = typia.compare.equals<number[][][]>(
 //   [[[1, 2, 3]]],
 //   [[[1, 2, 3]]],
+// );
+// export const matrix = typia.compare.equals<number[][]>(
+//   [[1, 2, 3]],
+//   [[1, 2, 3]],
 // );
 // interface ICategory {
 //   children: ICategory[];
@@ -38,34 +42,85 @@ export const objects = (() => {
 // export const unionNested = typia.compare.equals<
 //   Array<{ foo: string } | { bar: number }>
 // >([{ foo: "1" }], [{ foo: "1" }]);
-// type SpecificKeys = {
-//   "foo-bar-baz": number;
-// };
-// export const specificKeys = typia.compare.equals<SpecificKeys>(
-//   { "foo-bar-baz": 1 },
-//   { "foo-bar-baz": 2 },
-// );
-// class FooClass {
-//   foo: string = "";
-//   method() {}
+// export type Union = false | 1 | 2 | "three" | "four" | { key: "key" };
+// export function union(): Union[] {
+//   return [false, 1, 2, "three", "four", { key: "key" }];
 // }
+// export const arrayUnioun = typia.compare.equals(union(), union());
+// console.assert(arrayUnioun, union.name);
 //
-// export const fooClass = typia.compare.equals(new FooClass(), new FooClass());
-//
-// export const fooNestedClass = typia.compare.equals(
-//   { foo: new FooClass() },
-//   { foo: new FooClass() },
-// );
-export const sets = (() => {
-  return (a: Set<{ foo: number }>, b: Set<{ foo: number }>): boolean => {
+// typia.compare.equals([{ a: 1 }], [{ a: 1 }]);
+console.assert(
+  (() => {
+    return (a: Set<number>, b: Set<number>): boolean => {
+      return (
+        a === b ||
+        (a.size === b.size &&
+          Array.from(a.values()).every((item: any, index_1: any) => {
+            return item === (b as any)[index_1]!;
+          }))
+      );
+    };
+  })()(new Set([1]), new Set([1])),
+  "Set compares should be equal",
+);
+export type MegaUnion =
+  | number
+  | Uint8Array
+  | Set<boolean>
+  | Map<any, any>
+  | [string, string]
+  | [boolean, number, number]
+  | number[]
+  | boolean[]
+  | [];
+export function megaUnion(): MegaUnion[] {
+  return [
+    3,
+    // new Uint8Array(),
+    new Set([false, true]),
+    // new Map(),
+    // ["one", "two"],
+    // [false, 1, 2],
+    // [1, 2, 3],
+    // [true, false],
+    // [],
+  ];
+}
+export const arrayMegaUnioun = (() => {
+  return (a: MegaUnion[], b: MegaUnion[]): boolean => {
     return (
       a === b ||
-      (a.size === b.size &&
-        Array.from(a.values()).every((item: any, index: any) => {
+      (a.length === b.length &&
+        a.every((item: any, index_2: any) => {
           return (
-            item === (b as any)[index]! || item.foo === (b as any)[index]!.foo
+            item === (b as any)[index_2]! ||
+            (item instanceof Map &&
+              (item === (b as any)[index_2]! ||
+                (item.size === (b as any)[index_2]!.size &&
+                  Array.from(item.values()).every((item: any, index_3: any) => {
+                    return item === ((b as any)[index_2]! as any)[index_3]!;
+                  })))) ||
+            (item instanceof Map &&
+              (item === (b as any)[index_2]! ||
+                (item.size === (b as any)[index_2]!.size &&
+                  Array.from(item.values()).every((item: any, index_4: any) => {
+                    return item === ((b as any)[index_2]! as any)[index_4]!;
+                  })))) ||
+            (Array.isArray(item) &&
+              (item === (b as any)[index_2]! ||
+                (item.length === (b as any)[index_2]!.length &&
+                  item.every((item: any, index_5: any) => {
+                    return item === ((b as any)[index_2]! as any)[index_5]!;
+                  })) ||
+                item === (b as any)[index_2]! ||
+                (item.length === (b as any)[index_2]!.length &&
+                  item.every((item: any, index_6: any) => {
+                    return item === ((b as any)[index_2]! as any)[index_6]!;
+                  }))))
           );
         }))
     );
   };
-})()(new Set([{ foo: 1 }]), new Set([{ foo: 1 }]));
+})()(megaUnion(), megaUnion());
+console.assert(arrayMegaUnioun, megaUnion.name);

--- a/test/package.json
+++ b/test/package.json
@@ -17,6 +17,7 @@
     "prettier": "prettier ./src/**/*.ts --write",
     "setup": "node build/setup.js",
     "start": "node bin",
+    "dev": "ts-node src",
     "debug": "ts-node debug",
     "issue": "ts-node issue",
     "template": "ts-node --project build/tsconfig.json build/template.ts"

--- a/test/src/features/compare.equals/test_compare_equals_ArrayAny.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayAny.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayAny } from "../../structures/ArrayAny";
+
+export const test_compare_equals_ArrayAny = _test_compare_equals(
+    "ArrayAny",
+)<ArrayAny>(
+    ArrayAny
+)((a, b) => typia.compare.equals<ArrayAny>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayAtomicAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayAtomicAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayAtomicAlias } from "../../structures/ArrayAtomicAlias";
+
+export const test_compare_equals_ArrayAtomicAlias = _test_compare_equals(
+    "ArrayAtomicAlias",
+)<ArrayAtomicAlias>(
+    ArrayAtomicAlias
+)((a, b) => typia.compare.equals<ArrayAtomicAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayAtomicSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayAtomicSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayAtomicSimple } from "../../structures/ArrayAtomicSimple";
+
+export const test_compare_equals_ArrayAtomicSimple = _test_compare_equals(
+    "ArrayAtomicSimple",
+)<ArrayAtomicSimple>(
+    ArrayAtomicSimple
+)((a, b) => typia.compare.equals<ArrayAtomicSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayHierarchical.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayHierarchical.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayHierarchical } from "../../structures/ArrayHierarchical";
+
+export const test_compare_equals_ArrayHierarchical = _test_compare_equals(
+    "ArrayHierarchical",
+)<ArrayHierarchical>(
+    ArrayHierarchical
+)((a, b) => typia.compare.equals<ArrayHierarchical>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayHierarchicalPointer.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayHierarchicalPointer.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayHierarchicalPointer } from "../../structures/ArrayHierarchicalPointer";
+
+export const test_compare_equals_ArrayHierarchicalPointer = _test_compare_equals(
+    "ArrayHierarchicalPointer",
+)<ArrayHierarchicalPointer>(
+    ArrayHierarchicalPointer
+)((a, b) => typia.compare.equals<ArrayHierarchicalPointer>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayMatrix.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayMatrix.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayMatrix } from "../../structures/ArrayMatrix";
+
+export const test_compare_equals_ArrayMatrix = _test_compare_equals(
+    "ArrayMatrix",
+)<ArrayMatrix>(
+    ArrayMatrix
+)((a, b) => typia.compare.equals<ArrayMatrix>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRecursive.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRecursive.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRecursive } from "../../structures/ArrayRecursive";
+
+export const test_compare_equals_ArrayRecursive = _test_compare_equals(
+    "ArrayRecursive",
+)<ArrayRecursive>(
+    ArrayRecursive
+)((a, b) => typia.compare.equals<ArrayRecursive>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionExplicit.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionExplicit.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRecursiveUnionExplicit } from "../../structures/ArrayRecursiveUnionExplicit";
+
+export const test_compare_equals_ArrayRecursiveUnionExplicit = _test_compare_equals(
+    "ArrayRecursiveUnionExplicit",
+)<ArrayRecursiveUnionExplicit>(
+    ArrayRecursiveUnionExplicit
+)((a, b) => typia.compare.equals<ArrayRecursiveUnionExplicit>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionExplicitPointer.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionExplicitPointer.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRecursiveUnionExplicitPointer } from "../../structures/ArrayRecursiveUnionExplicitPointer";
+
+export const test_compare_equals_ArrayRecursiveUnionExplicitPointer = _test_compare_equals(
+    "ArrayRecursiveUnionExplicitPointer",
+)<ArrayRecursiveUnionExplicitPointer>(
+    ArrayRecursiveUnionExplicitPointer
+)((a, b) => typia.compare.equals<ArrayRecursiveUnionExplicitPointer>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionImplicit.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRecursiveUnionImplicit.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRecursiveUnionImplicit } from "../../structures/ArrayRecursiveUnionImplicit";
+
+export const test_compare_equals_ArrayRecursiveUnionImplicit = _test_compare_equals(
+    "ArrayRecursiveUnionImplicit",
+)<ArrayRecursiveUnionImplicit>(
+    ArrayRecursiveUnionImplicit
+)((a, b) => typia.compare.equals<ArrayRecursiveUnionImplicit>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRepeatedNullable } from "../../structures/ArrayRepeatedNullable";
+
+export const test_compare_equals_ArrayRepeatedNullable = _test_compare_equals(
+    "ArrayRepeatedNullable",
+)<ArrayRepeatedNullable>(
+    ArrayRepeatedNullable
+)((a, b) => typia.compare.equals<ArrayRepeatedNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRepeatedOptional } from "../../structures/ArrayRepeatedOptional";
+
+export const test_compare_equals_ArrayRepeatedOptional = _test_compare_equals(
+    "ArrayRepeatedOptional",
+)<ArrayRepeatedOptional>(
+    ArrayRepeatedOptional
+)((a, b) => typia.compare.equals<ArrayRepeatedOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedRequired.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedRequired.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRepeatedRequired } from "../../structures/ArrayRepeatedRequired";
+
+export const test_compare_equals_ArrayRepeatedRequired = _test_compare_equals(
+    "ArrayRepeatedRequired",
+)<ArrayRepeatedRequired>(
+    ArrayRepeatedRequired
+)((a, b) => typia.compare.equals<ArrayRepeatedRequired>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRepeatedUnion } from "../../structures/ArrayRepeatedUnion";
+
+export const test_compare_equals_ArrayRepeatedUnion = _test_compare_equals(
+    "ArrayRepeatedUnion",
+)<ArrayRepeatedUnion>(
+    ArrayRepeatedUnion
+)((a, b) => typia.compare.equals<ArrayRepeatedUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedUnionWithTuple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayRepeatedUnionWithTuple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayRepeatedUnionWithTuple } from "../../structures/ArrayRepeatedUnionWithTuple";
+
+export const test_compare_equals_ArrayRepeatedUnionWithTuple = _test_compare_equals(
+    "ArrayRepeatedUnionWithTuple",
+)<ArrayRepeatedUnionWithTuple>(
+    ArrayRepeatedUnionWithTuple
+)((a, b) => typia.compare.equals<ArrayRepeatedUnionWithTuple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArraySimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArraySimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArraySimple } from "../../structures/ArraySimple";
+
+export const test_compare_equals_ArraySimple = _test_compare_equals(
+    "ArraySimple",
+)<ArraySimple>(
+    ArraySimple
+)((a, b) => typia.compare.equals<ArraySimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobuf.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobuf.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArraySimpleProtobuf } from "../../structures/ArraySimpleProtobuf";
+
+export const test_compare_equals_ArraySimpleProtobuf = _test_compare_equals(
+    "ArraySimpleProtobuf",
+)<ArraySimpleProtobuf>(
+    ArraySimpleProtobuf
+)((a, b) => typia.compare.equals<ArraySimpleProtobuf>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobufNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobufNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArraySimpleProtobufNullable } from "../../structures/ArraySimpleProtobufNullable";
+
+export const test_compare_equals_ArraySimpleProtobufNullable = _test_compare_equals(
+    "ArraySimpleProtobufNullable",
+)<ArraySimpleProtobufNullable>(
+    ArraySimpleProtobufNullable
+)((a, b) => typia.compare.equals<ArraySimpleProtobufNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobufOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArraySimpleProtobufOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArraySimpleProtobufOptional } from "../../structures/ArraySimpleProtobufOptional";
+
+export const test_compare_equals_ArraySimpleProtobufOptional = _test_compare_equals(
+    "ArraySimpleProtobufOptional",
+)<ArraySimpleProtobufOptional>(
+    ArraySimpleProtobufOptional
+)((a, b) => typia.compare.equals<ArraySimpleProtobufOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ArrayUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ArrayUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ArrayUnion } from "../../structures/ArrayUnion";
+
+export const test_compare_equals_ArrayUnion = _test_compare_equals(
+    "ArrayUnion",
+)<ArrayUnion>(
+    ArrayUnion
+)((a, b) => typia.compare.equals<ArrayUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_AtomicAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_AtomicAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicAlias } from "../../structures/AtomicAlias";
+
+export const test_compare_equals_AtomicAlias = _test_compare_equals(
+    "AtomicAlias",
+)<AtomicAlias>(
+    AtomicAlias
+)((a, b) => typia.compare.equals<AtomicAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_AtomicClass.ts
+++ b/test/src/features/compare.equals/test_compare_equals_AtomicClass.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicClass } from "../../structures/AtomicClass";
+
+export const test_compare_equals_AtomicClass = _test_compare_equals(
+    "AtomicClass",
+)<AtomicClass>(
+    AtomicClass
+)((a, b) => typia.compare.equals<AtomicClass>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_AtomicIntersection.ts
+++ b/test/src/features/compare.equals/test_compare_equals_AtomicIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicIntersection } from "../../structures/AtomicIntersection";
+
+export const test_compare_equals_AtomicIntersection = _test_compare_equals(
+    "AtomicIntersection",
+)<AtomicIntersection>(
+    AtomicIntersection
+)((a, b) => typia.compare.equals<AtomicIntersection>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_AtomicSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_AtomicSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicSimple } from "../../structures/AtomicSimple";
+
+export const test_compare_equals_AtomicSimple = _test_compare_equals(
+    "AtomicSimple",
+)<AtomicSimple>(
+    AtomicSimple
+)((a, b) => typia.compare.equals<AtomicSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_AtomicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_AtomicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicUnion } from "../../structures/AtomicUnion";
+
+export const test_compare_equals_AtomicUnion = _test_compare_equals(
+    "AtomicUnion",
+)<AtomicUnion>(
+    AtomicUnion
+)((a, b) => typia.compare.equals<AtomicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ClassClosure.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ClassClosure.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ClassClosure } from "../../structures/ClassClosure";
+
+export const test_compare_equals_ClassClosure = _test_compare_equals(
+    "ClassClosure",
+)<ClassClosure>(
+    ClassClosure
+)((a, b) => typia.compare.equals<ClassClosure>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ClassGetter.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ClassGetter.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ClassGetter } from "../../structures/ClassGetter";
+
+export const test_compare_equals_ClassGetter = _test_compare_equals(
+    "ClassGetter",
+)<ClassGetter>(
+    ClassGetter
+)((a, b) => typia.compare.equals<ClassGetter>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ClassMethod.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ClassMethod.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ClassMethod } from "../../structures/ClassMethod";
+
+export const test_compare_equals_ClassMethod = _test_compare_equals(
+    "ClassMethod",
+)<ClassMethod>(
+    ClassMethod
+)((a, b) => typia.compare.equals<ClassMethod>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ClassNonPublic.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ClassNonPublic.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ClassNonPublic } from "../../structures/ClassNonPublic";
+
+export const test_compare_equals_ClassNonPublic = _test_compare_equals(
+    "ClassNonPublic",
+)<ClassNonPublic>(
+    ClassNonPublic
+)((a, b) => typia.compare.equals<ClassNonPublic>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ClassPropertyAssignment.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ClassPropertyAssignment.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ClassPropertyAssignment } from "../../structures/ClassPropertyAssignment";
+
+export const test_compare_equals_ClassPropertyAssignment = _test_compare_equals(
+    "ClassPropertyAssignment",
+)<ClassPropertyAssignment>(
+    ClassPropertyAssignment
+)((a, b) => typia.compare.equals<ClassPropertyAssignment>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagArray } from "../../structures/CommentTagArray";
+
+export const test_compare_equals_CommentTagArray = _test_compare_equals(
+    "CommentTagArray",
+)<CommentTagArray>(
+    CommentTagArray
+)((a, b) => typia.compare.equals<CommentTagArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagArrayUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagArrayUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagArrayUnion } from "../../structures/CommentTagArrayUnion";
+
+export const test_compare_equals_CommentTagArrayUnion = _test_compare_equals(
+    "CommentTagArrayUnion",
+)<CommentTagArrayUnion>(
+    CommentTagArrayUnion
+)((a, b) => typia.compare.equals<CommentTagArrayUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagAtomicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagAtomicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagAtomicUnion } from "../../structures/CommentTagAtomicUnion";
+
+export const test_compare_equals_CommentTagAtomicUnion = _test_compare_equals(
+    "CommentTagAtomicUnion",
+)<CommentTagAtomicUnion>(
+    CommentTagAtomicUnion
+)((a, b) => typia.compare.equals<CommentTagAtomicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagBigInt } from "../../structures/CommentTagBigInt";
+
+export const test_compare_equals_CommentTagBigInt = _test_compare_equals(
+    "CommentTagBigInt",
+)<CommentTagBigInt>(
+    CommentTagBigInt
+)((a, b) => typia.compare.equals<CommentTagBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagDefault.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagDefault.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagDefault } from "../../structures/CommentTagDefault";
+
+export const test_compare_equals_CommentTagDefault = _test_compare_equals(
+    "CommentTagDefault",
+)<CommentTagDefault>(
+    CommentTagDefault
+)((a, b) => typia.compare.equals<CommentTagDefault>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagFormat.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagFormat.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagFormat } from "../../structures/CommentTagFormat";
+
+export const test_compare_equals_CommentTagFormat = _test_compare_equals(
+    "CommentTagFormat",
+)<CommentTagFormat>(
+    CommentTagFormat
+)((a, b) => typia.compare.equals<CommentTagFormat>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagInfinite.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagInfinite.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagInfinite } from "../../structures/CommentTagInfinite";
+
+export const test_compare_equals_CommentTagInfinite = _test_compare_equals(
+    "CommentTagInfinite",
+)<CommentTagInfinite>(
+    CommentTagInfinite
+)((a, b) => typia.compare.equals<CommentTagInfinite>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagLength.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagLength.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagLength } from "../../structures/CommentTagLength";
+
+export const test_compare_equals_CommentTagLength = _test_compare_equals(
+    "CommentTagLength",
+)<CommentTagLength>(
+    CommentTagLength
+)((a, b) => typia.compare.equals<CommentTagLength>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagNaN.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagNaN.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagNaN } from "../../structures/CommentTagNaN";
+
+export const test_compare_equals_CommentTagNaN = _test_compare_equals(
+    "CommentTagNaN",
+)<CommentTagNaN>(
+    CommentTagNaN
+)((a, b) => typia.compare.equals<CommentTagNaN>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagObjectUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagObjectUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagObjectUnion } from "../../structures/CommentTagObjectUnion";
+
+export const test_compare_equals_CommentTagObjectUnion = _test_compare_equals(
+    "CommentTagObjectUnion",
+)<CommentTagObjectUnion>(
+    CommentTagObjectUnion
+)((a, b) => typia.compare.equals<CommentTagObjectUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagPattern.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagPattern.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagPattern } from "../../structures/CommentTagPattern";
+
+export const test_compare_equals_CommentTagPattern = _test_compare_equals(
+    "CommentTagPattern",
+)<CommentTagPattern>(
+    CommentTagPattern
+)((a, b) => typia.compare.equals<CommentTagPattern>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagRange.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagRange.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagRange } from "../../structures/CommentTagRange";
+
+export const test_compare_equals_CommentTagRange = _test_compare_equals(
+    "CommentTagRange",
+)<CommentTagRange>(
+    CommentTagRange
+)((a, b) => typia.compare.equals<CommentTagRange>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagRangeBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagRangeBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagRangeBigInt } from "../../structures/CommentTagRangeBigInt";
+
+export const test_compare_equals_CommentTagRangeBigInt = _test_compare_equals(
+    "CommentTagRangeBigInt",
+)<CommentTagRangeBigInt>(
+    CommentTagRangeBigInt
+)((a, b) => typia.compare.equals<CommentTagRangeBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagType.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagType.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagType } from "../../structures/CommentTagType";
+
+export const test_compare_equals_CommentTagType = _test_compare_equals(
+    "CommentTagType",
+)<CommentTagType>(
+    CommentTagType
+)((a, b) => typia.compare.equals<CommentTagType>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_CommentTagTypeBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_CommentTagTypeBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { CommentTagTypeBigInt } from "../../structures/CommentTagTypeBigInt";
+
+export const test_compare_equals_CommentTagTypeBigInt = _test_compare_equals(
+    "CommentTagTypeBigInt",
+)<CommentTagTypeBigInt>(
+    CommentTagTypeBigInt
+)((a, b) => typia.compare.equals<CommentTagTypeBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantAtomicAbsorbed.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantAtomicAbsorbed.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantAtomicAbsorbed } from "../../structures/ConstantAtomicAbsorbed";
+
+export const test_compare_equals_ConstantAtomicAbsorbed = _test_compare_equals(
+    "ConstantAtomicAbsorbed",
+)<ConstantAtomicAbsorbed>(
+    ConstantAtomicAbsorbed
+)((a, b) => typia.compare.equals<ConstantAtomicAbsorbed>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantAtomicSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantAtomicSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantAtomicSimple } from "../../structures/ConstantAtomicSimple";
+
+export const test_compare_equals_ConstantAtomicSimple = _test_compare_equals(
+    "ConstantAtomicSimple",
+)<ConstantAtomicSimple>(
+    ConstantAtomicSimple
+)((a, b) => typia.compare.equals<ConstantAtomicSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantAtomicTagged.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantAtomicTagged.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantAtomicTagged } from "../../structures/ConstantAtomicTagged";
+
+export const test_compare_equals_ConstantAtomicTagged = _test_compare_equals(
+    "ConstantAtomicTagged",
+)<ConstantAtomicTagged>(
+    ConstantAtomicTagged
+)((a, b) => typia.compare.equals<ConstantAtomicTagged>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantAtomicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantAtomicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantAtomicUnion } from "../../structures/ConstantAtomicUnion";
+
+export const test_compare_equals_ConstantAtomicUnion = _test_compare_equals(
+    "ConstantAtomicUnion",
+)<ConstantAtomicUnion>(
+    ConstantAtomicUnion
+)((a, b) => typia.compare.equals<ConstantAtomicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantAtomicWrapper.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantAtomicWrapper.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantAtomicWrapper } from "../../structures/ConstantAtomicWrapper";
+
+export const test_compare_equals_ConstantAtomicWrapper = _test_compare_equals(
+    "ConstantAtomicWrapper",
+)<ConstantAtomicWrapper>(
+    ConstantAtomicWrapper
+)((a, b) => typia.compare.equals<ConstantAtomicWrapper>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantConstEnumeration.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantConstEnumeration.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantConstEnumeration } from "../../structures/ConstantConstEnumeration";
+
+export const test_compare_equals_ConstantConstEnumeration = _test_compare_equals(
+    "ConstantConstEnumeration",
+)<ConstantConstEnumeration>(
+    ConstantConstEnumeration
+)((a, b) => typia.compare.equals<ConstantConstEnumeration>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantEnumeration.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantEnumeration.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantEnumeration } from "../../structures/ConstantEnumeration";
+
+export const test_compare_equals_ConstantEnumeration = _test_compare_equals(
+    "ConstantEnumeration",
+)<ConstantEnumeration>(
+    ConstantEnumeration
+)((a, b) => typia.compare.equals<ConstantEnumeration>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ConstantIntersection.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ConstantIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ConstantIntersection } from "../../structures/ConstantIntersection";
+
+export const test_compare_equals_ConstantIntersection = _test_compare_equals(
+    "ConstantIntersection",
+)<ConstantIntersection>(
+    ConstantIntersection
+)((a, b) => typia.compare.equals<ConstantIntersection>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicArray } from "../../structures/DynamicArray";
+
+export const test_compare_equals_DynamicArray = _test_compare_equals(
+    "DynamicArray",
+)<DynamicArray>(
+    DynamicArray
+)((a, b) => typia.compare.equals<DynamicArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicComposite.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicComposite.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicComposite } from "../../structures/DynamicComposite";
+
+export const test_compare_equals_DynamicComposite = _test_compare_equals(
+    "DynamicComposite",
+)<DynamicComposite>(
+    DynamicComposite
+)((a, b) => typia.compare.equals<DynamicComposite>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicConstant.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicConstant.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicConstant } from "../../structures/DynamicConstant";
+
+export const test_compare_equals_DynamicConstant = _test_compare_equals(
+    "DynamicConstant",
+)<DynamicConstant>(
+    DynamicConstant
+)((a, b) => typia.compare.equals<DynamicConstant>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicEnumeration.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicEnumeration.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicEnumeration } from "../../structures/DynamicEnumeration";
+
+export const test_compare_equals_DynamicEnumeration = _test_compare_equals(
+    "DynamicEnumeration",
+)<DynamicEnumeration>(
+    DynamicEnumeration
+)((a, b) => typia.compare.equals<DynamicEnumeration>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicJsonValue.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicJsonValue.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicJsonValue } from "../../structures/DynamicJsonValue";
+
+export const test_compare_equals_DynamicJsonValue = _test_compare_equals(
+    "DynamicJsonValue",
+)<DynamicJsonValue>(
+    DynamicJsonValue
+)((a, b) => typia.compare.equals<DynamicJsonValue>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicNever.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicNever.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicNever } from "../../structures/DynamicNever";
+
+export const test_compare_equals_DynamicNever = _test_compare_equals(
+    "DynamicNever",
+)<DynamicNever>(
+    DynamicNever
+)((a, b) => typia.compare.equals<DynamicNever>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicSimple } from "../../structures/DynamicSimple";
+
+export const test_compare_equals_DynamicSimple = _test_compare_equals(
+    "DynamicSimple",
+)<DynamicSimple>(
+    DynamicSimple
+)((a, b) => typia.compare.equals<DynamicSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicTag.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicTag.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicTag } from "../../structures/DynamicTag";
+
+export const test_compare_equals_DynamicTag = _test_compare_equals(
+    "DynamicTag",
+)<DynamicTag>(
+    DynamicTag
+)((a, b) => typia.compare.equals<DynamicTag>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicTemplate.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicTemplate.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicTemplate } from "../../structures/DynamicTemplate";
+
+export const test_compare_equals_DynamicTemplate = _test_compare_equals(
+    "DynamicTemplate",
+)<DynamicTemplate>(
+    DynamicTemplate
+)((a, b) => typia.compare.equals<DynamicTemplate>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicTree.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicTree.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicTree } from "../../structures/DynamicTree";
+
+export const test_compare_equals_DynamicTree = _test_compare_equals(
+    "DynamicTree",
+)<DynamicTree>(
+    DynamicTree
+)((a, b) => typia.compare.equals<DynamicTree>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicUndefined.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicUndefined.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicUndefined } from "../../structures/DynamicUndefined";
+
+export const test_compare_equals_DynamicUndefined = _test_compare_equals(
+    "DynamicUndefined",
+)<DynamicUndefined>(
+    DynamicUndefined
+)((a, b) => typia.compare.equals<DynamicUndefined>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_DynamicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_DynamicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { DynamicUnion } from "../../structures/DynamicUnion";
+
+export const test_compare_equals_DynamicUnion = _test_compare_equals(
+    "DynamicUnion",
+)<DynamicUnion>(
+    DynamicUnion
+)((a, b) => typia.compare.equals<DynamicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalArray } from "../../structures/FunctionalArray";
+
+export const test_compare_equals_FunctionalArray = _test_compare_equals(
+    "FunctionalArray",
+)<FunctionalArray>(
+    FunctionalArray
+)((a, b) => typia.compare.equals<FunctionalArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalArrayUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalArrayUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalArrayUnion } from "../../structures/FunctionalArrayUnion";
+
+export const test_compare_equals_FunctionalArrayUnion = _test_compare_equals(
+    "FunctionalArrayUnion",
+)<FunctionalArrayUnion>(
+    FunctionalArrayUnion
+)((a, b) => typia.compare.equals<FunctionalArrayUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalObjectUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalObjectUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalObjectUnion } from "../../structures/FunctionalObjectUnion";
+
+export const test_compare_equals_FunctionalObjectUnion = _test_compare_equals(
+    "FunctionalObjectUnion",
+)<FunctionalObjectUnion>(
+    FunctionalObjectUnion
+)((a, b) => typia.compare.equals<FunctionalObjectUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalProperty.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalProperty.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalProperty } from "../../structures/FunctionalProperty";
+
+export const test_compare_equals_FunctionalProperty = _test_compare_equals(
+    "FunctionalProperty",
+)<FunctionalProperty>(
+    FunctionalProperty
+)((a, b) => typia.compare.equals<FunctionalProperty>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalPropertyUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalPropertyUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalPropertyUnion } from "../../structures/FunctionalPropertyUnion";
+
+export const test_compare_equals_FunctionalPropertyUnion = _test_compare_equals(
+    "FunctionalPropertyUnion",
+)<FunctionalPropertyUnion>(
+    FunctionalPropertyUnion
+)((a, b) => typia.compare.equals<FunctionalPropertyUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalTuple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalTuple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalTuple } from "../../structures/FunctionalTuple";
+
+export const test_compare_equals_FunctionalTuple = _test_compare_equals(
+    "FunctionalTuple",
+)<FunctionalTuple>(
+    FunctionalTuple
+)((a, b) => typia.compare.equals<FunctionalTuple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalTupleUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalTupleUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalTupleUnion } from "../../structures/FunctionalTupleUnion";
+
+export const test_compare_equals_FunctionalTupleUnion = _test_compare_equals(
+    "FunctionalTupleUnion",
+)<FunctionalTupleUnion>(
+    FunctionalTupleUnion
+)((a, b) => typia.compare.equals<FunctionalTupleUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalValue.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalValue.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalValue } from "../../structures/FunctionalValue";
+
+export const test_compare_equals_FunctionalValue = _test_compare_equals(
+    "FunctionalValue",
+)<FunctionalValue>(
+    FunctionalValue
+)((a, b) => typia.compare.equals<FunctionalValue>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_FunctionalValueUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_FunctionalValueUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { FunctionalValueUnion } from "../../structures/FunctionalValueUnion";
+
+export const test_compare_equals_FunctionalValueUnion = _test_compare_equals(
+    "FunctionalValueUnion",
+)<FunctionalValueUnion>(
+    FunctionalValueUnion
+)((a, b) => typia.compare.equals<FunctionalValueUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_InstanceUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_InstanceUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { InstanceUnion } from "../../structures/InstanceUnion";
+
+export const test_compare_equals_InstanceUnion = _test_compare_equals(
+    "InstanceUnion",
+)<InstanceUnion>(
+    InstanceUnion
+)((a, b) => typia.compare.equals<InstanceUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapAlias } from "../../structures/MapAlias";
+
+export const test_compare_equals_MapAlias = _test_compare_equals(
+    "MapAlias",
+)<MapAlias>(
+    MapAlias
+)((a, b) => typia.compare.equals<MapAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapSimple } from "../../structures/MapSimple";
+
+export const test_compare_equals_MapSimple = _test_compare_equals(
+    "MapSimple",
+)<MapSimple>(
+    MapSimple
+)((a, b) => typia.compare.equals<MapSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobuf.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobuf.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapSimpleProtobuf } from "../../structures/MapSimpleProtobuf";
+
+export const test_compare_equals_MapSimpleProtobuf = _test_compare_equals(
+    "MapSimpleProtobuf",
+)<MapSimpleProtobuf>(
+    MapSimpleProtobuf
+)((a, b) => typia.compare.equals<MapSimpleProtobuf>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobufNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobufNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapSimpleProtobufNullable } from "../../structures/MapSimpleProtobufNullable";
+
+export const test_compare_equals_MapSimpleProtobufNullable = _test_compare_equals(
+    "MapSimpleProtobufNullable",
+)<MapSimpleProtobufNullable>(
+    MapSimpleProtobufNullable
+)((a, b) => typia.compare.equals<MapSimpleProtobufNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobufOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapSimpleProtobufOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapSimpleProtobufOptional } from "../../structures/MapSimpleProtobufOptional";
+
+export const test_compare_equals_MapSimpleProtobufOptional = _test_compare_equals(
+    "MapSimpleProtobufOptional",
+)<MapSimpleProtobufOptional>(
+    MapSimpleProtobufOptional
+)((a, b) => typia.compare.equals<MapSimpleProtobufOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_MapUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_MapUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { MapUnion } from "../../structures/MapUnion";
+
+export const test_compare_equals_MapUnion = _test_compare_equals(
+    "MapUnion",
+)<MapUnion>(
+    MapUnion
+)((a, b) => typia.compare.equals<MapUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_NativeSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_NativeSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { NativeSimple } from "../../structures/NativeSimple";
+
+export const test_compare_equals_NativeSimple = _test_compare_equals(
+    "NativeSimple",
+)<NativeSimple>(
+    NativeSimple
+)((a, b) => typia.compare.equals<NativeSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_NativeUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_NativeUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { NativeUnion } from "../../structures/NativeUnion";
+
+export const test_compare_equals_NativeUnion = _test_compare_equals(
+    "NativeUnion",
+)<NativeUnion>(
+    NativeUnion
+)((a, b) => typia.compare.equals<NativeUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectAlias } from "../../structures/ObjectAlias";
+
+export const test_compare_equals_ObjectAlias = _test_compare_equals(
+    "ObjectAlias",
+)<ObjectAlias>(
+    ObjectAlias
+)((a, b) => typia.compare.equals<ObjectAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectClosure.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectClosure.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectClosure } from "../../structures/ObjectClosure";
+
+export const test_compare_equals_ObjectClosure = _test_compare_equals(
+    "ObjectClosure",
+)<ObjectClosure>(
+    ObjectClosure
+)((a, b) => typia.compare.equals<ObjectClosure>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectDate.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectDate.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectDate } from "../../structures/ObjectDate";
+
+export const test_compare_equals_ObjectDate = _test_compare_equals(
+    "ObjectDate",
+)<ObjectDate>(
+    ObjectDate
+)((a, b) => typia.compare.equals<ObjectDate>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectDescription.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectDescription.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectDescription } from "../../structures/ObjectDescription";
+
+export const test_compare_equals_ObjectDescription = _test_compare_equals(
+    "ObjectDescription",
+)<ObjectDescription>(
+    ObjectDescription
+)((a, b) => typia.compare.equals<ObjectDescription>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectDynamic.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectDynamic.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectDynamic } from "../../structures/ObjectDynamic";
+
+export const test_compare_equals_ObjectDynamic = _test_compare_equals(
+    "ObjectDynamic",
+)<ObjectDynamic>(
+    ObjectDynamic
+)((a, b) => typia.compare.equals<ObjectDynamic>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectGeneric.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectGeneric.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectGeneric } from "../../structures/ObjectGeneric";
+
+export const test_compare_equals_ObjectGeneric = _test_compare_equals(
+    "ObjectGeneric",
+)<ObjectGeneric>(
+    ObjectGeneric
+)((a, b) => typia.compare.equals<ObjectGeneric>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectGenericAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectGenericAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectGenericAlias } from "../../structures/ObjectGenericAlias";
+
+export const test_compare_equals_ObjectGenericAlias = _test_compare_equals(
+    "ObjectGenericAlias",
+)<ObjectGenericAlias>(
+    ObjectGenericAlias
+)((a, b) => typia.compare.equals<ObjectGenericAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectGenericArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectGenericArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectGenericArray } from "../../structures/ObjectGenericArray";
+
+export const test_compare_equals_ObjectGenericArray = _test_compare_equals(
+    "ObjectGenericArray",
+)<ObjectGenericArray>(
+    ObjectGenericArray
+)((a, b) => typia.compare.equals<ObjectGenericArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectGenericUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectGenericUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectGenericUnion } from "../../structures/ObjectGenericUnion";
+
+export const test_compare_equals_ObjectGenericUnion = _test_compare_equals(
+    "ObjectGenericUnion",
+)<ObjectGenericUnion>(
+    ObjectGenericUnion
+)((a, b) => typia.compare.equals<ObjectGenericUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHierarchical.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHierarchical.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHierarchical } from "../../structures/ObjectHierarchical";
+
+export const test_compare_equals_ObjectHierarchical = _test_compare_equals(
+    "ObjectHierarchical",
+)<ObjectHierarchical>(
+    ObjectHierarchical
+)((a, b) => typia.compare.equals<ObjectHierarchical>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpArray } from "../../structures/ObjectHttpArray";
+
+export const test_compare_equals_ObjectHttpArray = _test_compare_equals(
+    "ObjectHttpArray",
+)<ObjectHttpArray>(
+    ObjectHttpArray
+)((a, b) => typia.compare.equals<ObjectHttpArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpAtomic.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpAtomic.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpAtomic } from "../../structures/ObjectHttpAtomic";
+
+export const test_compare_equals_ObjectHttpAtomic = _test_compare_equals(
+    "ObjectHttpAtomic",
+)<ObjectHttpAtomic>(
+    ObjectHttpAtomic
+)((a, b) => typia.compare.equals<ObjectHttpAtomic>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpCommentTag.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpCommentTag.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpCommentTag } from "../../structures/ObjectHttpCommentTag";
+
+export const test_compare_equals_ObjectHttpCommentTag = _test_compare_equals(
+    "ObjectHttpCommentTag",
+)<ObjectHttpCommentTag>(
+    ObjectHttpCommentTag
+)((a, b) => typia.compare.equals<ObjectHttpCommentTag>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpConstant.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpConstant.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpConstant } from "../../structures/ObjectHttpConstant";
+
+export const test_compare_equals_ObjectHttpConstant = _test_compare_equals(
+    "ObjectHttpConstant",
+)<ObjectHttpConstant>(
+    ObjectHttpConstant
+)((a, b) => typia.compare.equals<ObjectHttpConstant>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpFormData.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpFormData.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpFormData } from "../../structures/ObjectHttpFormData";
+
+export const test_compare_equals_ObjectHttpFormData = _test_compare_equals(
+    "ObjectHttpFormData",
+)<ObjectHttpFormData>(
+    ObjectHttpFormData
+)((a, b) => typia.compare.equals<ObjectHttpFormData>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpNullable } from "../../structures/ObjectHttpNullable";
+
+export const test_compare_equals_ObjectHttpNullable = _test_compare_equals(
+    "ObjectHttpNullable",
+)<ObjectHttpNullable>(
+    ObjectHttpNullable
+)((a, b) => typia.compare.equals<ObjectHttpNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpTypeTag.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpTypeTag.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpTypeTag } from "../../structures/ObjectHttpTypeTag";
+
+export const test_compare_equals_ObjectHttpTypeTag = _test_compare_equals(
+    "ObjectHttpTypeTag",
+)<ObjectHttpTypeTag>(
+    ObjectHttpTypeTag
+)((a, b) => typia.compare.equals<ObjectHttpTypeTag>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectHttpUndefindable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectHttpUndefindable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectHttpUndefindable } from "../../structures/ObjectHttpUndefindable";
+
+export const test_compare_equals_ObjectHttpUndefindable = _test_compare_equals(
+    "ObjectHttpUndefindable",
+)<ObjectHttpUndefindable>(
+    ObjectHttpUndefindable
+)((a, b) => typia.compare.equals<ObjectHttpUndefindable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectInternal.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectInternal.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectInternal } from "../../structures/ObjectInternal";
+
+export const test_compare_equals_ObjectInternal = _test_compare_equals(
+    "ObjectInternal",
+)<ObjectInternal>(
+    ObjectInternal
+)((a, b) => typia.compare.equals<ObjectInternal>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectIntersection.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectIntersection.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectIntersection } from "../../structures/ObjectIntersection";
+
+export const test_compare_equals_ObjectIntersection = _test_compare_equals(
+    "ObjectIntersection",
+)<ObjectIntersection>(
+    ObjectIntersection
+)((a, b) => typia.compare.equals<ObjectIntersection>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectJsonTag.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectJsonTag.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectJsonTag } from "../../structures/ObjectJsonTag";
+
+export const test_compare_equals_ObjectJsonTag = _test_compare_equals(
+    "ObjectJsonTag",
+)<ObjectJsonTag>(
+    ObjectJsonTag
+)((a, b) => typia.compare.equals<ObjectJsonTag>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectLiteralProperty.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectLiteralProperty.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectLiteralProperty } from "../../structures/ObjectLiteralProperty";
+
+export const test_compare_equals_ObjectLiteralProperty = _test_compare_equals(
+    "ObjectLiteralProperty",
+)<ObjectLiteralProperty>(
+    ObjectLiteralProperty
+)((a, b) => typia.compare.equals<ObjectLiteralProperty>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectLiteralType.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectLiteralType.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectLiteralType } from "../../structures/ObjectLiteralType";
+
+export const test_compare_equals_ObjectLiteralType = _test_compare_equals(
+    "ObjectLiteralType",
+)<ObjectLiteralType>(
+    ObjectLiteralType
+)((a, b) => typia.compare.equals<ObjectLiteralType>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectNullable } from "../../structures/ObjectNullable";
+
+export const test_compare_equals_ObjectNullable = _test_compare_equals(
+    "ObjectNullable",
+)<ObjectNullable>(
+    ObjectNullable
+)((a, b) => typia.compare.equals<ObjectNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectOptional } from "../../structures/ObjectOptional";
+
+export const test_compare_equals_ObjectOptional = _test_compare_equals(
+    "ObjectOptional",
+)<ObjectOptional>(
+    ObjectOptional
+)((a, b) => typia.compare.equals<ObjectOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectPartial.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectPartial.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectPartial } from "../../structures/ObjectPartial";
+
+export const test_compare_equals_ObjectPartial = _test_compare_equals(
+    "ObjectPartial",
+)<ObjectPartial>(
+    ObjectPartial
+)((a, b) => typia.compare.equals<ObjectPartial>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectPartialAndRequired.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectPartialAndRequired.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
+
+export const test_compare_equals_ObjectPartialAndRequired = _test_compare_equals(
+    "ObjectPartialAndRequired",
+)<ObjectPartialAndRequired>(
+    ObjectPartialAndRequired
+)((a, b) => typia.compare.equals<ObjectPartialAndRequired>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectPrimitive.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectPrimitive.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectPrimitive } from "../../structures/ObjectPrimitive";
+
+export const test_compare_equals_ObjectPrimitive = _test_compare_equals(
+    "ObjectPrimitive",
+)<ObjectPrimitive>(
+    ObjectPrimitive
+)((a, b) => typia.compare.equals<ObjectPrimitive>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectPropertyNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectPropertyNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectPropertyNullable } from "../../structures/ObjectPropertyNullable";
+
+export const test_compare_equals_ObjectPropertyNullable = _test_compare_equals(
+    "ObjectPropertyNullable",
+)<ObjectPropertyNullable>(
+    ObjectPropertyNullable
+)((a, b) => typia.compare.equals<ObjectPropertyNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectRecursive.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectRecursive.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectRecursive } from "../../structures/ObjectRecursive";
+
+export const test_compare_equals_ObjectRecursive = _test_compare_equals(
+    "ObjectRecursive",
+)<ObjectRecursive>(
+    ObjectRecursive
+)((a, b) => typia.compare.equals<ObjectRecursive>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectRequired.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectRequired.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectRequired } from "../../structures/ObjectRequired";
+
+export const test_compare_equals_ObjectRequired = _test_compare_equals(
+    "ObjectRequired",
+)<ObjectRequired>(
+    ObjectRequired
+)((a, b) => typia.compare.equals<ObjectRequired>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectSequenceProtobuf.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectSequenceProtobuf.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectSequenceProtobuf } from "../../structures/ObjectSequenceProtobuf";
+
+export const test_compare_equals_ObjectSequenceProtobuf = _test_compare_equals(
+    "ObjectSequenceProtobuf",
+)<ObjectSequenceProtobuf>(
+    ObjectSequenceProtobuf
+)((a, b) => typia.compare.equals<ObjectSequenceProtobuf>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectSimple } from "../../structures/ObjectSimple";
+
+export const test_compare_equals_ObjectSimple = _test_compare_equals(
+    "ObjectSimple",
+)<ObjectSimple>(
+    ObjectSimple
+)((a, b) => typia.compare.equals<ObjectSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobuf.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobuf.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectSimpleProtobuf } from "../../structures/ObjectSimpleProtobuf";
+
+export const test_compare_equals_ObjectSimpleProtobuf = _test_compare_equals(
+    "ObjectSimpleProtobuf",
+)<ObjectSimpleProtobuf>(
+    ObjectSimpleProtobuf
+)((a, b) => typia.compare.equals<ObjectSimpleProtobuf>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobufNullable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobufNullable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectSimpleProtobufNullable } from "../../structures/ObjectSimpleProtobufNullable";
+
+export const test_compare_equals_ObjectSimpleProtobufNullable = _test_compare_equals(
+    "ObjectSimpleProtobufNullable",
+)<ObjectSimpleProtobufNullable>(
+    ObjectSimpleProtobufNullable
+)((a, b) => typia.compare.equals<ObjectSimpleProtobufNullable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobufOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectSimpleProtobufOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectSimpleProtobufOptional } from "../../structures/ObjectSimpleProtobufOptional";
+
+export const test_compare_equals_ObjectSimpleProtobufOptional = _test_compare_equals(
+    "ObjectSimpleProtobufOptional",
+)<ObjectSimpleProtobufOptional>(
+    ObjectSimpleProtobufOptional
+)((a, b) => typia.compare.equals<ObjectSimpleProtobufOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectTuple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectTuple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectTuple } from "../../structures/ObjectTuple";
+
+export const test_compare_equals_ObjectTuple = _test_compare_equals(
+    "ObjectTuple",
+)<ObjectTuple>(
+    ObjectTuple
+)((a, b) => typia.compare.equals<ObjectTuple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUndefined.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUndefined.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUndefined } from "../../structures/ObjectUndefined";
+
+export const test_compare_equals_ObjectUndefined = _test_compare_equals(
+    "ObjectUndefined",
+)<ObjectUndefined>(
+    ObjectUndefined
+)((a, b) => typia.compare.equals<ObjectUndefined>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionComposite.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionComposite.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionComposite } from "../../structures/ObjectUnionComposite";
+
+export const test_compare_equals_ObjectUnionComposite = _test_compare_equals(
+    "ObjectUnionComposite",
+)<ObjectUnionComposite>(
+    ObjectUnionComposite
+)((a, b) => typia.compare.equals<ObjectUnionComposite>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionCompositePointer.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionCompositePointer.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionCompositePointer } from "../../structures/ObjectUnionCompositePointer";
+
+export const test_compare_equals_ObjectUnionCompositePointer = _test_compare_equals(
+    "ObjectUnionCompositePointer",
+)<ObjectUnionCompositePointer>(
+    ObjectUnionCompositePointer
+)((a, b) => typia.compare.equals<ObjectUnionCompositePointer>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionDouble.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionDouble.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionDouble } from "../../structures/ObjectUnionDouble";
+
+export const test_compare_equals_ObjectUnionDouble = _test_compare_equals(
+    "ObjectUnionDouble",
+)<ObjectUnionDouble>(
+    ObjectUnionDouble
+)((a, b) => typia.compare.equals<ObjectUnionDouble>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionExplicit.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionExplicit.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionExplicit } from "../../structures/ObjectUnionExplicit";
+
+export const test_compare_equals_ObjectUnionExplicit = _test_compare_equals(
+    "ObjectUnionExplicit",
+)<ObjectUnionExplicit>(
+    ObjectUnionExplicit
+)((a, b) => typia.compare.equals<ObjectUnionExplicit>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionExplicitPointer.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionExplicitPointer.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionExplicitPointer } from "../../structures/ObjectUnionExplicitPointer";
+
+export const test_compare_equals_ObjectUnionExplicitPointer = _test_compare_equals(
+    "ObjectUnionExplicitPointer",
+)<ObjectUnionExplicitPointer>(
+    ObjectUnionExplicitPointer
+)((a, b) => typia.compare.equals<ObjectUnionExplicitPointer>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionImplicit.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionImplicit.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionImplicit } from "../../structures/ObjectUnionImplicit";
+
+export const test_compare_equals_ObjectUnionImplicit = _test_compare_equals(
+    "ObjectUnionImplicit",
+)<ObjectUnionImplicit>(
+    ObjectUnionImplicit
+)((a, b) => typia.compare.equals<ObjectUnionImplicit>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ObjectUnionNonPredictable.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ObjectUnionNonPredictable.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ObjectUnionNonPredictable } from "../../structures/ObjectUnionNonPredictable";
+
+export const test_compare_equals_ObjectUnionNonPredictable = _test_compare_equals(
+    "ObjectUnionNonPredictable",
+)<ObjectUnionNonPredictable>(
+    ObjectUnionNonPredictable
+)((a, b) => typia.compare.equals<ObjectUnionNonPredictable>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_SetAlias.ts
+++ b/test/src/features/compare.equals/test_compare_equals_SetAlias.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { SetAlias } from "../../structures/SetAlias";
+
+export const test_compare_equals_SetAlias = _test_compare_equals(
+    "SetAlias",
+)<SetAlias>(
+    SetAlias
+)((a, b) => typia.compare.equals<SetAlias>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_SetSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_SetSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { SetSimple } from "../../structures/SetSimple";
+
+export const test_compare_equals_SetSimple = _test_compare_equals(
+    "SetSimple",
+)<SetSimple>(
+    SetSimple
+)((a, b) => typia.compare.equals<SetSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_SetUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_SetUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { SetUnion } from "../../structures/SetUnion";
+
+export const test_compare_equals_SetUnion = _test_compare_equals(
+    "SetUnion",
+)<SetUnion>(
+    SetUnion
+)((a, b) => typia.compare.equals<SetUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TemplateAtomic.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TemplateAtomic.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TemplateAtomic } from "../../structures/TemplateAtomic";
+
+export const test_compare_equals_TemplateAtomic = _test_compare_equals(
+    "TemplateAtomic",
+)<TemplateAtomic>(
+    TemplateAtomic
+)((a, b) => typia.compare.equals<TemplateAtomic>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TemplateConstant.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TemplateConstant.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TemplateConstant } from "../../structures/TemplateConstant";
+
+export const test_compare_equals_TemplateConstant = _test_compare_equals(
+    "TemplateConstant",
+)<TemplateConstant>(
+    TemplateConstant
+)((a, b) => typia.compare.equals<TemplateConstant>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TemplateUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TemplateUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TemplateUnion } from "../../structures/TemplateUnion";
+
+export const test_compare_equals_TemplateUnion = _test_compare_equals(
+    "TemplateUnion",
+)<TemplateUnion>(
+    TemplateUnion
+)((a, b) => typia.compare.equals<TemplateUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonArray } from "../../structures/ToJsonArray";
+
+export const test_compare_equals_ToJsonArray = _test_compare_equals(
+    "ToJsonArray",
+)<ToJsonArray>(
+    ToJsonArray
+)((a, b) => typia.compare.equals<ToJsonArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonAtomicSimple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonAtomicSimple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonAtomicSimple } from "../../structures/ToJsonAtomicSimple";
+
+export const test_compare_equals_ToJsonAtomicSimple = _test_compare_equals(
+    "ToJsonAtomicSimple",
+)<ToJsonAtomicSimple>(
+    ToJsonAtomicSimple
+)((a, b) => typia.compare.equals<ToJsonAtomicSimple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonAtomicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonAtomicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonAtomicUnion } from "../../structures/ToJsonAtomicUnion";
+
+export const test_compare_equals_ToJsonAtomicUnion = _test_compare_equals(
+    "ToJsonAtomicUnion",
+)<ToJsonAtomicUnion>(
+    ToJsonAtomicUnion
+)((a, b) => typia.compare.equals<ToJsonAtomicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonDouble.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonDouble.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonDouble } from "../../structures/ToJsonDouble";
+
+export const test_compare_equals_ToJsonDouble = _test_compare_equals(
+    "ToJsonDouble",
+)<ToJsonDouble>(
+    ToJsonDouble
+)((a, b) => typia.compare.equals<ToJsonDouble>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonNull.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonNull.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonNull } from "../../structures/ToJsonNull";
+
+export const test_compare_equals_ToJsonNull = _test_compare_equals(
+    "ToJsonNull",
+)<ToJsonNull>(
+    ToJsonNull
+)((a, b) => typia.compare.equals<ToJsonNull>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonTuple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonTuple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonTuple } from "../../structures/ToJsonTuple";
+
+export const test_compare_equals_ToJsonTuple = _test_compare_equals(
+    "ToJsonTuple",
+)<ToJsonTuple>(
+    ToJsonTuple
+)((a, b) => typia.compare.equals<ToJsonTuple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_ToJsonUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_ToJsonUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { ToJsonUnion } from "../../structures/ToJsonUnion";
+
+export const test_compare_equals_ToJsonUnion = _test_compare_equals(
+    "ToJsonUnion",
+)<ToJsonUnion>(
+    ToJsonUnion
+)((a, b) => typia.compare.equals<ToJsonUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleHierarchical.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleHierarchical.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleHierarchical } from "../../structures/TupleHierarchical";
+
+export const test_compare_equals_TupleHierarchical = _test_compare_equals(
+    "TupleHierarchical",
+)<TupleHierarchical>(
+    TupleHierarchical
+)((a, b) => typia.compare.equals<TupleHierarchical>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleOptional.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleOptional.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleOptional } from "../../structures/TupleOptional";
+
+export const test_compare_equals_TupleOptional = _test_compare_equals(
+    "TupleOptional",
+)<TupleOptional>(
+    TupleOptional
+)((a, b) => typia.compare.equals<TupleOptional>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleRestArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleRestArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleRestArray } from "../../structures/TupleRestArray";
+
+export const test_compare_equals_TupleRestArray = _test_compare_equals(
+    "TupleRestArray",
+)<TupleRestArray>(
+    TupleRestArray
+)((a, b) => typia.compare.equals<TupleRestArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleRestAtomic.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleRestAtomic.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleRestAtomic } from "../../structures/TupleRestAtomic";
+
+export const test_compare_equals_TupleRestAtomic = _test_compare_equals(
+    "TupleRestAtomic",
+)<TupleRestAtomic>(
+    TupleRestAtomic
+)((a, b) => typia.compare.equals<TupleRestAtomic>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleRestObject.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleRestObject.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleRestObject } from "../../structures/TupleRestObject";
+
+export const test_compare_equals_TupleRestObject = _test_compare_equals(
+    "TupleRestObject",
+)<TupleRestObject>(
+    TupleRestObject
+)((a, b) => typia.compare.equals<TupleRestObject>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TupleUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TupleUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TupleUnion } from "../../structures/TupleUnion";
+
+export const test_compare_equals_TupleUnion = _test_compare_equals(
+    "TupleUnion",
+)<TupleUnion>(
+    TupleUnion
+)((a, b) => typia.compare.equals<TupleUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagArray.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagArray.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagArray } from "../../structures/TypeTagArray";
+
+export const test_compare_equals_TypeTagArray = _test_compare_equals(
+    "TypeTagArray",
+)<TypeTagArray>(
+    TypeTagArray
+)((a, b) => typia.compare.equals<TypeTagArray>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagArrayUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagArrayUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagArrayUnion } from "../../structures/TypeTagArrayUnion";
+
+export const test_compare_equals_TypeTagArrayUnion = _test_compare_equals(
+    "TypeTagArrayUnion",
+)<TypeTagArrayUnion>(
+    TypeTagArrayUnion
+)((a, b) => typia.compare.equals<TypeTagArrayUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagAtomicUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagAtomicUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagAtomicUnion } from "../../structures/TypeTagAtomicUnion";
+
+export const test_compare_equals_TypeTagAtomicUnion = _test_compare_equals(
+    "TypeTagAtomicUnion",
+)<TypeTagAtomicUnion>(
+    TypeTagAtomicUnion
+)((a, b) => typia.compare.equals<TypeTagAtomicUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagBigInt } from "../../structures/TypeTagBigInt";
+
+export const test_compare_equals_TypeTagBigInt = _test_compare_equals(
+    "TypeTagBigInt",
+)<TypeTagBigInt>(
+    TypeTagBigInt
+)((a, b) => typia.compare.equals<TypeTagBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagCustom.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagCustom.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagCustom } from "../../structures/TypeTagCustom";
+
+export const test_compare_equals_TypeTagCustom = _test_compare_equals(
+    "TypeTagCustom",
+)<TypeTagCustom>(
+    TypeTagCustom
+)((a, b) => typia.compare.equals<TypeTagCustom>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagDefault.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagDefault.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagDefault } from "../../structures/TypeTagDefault";
+
+export const test_compare_equals_TypeTagDefault = _test_compare_equals(
+    "TypeTagDefault",
+)<TypeTagDefault>(
+    TypeTagDefault
+)((a, b) => typia.compare.equals<TypeTagDefault>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagFormat.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagFormat.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagFormat } from "../../structures/TypeTagFormat";
+
+export const test_compare_equals_TypeTagFormat = _test_compare_equals(
+    "TypeTagFormat",
+)<TypeTagFormat>(
+    TypeTagFormat
+)((a, b) => typia.compare.equals<TypeTagFormat>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagInfinite.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagInfinite.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagInfinite } from "../../structures/TypeTagInfinite";
+
+export const test_compare_equals_TypeTagInfinite = _test_compare_equals(
+    "TypeTagInfinite",
+)<TypeTagInfinite>(
+    TypeTagInfinite
+)((a, b) => typia.compare.equals<TypeTagInfinite>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagLength.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagLength.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagLength } from "../../structures/TypeTagLength";
+
+export const test_compare_equals_TypeTagLength = _test_compare_equals(
+    "TypeTagLength",
+)<TypeTagLength>(
+    TypeTagLength
+)((a, b) => typia.compare.equals<TypeTagLength>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagMatrix.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagMatrix.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagMatrix } from "../../structures/TypeTagMatrix";
+
+export const test_compare_equals_TypeTagMatrix = _test_compare_equals(
+    "TypeTagMatrix",
+)<TypeTagMatrix>(
+    TypeTagMatrix
+)((a, b) => typia.compare.equals<TypeTagMatrix>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagNaN.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagNaN.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagNaN } from "../../structures/TypeTagNaN";
+
+export const test_compare_equals_TypeTagNaN = _test_compare_equals(
+    "TypeTagNaN",
+)<TypeTagNaN>(
+    TypeTagNaN
+)((a, b) => typia.compare.equals<TypeTagNaN>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagObjectUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagObjectUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagObjectUnion } from "../../structures/TypeTagObjectUnion";
+
+export const test_compare_equals_TypeTagObjectUnion = _test_compare_equals(
+    "TypeTagObjectUnion",
+)<TypeTagObjectUnion>(
+    TypeTagObjectUnion
+)((a, b) => typia.compare.equals<TypeTagObjectUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagPattern.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagPattern.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagPattern } from "../../structures/TypeTagPattern";
+
+export const test_compare_equals_TypeTagPattern = _test_compare_equals(
+    "TypeTagPattern",
+)<TypeTagPattern>(
+    TypeTagPattern
+)((a, b) => typia.compare.equals<TypeTagPattern>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagRange.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagRange.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagRange } from "../../structures/TypeTagRange";
+
+export const test_compare_equals_TypeTagRange = _test_compare_equals(
+    "TypeTagRange",
+)<TypeTagRange>(
+    TypeTagRange
+)((a, b) => typia.compare.equals<TypeTagRange>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagRangeBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagRangeBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagRangeBigInt } from "../../structures/TypeTagRangeBigInt";
+
+export const test_compare_equals_TypeTagRangeBigInt = _test_compare_equals(
+    "TypeTagRangeBigInt",
+)<TypeTagRangeBigInt>(
+    TypeTagRangeBigInt
+)((a, b) => typia.compare.equals<TypeTagRangeBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagTuple.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagTuple.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagTuple } from "../../structures/TypeTagTuple";
+
+export const test_compare_equals_TypeTagTuple = _test_compare_equals(
+    "TypeTagTuple",
+)<TypeTagTuple>(
+    TypeTagTuple
+)((a, b) => typia.compare.equals<TypeTagTuple>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagType.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagType.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagType } from "../../structures/TypeTagType";
+
+export const test_compare_equals_TypeTagType = _test_compare_equals(
+    "TypeTagType",
+)<TypeTagType>(
+    TypeTagType
+)((a, b) => typia.compare.equals<TypeTagType>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagTypeBigInt.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagTypeBigInt.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagTypeBigInt } from "../../structures/TypeTagTypeBigInt";
+
+export const test_compare_equals_TypeTagTypeBigInt = _test_compare_equals(
+    "TypeTagTypeBigInt",
+)<TypeTagTypeBigInt>(
+    TypeTagTypeBigInt
+)((a, b) => typia.compare.equals<TypeTagTypeBigInt>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_TypeTagTypeUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_TypeTagTypeUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { TypeTagTypeUnion } from "../../structures/TypeTagTypeUnion";
+
+export const test_compare_equals_TypeTagTypeUnion = _test_compare_equals(
+    "TypeTagTypeUnion",
+)<TypeTagTypeUnion>(
+    TypeTagTypeUnion
+)((a, b) => typia.compare.equals<TypeTagTypeUnion>(a, b));

--- a/test/src/features/compare.equals/test_compare_equals_UltimateUnion.ts
+++ b/test/src/features/compare.equals/test_compare_equals_UltimateUnion.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { UltimateUnion } from "../../structures/UltimateUnion";
+
+export const test_compare_equals_UltimateUnion = _test_compare_equals(
+    "UltimateUnion",
+)<UltimateUnion>(
+    UltimateUnion
+)((a, b) => typia.compare.equals<UltimateUnion>(a, b));

--- a/test/src/features/compare/test_equals_AtomicType.ts
+++ b/test/src/features/compare/test_equals_AtomicType.ts
@@ -1,0 +1,10 @@
+import typia from "typia";
+
+import { _test_compare_equals } from "../../internal/_test_compare_equals";
+import { AtomicSimple } from "../../structures/AtomicSimple";
+
+export const test_compare_equals_AtomicSimple = _test_compare_equals(
+  "AtomicSimple",
+)<AtomicSimple>(AtomicSimple)((a, b) =>
+  typia.compare.equals<AtomicSimple>(a, b),
+);

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -6,17 +6,22 @@ import { DynamicImportIterator } from "./helpers/DynamicImportIterator";
 async function main(): Promise<void> {
   const counter: IPointer<number> = { value: 0 };
   const exceptions: Error[] = [];
+  const subfolder =
+    process.argv.find((a) => a.startsWith("--folder"))?.split("=")[1] ?? "";
 
   console.log("-------------------------------------------------------");
   console.log("  TRANSFORMATION TESTING");
   console.log("-------------------------------------------------------");
 
   exceptions.push(
-    ...(await DynamicImportIterator.force(__dirname + "/features", {
-      prefix: "test",
-      parameters: () => [],
-      counter,
-    })),
+    ...(await DynamicImportIterator.force(
+      __dirname + "/features/" + subfolder,
+      {
+        prefix: "test",
+        parameters: () => [],
+        counter,
+      },
+    )),
   );
 
   if (

--- a/test/src/internal/_test_compare_equals.ts
+++ b/test/src/internal/_test_compare_equals.ts
@@ -1,0 +1,20 @@
+import { TestStructure } from "../helpers/TestStructure";
+import { resolved_equal_to } from "../helpers/resolved_equal_to";
+
+export const _test_compare_equals =
+  (name: string) =>
+  <T>(factory: TestStructure<T>) =>
+  (equals: (a: T, b: T) => boolean) =>
+  () => {
+    const dataA: T = factory.generate();
+    const dataB: T = factory.generate();
+    const equaled = equals(dataA, dataB);
+    const resolved = resolved_equal_to(name)(dataA, dataB);
+
+    if (resolved !== equaled) {
+      throw new Error(
+        `typia.compare.equals(): failed to compare the ${name} type.`,
+        { cause: { dataA, dataB, equaled, resolved } },
+      );
+    }
+  };

--- a/test/src/internal/_test_compare_equals.ts
+++ b/test/src/internal/_test_compare_equals.ts
@@ -8,7 +8,19 @@ export const _test_compare_equals =
   () => {
     const dataA: T = factory.generate();
     const dataB: T = factory.generate();
-    const equaled = equals(dataA, dataB);
+    let equaled = false;
+    try {
+      equaled = equals(dataA, dataB);
+    } catch (e) {
+      if (
+        e instanceof Error &&
+        e.message.includes("no transform has been configured")
+      ) {
+        // This happens when there are unsupported types at the transformation stage. Expected behavior
+        return;
+      }
+      throw e;
+    }
     const resolved = resolved_equal_to(name)(dataA, dataB);
 
     if (resolved !== equaled) {


### PR DESCRIPTION
Feature of #1497

# Classes
Added "class" property to detect that object is class

Classes forbidden to compare because there is a lot of deep cases that might leads to bug with prototypes.

# Extends MetadataCollection
Added find method of type for objects. I think it's good idea to have possibility to get `ts.Type` by any `Metadata`.

It requires in my case, because metadata doesn't cover this methods declarations:
```ts
type Foo {
  bar(): void
}
```

I've noticed that it's hard to compare unions:
```ts
type Foo = { foo: number } 
type Bar = { bar?: number }
type Union = Foo | Bar

const a = { foo: 1 }
const b = { foo: 2 }

console.assert(
  a === b || (
    a.foo === b.foo
  ) || (
    a.bar === b.bar
  )
)
```
This will be true, because after fail on `foo` prop, `a.bar === b.bar` because `undefined === undefined`

And this unions a lot of corner cases. I just forbidden it. Left only for primitive types.

# Development & Test Environment

I've faced with problem that tests take too much time. I've added possibility to add flag that will filter tests by folder.
```sh
pnpm dev --folder=compare.equals
```

Also added watch mode for root:
```
pnpm dev
```

