### PR TITLE
Fix typo of `@deprecated` tag.

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -80,9 +80,9 @@ export function schemas(): never {
  * @template Version Version of OpenAPI specification. Default is 3.1
  * @return JSON schema list
  *
- * @deprcated Use {@link schemas} function instead please.
- *            This function would be changed to return {@linkk ILlmApplication} like
- *            structure in the future version (maybe next v8 major update).
+ * @deprecated Use {@link schemas} function instead please.
+ *             This function would be changed to return {@linkk ILlmApplication} like
+ *             structure in the future version (maybe next v8 major update).
  * @author Jeongho Nam - https://github.com/samchon
  */
 export function application(): never;
@@ -102,9 +102,9 @@ export function application(): never;
  * @template Version Version of OpenAPI specification. Default is 3.1
  * @return JSON schema list
  *
- * @deprcated Use {@link schemas} function instead please.
- *            This function would be changed to return {@linkk ILlmApplication} like
- *            structure in the future version (maybe next v8 major update).
+ * @deprecated Use {@link schemas} function instead please.
+ *             This function would be changed to return {@linkk ILlmApplication} like
+ *             structure in the future version (maybe next v8 major update).
  * @author Jeongho Nam - https://github.com/samchon
  */
 export function application<


### PR DESCRIPTION
This pull request includes minor changes to correct typos in the JSDoc comments of the `src/json.ts` file. The changes involve fixing the spelling of the `@deprecated` tag.

Typos corrected in JSDoc comments:

* [`src/json.ts`](diffhunk://#diff-5b45d0800ed9310a182e74c50faf3883830b08588277690cab7d7cd82e7e5089L83-R83): Corrected the spelling of the `@deprecated` tag in the `schemas` function.
* [`src/json.ts`](diffhunk://#diff-5b45d0800ed9310a182e74c50faf3883830b08588277690cab7d7cd82e7e5089L105-R105): Corrected the spelling of the `@deprecated` tag in the `application` function.