### PR TITLE
Upgrade `@samchon/openapi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "8.0.4",
+  "version": "8.1.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^3.0.0",
+    "@samchon/openapi": "^3.2.1",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -49,7 +49,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=3.0.0 <4.0.0",
+    "@samchon/openapi": ">=3.2.1 <4.0.0",
     "typescript": ">=4.8.0 <5.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^3.2.1",
+    "@samchon/openapi": "^3.2.2",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",
@@ -49,7 +49,7 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=3.2.1 <4.0.0",
+    "@samchon/openapi": ">=3.2.2 <4.0.0",
     "typescript": ">=4.8.0 <5.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.0.0
+        specifier: ^3.2.1
         version: 3.2.2
       commander:
         specifier: ^10.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@samchon/openapi':
-        specifier: ^3.2.1
+        specifier: ^3.2.2
         version: 3.2.2
       commander:
         specifier: ^10.0.0


### PR DESCRIPTION
Just for detailed description of LLM parameters schema.

- https://github.com/samchon/openapi/pull/165
- https://github.com/samchon/openapi/pull/166
- https://github.com/samchon/openapi/pull/167

It affects to `llm.application()` and `llm.parameters()` function about description properties of schema.

---------------

This pull request includes version updates for the `typia` package and its dependencies.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `8.0.4` to `8.1.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R52): Updated the `@samchon/openapi` dependency version from `^3.0.0` to `^3.2.2` and the peer dependency version range from `>=3.0.0 <4.0.0` to `>=3.2.2 <4.0.0`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R12): Updated the `@samchon/openapi` dependency specifier from `^3.0.0` to `^3.2.2`.