### PR TITLE
only allow pnpm for developing typia

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "------------------------------------------------": "",
     "package:latest": "ts-node deploy --tag latest",
     "package:next": "ts-node deploy --tag next",
-    "package:patch": "ts-node deploy --tag patch"
+    "package:patch": "ts-node deploy --tag patch",
+    "preinstall": "npx only-allow pnpm"
   },
   "repository": {
     "type": "git",
@@ -119,4 +120,3 @@
     "llama"
   ]
 }
-


### PR DESCRIPTION
This pull request includes updates to the `package.json` file, adding a new script to enforce the use of `pnpm` as the package manager.

* Added a `preinstall` script to enforce the use of `pnpm` as the package manager. (`package.json`)