### PR TITLE
feat: emit .d.mts declaration files

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,5 +51,22 @@ export default {
       module: "ESNext",
       target: "ESNext",
     }),
+    {
+      name: "copy-dts-to-dmts",
+      async generateBundle(_, bundle) {
+        for (const fileName of Object.keys(bundle)) {
+          if (fileName.endsWith(".d.ts")) {
+            const dtsFile = bundle[fileName];
+            const dmtsFileName = fileName.replace(/\.d\.ts$/, ".d.mts");
+
+            this.emitFile({
+              type: "asset",
+              fileName: dmtsFileName,
+              source: dtsFile.source,
+            });
+          }
+        }
+      },
+    },
   ],
 };


### PR DESCRIPTION
Add plugin to copy TypeScript declaration files to .d.mts format to support ES module imports in TypeScript projects that use the "moduleResolution": "node16" or "nodenext" setting.

Related to #1547
