### PR TITLE
Fix `typia.llm.schema<T, Model>()` not to properly assign `$defs`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/transformers/features/llm/LlmSchemaTransformer.ts
+++ b/src/transformers/features/llm/LlmSchemaTransformer.ts
@@ -101,10 +101,24 @@ export namespace LlmSchemaTransformer {
         undefined,
         [
           IdentifierFactory.parameter(
-            "$defs",
-            ts.factory.createTypeReferenceNode("Record", [
-              ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-              schemaTypeNode,
+            "props",
+            ts.factory.createTypeLiteralNode([
+              ts.factory.createPropertySignature(
+                undefined,
+                ts.factory.createIdentifier("$defs"),
+                ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                ts.factory.createUnionTypeNode([
+                  ts.factory.createTypeReferenceNode("Record", [
+                    ts.factory.createKeywordTypeNode(
+                      ts.SyntaxKind.StringKeyword,
+                    ),
+                    schemaTypeNode,
+                  ]),
+                  ts.factory.createKeywordTypeNode(
+                    ts.SyntaxKind.UndefinedKeyword,
+                  ),
+                ]),
+              ),
             ]),
             undefined,
           ),
@@ -113,22 +127,35 @@ export namespace LlmSchemaTransformer {
         undefined,
         ts.factory.createBlock(
           [
-            ts.factory.createExpressionStatement(
-              ts.factory.createCallExpression(
-                ts.factory.createIdentifier("Object.assign"),
-                undefined,
-                [
-                  ts.factory.createIdentifier("$defs"),
-                  ts.factory.createAsExpression(
-                    LiteralFactory.write(out.$defs),
-                    ts.factory.createTypeReferenceNode("Record", [
-                      ts.factory.createKeywordTypeNode(
-                        ts.SyntaxKind.StringKeyword,
-                      ),
-                      schemaTypeNode,
-                    ]),
-                  ),
-                ],
+            ts.factory.createIfStatement(
+              ts.factory.createStrictInequality(
+                ts.factory.createIdentifier("undefined"),
+                IdentifierFactory.access(
+                  ts.factory.createIdentifier("props"),
+                  "$defs",
+                  true,
+                ),
+              ),
+              ts.factory.createExpressionStatement(
+                ts.factory.createCallExpression(
+                  ts.factory.createIdentifier("Object.assign"),
+                  undefined,
+                  [
+                    IdentifierFactory.access(
+                      ts.factory.createIdentifier("props"),
+                      "$defs",
+                    ),
+                    ts.factory.createAsExpression(
+                      LiteralFactory.write(out.$defs),
+                      ts.factory.createTypeReferenceNode("Record", [
+                        ts.factory.createKeywordTypeNode(
+                          ts.SyntaxKind.StringKeyword,
+                        ),
+                        schemaTypeNode,
+                      ]),
+                    ),
+                  ],
+                ),
               ),
             ),
             ts.factory.createReturnStatement(literal),

--- a/test/generate/input/generate_llm.ts
+++ b/test/generate/input/generate_llm.ts
@@ -1,7 +1,11 @@
 import { LlmTypeCheckerV3_1 } from "@samchon/openapi";
 import typia, { tags } from "typia";
 
-export const schema = typia.llm.schema<ICompany, "chatgpt">({});
+export const schema = typia.llm.schema<
+  ICompany,
+  "chatgpt",
+  { reference: true }
+>({});
 
 export const parameters = typia.llm.parameters<
   {

--- a/test/generate/output/generate_llm.ts
+++ b/test/generate/output/generate_llm.ts
@@ -5,88 +5,104 @@ import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUu
 import * as __typia_transform__llmApplicationFinalize from "typia/lib/internal/_llmApplicationFinalize.js";
 import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
 
-export const schema = ((
-  $defs: Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>,
-) => {
-  Object.assign($defs, {
-    IDepartment: {
-      type: "object",
-      properties: {
-        id: {
-          description: "@format uuid",
-          type: "string",
-        },
-        code: {
-          type: "string",
-        },
-        sales: {
-          type: "number",
-        },
-        created_at: {
-          description: "@format date-time",
-          type: "string",
-        },
-        children: {
-          type: "array",
-          items: {
-            $ref: "#/$defs/IDepartment",
+export const schema = ((props: {
+  $defs?:
+    | Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>
+    | undefined;
+}) => {
+  if (undefined !== props?.$defs)
+    Object.assign(props.$defs, {
+      ICompany: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
           },
-        },
-        employees: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              id: {
-                description: "@format uuid",
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              age: {
-                type: "number",
-              },
-              grade: {
-                type: "number",
-              },
-              employed_at: {
-                description: "@format date-time",
-                type: "string",
-              },
+          serial: {
+            type: "number",
+          },
+          name: {
+            type: "string",
+          },
+          established_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+          departments: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IDepartment",
             },
-            required: ["id", "name", "age", "grade", "employed_at"],
           },
         },
+        required: ["id", "serial", "name", "established_at", "departments"],
       },
-      required: ["id", "code", "sales", "created_at", "children", "employees"],
-    },
-  } as Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>);
-  return {
-    type: "object",
-    properties: {
-      id: {
-        description: "@format uuid",
-        type: "string",
-      },
-      serial: {
-        type: "number",
-      },
-      name: {
-        type: "string",
-      },
-      established_at: {
-        description: "@format date-time",
-        type: "string",
-      },
-      departments: {
-        type: "array",
-        items: {
-          $ref: "#/$defs/IDepartment",
+      IDepartment: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
+          },
+          code: {
+            type: "string",
+          },
+          sales: {
+            type: "number",
+          },
+          created_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+          children: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+          employees: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IEmployee",
+            },
+          },
         },
+        required: [
+          "id",
+          "code",
+          "sales",
+          "created_at",
+          "children",
+          "employees",
+        ],
       },
-    },
-    required: ["id", "serial", "name", "established_at", "departments"],
+      IEmployee: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
+          },
+          name: {
+            type: "string",
+          },
+          age: {
+            type: "number",
+          },
+          grade: {
+            type: "number",
+          },
+          employed_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+        },
+        required: ["id", "name", "age", "grade", "employed_at"],
+      },
+    } as Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>);
+  return {
+    $ref: "#/$defs/ICompany",
   } as import("@samchon/openapi").ILlmSchema<"chatgpt">;
 })({});
 export const parameters = {

--- a/test/src/features/issues/test_issue_1390_llm_config_argument.ts
+++ b/test/src/features/issues/test_issue_1390_llm_config_argument.ts
@@ -7,12 +7,16 @@ import { ArrayRecursive } from "../../structures/ArrayRecursive";
 export const test_issue_1390_llm_config_argument = (): void => {
   TestValidator.equals("reference false")(
     keys(($defs) =>
-      typia.llm.schema<ArrayRecursive, "chatgpt", { reference: false }>($defs),
+      typia.llm.schema<ArrayRecursive, "chatgpt", { reference: false }>({
+        $defs,
+      }),
     ),
   )(["ArrayRecursive.ICategory"]);
   TestValidator.equals("reference true")(
     keys(($defs) =>
-      typia.llm.schema<ArrayRecursive, "chatgpt", { reference: true }>($defs),
+      typia.llm.schema<ArrayRecursive, "chatgpt", { reference: true }>({
+        $defs,
+      }),
     ),
   )(["ArrayRecursive.ICategory", "ArrayRecursive.ITimestamp"]);
 };

--- a/test/src/features/issues/test_pr_1541_llm_schema_$defs.ts
+++ b/test/src/features/issues/test_pr_1541_llm_schema_$defs.ts
@@ -1,0 +1,22 @@
+import { IChatGptSchema } from "@samchon/openapi";
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_pr_1541_llm_schema_$defs = (): void => {
+  const $defs: Record<string, IChatGptSchema> = {};
+  const schema: IChatGptSchema = typia.llm.schema<IDepartment, "chatgpt">({
+    $defs,
+  });
+  TestValidator.equals("$defs")(Object.keys($defs))(["IDepartment"]);
+  TestValidator.equals("schema")(schema)({
+    $ref: "#/$defs/IDepartment",
+  });
+
+  // just for checking none runtime error
+  typia.llm.schema<IDepartment, "chatgpt">({});
+};
+interface IDepartment {
+  id: string;
+  children: IDepartment[];
+}


### PR DESCRIPTION
This pull request includes several updates to the `typia` package, mainly focusing on schema transformation and test generation. The most important changes include updating the package version, modifying the schema transformation logic, and updating test generation files to reflect the new schema structure.

### Package Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `8.0.2` to `8.0.3`.

### Schema Transformation:
* [`src/transformers/features/llm/LlmSchemaTransformer.ts`](diffhunk://#diff-dc916c42d08107c3fc62a8ace827c6c123235b2efed885f7102d5c416bdd5563L104-R147): Modified the `LlmSchemaTransformer` to use `props` instead of `$defs` and added type literal and property signatures for better schema handling. [[1]](diffhunk://#diff-dc916c42d08107c3fc62a8ace827c6c123235b2efed885f7102d5c416bdd5563L104-R147) [[2]](diffhunk://#diff-dc916c42d08107c3fc62a8ace827c6c123235b2efed885f7102d5c416bdd5563R160)

### Test Generation:
* [`test/generate/input/generate_llm.ts`](diffhunk://#diff-ac448e4366952d79a31ba946b0485305329f6dbedb58b09aed1ba4983294d779L4-R8): Updated the schema generation to include an additional parameter `{ reference: true }`.
* [`test/generate/output/generate_llm.ts`](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L8-R40): Refactored the schema generation logic to use `props` with optional `$defs` and updated the schema definitions for `ICompany`, `IDepartment`, and `IEmployee`. [[1]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L8-R40) [[2]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0R67-R80) [[3]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L60-R105)