### PR TITLE
feat: add CJS/ESM module awareness for imports

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,5 +51,22 @@ export default {
       module: "ESNext",
       target: "ESNext",
     }),
+    {
+      name: "copy-dts-to-dmts",
+      async generateBundle(_, bundle) {
+        for (const fileName of Object.keys(bundle)) {
+          if (fileName.endsWith(".d.ts")) {
+            const dtsFile = bundle[fileName];
+            const dmtsFileName = fileName.replace(/\.d\.ts$/, ".d.mts");
+
+            this.emitFile({
+              type: "asset",
+              fileName: dmtsFileName,
+              source: dtsFile.source,
+            });
+          }
+        }
+      },
+    },
   ],
 };

--- a/src/programmers/ImportProgrammer.ts
+++ b/src/programmers/ImportProgrammer.ts
@@ -9,6 +9,7 @@ export class ImportProgrammer {
   public constructor(options?: Partial<ImportProgrammer.IOptions>) {
     this.options_ = {
       internalPrefix: options?.internalPrefix ?? "",
+      isCjs: options?.isCjs ?? false,
     };
   }
 
@@ -59,7 +60,7 @@ export class ImportProgrammer {
     if (name.startsWith("_") === false) name = `_${name}`;
     return ts.factory.createPropertyAccessExpression(
       this.namespace({
-        file: `typia/lib/internal/${name}.js`,
+        file: `typia/lib/internal/${name}${this.getInternalImportExtension()}`,
         name: this.alias(name),
       }),
       name,
@@ -72,7 +73,7 @@ export class ImportProgrammer {
   public getInternalText(name: string): string {
     if (name.startsWith("_") === false) name = `_${name}`;
     const asset: IAsset | undefined = this.take(
-      `typia/lib/internal/${name}.js`,
+      `typia/lib/internal/${name}${this.getInternalImportExtension()}`,
     );
     if (!asset?.namespace) throw new Error(`Internal asset not found: ${name}`);
     return `${asset.namespace.name}.${name}`;
@@ -92,6 +93,15 @@ export class ImportProgrammer {
 
   private alias(name: string): string {
     return `__${this.options_.internalPrefix}${name}`;
+  }
+
+  /**
+   * @internal
+   * return extension for internal imports
+   * for cjs it is ".js", for esm it is ".mjs"
+   */
+  private getInternalImportExtension(): string {
+    return this.options_.isCjs ? ".js" : ".mjs";
   }
 
   /* -----------------------------------------------------------
@@ -159,6 +169,7 @@ export class ImportProgrammer {
 export namespace ImportProgrammer {
   export interface IOptions {
     internalPrefix: string;
+    isCjs: boolean;
   }
 
   export interface IDefault {

--- a/src/transformers/FileTransformer.ts
+++ b/src/transformers/FileTransformer.ts
@@ -17,6 +17,7 @@ export namespace FileTransformer {
 
       const importer: ImportProgrammer = new ImportProgrammer({
         internalPrefix: "typia_transform_",
+        isCjs: environments.compilerOptions.module === ts.ModuleKind.CommonJS,
       });
       const context: ITypiaContext = {
         ...environments,


### PR DESCRIPTION
When I was working on Bun' plugin, I did some hack like this: https://github.com/ryoppippi/unplugin-typia/pull/347
But when typia support this operation, we don't need this hack anymore

Add support for distinguishing between CommonJS and ESM module systems when importing internal files. This allows the transformer to properly use empty or .mjs extensions based on the module type configured in the compiler options.

This pull request introduces several important changes to the `rollup.config.mjs` and `src/programmers/ImportProgrammer.ts` files, focusing on module handling and internal import logic. The key changes include adding a new Rollup plugin for copying `.d.ts` files, updating the `ImportProgrammer` class to handle different module types, and modifying internal import paths based on the module type.

### Module Handling Enhancements:

* [`rollup.config.mjs`](diffhunk://#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1R54-R70): Added a new Rollup plugin named `copy-dts-to-dmts` to generate `.d.mts` files from `.d.ts` files during the bundle generation process.

### Internal Import Logic Updates:

* [`src/programmers/ImportProgrammer.ts`](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35R12): Introduced a new option `isCjs` to the `ImportProgrammer` class to determine if the module type is CommonJS. This option is used to set the appropriate file extension for internal imports. [[1]](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35R12) [[2]](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35R172)
* [`src/programmers/ImportProgrammer.ts`](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35L62-R63): Modified internal import paths to use the correct file extension based on the module type (`.js` for CommonJS and `.mjs` for ESM) by implementing the `getInternalImportExtension` method. [[1]](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35L62-R63) [[2]](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35L75-R76) [[3]](diffhunk://#diff-3e4c81b8afac857195358ad5be616ac5fa93bf9c90090f912cb2013ef0deee35R98-R106)

### Configuration Integration:

* [`src/transformers/FileTransformer.ts`](diffhunk://#diff-f503bf0fc6bea085e2bded282119a3e521ded8ed85467e482683f61cb8a7c167R20): Updated the `FileTransformer` to pass the `isCjs` option to the `ImportProgrammer` based on the module type specified in the compiler options.