### PR TITLE
Detailed explanation of validation feedback strategy

### DIFF
--- a/website/pages/docs/llm/application.mdx
+++ b/website/pages/docs/llm/application.mdx
@@ -1,7 +1,20 @@
 ---
 title: Guide Documents > Large Language Model > application() function
 ---
-import { Callout, Tabs } from 'nextra/components'
+import { Callout, Tabs } from "nextra/components";
+
+import ILlmApplicationSnippet from "../../../src/snippets/ILlmApplicationSnippet.mdx";
+import ILlmFunctionSnippet from "../../../src/snippets/ILlmFunctionSnippet.mdx";
+import ILlmSchemaSnippet from "../../../src/snippets/ILlmSchemaSnippet.mdx";
+
+import BbsArticleServiceSnippet from "../../../src/snippets/BbsArticleServiceSnippet.mdx";
+import IBbsArticleSnippet from "../../../src/snippets/IBbsArticleSnippet.mdx";
+import LlmApplicationExampleSnippet from "../../../src/snippets/LlmApplicationExampleSnippet.mdx";
+import LlmApplicationJavaScriptSnippet from "../../../src/snippets/LlmApplicationJavaScriptSnippet.mdx";
+import LlmApplicationSeparateExampleSnippet from "../../../src/snippets/LlmApplicationSeparateExampleSnippet.mdx";
+import LlmApplicationSeparateJsonSnippet from "../../../src/snippets/LlmApplicationSeparateJsonSnippet.mdx";
+import ValidationFeedbackExampleSnippet from "../../../src/snippets/ValidationFeedbackExampleSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../src/snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `application()` function
 <Tabs items={[
@@ -46,291 +59,13 @@ export namespace llm {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlmFunction } from "./ILlmFunction";
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * Application of LLM function calling.
- *
- * `ILlmApplication` is a data structure representing a collection of
- * {@link ILlmFunction LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.application<App, Model>()`
- * function.
- *
- * Also, there can be some parameters (or their nested properties) which must be
- * composed by Human, not by LLM. File uploading feature or some sensitive information
- * like security keys (password) are the examples. In that case, you can separate the
- * function parameters to both LLM and human sides by configuring the
- * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
- * assigned to the {@link ILlmFunction.separated} property.
- *
- * For reference, when both LLM and Human filled parameter values to call, you can
- * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
- * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
- * have to merge the separated parameters before the function call execution.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmApplication<Model extends ILlmSchema.Model> {
-  /**
-   * Model of the LLM.
-   */
-  model: Model;
-
-  /**
-   * List of function metadata.
-   *
-   * List of function metadata that can be used for the LLM function call.
-   */
-  functions: ILlmFunction<Model>[];
-
-  /**
-   * Configuration for the application.
-   */
-  options: ILlmApplication.IOptions<Model>;
-}
-export namespace ILlmApplication {
-  /**
-   * Options for application composition.
-   */
-  export type IOptions<Model extends ILlmSchema.Model> = {
-    /**
-     * Separator function for the parameters.
-     *
-     * When composing parameter arguments through LLM function call,
-     * there can be a case that some parameters must be composed by human,
-     * or LLM cannot understand the parameter.
-     *
-     * For example, if the parameter type has configured
-     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
-     * uploading, it must be composed by human, not by LLM
-     * (Large Language Model).
-     *
-     * In that case, if you configure this property with a function that
-     * predicating whether the schema value must be composed by human or
-     * not, the parameters would be separated into two parts.
-     *
-     * - {@link ILlmFunction.separated.llm}
-     * - {@link ILlmFunction.separated.human}
-     *
-     * When writing the function, note that returning value `true` means
-     * to be a human composing the value, and `false` means to LLM
-     * composing the value. Also, when predicating the schema, it would
-     * better to utilize the {@link GeminiTypeChecker} like features.
-     *
-     * @param schema Schema to be separated.
-     * @returns Whether the schema value must be composed by human or not.
-     * @default null
-     */
-    separate: null | ((schema: ILlmSchema.ModelSchema[Model]) => boolean);
-  } & ILlmSchema.ModelConfig[Model];
-}
-```
+    <ILlmApplicationSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * LLM function metadata.
- *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
- *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
- *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
-
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<Model>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priority, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-
-  /**
-   * Validate function of the arguments.
-   *
-   * You know what? LLM (Large Language Model) like OpenAI takes a lot of
-   * mistakes when composing arguments in function calling. Even though
-   * `number` like simple type is defined in the {@link parameters} schema,
-   * LLM often fills it just by a `string` typed value.
-   *
-   * In that case, you have to give a validation feedback to the LLM by
-   * using this `validate` function. The `validate` function will return
-   * detailed information about every type errors about the arguments.
-   *
-   * And in my experience, OpenAI's `gpt-4o-mini` model tends to construct
-   * an invalid function calling arguments at the first trial about 50% of
-   * the time. However, if correct it through this `validate` function,
-   * the success rate soars to 99% at the second trial, and I've never failed
-   * at the third trial.
-   *
-   * @param args Arguments to validate.
-   * @returns Validation result
-   */
-  validate: (args: unknown) => IValidation<unknown>;
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Model extends ILlmSchema.Model> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: ILlmSchema.ModelParameters[Model] | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: ILlmSchema.ModelParameters[Model] | null;
-  }
-}
-```
+    <ILlmFunctionSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IChatGptSchema } from "./IChatGptSchema";
-import { IClaudeSchema } from "./IClaudeSchema";
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlamaSchema } from "./ILlamaSchema";
-import { ILlmSchemaV3 } from "./ILlmSchemaV3";
-import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
-
-/**
- * The schemas for the LLM function calling.
- *
- * `ILlmSchema` is an union type collecting every the schemas for the
- * LLM function calling.
- *
- * Select a proper schema type according to the LLM provider you're using.
- *
- * @template Model Name of the target LLM model
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @reference https://platform.openai.com/docs/guides/structured-outputs
- * @author Jeongho Nam - https://github.com/samchon
- */
-export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-  ILlmSchema.ModelSchema[Model];
-
-export namespace ILlmSchema {
-  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
-  export interface ModelConfig {
-    chatgpt: IChatGptSchema.IConfig;
-    claude: IClaudeSchema.IConfig;
-    gemini: IGeminiSchema.IConfig;
-    llama: ILlamaSchema.IConfig;
-    "3.0": ILlmSchemaV3.IConfig;
-    "3.1": ILlmSchemaV3_1.IConfig;
-  }
-  export interface ModelParameters {
-    chatgpt: IChatGptSchema.IParameters;
-    claude: IClaudeSchema.IParameters;
-    gemini: IGeminiSchema.IParameters;
-    llama: ILlamaSchema.IParameters;
-    "3.0": ILlmSchemaV3.IParameters;
-    "3.1": ILlmSchemaV3_1.IParameters;
-  }
-  export interface ModelSchema {
-    chatgpt: IChatGptSchema;
-    claude: IClaudeSchema;
-    gemini: IGeminiSchema;
-    llama: ILlamaSchema;
-    "3.0": ILlmSchemaV3;
-    "3.1": ILlmSchemaV3_1;
-  }
-
-  /**
-   * Type of function parameters.
-   *
-   * `ILlmSchema.IParameters` is a type defining a function's pamameters
-   * as a keyworded object type.
-   *
-   * It also can be utilized for the structured output metadata.
-   *
-   * @reference https://platform.openai.com/docs/guides/structured-outputs
-   */
-  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Configuration for the LLM schema composition.
-   */
-  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelConfig[Model];
-}
-```
+    <ILlmSchemaSnippet />
   </Tabs.Tab>
 </Tabs>
 
@@ -366,6 +101,57 @@ Structured output is another feature of LLM. The "structured output" means that 
 - https://platform.openai.com/docs/guides/structured-outputs
 </Callout>
 
+<Tabs items={[
+    "TypeScript Source Code",
+    "Compiled JavaScript",
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
+  <Tabs.Tab>
+    <LlmApplicationExampleSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LlmApplicationJavaScriptSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <BbsArticleServiceSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <IBbsArticleSnippet />
+  </Tabs.Tab>
+</Tabs>
+
+> [💻 Playground Link](https://typia.io/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQEExncAYwEMZgIA7OAXzgDMoIQ4AiAAQGciQCALCgeghgApuSJhgzANwAoUJFhwYATwlEANIiVEA5u2p0GTZirXSZMghXbxxYAFwoM2XPmKkKAHma8SOsDDMAHxwALxKqsBEAHTomNF2biRk5J4ycHAAQgBG7FiwhOjCAMrCUABuhMLq6Sy+MP6BMkEAFACUslbk7BBFsRA6LXYdFsDkMGW0RATCWbn5pARFpRVViLX8AFSbtXCbcADiwrZxcEQFS8Ls0bs7GXtwqMA2cACuYHDC5WXKZxdF+nOvGA3wAJnAxkoeLNMplinAACKZG73O4ZfasKDHV5QbqPZ7wCC0T7fKC-c6LAG3fi1Mag4QAD3ajmQOTy-2EAG0ALqyOAbba3OAAYSxJFmRDg5GEAHc-pThCj0UKAOpQYATQFS2XywoS8jgoE8EFXCHwMYwCBQ2ZIpV7IWsMDnLhwMAMMD6AAK7rKpFNRLgBDFEzor3IBA85AdWJgOLxADlZehfkHhOLDRzqbVU+KWm6hOxHAhdnAtmjUShyLRoCBkhQ4AGYNDdZclFacxMS3safcIeQwK8YCy2Qs9dFkKK0xM+dQ2sP5hy+QLy-sAKpgUHis6UClj25C9ebzXbltFOAyjU8bVyroTcZ2ldwR3Opj5j1wb1CX3Af3E95H2ZaDDCMUgdJ0oBdMYB3gRMbwoO94EtN4N3FLMMn-XM30LdZezLLt9gAFXOHRjlPYQAHJ9AQVh8HIABrFARw5aJgFBKg7XRHt7lYxwbHVcgdDgAAybQ9GiAAxGsSG8V5XlY4Il1wwVeweWDA3g0REKtDCJg47sSygwd53ZBVx0PcUZyoOc4HKCBWMU0tlPROAAFEIPYfUyIfIU3KIDzAR3DlDEYa1EWRfcK2fCDX3dL0fQKX9PncwDgMjNCkr84Q81iosSzwlTCOI0jd0uSjEBosYGNZBdTNY9j8K4jIeLgPixkEkSYF0a5JKgWsYBkuTQQU2orMcWz7JkKgLHy-ZR1bTSNWUFE7n2AADaqTL1VaIQCz5xkWuAsTdK4FoEk8SrPSEmxhOE4BaTJXjiY5IUyCBznBYplBsYQQDaZaaQtSZplmDa5rPRk71BfRQeYidg1mYsMny5zvVAc5fgAaWEJb0ua1qzo6rqJKk-rmFk+Sggc5GHknOtKFIEBZkbZsLsVdKO2EUEAH0SF4mB+Pa0TupJ7wAIAWgZ4Rhv5JGnIeVA-PgHTOaUUAmeJa6vPS5Xud5lr+ba4SheJ3rpOYcXJeGqaxEZ9gnRmRiar1HDHMfZAqxJlIGw1lmgqQjmHy4xkFHNcYgYduGpwRvK5ecgiNTPZmJWY-D8LgAAlYRjo88Zkm+VWYETn3k9MhqS1IQvhD5gWHNl8tnOFDTxjgbIIFBHGCrTxuw+b1v2+90LWfPdUYBgSgrubWsoDo0EIBlShq1NmA9M2RqW7b5Rq7a2vXbTgieFeEBsjEYB0AhWsSLgVd0+QFe94Po+T7PtHL+v5Bz2NXhAyISgjqxHPEK+1Lp3AqKBiRdFoMAHQOIVZ+TgKtcgj10CrU0BqOAjMf76CbCQKUVomyH2PkQU+59dCzAniXPcBU174MfkQ9A9guxwAAD5SiQYwlhLR8aC06mJHqfUZLqmCEbHh1xu4IQALKcyiARVQwhvAv2EFsYIIwMhTRlrvCs7tF59S9knMibZkIAW8hWAA8uQZMoVIFPXBG+b8poLynGyLMHWgdajB2gIhWRKBzIhnCJ6XcRB0CeEjuKSmk0gA)
+
+
+
+
+## Validation Feedback
+<ValidationFeedbackExampleSnippet />
+
+Is LLM Function Calling perfect? No, absolutely not.
+
+LLM (Large Language Model) service vendor like OpenAI takes a lot of type level mistakes when composing the arguments of function calling or structured output. Even though target schema is super simple like `Array<string>` type, LLM often fills it just by a `string` typed value.
+
+In my experience, OpenAI `gpt-4o-mini` (`8b` parameters) is taking about 70% of type level mistakes when filling the arguments of function calling to Shopping Mall service. To overcome the imperfection of such LLM function calling, `typia.llm.application<App, Model>()` function embeds [`typia.validate<T>()`](/docs/validators/validate) function for the validation feedback strategy.
+
+The key concept of validation feedback strategy is, let LLM function calling to construct invalid typed arguments first, and informing detailed type errors to the LLM, so that induce LLM to emend the wrong typed arguments at the next turn. In this way, I could uprise the success rate of function calling from 30% to 99% just by one step validation feedback. Even though the LLM is still occurs type error, it always has been caught at the next turn.
+
+For reference, embedded [`typia.validate<T>()`](/docs/validators/validate) is the best runtime type checker which can validate every TypeScript (JSON schema) types exactly and detaily than any other libraries. With this validation feedback strategy and the best runtime type checker, let's accomplish the [Agentic AI](https://wrtnlabs.io/agentica) with function calling.
+
+<ValidatorSupportMatrixSnippet />
+
+Also, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema like OpenAI ([`IChatGptSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IChatGptSchema.ts)) and Gemini ([`IGeminiSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IGeminiSchema.ts)). And some LLM providers which do not specified the JSON schema version like Claude ([`IClaudeSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IClaudeSchema.ts)) and Llama ([`ILlamaSchema`](https://github.com/samchon/openapi/blob/master/src/structures/ILlamaSchema.ts)), they tend to fail a lot of function calling in the restriction properties,
+
+For example, OpenAI and Gemini does not support `format` property of JSON schema, so that cannot let LLM to understand the `UUID` like type. Even though `typia.llm.application<App, Model>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
+
+In that case, if you give validation feedback from `ILlmFunction.validate()` function, the LLM will be able to understand the restriction information exactly and fill the arguments properly.
+
+  - Restriction properties of JSON schema
+    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+
 
 
 
@@ -380,391 +166,25 @@ Here is the example separating the parameter schemas.
 
 <Tabs items={[
     "TypeScript Source Code",
-    "LLM Function Calling Application Schema",
+    "Generated Schema",
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
   ]}>
   <Tabs.Tab>
-```typescript filename="example/src/llm.application.separate.ts" showLineNumbers {4-7}
-import { ILlmApplication } from "@samchon/openapi";
-import typia, { tags } from "typia";
-
-const app: ILlmApplication<"claude"> = typia.llm.application<
-  BbsArticleController,
-  "claude"
->({
-  separate: (schema: ILlmSchema<"claude">) =>
-    ClaudeTypeChecker.isString(schema) && schema.contentMediaType !== undefined,
-});
-
-console.log(app);
-
-interface BbsArticleController {
-  /**
-   * Create a new article.
-   *
-   * Writes a new article and archives it into the DB.
-   *
-   * @param props Properties of create function
-   * @returns Newly created article
-   */
-  create(props: {
-    /**
-     * Information of the article to create
-     */
-    input: IBbsArticle.ICreate;
-  }): Promise<IBbsArticle>;
-
-  /**
-   * Update an article.
-   *
-   * Updates an article with new content.
-   *
-   * @param props Properties of update function
-   * @param input New content to update
-   */
-  update(props: {
-    /**
-     * Target article's {@link IBbsArticle.id}.
-     */
-    id: string & tags.Format<"uuid">;
-
-    /**
-     * New content to update.
-     */
-    input: IBbsArticle.IUpdate;
-  }): Promise<void>;
-
-  /**
-   * Erase an article.
-   *
-   * Erases an article from the DB.
-   *
-   * @param props Properties of erase function
-   */
-  erase(props: {
-    /**
-     * Target article's {@link IBbsArticle.id}.
-     */
-    id: string & tags.Format<"uuid">;
-  }): Promise<void>;
-}
-```
+    <LlmApplicationSeparateExampleSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```json filename="example/schemas/llm.application.separate.json" showLineNumbers {41-91}
-{
-  "model": "claude",
-  "options": {
-    "reference": false
-  },
-  "functions": [
-    {
-      "name": "create",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "input": {
-            "description": "Information of the article to create.\n\n------------------------------\n\nDescription of the current {@link IBbsArticle.ICreate} type:\n\n> Information of the article to create.\n\n------------------------------\n\nDescription of the parent {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
-            "type": "object",
-            "properties": {
-              "title": {
-                "title": "Title of the article",
-                "description": "Title of the article.\n\nRepresentative title of the article.",
-                "type": "string"
-              },
-              "body": {
-                "title": "Content body",
-                "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
-                "type": "string"
-              },
-              "thumbnail": {
-                "title": "Thumbnail image URI",
-                "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "string",
-                    "format": "uri",
-                    "contentMediaType": "image/*"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "title",
-              "body",
-              "thumbnail"
-            ]
-          }
-        },
-        "required": [
-          "input"
-        ],
-        "additionalProperties": false,
-        "$defs": {}
-      },
-      "output": {
-        "description": "Article entity.\n\n`IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Primary Key",
-            "description": "Primary Key.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "created_at": {
-            "title": "Creation time of the article",
-            "description": "Creation time of the article.",
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "title": "Last updated time of the article",
-            "description": "Last updated time of the article.",
-            "type": "string",
-            "format": "date-time"
-          },
-          "title": {
-            "title": "Title of the article",
-            "description": "Title of the article.\n\nRepresentative title of the article.",
-            "type": "string"
-          },
-          "body": {
-            "title": "Content body",
-            "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
-            "type": "string"
-          },
-          "thumbnail": {
-            "title": "Thumbnail image URI",
-            "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "string",
-                "format": "uri",
-                "contentMediaType": "image/*"
-              }
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "created_at",
-          "updated_at",
-          "title",
-          "body",
-          "thumbnail"
-        ]
-      },
-      "description": "Create a new article.\n\nWrites a new article and archives it into the DB.",
-      "separated": {
-        "llm": {
-          "type": "object",
-          "properties": {
-            "input": {
-              "description": "Information of the article to create.\n\n------------------------------\n\nDescription of the current {@link IBbsArticle.ICreate} type:\n\n> Information of the article to create.\n\n------------------------------\n\nDescription of the parent {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
-              "type": "object",
-              "properties": {
-                "title": {
-                  "title": "Title of the article",
-                  "description": "Title of the article.\n\nRepresentative title of the article.",
-                  "type": "string"
-                },
-                "body": {
-                  "title": "Content body",
-                  "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
-                  "type": "string"
-                },
-                "thumbnail": {
-                  "title": "Thumbnail image URI",
-                  "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string",
-                      "format": "uri",
-                      "contentMediaType": "image/*"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "title",
-                "body",
-                "thumbnail"
-              ]
-            }
-          },
-          "required": [
-            "input"
-          ],
-          "additionalProperties": false,
-          "$defs": {}
-        },
-        "human": null
-      }
-    },
-    {
-      "name": "update",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Target article's {@link IBbsArticle.id}",
-            "description": "Target article's {@link IBbsArticle.id}.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "input": {
-            "description": "Make all properties in T optional\n\n------------------------------\n\nDescription of the current {@link PartialIBbsArticle.ICreate} type:\n\n> Make all properties in T optional",
-            "type": "object",
-            "properties": {
-              "title": {
-                "title": "Title of the article",
-                "description": "Title of the article.\n\nRepresentative title of the article.",
-                "type": "string"
-              },
-              "body": {
-                "title": "Content body",
-                "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
-                "type": "string"
-              },
-              "thumbnail": {
-                "title": "Thumbnail image URI",
-                "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "type": "string",
-                    "format": "uri",
-                    "contentMediaType": "image/*"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "title",
-              "body",
-              "thumbnail"
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "input"
-        ],
-        "additionalProperties": false,
-        "$defs": {}
-      },
-      "description": "Update an article.\n\nUpdates an article with new content.",
-      "separated": {
-        "llm": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "title": "Target article's {@link IBbsArticle.id}",
-              "description": "Target article's {@link IBbsArticle.id}.",
-              "type": "string",
-              "format": "uuid"
-            },
-            "input": {
-              "description": "Make all properties in T optional\n\n------------------------------\n\nDescription of the current {@link PartialIBbsArticle.ICreate} type:\n\n> Make all properties in T optional",
-              "type": "object",
-              "properties": {
-                "title": {
-                  "title": "Title of the article",
-                  "description": "Title of the article.\n\nRepresentative title of the article.",
-                  "type": "string"
-                },
-                "body": {
-                  "title": "Content body",
-                  "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
-                  "type": "string"
-                },
-                "thumbnail": {
-                  "title": "Thumbnail image URI",
-                  "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string",
-                      "format": "uri",
-                      "contentMediaType": "image/*"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "title",
-                "body",
-                "thumbnail"
-              ]
-            }
-          },
-          "required": [
-            "id",
-            "input"
-          ],
-          "additionalProperties": false,
-          "$defs": {}
-        },
-        "human": null
-      }
-    },
-    {
-      "name": "erase",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Target article's {@link IBbsArticle.id}",
-            "description": "Target article's {@link IBbsArticle.id}.",
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "additionalProperties": false,
-        "$defs": {}
-      },
-      "description": "Erase an article.\n\nErases an article from the DB.",
-      "separated": {
-        "llm": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "title": "Target article's {@link IBbsArticle.id}",
-              "description": "Target article's {@link IBbsArticle.id}.",
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          "required": [
-            "id"
-          ],
-          "additionalProperties": false,
-          "$defs": {}
-        },
-        "human": null
-      }
-    }
-  ]
-}
-```
+    <LlmApplicationSeparateJsonSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <BbsArticleServiceSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <IBbsArticleSnippet />
   </Tabs.Tab>
 </Tabs>
+
+> [💻 Playground Link](https://typia.io/playground/?script=JYWwDg9gTgLgBAbzgYQDYEMCuATApgFQE8xdkALXAYwGtcoAaOASTSzwGVKKR1GmAZVCACCYMKmCV0MYBAB2cAL5wAZlAgg4AIgACAZ3Qgu8gPQQSc9GGBaA3AChQkWHBjFgvRK-QBzPUtV1TS03a3Q7e3tKeT14KzAALmZBETEJKRl5AB4tSgwcXC0APjgAXld3dAA6VCEq+PTpWTks+zg4ACEAIz1hWElUXHY6ADdJXHo27Ty2QvsigAoEKb1cMHQoaVwkhb0uXB4klnyOfZ4ASjKiqfbWAqIScipaKCrgPXYYKGA5H12z9CXABkQLge241WichguGhAFlcNgPA9cHAAISlcqYOR4FQ-RGTRTnBxQvQQQY1CB-eLEyI-GFQFToSio7q9fp5IajcaIKYmABU-Ju-LgAHFcHFanANjJOXoqsLhXB+O94JgwHBcCM6IRpRzBv4NlxgNrsHAfq4KJ0Ouw4AARDoK9pwIXOkU6KASzBQOT+FWxOAQFSa7VQXUyga4PTCkxTH54AAeC3ORzZfVlgwA2gBdBxwPmCpXIT1baVwOS4ADueozuCd7VdDbgAHVvjDDeWqzXI9KcXrjdr-MB4PSIJbUQ76y6lTp1ptNGB1GB-AAFJd0GRRwPByglmGqbGUTJyGeemDe31wAByVdQut3uC2ZojnJjUwfWwWi-MeiSy2dcACo2brMHIKjQDwx7buO3acq4Y4fjCNwNrGAE-GAmAwKmPTppGVQsHuuB5koKbMGm+pEW0BbASKACqYDYKW6AKC+FKKiB9GMe2vawYMcCVsOZCdtWUIwtCU40XAs4bIYcDfsucBruYG7AFuQZwOqXGoioh7HjOc6yehmHXl2omwvAMBjppWxvu01kwl+S6-ryAFAchLpwPgGw+BKvG4AA5P4CA6BIcjUGROEUW82CKFOKHIcA2BJLE3y-HAoIwL48oAGIQdIOSYJgiXFHmyFuQBHk3iJ8hiRZVkMVscUuqhzpGVhEXsrW+GcVsxFEkkIwQIlpXtOVTYAKKbKsPGsXW7ETVNW7MX5gQaDBk7zR50nznJTmKeu-RqcGdDoNNOlyEezS2Zqi2OT+f5lYWFUil5UA+XEFGBYgIU-OFTDkV1iWxe5-Ite0iXJV8Pw+Ol3h+FUuVQJBBVFdgJVTP1cCDcN9iKJE5UirhcHmcOhBOq6IoAAb-ZFtaU+ahoKCTbhwJ6i5RiTaXLbN5oKDAVodDacALB0mC1BKFodBAGxmuwhCxAc5zk7G9J0EyLIdUTfG4AmYnYP4NOdXhBGPvu-6AU9TZrqAGy6gA0rgZPXRDYJQ2lGVZQjeUwCjxVFCNFuScWpvNK4oCoup-OorNEktYhiIAPrSJDqUwx78OI8jWhaQAtDIICFP7VGjZbHn8KdaoNTCZr5xHwZR35sdTPZifJ67qew5lGfezkue1+jeOWAXejrBrhta6i5tjR5TBgd7oeR1aPOWXA8dN+0OvOCO0Jq8yqIm6W5sl8BTb4MOfGL9HUUgyDcAAEprJ6qzQk02phzAF-10v1-PWD7+DCnaGAdj632QDVcycAugQGwE7Z6oDwHQkgdA3Ul8VqVjbDABQFoG48CgNQbAEBKwKHAkjaQTVQbISgTAwBvxgGB1vvgMgmAQBdEsMAVA5oeA+TgLRO+TByEMKYSwthHCbbcN4UwfiZBJBCSkAoNmT8IENxjjfZ6zAdzyDxD4b0iJpT+EpnIMWqBKaMGHHAAuzF-D82kOWMc-NmGsPQOwzhvhUTYO-l1EGf97HCKcagBI7k4AAB9yxGMCSE3Ybs05wxyj3LQ3obAlHTvKMBO94SImRMQXAOQxG4AFMUWk7Q8b5hASBWeJDIILy-lfWs8ENJVzmm6JUAB5OQd4YJ4nFmaeSKktwCSlF0VELdsDr01AmLeFQSDMB6vucoK4IzoFQFkA+MIi6KCAA)
 
 
 
@@ -781,7 +201,7 @@ About the return value type, it follows the restriction of [`typia.llm.schema<T,
 
 <Tabs items={["TypeScript Source Code", "Console Output"]}>
   <Tabs.Tab>
-```typescript filename="src/examples/llm.application.violation.ts" showLineNumbers
+```typescript filename="example/src/llm.application.violation.ts" showLineNumbers
 import { ILlmApplication } from "@samchon/openapi";
 import typia, { tags } from "typia";
 

--- a/website/pages/docs/llm/chat.mdx
+++ b/website/pages/docs/llm/chat.mdx
@@ -1,7 +1,11 @@
 ---
 title: Guide Documents > Large Language Model > AI Chatbot Development
 ---
-import { Callout, Tabs } from 'nextra/components'
+import { Callout, Tabs } from "nextra/components";
+
+import BbsArticleServiceSnippet from "../../../src/snippets/BbsArticleServiceSnippet.mdx";
+import IBbsArticleSnippet from "../../../src/snippets/IBbsArticleSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../src/snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## Agentica
 ![agentica-conceptual-diagram](https://github.com/user-attachments/assets/d7ebbd1f-04d3-4b0d-9e2a-234e29dd6c57)
@@ -66,167 +70,10 @@ await agent.conversate("Hello, I want to create an article.");
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="src/BbsArticleService.ts" showLineNumbers
-import { tags } from "typia";
-import { v4 } from "uuid";
-
-import { IBbsArticle } from "./IBbsArticle";
-
-export class BbsArticleService {
-  private readonly articles: IBbsArticle[] = [];
-
-  /**
-   * Get all articles.
-   *
-   * List up every articles archived in the BBS DB.
-   *
-   * @returns List of every articles
-   */
-  public index(): IBbsArticle[] {
-    return this.articles;
-  }
-
-  /**
-   * Create a new article.
-   *
-   * Writes a new article and archives it into the DB.
-   *
-   * @param props Properties of create function
-   * @returns Newly created article
-   */
-  public create(props: {
-    /**
-     * Information of the article to create
-     */
-    input: IBbsArticle.ICreate;
-  }): IBbsArticle {
-    const article: IBbsArticle = {
-      id: v4(),
-      title: props.input.title,
-      body: props.input.body,
-      thumbnail: props.input.thumbnail,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
-    this.articles.push(article);
-    return article;
-  }
-
-  /**
-   * Update an article.
-   *
-   * Updates an article with new content.
-   *
-   * @param props Properties of update function
-   * @param input New content to update
-   */
-  public update(props: {
-    /**
-     * Target article's {@link IBbsArticle.id}.
-     */
-    id: string & tags.Format<"uuid">;
-
-    /**
-     * New content to update.
-     */
-    input: IBbsArticle.IUpdate;
-  }): void {
-    const article: IBbsArticle | undefined = this.articles.find(
-      (a) => a.id === props.id,
-    );
-    if (article === undefined)
-      throw new Error("Unable to find the matched article.");
-    if (props.input.title !== undefined) article.title = props.input.title;
-    if (props.input.body !== undefined) article.body = props.input.body;
-    if (props.input.thumbnail !== undefined)
-      article.thumbnail = props.input.thumbnail;
-    article.updated_at = new Date().toISOString();
-  }
-
-  /**
-   * Erase an article.
-   *
-   * Erases an article from the DB.
-   *
-   * @param props Properties of erase function
-   */
-  public erase(props: {
-    /**
-     * Target article's {@link IBbsArticle.id}.
-     */
-    id: string & tags.Format<"uuid">;
-  }): void {
-    const index: number = this.articles.findIndex((a) => a.id === props.id);
-    if (index === -1) throw new Error("Unable to find the matched article.");
-    this.articles.splice(index, 1);
-  }
-}
-```
+    <BbsArticleServiceSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="src/IBbsArticle.ts" showLineNumbers
-import { tags } from "typia";
-
-/**
- * Article entity.
- *
- * `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).
- */
-export interface IBbsArticle extends IBbsArticle.ICreate {
-  /**
-   * Primary Key.
-   */
-  id: string & tags.Format<"uuid">;
-
-  /**
-   * Creation time of the article.
-   */
-  created_at: string & tags.Format<"date-time">;
-
-  /**
-   * Last updated time of the article.
-   */
-  updated_at: string & tags.Format<"date-time">;
-}
-export namespace IBbsArticle {
-  /**
-   * Information of the article to create.
-   */
-  export interface ICreate {
-    /**
-     * Title of the article.
-     *
-     * Representative title of the article.
-     */
-    title: string;
-
-    /**
-     * Content body.
-     *
-     * Content body of the article writtn in the markdown format.
-     */
-    body: string;
-
-    /**
-     * Thumbnail image URI.
-     *
-     * Thumbnail image URI which can represent the article.
-     *
-     * If configured as `null`, it means that no thumbnail image in the article.
-     */
-    thumbnail:
-      | null
-      | (string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">);
-  }
-
-  /**
-   * Information of the article to update.
-   *
-   * Only the filled properties will be updated.
-   */
-  export type IUpdate = Partial<ICreate>;
-}
-```
+    <IBbsArticleSnippet />
   </Tabs.Tab>
 </Tabs>
 
@@ -453,27 +300,20 @@ About the validation feedback, `@agentica/core` is utilizing [`typia.validate<T>
 
 Such validation feedback strategy and combination with `typia` runtime validator, `@agentica/core` has achieved the most ideal LLM function calling. In my experience, when using OpenAI's `gpt-4o-mini` model, it tends to construct invalid function calling arguments at the first trial about 50% of the time. By the way, if correct it through validation feedback with `typia`, success rate soars to 99%. And I've never had a failure when trying validation feedback twice.
 
-Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
--------------------------|--------|-----------|-------|---------|-------|------------------
-**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
-[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
-[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
-[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
-[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
-[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
-[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+For reference, embedded [`typia.validate<T>()`](/docs/validators/validate) is the best runtime type checker which can validate every TypeScript (JSON schema) types exactly and detaily than any other libraries. With this validation feedback strategy and the best runtime type checker, let's accomplish the [Agentic AI](https://wrtnlabs.io/agentica) with function calling.
 
-> `C.V.` means `class-validator`
+<ValidatorSupportMatrixSnippet />
+
+Also, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema like OpenAI ([`IChatGptSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IChatGptSchema.ts)) and Gemini ([`IGeminiSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IGeminiSchema.ts)). And some LLM providers which do not specified the JSON schema version like Claude ([`IClaudeSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IClaudeSchema.ts)) and Llama ([`ILlamaSchema`](https://github.com/samchon/openapi/blob/master/src/structures/ILlamaSchema.ts)), they tend to fail a lot of function calling in the restriction properties,
+
+For example, OpenAI and Gemini does not support `format` property of JSON schema, so that cannot let LLM to understand the `UUID` like type. Even though `typia.llm.application<App, Model>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
+
+In that case, validation feedback from `ILlmFunction.validate()` function will inform understand the restriction exactly to the LLM, so that corrects the arguments properly.
+
+  - Restriction properties of JSON schema
+    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
 
 ### OpenAPI Specification
 ```mermaid

--- a/website/pages/docs/llm/parameters.mdx
+++ b/website/pages/docs/llm/parameters.mdx
@@ -1,7 +1,15 @@
 ---
 title: Guide Documents > Large Language Model > parameters() function
 ---
-import { Callout, Tabs } from 'nextra/components'
+import { Callout, Tabs } from "nextra/components";
+
+import ILlmApplicationSnippet from "../../../src/snippets/ILlmApplicationSnippet.mdx";
+import ILlmFunctionSnippet from "../../../src/snippets/ILlmFunctionSnippet.mdx";
+import ILlmSchemaSnippet from "../../../src/snippets/ILlmSchemaSnippet.mdx";
+
+import LlmParametersExampleSnippet from "../../../src/snippets/LlmParametersExampleSnippet.mdx";
+import LlmParametersJavaScriptSnippet from "../../../src/snippets/LlmParametersJavaScriptSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../src/snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `parameters()` function
 <Tabs items={[
@@ -55,363 +63,13 @@ export namespace llm {
 ```
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlmFunction } from "./ILlmFunction";
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * Application of LLM function calling.
- *
- * `ILlmApplication` is a data structure representing a collection of
- * {@link ILlmFunction LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.application<App, Model>()`
- * function.
- *
- * Also, there can be some parameters (or their nested properties) which must be
- * composed by Human, not by LLM. File uploading feature or some sensitive information
- * like security keys (password) are the examples. In that case, you can separate the
- * function parameters to both LLM and human sides by configuring the
- * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
- * assigned to the {@link ILlmFunction.separated} property.
- *
- * For reference, when both LLM and Human filled parameter values to call, you can
- * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
- * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
- * have to merge the separated parameters before the function call execution.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmApplication<Model extends ILlmSchema.Model> {
-  /**
-   * Model of the LLM.
-   */
-  model: Model;
-
-  /**
-   * List of function metadata.
-   *
-   * List of function metadata that can be used for the LLM function call.
-   */
-  functions: ILlmFunction<Model>[];
-
-  /**
-   * Configuration for the application.
-   */
-  options: ILlmApplication.IOptions<Model>;
-}
-export namespace ILlmApplication {
-  /**
-   * Options for application composition.
-   */
-  export type IOptions<Model extends ILlmSchema.Model> = {
-    /**
-     * Separator function for the parameters.
-     *
-     * When composing parameter arguments through LLM function call,
-     * there can be a case that some parameters must be composed by human,
-     * or LLM cannot understand the parameter.
-     *
-     * For example, if the parameter type has configured
-     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
-     * uploading, it must be composed by human, not by LLM
-     * (Large Language Model).
-     *
-     * In that case, if you configure this property with a function that
-     * predicating whether the schema value must be composed by human or
-     * not, the parameters would be separated into two parts.
-     *
-     * - {@link ILlmFunction.separated.llm}
-     * - {@link ILlmFunction.separated.human}
-     *
-     * When writing the function, note that returning value `true` means
-     * to be a human composing the value, and `false` means to LLM
-     * composing the value. Also, when predicating the schema, it would
-     * better to utilize the {@link GeminiTypeChecker} like features.
-     *
-     * @param schema Schema to be separated.
-     * @returns Whether the schema value must be composed by human or not.
-     * @default null
-     */
-    separate: null | ((schema: ILlmSchema.ModelSchema[Model]) => boolean);
-  } & ILlmSchema.ModelConfig[Model];
-}
-```
+    <ILlmApplicationSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * LLM function metadata.
- *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
- *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
- *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
-
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<Model>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priority, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Model extends ILlmSchema.Model> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: ILlmSchema.ModelParameters[Model] | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: ILlmSchema.ModelParameters[Model] | null;
-  }
-}
-```
+    <ILlmFunctionSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IChatGptSchema } from "./IChatGptSchema";
-import { IClaudeSchema } from "./IClaudeSchema";
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlamaSchema } from "./ILlamaSchema";
-import { ILlmSchemaV3 } from "./ILlmSchemaV3";
-import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
-
-/**
- * The schemas for the LLM function calling.
- *
- * `ILlmSchema` is an union type collecting every the schemas for the
- * LLM function calling.
- *
- * Select a proper schema type according to the LLM provider you're using.
- *
- * @template Model Name of the target LLM model
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @reference https://platform.openai.com/docs/guides/structured-outputs
- * @author Jeongho Nam - https://github.com/samchon
- */
-export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-  ILlmSchema.ModelSchema[Model];
-
-export namespace ILlmSchema {
-  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
-  export interface ModelConfig {
-    chatgpt: IChatGptSchema.IConfig;
-    claude: IClaudeSchema.IConfig;
-    gemini: IGeminiSchema.IConfig;
-    llama: ILlamaSchema.IConfig;
-    "3.0": ILlmSchemaV3.IConfig;
-    "3.1": ILlmSchemaV3_1.IConfig;
-  }
-  export interface ModelParameters {
-    chatgpt: IChatGptSchema.IParameters;
-    claude: IClaudeSchema.IParameters;
-    gemini: IGeminiSchema.IParameters;
-    llama: ILlamaSchema.IParameters;
-    "3.0": ILlmSchemaV3.IParameters;
-    "3.1": ILlmSchemaV3_1.IParameters;
-  }
-  export interface ModelSchema {
-    chatgpt: IChatGptSchema;
-    claude: IClaudeSchema;
-    gemini: IGeminiSchema;
-    llama: ILlamaSchema;
-    "3.0": ILlmSchemaV3;
-    "3.1": ILlmSchemaV3_1;
-  }
-
-  /**
-   * Type of function parameters.
-   *
-   * `ILlmSchema.IParameters` is a type defining a function's pamameters
-   * as a keyworded object type.
-   *
-   * It also can be utilized for the structured output metadata.
-   *
-   * @reference https://platform.openai.com/docs/guides/structured-outputs
-   */
-  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Configuration for the LLM schema composition.
-   */
-  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelConfig[Model];
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-```typescript filename="typia" showLineNumbers
-import { ILlmApplication, ILlmFunction, ILlmSchema } from "@samchon/openapi";
-
-import { IValidation } from "../../IValidation";
-
-/**
- * Application of LLM function calling with validators.
- *
- * `ILlmApplication` is a data structure representing a collection of
- * {@link ILlmFunctionOfValidate LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.applicationOfValidate<App, Model>()`
- * function.
- *
- * If you put the returned {@link ILlmApplicationOfValidate.functions} objects to the
- * LLM provider like [OpenAI (ChatGPT)](https://openai.com/), the LLM will automatically
- * select the proper function and fill its arguments from the conversation
- * (maybe chatting text) with user (human). This is the concept of the LLM function calling.
- *
- * Additionally, the LLM function calling sometimes take a mistake that composing wrong typed
- * {@link ILlmFunctionOfValidate.parameters}. In that case, deliver return value of the
- * {@link ILlmFunctionOfValidate.validate} function, then LLM provider will correct the
- * parameters at the next conversation. The {@link ILlmFunctionOfValidate.validate} function
- * is a validator function reporting the detailed information about the wrong typed parameters.
- *
- * By the way, there can be some parameters (or their nested properties) which must be
- * composed by Human, not by LLM. File uploading feature or some sensitive information
- * like security keys (password) are the examples. In that case, you can separate the
- * function parameters to both LLM and human sides by configuring the
- * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
- * assigned to the {@link ILlmFunction.separated} property.
- *
- * For reference, when both LLM and Human filled parameter values to call, you can
- * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
- * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
- * have to merge the separated parameters before the function call execution.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmApplicationOfValidate<Model extends ILlmSchema.Model>
-  extends ILlmApplication<Model> {
-  /**
-   * List of function metadata.
-   *
-   * List of function metadata that can be used for the LLM function call.
-   *
-   * Also, every functions have their own parameters validator
-   * {@link ILlmFunctionOfValidate.validate}. If the LLM function calling composes wrong
-   * typed parameters, then deliver return value of it, then LLM will correct parameters
-   * at the next conversation.
-   */
-  functions: ILlmFunctionOfValidate<Model>[];
-}
-export namespace ILlmApplicationOfValidate {
-  export import IOptions = ILlmApplication.IOptions;
-}
-
-/**
- * LLM function metadata with validator.
- *
- * `ILlmFunctionOfValidate` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
- *
- * If you provide this `ILlmFunctionOfValidate` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
- *
- * If the LLM function calling take s a mistake that composing wrong typed
- * {@link parameters}, you can correct the parameters by delivering the return
- * value of the {@link validate} function. The {@link validate} function is a
- * validator function reporting the detailed information about the wrong typed
- * {@link parameters}.
- *
- * By the way, do not ensure that LLM will always provide the correct arguments.
- * The LLM of present age is not perfect, and sometimes takes a mistake that composing
- * wrong typed {@link parameters}. In that case, you can correc the parameters by
- * delivering the return value of the {@link validate} function. The {@link validate}
- * function reports the detailed information about the wrong typed {@link parameters},
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmFunctionOfValidate<Model extends ILlmSchema.Model>
-  extends ILlmFunction<Model> {
-  validate(props: object): IValidation<unknown>;
-}
-export namespace ILlmFunctionOfValidate {
-  export import ISeparated = ILlmFunction.ISeparated;
-}
-```
+    <ILlmSchemaSnippet />
   </Tabs.Tab>
 </Tabs>
 
@@ -442,6 +100,17 @@ Structured output is another feature of LLM. The "structured output" means that 
 - https://platform.openai.com/docs/guides/function-calling
 - https://platform.openai.com/docs/guides/structured-outputs
 </Callout>
+
+<Tabs items={["TypeScript Source Code", "Compiled JavaScript"]}>
+  <Tabs.Tab>
+    <LlmParametersExampleSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LlmParametersJavaScriptSnippet />
+  </Tabs.Tab>
+</Tabs>
+
+[📖 Playground Link](https://typia.io/playground/?script=JYWwDg9gTgLgBAbzgSQMIAsCGMDiYYDKAxugKYiZwC+cAZlBCHAEQACAzpiCRAHYD0EMKV6YwwZgG4AUKEiw4MAJ7jMAGkSLMAc3bU6DJs2Wqp0uLN4xSUWpiKkUAWXIAjG4nNxymYABsALjh2GChgXm04ADItXQA6ADFoChgAHmYff2YAPhk4OFEQUiCQsIi8uB1igoBXEHcoCvQIV1dgUnYS0PDtAG0AXQqAKwhw0gATAH1sLrLImJgddkTk7HTx7FIcmSppIj4QuDAgtCxcfGIyCjjkAAVMKC5Sayg9AF5FFWBMOL8-EDiYAeTxe7FSyBc9RsGmYJGw2nwOQAFABKGT7XjsCB+Ui-CDaJFgNFAA)
 
 
 
@@ -595,12 +264,28 @@ main().catch(console.error);
 > }
 > ```
 
-In sometimes, LLM takes a mistake composing wrong typed structured data.
+Is LLM Structured Output perfect? No, absolutely not.
 
-In that case, you can guide the LLM (Large Language Model) to generate the correct typed structured data at the next step just by delivering the validation error message of the [`typia.validate<T>()`](../validators/validate) function as a system prompt like above.
+LLM (Large Language Model) service vendor like OpenAI takes a lot of type level mistakes when composing the arguments of function calling or structured output. Even though target schema is super simple like `Array<string>` type, LLM often fills it just by a `string` typed value.
 
-Note that, if you are developing an A.I. chatbot project, such validation feedback strategy is essential for both LLM function calling and structured output features. Tends to my experiments, even though the LLM makes a wrong typed structured data, it always be corrected just by only one validation feedback step.
+In my experience, OpenAI `gpt-4o-mini` (`8b` parameters) is taking about 70% of type level mistakes when filling the arguments of structured output to Shopping Mall service. To overcome the imperfection of such structured output, you have to utilize the validation feedback strategy with [`typia.validate<T>()`](/docs/validators/validate) function.
 
+The key concept of validation feedback strategy is, let LLM structured output to construct invalid typed arguments first, and informing detailed type errors to the LLM, so that induce LLM to emend the wrong typed arguments at the next turn. In this way, I could uprise the success rate of structured output from 30% to 99% just by one step validation feedback. Even though the LLM is still occurs type error, it always has been caught at the next turn.
+
+For reference, embedded [`typia.validate<T>()`](/docs/validators/validate) is the best runtime type checker which can validate every TypeScript (JSON schema) types exactly and detaily than any other libraries. With this validation feedback strategy and the best runtime type checker, let's accomplish the [Agentic AI](https://wrtnlabs.io/agentica) with function calling and structured output.
+
+<ValidatorSupportMatrixSnippet />
+
+Also, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema like OpenAI ([`IChatGptSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IChatGptSchema.ts)) and Gemini ([`IGeminiSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IGeminiSchema.ts)). And some LLM providers which do not specified the JSON schema version like Claude ([`IClaudeSchema`](https://github.com/samchon/openapi/blob/master/src/structures/IClaudeSchema.ts)) and Llama ([`ILlamaSchema`](https://github.com/samchon/openapi/blob/master/src/structures/ILlamaSchema.ts)), they tend to fail a lot of function calling in the restriction properties,
+
+For example, OpenAI and Gemini does not support `format` property of JSON schema, so that cannot let LLM to understand the `UUID` like type. Even though `typia.llm.parameters<T, Model>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
+
+In that case, if you give validation feedback from [`typia.validate<T>()`](/docs/validators/validate) function, the LLM will be able to understand the restriction information exactly and fill the arguments properly.
+
+  - Restriction properties of JSON schema
+    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
 
 
 

--- a/website/pages/docs/llm/schema.mdx
+++ b/website/pages/docs/llm/schema.mdx
@@ -1,7 +1,14 @@
 ---
 title: Guide Documents > Large Language Model > schema() function
 ---
-import { Callout, Tabs } from 'nextra/components'
+import { Callout, Tabs } from "nextra/components";
+
+import ILlmApplicationSnippet from "../../../src/snippets/ILlmApplicationSnippet.mdx";
+import ILlmFunctionSnippet from "../../../src/snippets/ILlmFunctionSnippet.mdx";
+import ILlmSchemaSnippet from "../../../src/snippets/ILlmSchemaSnippet.mdx";
+
+import LlmSchemaExampleSnippet from "../../../src/snippets/LlmSchemaExampleSnippet.mdx";
+import LlmSchemaJavaScriptSnippet from "../../../src/snippets/LlmSchemaJavaScriptSnippet.mdx";
 
 ## `schema()` function
 <Tabs items={[
@@ -54,364 +61,14 @@ export namespace llm {
 }
 ```
   </Tabs.Tab>
-  <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlmFunction } from "./ILlmFunction";
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * Application of LLM function calling.
- *
- * `ILlmApplication` is a data structure representing a collection of
- * {@link ILlmFunction LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.application<App, Model>()`
- * function.
- *
- * Also, there can be some parameters (or their nested properties) which must be
- * composed by Human, not by LLM. File uploading feature or some sensitive information
- * like security keys (password) are the examples. In that case, you can separate the
- * function parameters to both LLM and human sides by configuring the
- * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
- * assigned to the {@link ILlmFunction.separated} property.
- *
- * For reference, when both LLM and Human filled parameter values to call, you can
- * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
- * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
- * have to merge the separated parameters before the function call execution.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmApplication<Model extends ILlmSchema.Model> {
-  /**
-   * Model of the LLM.
-   */
-  model: Model;
-
-  /**
-   * List of function metadata.
-   *
-   * List of function metadata that can be used for the LLM function call.
-   */
-  functions: ILlmFunction<Model>[];
-
-  /**
-   * Configuration for the application.
-   */
-  options: ILlmApplication.IOptions<Model>;
-}
-export namespace ILlmApplication {
-  /**
-   * Options for application composition.
-   */
-  export type IOptions<Model extends ILlmSchema.Model> = {
-    /**
-     * Separator function for the parameters.
-     *
-     * When composing parameter arguments through LLM function call,
-     * there can be a case that some parameters must be composed by human,
-     * or LLM cannot understand the parameter.
-     *
-     * For example, if the parameter type has configured
-     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
-     * uploading, it must be composed by human, not by LLM
-     * (Large Language Model).
-     *
-     * In that case, if you configure this property with a function that
-     * predicating whether the schema value must be composed by human or
-     * not, the parameters would be separated into two parts.
-     *
-     * - {@link ILlmFunction.separated.llm}
-     * - {@link ILlmFunction.separated.human}
-     *
-     * When writing the function, note that returning value `true` means
-     * to be a human composing the value, and `false` means to LLM
-     * composing the value. Also, when predicating the schema, it would
-     * better to utilize the {@link GeminiTypeChecker} like features.
-     *
-     * @param schema Schema to be separated.
-     * @returns Whether the schema value must be composed by human or not.
-     * @default null
-     */
-    separate: null | ((schema: ILlmSchema.ModelSchema[Model]) => boolean);
-  } & ILlmSchema.ModelConfig[Model];
-}
-```
+    <Tabs.Tab>
+    <ILlmApplicationSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { ILlmSchema } from "./ILlmSchema";
-
-/**
- * LLM function metadata.
- *
- * `ILlmFunction` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
- *
- * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
- *
- * By the way, do not ensure that LLM will always provide the correct
- * arguments. The LLM of present age is not perfect, so that you would
- * better to validate the arguments before executing the function.
- * I recommend you to validate the arguments before execution by using
- * [`typia`](https://github.com/samchon/typia) library.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmFunction<Model extends ILlmSchema.Model> {
-  /**
-   * Representative name of the function.
-   */
-  name: string;
-
-  /**
-   * List of parameter types.
-   */
-  parameters: ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Collection of separated parameters.
-   */
-  separated?: ILlmFunction.ISeparated<Model>;
-
-  /**
-   * Expected return type.
-   *
-   * If the function returns nothing (`void`), the `output` value would
-   * be `undefined`.
-   */
-  output?: ILlmSchema.ModelSchema[Model];
-
-  /**
-   * Whether the function schema types are strict or not.
-   *
-   * Newly added specification to "OpenAI" at 2024-08-07.
-   *
-   * @reference https://openai.com/index/introducing-structured-outputs-in-the-api/
-   */
-  strict: true;
-
-  /**
-   * Description of the function.
-   *
-   * For reference, the `description` is very important property to teach
-   * the purpose of the function to the LLM (Language Large Model), and
-   * LLM actually determines which function to call by the description.
-   *
-   * Also, when the LLM conversates with the user, the `description` is
-   * used to explain the function to the user. Therefore, the `description`
-   * property has the highest priority, and you have to consider it.
-   */
-  description?: string | undefined;
-
-  /**
-   * Whether the function is deprecated or not.
-   *
-   * If the `deprecated` is `true`, the function is not recommended to use.
-   *
-   * LLM (Large Language Model) may not use the deprecated function.
-   */
-  deprecated?: boolean | undefined;
-
-  /**
-   * Category tags for the function.
-   *
-   * You can fill this property by the `@tag ${name}` comment tag.
-   */
-  tags?: string[];
-}
-export namespace ILlmFunction {
-  /**
-   * Collection of separated parameters.
-   */
-  export interface ISeparated<Model extends ILlmSchema.Model> {
-    /**
-     * Parameters that would be composed by the LLM.
-     */
-    llm: ILlmSchema.ModelParameters[Model] | null;
-
-    /**
-     * Parameters that would be composed by the human.
-     */
-    human: ILlmSchema.ModelParameters[Model] | null;
-  }
-}
-```
+    <ILlmFunctionSnippet />
   </Tabs.Tab>
   <Tabs.Tab>
-```typescript filename="@samchon/openapi" showLineNumbers
-import { IChatGptSchema } from "./IChatGptSchema";
-import { IClaudeSchema } from "./IClaudeSchema";
-import { IGeminiSchema } from "./IGeminiSchema";
-import { ILlamaSchema } from "./ILlamaSchema";
-import { ILlmSchemaV3 } from "./ILlmSchemaV3";
-import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
-
-/**
- * The schemas for the LLM function calling.
- *
- * `ILlmSchema` is an union type collecting every the schemas for the
- * LLM function calling.
- *
- * Select a proper schema type according to the LLM provider you're using.
- *
- * @template Model Name of the target LLM model
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @reference https://platform.openai.com/docs/guides/structured-outputs
- * @author Jeongho Nam - https://github.com/samchon
- */
-export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-  ILlmSchema.ModelSchema[Model];
-
-export namespace ILlmSchema {
-  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
-  export interface ModelConfig {
-    chatgpt: IChatGptSchema.IConfig;
-    claude: IClaudeSchema.IConfig;
-    gemini: IGeminiSchema.IConfig;
-    llama: ILlamaSchema.IConfig;
-    "3.0": ILlmSchemaV3.IConfig;
-    "3.1": ILlmSchemaV3_1.IConfig;
-  }
-  export interface ModelParameters {
-    chatgpt: IChatGptSchema.IParameters;
-    claude: IClaudeSchema.IParameters;
-    gemini: IGeminiSchema.IParameters;
-    llama: ILlamaSchema.IParameters;
-    "3.0": ILlmSchemaV3.IParameters;
-    "3.1": ILlmSchemaV3_1.IParameters;
-  }
-  export interface ModelSchema {
-    chatgpt: IChatGptSchema;
-    claude: IClaudeSchema;
-    gemini: IGeminiSchema;
-    llama: ILlamaSchema;
-    "3.0": ILlmSchemaV3;
-    "3.1": ILlmSchemaV3_1;
-  }
-
-  /**
-   * Type of function parameters.
-   *
-   * `ILlmSchema.IParameters` is a type defining a function's pamameters
-   * as a keyworded object type.
-   *
-   * It also can be utilized for the structured output metadata.
-   *
-   * @reference https://platform.openai.com/docs/guides/structured-outputs
-   */
-  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelParameters[Model];
-
-  /**
-   * Configuration for the LLM schema composition.
-   */
-  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
-    ILlmSchema.ModelConfig[Model];
-}
-```
-  </Tabs.Tab>
-  <Tabs.Tab>
-```typescript filename="typia" showLineNumbers
-import { ILlmApplication, ILlmFunction, ILlmSchema } from "@samchon/openapi";
-
-import { IValidation } from "../../IValidation";
-
-/**
- * Application of LLM function calling with validators.
- *
- * `ILlmApplication` is a data structure representing a collection of
- * {@link ILlmFunctionOfValidate LLM function calling schemas}, composed from a native
- * TypeScript class (or interface) type by the `typia.llm.applicationOfValidate<App, Model>()`
- * function.
- *
- * If you put the returned {@link ILlmApplicationOfValidate.functions} objects to the
- * LLM provider like [OpenAI (ChatGPT)](https://openai.com/), the LLM will automatically
- * select the proper function and fill its arguments from the conversation
- * (maybe chatting text) with user (human). This is the concept of the LLM function calling.
- *
- * Additionally, the LLM function calling sometimes take a mistake that composing wrong typed
- * {@link ILlmFunctionOfValidate.parameters}. In that case, deliver return value of the
- * {@link ILlmFunctionOfValidate.validate} function, then LLM provider will correct the
- * parameters at the next conversation. The {@link ILlmFunctionOfValidate.validate} function
- * is a validator function reporting the detailed information about the wrong typed parameters.
- *
- * By the way, there can be some parameters (or their nested properties) which must be
- * composed by Human, not by LLM. File uploading feature or some sensitive information
- * like security keys (password) are the examples. In that case, you can separate the
- * function parameters to both LLM and human sides by configuring the
- * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
- * assigned to the {@link ILlmFunction.separated} property.
- *
- * For reference, when both LLM and Human filled parameter values to call, you can
- * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
- * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
- * have to merge the separated parameters before the function call execution.
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmApplicationOfValidate<Model extends ILlmSchema.Model>
-  extends ILlmApplication<Model> {
-  /**
-   * List of function metadata.
-   *
-   * List of function metadata that can be used for the LLM function call.
-   *
-   * Also, every functions have their own parameters validator
-   * {@link ILlmFunctionOfValidate.validate}. If the LLM function calling composes wrong
-   * typed parameters, then deliver return value of it, then LLM will correct parameters
-   * at the next conversation.
-   */
-  functions: ILlmFunctionOfValidate<Model>[];
-}
-export namespace ILlmApplicationOfValidate {
-  export import IOptions = ILlmApplication.IOptions;
-}
-
-/**
- * LLM function metadata with validator.
- *
- * `ILlmFunctionOfValidate` is an interface representing a function metadata,
- * which has been used for the LLM (Language Large Model) function
- * calling. Also, it's a function structure containing the function
- * {@link name}, {@link parameters} and {@link output return type}.
- *
- * If you provide this `ILlmFunctionOfValidate` data to the LLM provider like "OpenAI",
- * the "OpenAI" will compose a function arguments by analyzing conversations
- * with the user. With the LLM composed arguments, you can execute the function
- * and get the result.
- *
- * If the LLM function calling take s a mistake that composing wrong typed
- * {@link parameters}, you can correct the parameters by delivering the return
- * value of the {@link validate} function. The {@link validate} function is a
- * validator function reporting the detailed information about the wrong typed
- * {@link parameters}.
- *
- * By the way, do not ensure that LLM will always provide the correct arguments.
- * The LLM of present age is not perfect, and sometimes takes a mistake that composing
- * wrong typed {@link parameters}. In that case, you can correc the parameters by
- * delivering the return value of the {@link validate} function. The {@link validate}
- * function reports the detailed information about the wrong typed {@link parameters},
- *
- * @reference https://platform.openai.com/docs/guides/function-calling
- * @author Jeongho Nam - https://github.com/samchon
- */
-export interface ILlmFunctionOfValidate<Model extends ILlmSchema.Model>
-  extends ILlmFunction<Model> {
-  validate(props: object): IValidation<unknown>;
-}
-export namespace ILlmFunctionOfValidate {
-  export import ISeparated = ILlmFunction.ISeparated;
-}
-```
+    <ILlmSchemaSnippet />
   </Tabs.Tab>
 </Tabs>
 
@@ -443,6 +100,15 @@ Structured output is another feature of LLM. The "structured output" means that 
 - https://platform.openai.com/docs/guides/structured-outputs
 </Callout>
 
+<Tabs items={['TypeScript Source Code', 'Compiled JavaScript File']}>
+  <Tabs.Tab>
+    <LlmSchemaExampleSnippet />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LlmSchemaJavaScriptSnippet />
+  </Tabs.Tab>
+</Tabs>
+
 
 
 
@@ -464,7 +130,9 @@ Let's see how those [type tags](../validators/tags/#type-tags), comment tags and
 import { IChatGptSchema } from "@samchon/openapi";
 import typia, { tags } from "typia";
 
-export const schema: IChatGptSchema = typia.llm.schema<Special, "claude">();
+export const schema: IChatGptSchema = typia.llm.schema<Special, "claude">({
+  $defs: {},
+});
 
 interface Special {
   /**

--- a/website/src/snippets/BbsArticleServiceSnippet.mdx
+++ b/website/src/snippets/BbsArticleServiceSnippet.mdx
@@ -1,0 +1,96 @@
+```typescript filename="example/src/BbsArticleService.ts" showLineNumbers
+import { tags } from "typia";
+import { v4 } from "uuid";
+
+import { IBbsArticle } from "./IBbsArticle";
+
+export class BbsArticleService {
+  private readonly articles: IBbsArticle[] = [];
+
+  /**
+   * Get all articles.
+   *
+   * List up every articles archived in the BBS DB.
+   *
+   * @returns List of every articles
+   */
+  public index(): IBbsArticle[] {
+    return this.articles;
+  }
+
+  /**
+   * Create a new article.
+   *
+   * Writes a new article and archives it into the DB.
+   *
+   * @param props Properties of create function
+   * @returns Newly created article
+   */
+  public create(props: {
+    /**
+     * Information of the article to create
+     */
+    input: IBbsArticle.ICreate;
+  }): IBbsArticle {
+    const article: IBbsArticle = {
+      id: v4(),
+      title: props.input.title,
+      body: props.input.body,
+      thumbnail: props.input.thumbnail,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    this.articles.push(article);
+    return article;
+  }
+
+  /**
+   * Update an article.
+   *
+   * Updates an article with new content.
+   *
+   * @param props Properties of update function
+   * @param input New content to update
+   */
+  public update(props: {
+    /**
+     * Target article's {@link IBbsArticle.id}.
+     */
+    id: string & tags.Format<"uuid">;
+
+    /**
+     * New content to update.
+     */
+    input: IBbsArticle.IUpdate;
+  }): void {
+    const article: IBbsArticle | undefined = this.articles.find(
+      (a) => a.id === props.id,
+    );
+    if (article === undefined)
+      throw new Error("Unable to find the matched article.");
+    if (props.input.title !== undefined) article.title = props.input.title;
+    if (props.input.body !== undefined) article.body = props.input.body;
+    if (props.input.thumbnail !== undefined)
+      article.thumbnail = props.input.thumbnail;
+    article.updated_at = new Date().toISOString();
+  }
+
+  /**
+   * Erase an article.
+   *
+   * Erases an article from the DB.
+   *
+   * @param props Properties of erase function
+   */
+  public erase(props: {
+    /**
+     * Target article's {@link IBbsArticle.id}.
+     */
+    id: string & tags.Format<"uuid">;
+  }): void {
+    const index: number = this.articles.findIndex((a) => a.id === props.id);
+    if (index === -1) throw new Error("Unable to find the matched article.");
+    this.articles.splice(index, 1);
+  }
+}
+```

--- a/website/src/snippets/IBbsArticleSnippet.mdx
+++ b/website/src/snippets/IBbsArticleSnippet.mdx
@@ -1,0 +1,63 @@
+```typescript filename="example/src/IBbsArticle.ts" showLineNumbers
+import { tags } from "typia";
+
+/**
+ * Article entity.
+ *
+ * `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).
+ */
+export interface IBbsArticle extends IBbsArticle.ICreate {
+  /**
+   * Primary Key.
+   */
+  id: string & tags.Format<"uuid">;
+ 
+  /**
+   * Creation time of the article.
+   */
+  created_at: string & tags.Format<"date-time">;
+ 
+  /**
+   * Last updated time of the article.
+   */
+  updated_at: string & tags.Format<"date-time">;
+}
+export namespace IBbsArticle {
+  /**
+   * Information of the article to create.
+   */
+  export interface ICreate {
+    /**
+     * Title of the article.
+     *
+     * Representative title of the article.
+     */
+    title: string;
+ 
+    /**
+     * Content body.
+     *
+     * Content body of the article writtn in the markdown format.
+     */
+    body: string;
+ 
+    /**
+     * Thumbnail image URI.
+     *
+     * Thumbnail image URI which can represent the article.
+     *
+     * If configured as `null`, it means that no thumbnail image in the article.
+     */
+    thumbnail:
+      | null
+      | (string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">);
+  }
+ 
+  /**
+   * Information of the article to update.
+   *
+   * Only the filled properties will be updated.
+   */
+  export type IUpdate = Partial<ICreate>;
+}
+```

--- a/website/src/snippets/ILlmApplicationSnippet.mdx
+++ b/website/src/snippets/ILlmApplicationSnippet.mdx
@@ -1,0 +1,93 @@
+```typescript filename="@samchon/openapi" showLineNumbers
+import { ILlmFunction } from "./ILlmFunction";
+import { ILlmSchema } from "./ILlmSchema";
+
+/**
+ * Application of LLM function calling.
+ *
+ * `ILlmApplication` is a data structure representing a collection of
+ * {@link ILlmFunction LLM function calling schemas}, composed from a native
+ * TypeScript class (or interface) type by the `typia.llm.application<App, Model>()`
+ * function.
+ *
+ * Also, there can be some parameters (or their nested properties) which must be
+ * composed by Human, not by LLM. File uploading feature or some sensitive information
+ * like secret key (password) are the examples. In that case, you can separate the
+ * function parameters to both LLM and human sides by configuring the
+ * {@link ILlmApplication.IOptions.separate} property. The separated parameters are
+ * assigned to the {@link ILlmFunction.separated} property.
+ *
+ * For reference, when both LLM and Human filled parameter values to call, you can
+ * merge them by calling the {@link HttpLlm.mergeParameters} function. In other words,
+ * if you've configured the {@link ILlmApplication.IOptions.separate} property, you
+ * have to merge the separated parameters before the function call execution.
+ *
+ * @reference https://platform.openai.com/docs/guides/function-calling
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface ILlmApplication<
+  Model extends ILlmSchema.Model,
+  Class extends object = any,
+> {
+  /**
+   * Model of the LLM.
+   */
+  model: Model;
+
+  /**
+   * List of function metadata.
+   *
+   * List of function metadata that can be used for the LLM function call.
+   */
+  functions: ILlmFunction<Model>[];
+
+  /**
+   * Configuration for the application.
+   */
+  options: ILlmApplication.IOptions<Model>;
+
+  /**
+   * Class type, the source of the LLM application.
+   *
+   * This property is just for the generic type inference,
+   * and its value is always `undefined`.
+   */
+  __class?: Class | undefined;
+}
+export namespace ILlmApplication {
+  /**
+   * Options for application composition.
+   */
+  export type IOptions<Model extends ILlmSchema.Model> = {
+    /**
+     * Separator function for the parameters.
+     *
+     * When composing parameter arguments through LLM function call,
+     * there can be a case that some parameters must be composed by human,
+     * or LLM cannot understand the parameter.
+     *
+     * For example, if the parameter type has configured
+     * {@link IGeminiSchema.IString.contentMediaType} which indicates file
+     * uploading, it must be composed by human, not by LLM
+     * (Large Language Model).
+     *
+     * In that case, if you configure this property with a function that
+     * predicating whether the schema value must be composed by human or
+     * not, the parameters would be separated into two parts.
+     *
+     * - {@link ILlmFunction.separated.llm}
+     * - {@link ILlmFunction.separated.human}
+     *
+     * When writing the function, note that returning value `true` means
+     * to be a human composing the value, and `false` means to LLM
+     * composing the value. Also, when predicating the schema, it would
+     * better to utilize the {@link GeminiTypeChecker} like features.
+     *
+     * @param schema Schema to be separated.
+     * @returns Whether the schema value must be composed by human or not.
+     * @default null
+     */
+    separate: null | ((schema: ILlmSchema.ModelSchema[Model]) => boolean);
+  } & ILlmSchema.ModelConfig[Model];
+}
+```

--- a/website/src/snippets/ILlmFunctionSnippet.mdx
+++ b/website/src/snippets/ILlmFunctionSnippet.mdx
@@ -1,0 +1,159 @@
+```typescript filename="@samchon/openapi" showLineNumbers
+import { ILlmSchema } from "./ILlmSchema";
+import { IValidation } from "./IValidation";
+
+/**
+ * LLM function metadata.
+ *
+ * `ILlmFunction` is an interface representing a function metadata,
+ * which has been used for the LLM (Language Large Model) function
+ * calling. Also, it's a function structure containing the function
+ * {@link name}, {@link parameters} and {@link output return type}.
+ *
+ * If you provide this `ILlmFunction` data to the LLM provider like "OpenAI",
+ * the "OpenAI" will compose a function arguments by analyzing conversations
+ * with the user. With the LLM composed arguments, you can execute the function
+ * and get the result.
+ *
+ * By the way, do not ensure that LLM will always provide the correct
+ * arguments. The LLM of present age is not perfect, so that you would
+ * better to validate the arguments before executing the function.
+ * I recommend you to validate the arguments before execution by using
+ * [`typia`](https://github.com/samchon/typia) library.
+ *
+ * @reference https://platform.openai.com/docs/guides/function-calling
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface ILlmFunction<Model extends ILlmSchema.Model> {
+  /**
+   * Representative name of the function.
+   *
+   * @maxLength 64
+   */
+  name: string;
+
+  /**
+   * List of parameter types.
+   */
+  parameters: ILlmSchema.ModelParameters[Model];
+
+  /**
+   * Collection of separated parameters.
+   */
+  separated?: ILlmFunction.ISeparated<Model>;
+
+  /**
+   * Expected return type.
+   *
+   * If the function returns nothing (`void`), the `output` value would
+   * be `undefined`.
+   */
+  output?: ILlmSchema.ModelSchema[Model];
+
+  /**
+   * Description of the function.
+   *
+   * For reference, the `description` is very important property to teach
+   * the purpose of the function to the LLM (Language Large Model), and
+   * LLM actually determines which function to call by the description.
+   *
+   * Also, when the LLM conversates with the user, the `description` is
+   * used to explain the function to the user. Therefore, the `description`
+   * property has the highest priority, and you have to consider it.
+   */
+  description?: string | undefined;
+
+  /**
+   * Whether the function is deprecated or not.
+   *
+   * If the `deprecated` is `true`, the function is not recommended to use.
+   *
+   * LLM (Large Language Model) may not use the deprecated function.
+   */
+  deprecated?: boolean | undefined;
+
+  /**
+   * Category tags for the function.
+   *
+   * You can fill this property by the `@tag ${name}` comment tag.
+   */
+  tags?: string[] | undefined;
+
+  /**
+   * Validate function of the arguments.
+   *
+   * You know what? LLM (Large Language Model) like OpenAI takes a lot of
+   * mistakes when composing arguments in function calling. Even though
+   * `number` like simple type is defined in the {@link parameters} schema,
+   * LLM often fills it just by a `string` typed value.
+   *
+   * In that case, you have to give a validation feedback to the LLM by
+   * using this `validate` function. The `validate` function will return
+   * detailed information about every type errors about the arguments.
+   *
+   * And in my experience, OpenAI's `gpt-4o-mini` model tends to construct
+   * an invalid function calling arguments at the first trial about 50% of
+   * the time. However, if correct it through this `validate` function,
+   * the success rate soars to 99% at the second trial, and I've never
+   * failed at the third trial.
+   *
+   * > If you've {@link separated} parameters, use the
+   * > {@link ILlmFunction.ISeparated.validate} function instead when
+   * > validating the LLM composed arguments.
+   * >
+   * > In that case, This `validate` function would be meaningful only
+   * > when you've merged the LLM and human composed arguments by
+   * > {@link HttpLlm.mergeParameters} function.
+   *
+   * @param args Arguments to validate
+   * @returns Validation result
+   */
+  validate: (args: unknown) => IValidation<unknown>;
+}
+export namespace ILlmFunction {
+  /**
+   * Collection of separated parameters.
+   */
+  export interface ISeparated<Model extends ILlmSchema.Model> {
+    /**
+     * Parameters that would be composed by the LLM.
+     *
+     * Even though no property exists in the LLM side, the `llm` property
+     * would have at least empty object type.
+     */
+    llm: ILlmSchema.ModelParameters[Model];
+
+    /**
+     * Parameters that would be composed by the human.
+     */
+    human: ILlmSchema.ModelParameters[Model] | null;
+
+    /**
+     * Validate function of the separated arguments.
+     *
+     * If LLM part of separated parameters has some properties,
+     * this `validate` function will be filled for the {@link llm}
+     * type validation.
+     *
+     * > You know what? LLM (Large Language Model) like OpenAI takes a lot of
+     * > mistakes when composing arguments in function calling. Even though
+     * > `number` like simple type is defined in the {@link parameters} schema,
+     * > LLM often fills it just by a `string` typed value.
+     * >
+     * > In that case, you have to give a validation feedback to the LLM by
+     * > using this `validate` function. The `validate` function will return
+     * > detailed information about every type errors about the arguments.
+     * >
+     * > And in my experience, OpenAI's `gpt-4o-mini` model tends to construct
+     * > an invalid function calling arguments at the first trial about 50% of
+     * > the time. However, if correct it through this `validate` function,
+     * > the success rate soars to 99% at the second trial, and I've never
+     * > failed at the third trial.
+     *
+     * @param args Arguments to validate
+     * @returns Validate result
+     */
+    validate?: ((args: unknown) => IValidation<unknown>) | undefined;
+  }
+}
+```

--- a/website/src/snippets/ILlmSchemaSnippet.mdx
+++ b/website/src/snippets/ILlmSchemaSnippet.mdx
@@ -1,0 +1,71 @@
+```typescript filename="@samchon/openapi" showLineNumbers
+import { IChatGptSchema } from "./IChatGptSchema";
+import { IClaudeSchema } from "./IClaudeSchema";
+import { IGeminiSchema } from "./IGeminiSchema";
+import { ILlamaSchema } from "./ILlamaSchema";
+import { ILlmSchemaV3 } from "./ILlmSchemaV3";
+import { ILlmSchemaV3_1 } from "./ILlmSchemaV3_1";
+
+/**
+ * The schemas for the LLM function calling.
+ *
+ * `ILlmSchema` is an union type collecting every the schemas for the
+ * LLM function calling.
+ *
+ * Select a proper schema type according to the LLM provider you're using.
+ *
+ * @template Model Name of the target LLM model
+ * @reference https://platform.openai.com/docs/guides/function-calling
+ * @reference https://platform.openai.com/docs/guides/structured-outputs
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export type ILlmSchema<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+  ILlmSchema.ModelSchema[Model];
+
+export namespace ILlmSchema {
+  export type Model = "chatgpt" | "claude" | "gemini" | "llama" | "3.0" | "3.1";
+  export interface ModelConfig {
+    chatgpt: IChatGptSchema.IConfig;
+    claude: IClaudeSchema.IConfig;
+    gemini: IGeminiSchema.IConfig;
+    llama: ILlamaSchema.IConfig;
+    "3.0": ILlmSchemaV3.IConfig;
+    "3.1": ILlmSchemaV3_1.IConfig;
+  }
+  export interface ModelParameters {
+    chatgpt: IChatGptSchema.IParameters;
+    claude: IClaudeSchema.IParameters;
+    gemini: IGeminiSchema.IParameters;
+    llama: ILlamaSchema.IParameters;
+    "3.0": ILlmSchemaV3.IParameters;
+    "3.1": ILlmSchemaV3_1.IParameters;
+  }
+  export interface ModelSchema {
+    chatgpt: IChatGptSchema;
+    claude: IClaudeSchema;
+    gemini: IGeminiSchema;
+    llama: ILlamaSchema;
+    "3.0": ILlmSchemaV3;
+    "3.1": ILlmSchemaV3_1;
+  }
+
+  /**
+   * Type of function parameters.
+   *
+   * `ILlmSchema.IParameters` is a type defining a function's pamameters
+   * as a keyworded object type.
+   *
+   * It also can be utilized for the structured output metadata.
+   *
+   * @reference https://platform.openai.com/docs/guides/structured-outputs
+   */
+  export type IParameters<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelParameters[Model];
+
+  /**
+   * Configuration for the LLM schema composition.
+   */
+  export type IConfig<Model extends ILlmSchema.Model = ILlmSchema.Model> =
+    ILlmSchema.ModelConfig[Model];
+}
+```

--- a/website/src/snippets/LlmApplicationExampleSnippet.mdx
+++ b/website/src/snippets/LlmApplicationExampleSnippet.mdx
@@ -1,0 +1,12 @@
+```typescript filename="example/src/llm.application.separate.ts" showLineNumbers {11-12}
+import { ILlmApplication } from "@samchon/openapi";
+import typia from "typia";
+
+import { BbsArticleService } from "./BbsArticleService";
+
+const app: ILlmApplication<"chatgpt"> = typia.llm.application<
+  BbsArticleService,
+  "chatgpt"
+>();
+console.log(app);
+```

--- a/website/src/snippets/LlmApplicationJavaScriptSnippet.mdx
+++ b/website/src/snippets/LlmApplicationJavaScriptSnippet.mdx
@@ -1,0 +1,566 @@
+```javascript filename="example/bin/llm.application.js" showLineNumbers
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+import * as __typia_transform__isFormatUri from "typia/lib/internal/_isFormatUri.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import typia from "typia";
+const app = {
+  model: "chatgpt",
+  options: {
+    reference: false,
+    strict: false,
+    separate: null,
+  },
+  functions: [
+    {
+      name: "index",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+        required: [],
+        $defs: {},
+      },
+      output: {
+        description: "List of every articles",
+        type: "array",
+        items: {
+          description:
+            "Article entity.\n\n`IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+          type: "object",
+          properties: {
+            id: {
+              title: "Primary Key",
+              description: "Primary Key.\n\n\n@format uuid",
+              type: "string",
+            },
+            created_at: {
+              title: "Creation time of the article",
+              description:
+                "Creation time of the article.\n\n\n@format date-time",
+              type: "string",
+            },
+            updated_at: {
+              title: "Last updated time of the article",
+              description:
+                "Last updated time of the article.\n\n\n@format date-time",
+              type: "string",
+            },
+            title: {
+              title: "Title of the article",
+              description:
+                "Title of the article.\n\nRepresentative title of the article.",
+              type: "string",
+            },
+            body: {
+              title: "Content body",
+              description:
+                "Content body.\n\nContent body of the article writtn in the markdown format.",
+              type: "string",
+            },
+            thumbnail: {
+              title: "Thumbnail image URI",
+              description:
+                "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+              anyOf: [
+                {
+                  type: "null",
+                },
+                {
+                  type: "string",
+                  description: "@format uri\n@contentMediaType image/*",
+                },
+              ],
+            },
+          },
+          required: [
+            "id",
+            "created_at",
+            "updated_at",
+            "title",
+            "body",
+            "thumbnail",
+          ],
+        },
+      },
+      description:
+        "Get all articles.\n\nList up every articles archived in the BBS DB.",
+      validate: (() => {
+        const __is = (input) => true;
+        let errors;
+        let _report;
+        return (input) => {
+          if (false === __is(input)) {
+            errors = [];
+            _report = __typia_transform__validateReport._validateReport(errors);
+            ((input, _path, _exceptionable = true) => true)(
+              input,
+              "$input",
+              true,
+            );
+            const success = 0 === errors.length;
+            return success
+              ? {
+                  success,
+                  data: input,
+                }
+              : {
+                  success,
+                  errors,
+                  data: input,
+                };
+          }
+          return {
+            success: true,
+            data: input,
+          };
+        };
+      })(),
+    },
+    {
+      name: "create",
+      parameters: {
+        description: " Properties of create function",
+        type: "object",
+        properties: {
+          input: {
+            description:
+              "Information of the article to create.\n\n------------------------------\n\nDescription of the current {@link IBbsArticle.ICreate} type:\n\n> Information of the article to create.\n\n------------------------------\n\nDescription of the parent {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+            type: "object",
+            properties: {
+              title: {
+                title: "Title of the article",
+                description:
+                  "Title of the article.\n\nRepresentative title of the article.",
+                type: "string",
+              },
+              body: {
+                title: "Content body",
+                description:
+                  "Content body.\n\nContent body of the article writtn in the markdown format.",
+                type: "string",
+              },
+              thumbnail: {
+                title: "Thumbnail image URI",
+                description:
+                  "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                anyOf: [
+                  {
+                    type: "null",
+                  },
+                  {
+                    type: "string",
+                    description: "@format uri\n@contentMediaType image/*",
+                  },
+                ],
+              },
+            },
+            required: ["title", "body", "thumbnail"],
+          },
+        },
+        required: ["input"],
+        additionalProperties: false,
+        $defs: {},
+      },
+      output: {
+        description:
+          "Article entity.\n\n`IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+        type: "object",
+        properties: {
+          id: {
+            title: "Primary Key",
+            description: "Primary Key.\n\n\n@format uuid",
+            type: "string",
+          },
+          created_at: {
+            title: "Creation time of the article",
+            description: "Creation time of the article.\n\n\n@format date-time",
+            type: "string",
+          },
+          updated_at: {
+            title: "Last updated time of the article",
+            description:
+              "Last updated time of the article.\n\n\n@format date-time",
+            type: "string",
+          },
+          title: {
+            title: "Title of the article",
+            description:
+              "Title of the article.\n\nRepresentative title of the article.",
+            type: "string",
+          },
+          body: {
+            title: "Content body",
+            description:
+              "Content body.\n\nContent body of the article writtn in the markdown format.",
+            type: "string",
+          },
+          thumbnail: {
+            title: "Thumbnail image URI",
+            description:
+              "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+            anyOf: [
+              {
+                type: "null",
+              },
+              {
+                type: "string",
+                description: "@format uri\n@contentMediaType image/*",
+              },
+            ],
+          },
+        },
+        required: [
+          "id",
+          "created_at",
+          "updated_at",
+          "title",
+          "body",
+          "thumbnail",
+        ],
+      },
+      description:
+        "Create a new article.\n\nWrites a new article and archives it into the DB.",
+      validate: (() => {
+        const _io0 = (input) =>
+          "object" === typeof input.input &&
+          null !== input.input &&
+          _io1(input.input);
+        const _io1 = (input) =>
+          "string" === typeof input.title &&
+          "string" === typeof input.body &&
+          (null === input.thumbnail ||
+            ("string" === typeof input.thumbnail &&
+              __typia_transform__isFormatUri._isFormatUri(input.thumbnail)));
+        const _vo0 = (input, _path, _exceptionable = true) =>
+          [
+            ((("object" === typeof input.input && null !== input.input) ||
+              _report(_exceptionable, {
+                path: _path + ".input",
+                expected: "IBbsArticle.ICreate",
+                value: input.input,
+              })) &&
+              _vo1(input.input, _path + ".input", true && _exceptionable)) ||
+              _report(_exceptionable, {
+                path: _path + ".input",
+                expected: "IBbsArticle.ICreate",
+                value: input.input,
+              }),
+          ].every((flag) => flag);
+        const _vo1 = (input, _path, _exceptionable = true) =>
+          [
+            "string" === typeof input.title ||
+              _report(_exceptionable, {
+                path: _path + ".title",
+                expected: "string",
+                value: input.title,
+              }),
+            "string" === typeof input.body ||
+              _report(_exceptionable, {
+                path: _path + ".body",
+                expected: "string",
+                value: input.body,
+              }),
+            null === input.thumbnail ||
+              ("string" === typeof input.thumbnail &&
+                (__typia_transform__isFormatUri._isFormatUri(input.thumbnail) ||
+                  _report(_exceptionable, {
+                    path: _path + ".thumbnail",
+                    expected: 'string & Format<"uri">',
+                    value: input.thumbnail,
+                  }))) ||
+              _report(_exceptionable, {
+                path: _path + ".thumbnail",
+                expected:
+                  '((string & Format<"uri"> & ContentMediaType<"image/*">) | null)',
+                value: input.thumbnail,
+              }),
+          ].every((flag) => flag);
+        const __is = (input) =>
+          "object" === typeof input && null !== input && _io0(input);
+        let errors;
+        let _report;
+        return (input) => {
+          if (false === __is(input)) {
+            errors = [];
+            _report = __typia_transform__validateReport._validateReport(errors);
+            ((input, _path, _exceptionable = true) =>
+              ((("object" === typeof input && null !== input) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                })) &&
+                _vo0(input, _path + "", true)) ||
+              _report(true, {
+                path: _path + "",
+                expected: "__type",
+                value: input,
+              }))(input, "$input", true);
+            const success = 0 === errors.length;
+            return success
+              ? {
+                  success,
+                  data: input,
+                }
+              : {
+                  success,
+                  errors,
+                  data: input,
+                };
+          }
+          return {
+            success: true,
+            data: input,
+          };
+        };
+      })(),
+    },
+    {
+      name: "update",
+      parameters: {
+        description: " Properties of update function",
+        type: "object",
+        properties: {
+          id: {
+            title: "Target article's {@link IBbsArticle.id}",
+            description:
+              "Target article's {@link IBbsArticle.id}.\n\n\n@format uuid",
+            type: "string",
+          },
+          input: {
+            description:
+              "Make all properties in T optional\n\n------------------------------\n\nDescription of the current {@link PartialIBbsArticle.ICreate} type:\n\n> Make all properties in T optional",
+            type: "object",
+            properties: {
+              title: {
+                title: "Title of the article",
+                description:
+                  "Title of the article.\n\nRepresentative title of the article.",
+                type: "string",
+              },
+              body: {
+                title: "Content body",
+                description:
+                  "Content body.\n\nContent body of the article writtn in the markdown format.",
+                type: "string",
+              },
+              thumbnail: {
+                title: "Thumbnail image URI",
+                description:
+                  "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                anyOf: [
+                  {
+                    type: "null",
+                  },
+                  {
+                    type: "string",
+                    description: "@format uri\n@contentMediaType image/*",
+                  },
+                ],
+              },
+            },
+            required: [],
+          },
+        },
+        required: ["id", "input"],
+        additionalProperties: false,
+        $defs: {},
+      },
+      description: "Update an article.\n\nUpdates an article with new content.",
+      validate: (() => {
+        const _io0 = (input) =>
+          "string" === typeof input.id &&
+          __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+          "object" === typeof input.input &&
+          null !== input.input &&
+          false === Array.isArray(input.input) &&
+          _io1(input.input);
+        const _io1 = (input) =>
+          (undefined === input.title || "string" === typeof input.title) &&
+          (undefined === input.body || "string" === typeof input.body) &&
+          (null === input.thumbnail ||
+            undefined === input.thumbnail ||
+            ("string" === typeof input.thumbnail &&
+              __typia_transform__isFormatUri._isFormatUri(input.thumbnail)));
+        const _vo0 = (input, _path, _exceptionable = true) =>
+          [
+            ("string" === typeof input.id &&
+              (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: 'string & Format<"uuid">',
+                  value: input.id,
+                }))) ||
+              _report(_exceptionable, {
+                path: _path + ".id",
+                expected: '(string & Format<"uuid">)',
+                value: input.id,
+              }),
+            ((("object" === typeof input.input &&
+              null !== input.input &&
+              false === Array.isArray(input.input)) ||
+              _report(_exceptionable, {
+                path: _path + ".input",
+                expected: "Partial<IBbsArticle.ICreate>",
+                value: input.input,
+              })) &&
+              _vo1(input.input, _path + ".input", true && _exceptionable)) ||
+              _report(_exceptionable, {
+                path: _path + ".input",
+                expected: "Partial<IBbsArticle.ICreate>",
+                value: input.input,
+              }),
+          ].every((flag) => flag);
+        const _vo1 = (input, _path, _exceptionable = true) =>
+          [
+            undefined === input.title ||
+              "string" === typeof input.title ||
+              _report(_exceptionable, {
+                path: _path + ".title",
+                expected: "(string | undefined)",
+                value: input.title,
+              }),
+            undefined === input.body ||
+              "string" === typeof input.body ||
+              _report(_exceptionable, {
+                path: _path + ".body",
+                expected: "(string | undefined)",
+                value: input.body,
+              }),
+            null === input.thumbnail ||
+              undefined === input.thumbnail ||
+              ("string" === typeof input.thumbnail &&
+                (__typia_transform__isFormatUri._isFormatUri(input.thumbnail) ||
+                  _report(_exceptionable, {
+                    path: _path + ".thumbnail",
+                    expected: 'string & Format<"uri">',
+                    value: input.thumbnail,
+                  }))) ||
+              _report(_exceptionable, {
+                path: _path + ".thumbnail",
+                expected:
+                  '((string & Format<"uri"> & ContentMediaType<"image/*">) | null | undefined)',
+                value: input.thumbnail,
+              }),
+          ].every((flag) => flag);
+        const __is = (input) =>
+          "object" === typeof input && null !== input && _io0(input);
+        let errors;
+        let _report;
+        return (input) => {
+          if (false === __is(input)) {
+            errors = [];
+            _report = __typia_transform__validateReport._validateReport(errors);
+            ((input, _path, _exceptionable = true) =>
+              ((("object" === typeof input && null !== input) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                })) &&
+                _vo0(input, _path + "", true)) ||
+              _report(true, {
+                path: _path + "",
+                expected: "__type",
+                value: input,
+              }))(input, "$input", true);
+            const success = 0 === errors.length;
+            return success
+              ? {
+                  success,
+                  data: input,
+                }
+              : {
+                  success,
+                  errors,
+                  data: input,
+                };
+          }
+          return {
+            success: true,
+            data: input,
+          };
+        };
+      })(),
+    },
+    {
+      name: "erase",
+      parameters: {
+        description: " Properties of erase function",
+        type: "object",
+        properties: {
+          id: {
+            title: "Target article's {@link IBbsArticle.id}",
+            description:
+              "Target article's {@link IBbsArticle.id}.\n\n\n@format uuid",
+            type: "string",
+          },
+        },
+        required: ["id"],
+        additionalProperties: false,
+        $defs: {},
+      },
+      description: "Erase an article.\n\nErases an article from the DB.",
+      validate: (() => {
+        const _io0 = (input) =>
+          "string" === typeof input.id &&
+          __typia_transform__isFormatUuid._isFormatUuid(input.id);
+        const _vo0 = (input, _path, _exceptionable = true) =>
+          [
+            ("string" === typeof input.id &&
+              (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: 'string & Format<"uuid">',
+                  value: input.id,
+                }))) ||
+              _report(_exceptionable, {
+                path: _path + ".id",
+                expected: '(string & Format<"uuid">)',
+                value: input.id,
+              }),
+          ].every((flag) => flag);
+        const __is = (input) =>
+          "object" === typeof input && null !== input && _io0(input);
+        let errors;
+        let _report;
+        return (input) => {
+          if (false === __is(input)) {
+            errors = [];
+            _report = __typia_transform__validateReport._validateReport(errors);
+            ((input, _path, _exceptionable = true) =>
+              ((("object" === typeof input && null !== input) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                })) &&
+                _vo0(input, _path + "", true)) ||
+              _report(true, {
+                path: _path + "",
+                expected: "__type",
+                value: input,
+              }))(input, "$input", true);
+            const success = 0 === errors.length;
+            return success
+              ? {
+                  success,
+                  data: input,
+                }
+              : {
+                  success,
+                  errors,
+                  data: input,
+                };
+          }
+          return {
+            success: true,
+            data: input,
+          };
+        };
+      })(),
+    },
+  ],
+};
+console.log(app);
+```

--- a/website/src/snippets/LlmApplicationSeparateExampleSnippet.mdx
+++ b/website/src/snippets/LlmApplicationSeparateExampleSnippet.mdx
@@ -1,0 +1,15 @@
+```typescript filename="example/src/llm.application.separate.ts" showLineNumbers {11-12}
+import { ClaudeTypeChecker, IClaudeSchema, ILlmApplication } from "@samchon/openapi";
+import typia from "typia";
+
+import { BbsArticleService } from "./BbsArticleService";
+
+const app: ILlmApplication<"claude"> = typia.llm.application<
+  BbsArticleService,
+  "claude"
+>({
+  separate: (schema: IClaudeSchema) =>
+    ClaudeTypeChecker.isString(schema) && schema.contentMediaType !== undefined,
+});
+console.log(app);
+```

--- a/website/src/snippets/LlmApplicationSeparateJsonSnippet.mdx
+++ b/website/src/snippets/LlmApplicationSeparateJsonSnippet.mdx
@@ -1,0 +1,313 @@
+```json filename="example/schemas/llm.application.separate.json" showLineNumbers {111-158}
+{
+  "model": "claude",
+  "options": {
+    "reference": false
+  },
+  "functions": [
+    {
+      "name": "create",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "input": {
+            "description": "Information of the article to create.\n\n------------------------------\n\nDescription of the current {@link IBbsArticle.ICreate} type:\n\n> Information of the article to create.\n\n------------------------------\n\nDescription of the parent {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+            "type": "object",
+            "properties": {
+              "title": {
+                "title": "Title of the article",
+                "description": "Title of the article.\n\nRepresentative title of the article.",
+                "type": "string"
+              },
+              "body": {
+                "title": "Content body",
+                "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
+                "type": "string"
+              },
+              "thumbnail": {
+                "title": "Thumbnail image URI",
+                "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "contentMediaType": "image/*"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "title",
+              "body",
+              "thumbnail"
+            ]
+          }
+        },
+        "required": [
+          "input"
+        ],
+        "additionalProperties": false,
+        "$defs": {}
+      },
+      "output": {
+        "description": "Article entity.\n\n`IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Primary Key",
+            "description": "Primary Key.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "created_at": {
+            "title": "Creation time of the article",
+            "description": "Creation time of the article.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "title": "Last updated time of the article",
+            "description": "Last updated time of the article.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "title": "Title of the article",
+            "description": "Title of the article.\n\nRepresentative title of the article.",
+            "type": "string"
+          },
+          "body": {
+            "title": "Content body",
+            "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
+            "type": "string"
+          },
+          "thumbnail": {
+            "title": "Thumbnail image URI",
+            "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "contentMediaType": "image/*"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "title",
+          "body",
+          "thumbnail"
+        ]
+      },
+      "description": "Create a new article.\n\nWrites a new article and archives it into the DB.",
+      "separated": {
+        "llm": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "description": "Information of the article to create.\n\n------------------------------\n\nDescription of the current {@link IBbsArticle.ICreate} type:\n\n> Information of the article to create.\n\n------------------------------\n\nDescription of the parent {@link IBbsArticle} type:\n\n> Article entity.\n> \n> `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title of the article",
+                  "description": "Title of the article.\n\nRepresentative title of the article.",
+                  "type": "string"
+                },
+                "body": {
+                  "title": "Content body",
+                  "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
+                  "type": "string"
+                },
+                "thumbnail": {
+                  "title": "Thumbnail image URI",
+                  "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "image/*"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "title",
+                "body",
+                "thumbnail"
+              ]
+            }
+          },
+          "required": [
+            "input"
+          ],
+          "additionalProperties": false,
+          "$defs": {}
+        },
+        "human": null
+      }
+    },
+    {
+      "name": "update",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Target article's {@link IBbsArticle.id}",
+            "description": "Target article's {@link IBbsArticle.id}.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "input": {
+            "description": "Make all properties in T optional\n\n------------------------------\n\nDescription of the current {@link PartialIBbsArticle.ICreate} type:\n\n> Make all properties in T optional",
+            "type": "object",
+            "properties": {
+              "title": {
+                "title": "Title of the article",
+                "description": "Title of the article.\n\nRepresentative title of the article.",
+                "type": "string"
+              },
+              "body": {
+                "title": "Content body",
+                "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
+                "type": "string"
+              },
+              "thumbnail": {
+                "title": "Thumbnail image URI",
+                "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri",
+                    "contentMediaType": "image/*"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "title",
+              "body",
+              "thumbnail"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "input"
+        ],
+        "additionalProperties": false,
+        "$defs": {}
+      },
+      "description": "Update an article.\n\nUpdates an article with new content.",
+      "separated": {
+        "llm": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Target article's {@link IBbsArticle.id}",
+              "description": "Target article's {@link IBbsArticle.id}.",
+              "type": "string",
+              "format": "uuid"
+            },
+            "input": {
+              "description": "Make all properties in T optional\n\n------------------------------\n\nDescription of the current {@link PartialIBbsArticle.ICreate} type:\n\n> Make all properties in T optional",
+              "type": "object",
+              "properties": {
+                "title": {
+                  "title": "Title of the article",
+                  "description": "Title of the article.\n\nRepresentative title of the article.",
+                  "type": "string"
+                },
+                "body": {
+                  "title": "Content body",
+                  "description": "Content body.\n\nContent body of the article writtn in the markdown format.",
+                  "type": "string"
+                },
+                "thumbnail": {
+                  "title": "Thumbnail image URI",
+                  "description": "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "image/*"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "title",
+                "body",
+                "thumbnail"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "input"
+          ],
+          "additionalProperties": false,
+          "$defs": {}
+        },
+        "human": null
+      }
+    },
+    {
+      "name": "erase",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Target article's {@link IBbsArticle.id}",
+            "description": "Target article's {@link IBbsArticle.id}.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "$defs": {}
+      },
+      "description": "Erase an article.\n\nErases an article from the DB.",
+      "separated": {
+        "llm": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Target article's {@link IBbsArticle.id}",
+              "description": "Target article's {@link IBbsArticle.id}.",
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false,
+          "$defs": {}
+        },
+        "human": null
+      }
+    }
+  ]
+}
+```

--- a/website/src/snippets/LlmParametersExampleSnippet.mdx
+++ b/website/src/snippets/LlmParametersExampleSnippet.mdx
@@ -1,0 +1,14 @@
+```typescript filename="example/src/llm.parameters.ts" showLineNumbers
+import { IChatGptSchema } from "@samchon/openapi";
+import typia, { tags } from "typia";
+ 
+interface IMember {
+  email: string & tags.Format<"email">;
+  name: string;
+  age: number;
+  hobbies: string[];
+  joined_at: string & tags.Format<"date">;
+}
+const p: IChatGptSchema.IParameters = typia.llm.parameters<IMember, "chatgpt">();
+console.log(p);
+```

--- a/website/src/snippets/LlmParametersJavaScriptSnippet.mdx
+++ b/website/src/snippets/LlmParametersJavaScriptSnippet.mdx
@@ -1,0 +1,32 @@
+```javascript filename="example/src/llm.parameters.js" showLineNumbers
+import typia from "typia";
+const p = {
+  type: "object",
+  properties: {
+    email: {
+      description: "@format email",
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    age: {
+      type: "number",
+    },
+    hobbies: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    joined_at: {
+      description: "@format date",
+      type: "string",
+    },
+  },
+  required: ["email", "name", "age", "hobbies", "joined_at"],
+  additionalProperties: false,
+  $defs: {},
+};
+console.log(p);
+```

--- a/website/src/snippets/LlmSchemaExampleSnippet.mdx
+++ b/website/src/snippets/LlmSchemaExampleSnippet.mdx
@@ -1,0 +1,60 @@
+```typescript filename="example/src/llm.schema.ts" showLineNumbers
+import { IChatGptSchema } from "@samchon/openapi";
+import typia, { tags } from "typia";
+
+const $defs: Record<string, IChatGptSchema> = {};
+export const schema: IChatGptSchema = typia.llm.schema<
+  IBbsArticle, 
+  "chatgpt",
+  { reference: true }
+>({
+  $defs,
+});
+
+/**
+ * Article entity.
+ *
+ * `IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).
+ */
+interface IBbsArticle {
+  /**
+   * Primary Key.
+   */
+  id: string & tags.Format<"uuid">;
+
+  /**
+   * Title of the article.
+   *
+   * Representative title of the article.
+   */
+  title: string;
+
+  /**
+   * Content body.
+   *
+   * Content body of the article writtn in the markdown format.
+   */
+  body: string;
+
+  /**
+   * Thumbnail image URI.
+   *
+   * Thumbnail image URI which can represent the article.
+   *
+   * If configured as `null`, it means that no thumbnail image in the article.
+   */
+  thumbnail:
+    | null
+    | (string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">);
+ 
+  /**
+   * Creation time of the article.
+   */
+  created_at: string & tags.Format<"date-time">;
+ 
+  /**
+   * Last updated time of the article.
+   */
+  updated_at: string & tags.Format<"date-time">;
+}
+```

--- a/website/src/snippets/LlmSchemaJavaScriptSnippet.mdx
+++ b/website/src/snippets/LlmSchemaJavaScriptSnippet.mdx
@@ -1,0 +1,71 @@
+```javascript filename="example/bin/llm.schema.js" showLineNumbers
+import typia from "typia";
+const $defs = {};
+export const schema = ((props) => {
+  Object.assign(props.$defs, {
+    IBbsArticle: {
+      description:
+        "Article entity.\n\n`IBbsArticle` is an entity representing an article in the BBS (Bulletin Board System).",
+      type: "object",
+      properties: {
+        id: {
+          title: "Primary Key",
+          description: "Primary Key.\n\n\n@format uuid",
+          type: "string",
+        },
+        title: {
+          title: "Title of the article",
+          description:
+            "Title of the article.\n\nRepresentative title of the article.",
+          type: "string",
+        },
+        body: {
+          title: "Content body",
+          description:
+            "Content body.\n\nContent body of the article writtn in the markdown format.",
+          type: "string",
+        },
+        thumbnail: {
+          title: "Thumbnail image URI",
+          description:
+            "Thumbnail image URI.\n\nThumbnail image URI which can represent the article.\n\nIf configured as `null`, it means that no thumbnail image in the article.",
+          anyOf: [
+            {
+              type: "null",
+            },
+            {
+              type: "string",
+              description: "@format uri\n@contentMediaType image/*",
+            },
+          ],
+        },
+        created_at: {
+          title: "Creation time of the article",
+          description: "Creation time of the article.\n\n\n@format date-time",
+          type: "string",
+        },
+        updated_at: {
+          title: "Last updated time of the article",
+          description:
+            "Last updated time of the article.\n\n\n@format date-time",
+          type: "string",
+        },
+      },
+      required: [
+        "id",
+        "title",
+        "body",
+        "thumbnail",
+        "created_at",
+        "updated_at",
+      ],
+    },
+  });
+  return {
+    $ref: "#/$defs/IBbsArticle",
+  };
+})({
+  $defs,
+});
+
+```

--- a/website/src/snippets/ValidationFeedbackExampleSnippet.mdx
+++ b/website/src/snippets/ValidationFeedbackExampleSnippet.mdx
@@ -1,0 +1,35 @@
+```typescript filename="validation-feedback-concept.ts" showLineNumbers copy
+import { ILlmApplication, ILlmFunction, IValidation } from "@samchon/openapi";
+import { FunctionCall } from "pseudo";
+
+export const correctFunctionCall = (
+  app: ILlmApplication<"chatgpt">;
+  retry: (reason: string, errors?: IValidation.IError[]) => Promise<unknown>;
+): Promise<unknown> => {
+  // FIND FUNCTION
+  const func: ILlmFunction<"chatgpt"> | undefined = app.functions.find(
+    (f) => f.name === p.call.name,
+  );
+  if (func === undefined) {
+    // never happened in my experience
+    return retry(
+      "Unable to find the matched function name. Try it again.",
+    );
+  }
+
+  // VALIDATE
+  const result: IValidation<unknown> = func.validate(p.call.arguments);
+  if (result.success === false) {
+    // 1st trial: 30% (gpt-4o-mini in shopping mall chatbot)
+    // 2nd trial with validation feedback: 99%
+    // 3nd trial with validation feedback again: never have failed
+    return retry(
+      "Type errors are detected. Correct it through validation errors",
+      {
+        errors: result.errors,
+      },
+    );
+  }
+  return result.data;
+}
+```

--- a/website/src/snippets/ValidatorSupportMatrixSnippet.mdx
+++ b/website/src/snippets/ValidatorSupportMatrixSnippet.mdx
@@ -1,0 +1,21 @@
+Components               | `typia` | `TypeBox` | `ajv` | `io-ts` | `zod` | `C.V.`
+-------------------------|--------|-----------|-------|---------|-------|------------------
+**Easy to use**          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ 
+[Object (simple)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectSimple.ts)          | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectHierarchical.ts)    | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectRecursive.ts)       | ✔ | ❌ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (union, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionImplicit.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Object (union, explicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ObjectUnionExplicit.ts) | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+[Object (additional tags)](https://github.com/samchon/typia/#comment-tags)        | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Object (template literal types)](https://github.com/samchon/typia/blob/master/test/src/structures/TemplateUnion.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+[Object (dynamic properties)](https://github.com/samchon/typia/blob/master/test/src/structures/DynamicTemplate.ts) | ✔ | ✔ | ✔ | ❌ | ❌ | ❌
+[Array (rest tuple)](https://github.com/samchon/typia/blob/master/test/src/structures/TupleRestAtomic.ts) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (hierarchical)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayHierarchical.ts)     | ✔ | ✔ | ✔ | ✔ | ✔ | ✔
+[Array (recursive)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursive.ts)        | ✔ | ✔ | ✔ | ✔ | ✔ | ❌
+[Array (recursive, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionExplicit.ts) | ✔ | ✔ | ❌ | ✔ | ✔ | ❌
+[Array (R+U, implicit)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRecursiveUnionImplicit.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedNullable.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[Array (repeated, union)](https://github.com/samchon/typia/blob/master/test/src/structures/ArrayRepeatedUnionWithTuple.ts)    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+[**Ultimate Union Type**](https://github.com/samchon/typia/blob/master/test/src/structures/UltimateUnion.ts)  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
+
+> `C.V.` means `class-validator`


### PR DESCRIPTION
This pull request includes changes to the documentation for the Large Language Model (LLM) and parameters function. The changes primarily involve simplifying the code examples by using reusable snippets and updating the validation feedback strategy.

### Documentation Updates:

* [`website/pages/docs/llm/chat.mdx`](diffhunk://#diff-32e2198139f141d4524b1e0538d0d9595321b55d78846ade27e6c797b12d679cL4-R8): Added imports for reusable snippets (`BbsArticleServiceSnippet`, `IBbsArticleSnippet`, `ValidatorSupportMatrixSnippet`) and replaced inline code examples with these snippets. [[1]](diffhunk://#diff-32e2198139f141d4524b1e0538d0d9595321b55d78846ade27e6c797b12d679cL4-R8) [[2]](diffhunk://#diff-32e2198139f141d4524b1e0538d0d9595321b55d78846ade27e6c797b12d679cL69-R76) [[3]](diffhunk://#diff-32e2198139f141d4524b1e0538d0d9595321b55d78846ade27e6c797b12d679cL456-R316)

* [`website/pages/docs/llm/parameters.mdx`](diffhunk://#diff-685aa2b52f8394e7f9914c616b152fd5a37345e483bf0577206d2d839105f6d1L4-R12): Added imports for reusable snippets (`ILlmApplicationSnippet`, `ILlmFunctionSnippet`, `ILlmSchemaSnippet`, `LlmParametersExampleSnippet`, `LlmParametersJavaScriptSnippet`, `ValidatorSupportMatrixSnippet`) and replaced inline code examples with these snippets. [[1]](diffhunk://#diff-685aa2b52f8394e7f9914c616b152fd5a37345e483bf0577206d2d839105f6d1L4-R12) [[2]](diffhunk://#diff-685aa2b52f8394e7f9914c616b152fd5a37345e483bf0577206d2d839105f6d1L58-R72) [[3]](diffhunk://#diff-685aa2b52f8394e7f9914c616b152fd5a37345e483bf0577206d2d839105f6d1R104-R114)