### PR TITLE
Fix #1532: private class member with JsDoc commented.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -32,14 +32,16 @@ export const emplace_metadata_object = (
   const isProperty = significant(!!props.options.functional);
   const pred: (node: ts.Declaration) => boolean = isClass
     ? (node) => {
-        const kind: ts.SyntaxKind | undefined = node
-          .getChildren()[0]
-          ?.getChildren()[0]?.kind;
-        return (
-          kind !== ts.SyntaxKind.PrivateKeyword &&
-          kind !== ts.SyntaxKind.ProtectedKeyword &&
-          isProperty(node)
-        );
+        const capsuled: boolean = node
+          .getChildren()
+          .some(
+            (c) => c.getChildren().some(
+              (n) =>
+                n.kind === ts.SyntaxKind.PrivateKeyword ||
+                n.kind === ts.SyntaxKind.ProtectedKeyword,
+            ),
+          );
+        return capsuled === false && isProperty(node);
       }
     : (node) => isProperty(node);
 

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -34,12 +34,14 @@ export const emplace_metadata_object = (
     ? (node) => {
         const capsuled: boolean = node
           .getChildren()
-          .some(
-            (c) => c.getChildren().some(
-              (n) =>
-                n.kind === ts.SyntaxKind.PrivateKeyword ||
-                n.kind === ts.SyntaxKind.ProtectedKeyword,
-            ),
+          .some((c) =>
+            c
+              .getChildren()
+              .some(
+                (n) =>
+                  n.kind === ts.SyntaxKind.PrivateKeyword ||
+                  n.kind === ts.SyntaxKind.ProtectedKeyword,
+              ),
           );
         return capsuled === false && isProperty(node);
       }

--- a/test/src/features/issues/test_issue_1532_class_private.ts
+++ b/test/src/features/issues/test_issue_1532_class_private.ts
@@ -1,0 +1,58 @@
+import { ILlmApplication, ILlmFunction } from "@samchon/openapi";
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_1532_class_private = (): void => {
+  const app: ILlmApplication<"chatgpt"> = typia.llm.application<
+    Application,
+    "chatgpt"
+  >();
+  const assert = (name: string, visible: boolean): void => {
+    const func: ILlmFunction<"chatgpt"> | undefined = app.functions.find(
+      (f) => f.name === name,
+    );
+    TestValidator.equals("visible")(visible)(!!func);
+  };
+  assert("private", false);
+  assert("privateButCommented", false);
+  assert("protected", false);
+  assert("protectedButCommented", false);
+  assert("public", true);
+  assert("publicButCommented", true);
+  assert("nothing", true);
+  assert("nothingButCommented", true);
+};
+
+class Application {
+  private private(): void {}
+
+  /**
+   * Some comment.
+   */
+  private privateButCommented(): void {}
+
+  protected protected(): void {}
+
+  /**
+   * @inheritDoc
+   */
+  protected protectedButCommented(): void {}
+
+  public public(): void {}
+
+  /**
+   * Hello world.
+   */
+  public publicButCommented(): void {}
+
+  nothing(): void {
+    this.private;
+    this.privateButCommented;
+  }
+
+  /**
+   * @title nothing
+   */
+  nothingButCommented(): void {}
+}


### PR DESCRIPTION
This pull request includes several changes to the `typia` package, focusing on version updates, improvements to metadata handling, and adding new tests for class privacy.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `8.0.0` to `8.0.1`.

### Metadata Handling Improvements:
* [`src/factories/internal/metadata/emplace_metadata_object.ts`](diffhunk://#diff-9c9ae7bf4163021570485acb821f0407a5094152c7e7c096db41d4c7fd32c8e4L35-R44): Refactored the logic to determine if a node is private or protected by using nested `some` calls, improving readability and maintainability.

### New Tests:
* [`test/src/features/issues/test_issue_1532_class_private.ts`](diffhunk://#diff-59fefe2a4c8374601957102bcd87733b5e0c168f2d3ed7e49d626b9ffc30ad41R1-R58): Added a new test file to validate the visibility of class methods, ensuring that private and protected methods are correctly identified and handled.