### PR TITLE
fix(rollup): remove external property

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,7 +21,6 @@ export default {
     },
     preserveModules: true,
     preserveModulesRoot: "src",
-    external: ["randexp"],
   },
   plugins: [
     {


### PR DESCRIPTION
Now we use auto external plugin for rollup so we don't need to specify this option

