### PR TITLE
docs: explicitly mention results of Typia errors being swallowed by NX

### DIFF
--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -537,7 +537,7 @@ After installing `typia` like above, and ensuring the `prepare` script is someth
 }
 ```
 
-After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and the resulting transpiled code will not have typia transformations applied. This will result in the following error when running you tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
+After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and the resulting transpiled code will not have typia transformations applied. This will result in an error such as the following when running you tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
 
 ```bash filename="Terminal"
 Error on typia.createAssert(): no transform has been configured.

--- a/website/pages/docs/setup.mdx
+++ b/website/pages/docs/setup.mdx
@@ -537,7 +537,13 @@ After installing `typia` like above, and ensuring the `prepare` script is someth
 }
 ```
 
-After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. But if Typia fails for any reasons (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and you will just not get the output you expect. To debug this, you can create a new task in your `project.json` file similar to the below.
+After this, when running `nx <package-name>:build` it _should_ now output with the Typia transforms applied. **But if Typia fails for any reason** (for example it considers some type you have to be invalid), this error is not reported back via Nx. Nx will silent swallow these errors from ts-patch/typia, and the resulting transpiled code will not have typia transformations applied. This will result in the following error when running you tests that use typia (`nx <package-name>:test`), dev versions of your application (`nx <package-name>:serve`), as well as running your application after building.
+
+```bash filename="Terminal"
+Error on typia.createAssert(): no transform has been configured.
+```
+
+To debug whether this is an issue with your setup or simply NX just silently swallowing typia errors, you can create a new task in your `project.json` file similar to the one below.
 
 ```json filename="project.json" showLineNumbers copy
  "targets": {


### PR DESCRIPTION
I've recently been playing around with NX using a codebase which makes use of Typia, where I encountered an issue that sent me down a rabbit hole for a few days.

The issue was that I was getting errors that I did not configure transforms, when in reality I had.
Well, as it turns out, the issue was actually that Typia encountered a nonsensical type and just did not transform the code, resulting in those transform not being applied and getting the error I just mentioned... and NX in all its glory swallowing those errors and leaving me none the wiser.

I did see that the typia setup guide mentions this behavior, but I failed to make the connection that type errors would result in "did not configure" errors, leaving me to dismiss that as a possible cause of my issues and focusing on the wrong thing: Transpiler / Bundler / Setup issues.

I've updated the setup guide for NX to include an explicit mention of this behavior.

I managed to make the connection thanks to this comment on a similar issue: https://github.com/samchon/typia/issues/900#issuecomment-2492677787

This is how the setup guide would look like now:
![image](https://github.com/user-attachments/assets/a62f2a85-333f-4c2a-b42d-035aebb1b71c)


