### PR TITLE
Enhance `uint` type's JSON schema property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "9.0.0-dev.20250405-3",
+  "version": "9.0.0-dev.20250405-4",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "9.0.0-dev.20250405-2",
+  "version": "9.0.0-dev.20250405-3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^4.0.0-dev.20250405-3",
+    "@samchon/openapi": "^4.0.0-dev.20250405-4",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",
     "inquirer": "^8.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@samchon/openapi':
-        specifier: ^4.0.0-dev.20250405-3
-        version: 4.0.0-dev.20250405-3
+        specifier: ^4.0.0-dev.20250405-4
+        version: 4.0.0-dev.20250405-4
       commander:
         specifier: ^10.0.0
         version: 10.0.1
@@ -825,8 +825,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@4.0.0-dev.20250405-3':
-    resolution: {integrity: sha512-QhHmk6NXpW31XKpZReAExV2KhgvyFMwwSOwf65OUg5SvRO5KePH21h321/yjVihovUMz6uIqnS7kxF0utDvrOQ==}
+  '@samchon/openapi@4.0.0-dev.20250405-4':
+    resolution: {integrity: sha512-M/E52w5vgvJ1B3SLJezRBDuCc7O8odBBUVmt4D8ZN27AyW02bEJARsP8gcOoE+2Tpy8twmfRhTPmXaGkipxb1g==}
 
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
@@ -4090,7 +4090,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.37.0':
     optional: true
 
-  '@samchon/openapi@4.0.0-dev.20250405-3': {}
+  '@samchon/openapi@4.0.0-dev.20250405-4': {}
 
   '@sinclair/typebox@0.31.28': {}
 

--- a/src/programmers/internal/json_schema_station.ts
+++ b/src/programmers/internal/json_schema_station.ts
@@ -4,6 +4,8 @@ import { Metadata } from "../../schemas/metadata/Metadata";
 import { MetadataAtomic } from "../../schemas/metadata/MetadataAtomic";
 import { MetadataNative } from "../../schemas/metadata/MetadataNative";
 
+import { OpenApiExclusiveEmender } from "@samchon/openapi/lib/utils/OpenApiExclusiveEmender";
+
 import { AtomicPredicator } from "../helpers/AtomicPredicator";
 import { json_schema_alias } from "./json_schema_alias";
 import { json_schema_array } from "./json_schema_array";
@@ -70,7 +72,8 @@ export const json_schema_station = <BlockNever extends boolean>(props: {
   for (const a of props.metadata.atomics)
     if (a.type === "boolean") json_schema_boolean(a).forEach(insert);
     else if (a.type === "bigint") json_schema_bigint(a).forEach(insert);
-    else if (a.type === "number") json_schema_number(a).forEach(insert);
+    else if (a.type === "number")
+      json_schema_number(a).map(OpenApiExclusiveEmender.emend).forEach(insert);
     else if (a.type === "string") json_schema_string(a).forEach(insert);
 
   // ARRAY

--- a/src/tags/Type.ts
+++ b/src/tags/Type.ts
@@ -24,9 +24,14 @@ export type Type<
             ? `$importInternal("isTypeFloat")($input)`
             : `true`;
   exclusive: true;
-  schema: {
-    type: Value extends "int32" | "uint32" | "int64" | "uint64"
-      ? "integer"
-      : "number";
-  };
+  schema: Value extends "uint32" | "uint64"
+    ? {
+        type: "integer";
+        minimum: 0;
+      }
+    : {
+        type: Value extends "int32" | "uint32" | "int64" | "uint64"
+          ? "integer"
+          : "number";
+      };
 }>;

--- a/test/generate/output/generate_index.ts
+++ b/test/generate/output/generate_index.ts
@@ -1741,6 +1741,7 @@ export const random = (() => {
       _generator?.integer ?? __typia_transform__randomInteger._randomInteger
     )({
       type: "integer",
+      minimum: 0,
       exclusiveMaximum: 100,
     }),
     motto: (

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -39,6 +39,7 @@ export const collection = {
           },
           age: {
             type: "integer",
+            minimum: 0,
             exclusiveMaximum: 100,
           },
           motto: {

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1741,6 +1741,7 @@ export const createRandom = (() => {
       _generator?.integer ?? __typia_transform__randomInteger._randomInteger
     )({
       type: "integer",
+      minimum: 0,
       exclusiveMaximum: 100,
     }),
     motto: (

--- a/test/schemas/json.schemas/v3_0/ConstantAtomicTagged.json
+++ b/test/schemas/json.schemas/v3_0/ConstantAtomicTagged.json
@@ -16,6 +16,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               },
               {

--- a/test/schemas/json.schemas/v3_0/TypeTagAtomicUnion.json
+++ b/test/schemas/json.schemas/v3_0/TypeTagAtomicUnion.json
@@ -22,13 +22,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/json.schemas/v3_0/TypeTagType.json
+++ b/test/schemas/json.schemas/v3_0/TypeTagType.json
@@ -23,19 +23,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/json.schemas/v3_1/ConstantAtomicTagged.json
+++ b/test/schemas/json.schemas/v3_1/ConstantAtomicTagged.json
@@ -23,6 +23,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]

--- a/test/schemas/json.schemas/v3_1/TypeTagAtomicUnion.json
+++ b/test/schemas/json.schemas/v3_1/TypeTagAtomicUnion.json
@@ -22,13 +22,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/json.schemas/v3_1/TypeTagType.json
+++ b/test/schemas/json.schemas/v3_1/TypeTagType.json
@@ -23,19 +23,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/llm.application/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/3.0/ConstantAtomicTagged.json
@@ -25,6 +25,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -69,6 +70,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -101,6 +103,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -140,6 +143,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               },
               {
@@ -178,6 +182,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -210,6 +215,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -242,6 +248,7 @@
                 "oneOf": [
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   },
                   {
@@ -281,6 +288,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               },
               {

--- a/test/schemas/llm.application/3.0/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/3.0/TypeTagAtomicUnion.json
@@ -22,13 +22,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -70,13 +70,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -106,13 +106,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -149,13 +149,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }
@@ -191,13 +191,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -227,13 +227,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -263,13 +263,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -306,13 +306,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }

--- a/test/schemas/llm.application/3.0/TypeTagType.json
+++ b/test/schemas/llm.application/3.0/TypeTagType.json
@@ -23,19 +23,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -85,19 +88,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -135,19 +141,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -192,19 +201,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"
@@ -248,19 +260,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -298,19 +313,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -348,19 +366,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -405,19 +426,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.application/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/3.1/ConstantAtomicTagged.json
@@ -33,6 +33,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -78,6 +79,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -114,6 +116,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -157,6 +160,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]
@@ -199,6 +203,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -238,6 +243,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -277,6 +283,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -324,6 +331,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/3.1/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/3.1/TypeTagAtomicUnion.json
@@ -24,13 +24,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -71,13 +71,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -109,13 +109,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -154,13 +154,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }
@@ -198,13 +198,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -239,13 +239,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -280,13 +280,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -329,13 +329,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }

--- a/test/schemas/llm.application/3.1/TypeTagType.json
+++ b/test/schemas/llm.application/3.1/TypeTagType.json
@@ -25,19 +25,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -86,19 +89,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -138,19 +144,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -197,19 +206,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"
@@ -255,19 +267,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -310,19 +325,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -365,19 +383,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -428,19 +449,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
@@ -27,7 +27,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@minimum 0\n@maximum 100"
                   },
                   {
                     "type": "number",
@@ -72,7 +72,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@minimum 0\n@maximum 100"
                   },
                   {
                     "type": "number",
@@ -107,7 +107,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@minimum 0\n@maximum 100"
                       },
                       {
                         "type": "number",
@@ -149,7 +149,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "description": "@maximum 100"
+                "description": "@minimum 0\n@maximum 100"
               },
               {
                 "type": "number",
@@ -191,7 +191,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@minimum 0\n@maximum 100"
                       },
                       {
                         "type": "number",
@@ -229,7 +229,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@minimum 0\n@maximum 100"
                       },
                       {
                         "type": "number",
@@ -267,7 +267,7 @@
                     "anyOf": [
                       {
                         "type": "integer",
-                        "description": "@maximum 100"
+                        "description": "@minimum 0\n@maximum 100"
                       },
                       {
                         "type": "number",
@@ -313,7 +313,7 @@
                 "anyOf": [
                   {
                     "type": "integer",
-                    "description": "@maximum 100"
+                    "description": "@minimum 0\n@maximum 100"
                   },
                   {
                     "type": "number",

--- a/test/schemas/llm.application/chatgpt/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagAtomicUnion.json
@@ -25,12 +25,12 @@
                     "value": {
                       "anyOf": [
                         {
-                          "type": "number",
-                          "description": "@minimum 3"
-                        },
-                        {
                           "type": "string",
                           "description": "@minLength 3\n@maxLength 7"
+                        },
+                        {
+                          "type": "number",
+                          "description": "@minimum 3"
                         }
                       ]
                     }
@@ -72,12 +72,12 @@
                     "value": {
                       "anyOf": [
                         {
-                          "type": "number",
-                          "description": "@minimum 3"
-                        },
-                        {
                           "type": "string",
                           "description": "@minLength 3\n@maxLength 7"
+                        },
+                        {
+                          "type": "number",
+                          "description": "@minimum 3"
                         }
                       ]
                     }
@@ -109,12 +109,12 @@
                         "value": {
                           "anyOf": [
                             {
-                              "type": "number",
-                              "description": "@minimum 3"
-                            },
-                            {
                               "type": "string",
                               "description": "@minLength 3\n@maxLength 7"
+                            },
+                            {
+                              "type": "number",
+                              "description": "@minimum 3"
                             }
                           ]
                         }
@@ -153,12 +153,12 @@
                 "value": {
                   "anyOf": [
                     {
-                      "type": "number",
-                      "description": "@minimum 3"
-                    },
-                    {
                       "type": "string",
                       "description": "@minLength 3\n@maxLength 7"
+                    },
+                    {
+                      "type": "number",
+                      "description": "@minimum 3"
                     }
                   ]
                 }
@@ -197,12 +197,12 @@
                         "value": {
                           "anyOf": [
                             {
-                              "type": "number",
-                              "description": "@minimum 3"
-                            },
-                            {
                               "type": "string",
                               "description": "@minLength 3\n@maxLength 7"
+                            },
+                            {
+                              "type": "number",
+                              "description": "@minimum 3"
                             }
                           ]
                         }
@@ -237,12 +237,12 @@
                         "value": {
                           "anyOf": [
                             {
-                              "type": "number",
-                              "description": "@minimum 3"
-                            },
-                            {
                               "type": "string",
                               "description": "@minLength 3\n@maxLength 7"
+                            },
+                            {
+                              "type": "number",
+                              "description": "@minimum 3"
                             }
                           ]
                         }
@@ -277,12 +277,12 @@
                         "value": {
                           "anyOf": [
                             {
-                              "type": "number",
-                              "description": "@minimum 3"
-                            },
-                            {
                               "type": "string",
                               "description": "@minLength 3\n@maxLength 7"
+                            },
+                            {
+                              "type": "number",
+                              "description": "@minimum 3"
                             }
                           ]
                         }
@@ -325,12 +325,12 @@
                     "value": {
                       "anyOf": [
                         {
-                          "type": "number",
-                          "description": "@minimum 3"
-                        },
-                        {
                           "type": "string",
                           "description": "@minLength 3\n@maxLength 7"
+                        },
+                        {
+                          "type": "number",
+                          "description": "@minimum 3"
                         }
                       ]
                     }

--- a/test/schemas/llm.application/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagType.json
@@ -26,18 +26,21 @@
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "float": {
@@ -88,18 +91,21 @@
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "float": {
@@ -140,18 +146,21 @@
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "float": {
@@ -199,18 +208,21 @@
                   "type": "integer"
                 },
                 "uint": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "float": {
@@ -258,18 +270,21 @@
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "float": {
@@ -313,18 +328,21 @@
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "float": {
@@ -368,18 +386,21 @@
                           "type": "integer"
                         },
                         "uint": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
+                          "description": "@minimum 0",
                           "type": "integer"
                         },
                         "float": {
@@ -431,18 +452,21 @@
                       "type": "integer"
                     },
                     "uint": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
+                      "description": "@minimum 0",
                       "type": "integer"
                     },
                     "float": {

--- a/test/schemas/llm.application/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/claude/ConstantAtomicTagged.json
@@ -32,6 +32,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -77,6 +78,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -113,6 +115,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -156,6 +159,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]
@@ -198,6 +202,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -237,6 +242,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -276,6 +282,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -323,6 +330,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/claude/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/claude/TypeTagAtomicUnion.json
@@ -23,13 +23,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -70,13 +70,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -108,13 +108,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -153,13 +153,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }
@@ -197,13 +197,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -238,13 +238,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -279,13 +279,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -328,13 +328,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }

--- a/test/schemas/llm.application/claude/TypeTagType.json
+++ b/test/schemas/llm.application/claude/TypeTagType.json
@@ -24,19 +24,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -85,19 +88,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -137,19 +143,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -196,19 +205,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"
@@ -254,19 +266,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -309,19 +324,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -364,19 +382,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -427,19 +448,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"

--- a/test/schemas/llm.application/gemini/TypeTagType.json
+++ b/test/schemas/llm.application/gemini/TypeTagType.json
@@ -22,19 +22,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -81,19 +84,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -129,19 +135,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -183,19 +192,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "float": {
                   "type": "number"
@@ -237,19 +249,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -285,19 +300,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -333,19 +351,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "@minimum 0"
                     },
                     "float": {
                       "type": "number"
@@ -387,19 +408,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.application/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/llama/ConstantAtomicTagged.json
@@ -32,6 +32,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -77,6 +78,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]
@@ -113,6 +115,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -156,6 +159,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]
@@ -198,6 +202,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -237,6 +242,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -276,6 +282,7 @@
                       },
                       {
                         "type": "integer",
+                        "minimum": 0,
                         "maximum": 100
                       }
                     ]
@@ -323,6 +330,7 @@
                   },
                   {
                     "type": "integer",
+                    "minimum": 0,
                     "maximum": 100
                   }
                 ]

--- a/test/schemas/llm.application/llama/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/llama/TypeTagAtomicUnion.json
@@ -23,13 +23,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -70,13 +70,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }
@@ -108,13 +108,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -153,13 +153,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }
@@ -197,13 +197,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -238,13 +238,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -279,13 +279,13 @@
                         "value": {
                           "oneOf": [
                             {
-                              "type": "number",
-                              "minimum": 3
-                            },
-                            {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 7
+                            },
+                            {
+                              "type": "number",
+                              "minimum": 3
                             }
                           ]
                         }
@@ -328,13 +328,13 @@
                     "value": {
                       "oneOf": [
                         {
-                          "type": "number",
-                          "minimum": 3
-                        },
-                        {
                           "type": "string",
                           "minLength": 3,
                           "maxLength": 7
+                        },
+                        {
+                          "type": "number",
+                          "minimum": 3
                         }
                       ]
                     }

--- a/test/schemas/llm.application/llama/TypeTagType.json
+++ b/test/schemas/llm.application/llama/TypeTagType.json
@@ -24,19 +24,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -85,19 +88,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"
@@ -137,19 +143,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -196,19 +205,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"
@@ -254,19 +266,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -309,19 +324,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -364,19 +382,22 @@
                           "type": "integer"
                         },
                         "uint": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int32": {
                           "type": "integer"
                         },
                         "uint32": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "int64": {
                           "type": "integer"
                         },
                         "uint64": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         },
                         "float": {
                           "type": "number"
@@ -427,19 +448,22 @@
                       "type": "integer"
                     },
                     "uint": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int32": {
                       "type": "integer"
                     },
                     "uint32": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "int64": {
                       "type": "integer"
                     },
                     "uint64": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "float": {
                       "type": "number"

--- a/test/schemas/llm.parameters/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/3.0/ConstantAtomicTagged.json
@@ -15,6 +15,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             },
             {
@@ -47,6 +48,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             },
             {
@@ -79,6 +81,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             },
             {
@@ -111,6 +114,7 @@
           "oneOf": [
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             },
             {
@@ -145,6 +149,7 @@
             "oneOf": [
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               },
               {

--- a/test/schemas/llm.parameters/3.0/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/3.0/TypeTagAtomicUnion.json
@@ -12,13 +12,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -48,13 +48,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -84,13 +84,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -120,13 +120,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -158,13 +158,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/3.0/TypeTagType.json
+++ b/test/schemas/llm.parameters/3.0/TypeTagType.json
@@ -13,19 +13,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -63,19 +66,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -113,19 +119,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -163,19 +172,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -215,19 +227,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.parameters/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/3.1/ConstantAtomicTagged.json
@@ -23,6 +23,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -59,6 +60,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -94,6 +96,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -130,6 +133,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -167,6 +171,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/3.1/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/3.1/TypeTagAtomicUnion.json
@@ -14,13 +14,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -52,13 +52,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -89,13 +89,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -127,13 +127,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -166,13 +166,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/3.1/TypeTagType.json
+++ b/test/schemas/llm.parameters/3.1/TypeTagType.json
@@ -15,19 +15,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -67,19 +70,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -118,19 +124,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -170,19 +179,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -223,19 +235,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
@@ -17,7 +17,7 @@
           "anyOf": [
             {
               "type": "integer",
-              "description": "@maximum 100"
+              "description": "@minimum 0\n@maximum 100"
             },
             {
               "type": "number",
@@ -52,7 +52,7 @@
               "anyOf": [
                 {
                   "type": "integer",
-                  "description": "@maximum 100"
+                  "description": "@minimum 0\n@maximum 100"
                 },
                 {
                   "type": "number",
@@ -86,7 +86,7 @@
           "anyOf": [
             {
               "type": "integer",
-              "description": "@maximum 100"
+              "description": "@minimum 0\n@maximum 100"
             },
             {
               "type": "number",
@@ -121,7 +121,7 @@
               "anyOf": [
                 {
                   "type": "integer",
-                  "description": "@maximum 100"
+                  "description": "@minimum 0\n@maximum 100"
                 },
                 {
                   "type": "number",
@@ -157,7 +157,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "description": "@maximum 100"
+                "description": "@minimum 0\n@maximum 100"
               },
               {
                 "type": "number",

--- a/test/schemas/llm.parameters/chatgpt/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagAtomicUnion.json
@@ -15,12 +15,12 @@
               "value": {
                 "anyOf": [
                   {
-                    "type": "number",
-                    "description": "@minimum 3"
-                  },
-                  {
                     "type": "string",
                     "description": "@minLength 3\n@maxLength 7"
+                  },
+                  {
+                    "type": "number",
+                    "description": "@minimum 3"
                   }
                 ]
               }
@@ -52,12 +52,12 @@
                   "value": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@minimum 3"
-                      },
-                      {
                         "type": "string",
                         "description": "@minLength 3\n@maxLength 7"
+                      },
+                      {
+                        "type": "number",
+                        "description": "@minimum 3"
                       }
                     ]
                   }
@@ -88,12 +88,12 @@
               "value": {
                 "anyOf": [
                   {
-                    "type": "number",
-                    "description": "@minimum 3"
-                  },
-                  {
                     "type": "string",
                     "description": "@minLength 3\n@maxLength 7"
+                  },
+                  {
+                    "type": "number",
+                    "description": "@minimum 3"
                   }
                 ]
               }
@@ -125,12 +125,12 @@
                   "value": {
                     "anyOf": [
                       {
-                        "type": "number",
-                        "description": "@minimum 3"
-                      },
-                      {
                         "type": "string",
                         "description": "@minLength 3\n@maxLength 7"
+                      },
+                      {
+                        "type": "number",
+                        "description": "@minimum 3"
                       }
                     ]
                   }
@@ -163,12 +163,12 @@
                 "value": {
                   "anyOf": [
                     {
-                      "type": "number",
-                      "description": "@minimum 3"
-                    },
-                    {
                       "type": "string",
                       "description": "@minLength 3\n@maxLength 7"
+                    },
+                    {
+                      "type": "number",
+                      "description": "@minimum 3"
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagType.json
@@ -16,18 +16,21 @@
                 "type": "integer"
               },
               "uint": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "float": {
@@ -68,18 +71,21 @@
                     "type": "integer"
                   },
                   "uint": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "float": {
@@ -119,18 +125,21 @@
                 "type": "integer"
               },
               "uint": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
+                "description": "@minimum 0",
                 "type": "integer"
               },
               "float": {
@@ -171,18 +180,21 @@
                     "type": "integer"
                   },
                   "uint": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
+                    "description": "@minimum 0",
                     "type": "integer"
                   },
                   "float": {
@@ -224,18 +236,21 @@
                   "type": "integer"
                 },
                 "uint": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
+                  "description": "@minimum 0",
                   "type": "integer"
                 },
                 "float": {

--- a/test/schemas/llm.parameters/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/claude/ConstantAtomicTagged.json
@@ -23,6 +23,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -59,6 +60,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -94,6 +96,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -130,6 +133,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -167,6 +171,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/claude/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/claude/TypeTagAtomicUnion.json
@@ -14,13 +14,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -52,13 +52,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -89,13 +89,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -127,13 +127,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -166,13 +166,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/claude/TypeTagType.json
+++ b/test/schemas/llm.parameters/claude/TypeTagType.json
@@ -15,19 +15,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -67,19 +70,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -118,19 +124,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -170,19 +179,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -223,19 +235,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.parameters/gemini/TypeTagType.json
+++ b/test/schemas/llm.parameters/gemini/TypeTagType.json
@@ -13,19 +13,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "float": {
                 "type": "number"
@@ -61,19 +64,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "float": {
                 "type": "number"
@@ -109,19 +115,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "float": {
                 "type": "number"
@@ -157,19 +166,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "description": "@minimum 0"
               },
               "float": {
                 "type": "number"
@@ -207,19 +219,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "@minimum 0"
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.parameters/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/llama/ConstantAtomicTagged.json
@@ -23,6 +23,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -59,6 +60,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -94,6 +96,7 @@
             },
             {
               "type": "integer",
+              "minimum": 0,
               "maximum": 100
             }
           ]
@@ -130,6 +133,7 @@
                 },
                 {
                   "type": "integer",
+                  "minimum": 0,
                   "maximum": 100
                 }
               ]
@@ -167,6 +171,7 @@
               },
               {
                 "type": "integer",
+                "minimum": 0,
                 "maximum": 100
               }
             ]

--- a/test/schemas/llm.parameters/llama/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/llama/TypeTagAtomicUnion.json
@@ -14,13 +14,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -52,13 +52,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -89,13 +89,13 @@
               "value": {
                 "oneOf": [
                   {
-                    "type": "number",
-                    "minimum": 3
-                  },
-                  {
                     "type": "string",
                     "minLength": 3,
                     "maxLength": 7
+                  },
+                  {
+                    "type": "number",
+                    "minimum": 3
                   }
                 ]
               }
@@ -127,13 +127,13 @@
                   "value": {
                     "oneOf": [
                       {
-                        "type": "number",
-                        "minimum": 3
-                      },
-                      {
                         "type": "string",
                         "minLength": 3,
                         "maxLength": 7
+                      },
+                      {
+                        "type": "number",
+                        "minimum": 3
                       }
                     ]
                   }
@@ -166,13 +166,13 @@
                 "value": {
                   "oneOf": [
                     {
-                      "type": "number",
-                      "minimum": 3
-                    },
-                    {
                       "type": "string",
                       "minLength": 3,
                       "maxLength": 7
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 3
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/llama/TypeTagType.json
+++ b/test/schemas/llm.parameters/llama/TypeTagType.json
@@ -15,19 +15,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -67,19 +70,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -118,19 +124,22 @@
                 "type": "integer"
               },
               "uint": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int32": {
                 "type": "integer"
               },
               "uint32": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "int64": {
                 "type": "integer"
               },
               "uint64": {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0
               },
               "float": {
                 "type": "number"
@@ -170,19 +179,22 @@
                     "type": "integer"
                   },
                   "uint": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int32": {
                     "type": "integer"
                   },
                   "uint32": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "int64": {
                     "type": "integer"
                   },
                   "uint64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                   },
                   "float": {
                     "type": "number"
@@ -223,19 +235,22 @@
                   "type": "integer"
                 },
                 "uint": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int32": {
                   "type": "integer"
                 },
                 "uint32": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "int64": {
                   "type": "integer"
                 },
                 "uint64": {
-                  "type": "integer"
+                  "type": "integer",
+                  "minimum": 0
                 },
                 "float": {
                   "type": "number"

--- a/test/schemas/llm.schema/3.0/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/3.0/ConstantAtomicTagged.json
@@ -12,6 +12,7 @@
       "oneOf": [
         {
           "type": "integer",
+          "minimum": 0,
           "maximum": 100
         },
         {

--- a/test/schemas/llm.schema/3.0/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.schema/3.0/TypeTagAtomicUnion.json
@@ -9,13 +9,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/llm.schema/3.0/TypeTagType.json
+++ b/test/schemas/llm.schema/3.0/TypeTagType.json
@@ -10,19 +10,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/llm.schema/3.1/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/3.1/ConstantAtomicTagged.json
@@ -20,6 +20,7 @@
         },
         {
           "type": "integer",
+          "minimum": 0,
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/3.1/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.schema/3.1/TypeTagAtomicUnion.json
@@ -11,13 +11,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/llm.schema/3.1/TypeTagType.json
+++ b/test/schemas/llm.schema/3.1/TypeTagType.json
@@ -12,19 +12,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/llm.schema/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/chatgpt/ConstantAtomicTagged.json
@@ -13,7 +13,7 @@
       "anyOf": [
         {
           "type": "integer",
-          "description": "@maximum 100"
+          "description": "@minimum 0\n@maximum 100"
         },
         {
           "type": "number",

--- a/test/schemas/llm.schema/chatgpt/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagAtomicUnion.json
@@ -11,12 +11,12 @@
           "value": {
             "anyOf": [
               {
-                "type": "number",
-                "description": "@minimum 3"
-              },
-              {
                 "type": "string",
                 "description": "@minLength 3\n@maxLength 7"
+              },
+              {
+                "type": "number",
+                "description": "@minimum 3"
               }
             ]
           }

--- a/test/schemas/llm.schema/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.schema/chatgpt/TypeTagType.json
@@ -12,18 +12,21 @@
             "type": "integer"
           },
           "uint": {
+            "description": "@minimum 0",
             "type": "integer"
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
+            "description": "@minimum 0",
             "type": "integer"
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
+            "description": "@minimum 0",
             "type": "integer"
           },
           "float": {

--- a/test/schemas/llm.schema/claude/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/claude/ConstantAtomicTagged.json
@@ -20,6 +20,7 @@
         },
         {
           "type": "integer",
+          "minimum": 0,
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/claude/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.schema/claude/TypeTagAtomicUnion.json
@@ -11,13 +11,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/llm.schema/claude/TypeTagType.json
+++ b/test/schemas/llm.schema/claude/TypeTagType.json
@@ -12,19 +12,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/llm.schema/gemini/TypeTagType.json
+++ b/test/schemas/llm.schema/gemini/TypeTagType.json
@@ -10,19 +10,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@minimum 0"
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@minimum 0"
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "description": "@minimum 0"
           },
           "float": {
             "type": "number"

--- a/test/schemas/llm.schema/llama/ConstantAtomicTagged.json
+++ b/test/schemas/llm.schema/llama/ConstantAtomicTagged.json
@@ -20,6 +20,7 @@
         },
         {
           "type": "integer",
+          "minimum": 0,
           "maximum": 100
         }
       ]

--- a/test/schemas/llm.schema/llama/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.schema/llama/TypeTagAtomicUnion.json
@@ -11,13 +11,13 @@
           "value": {
             "oneOf": [
               {
-                "type": "number",
-                "minimum": 3
-              },
-              {
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 7
+              },
+              {
+                "type": "number",
+                "minimum": 3
               }
             ]
           }

--- a/test/schemas/llm.schema/llama/TypeTagType.json
+++ b/test/schemas/llm.schema/llama/TypeTagType.json
@@ -12,19 +12,22 @@
             "type": "integer"
           },
           "uint": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int32": {
             "type": "integer"
           },
           "uint32": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "int64": {
             "type": "integer"
           },
           "uint64": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
           },
           "float": {
             "type": "number"

--- a/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
@@ -710,7 +710,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]
@@ -802,7 +803,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
@@ -710,7 +710,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]
@@ -802,7 +803,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
@@ -710,7 +710,8 @@
                     "validate": "$importInternal(\"isTypeUint32\")($input)",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]
@@ -802,7 +803,8 @@
                     "validate": "BigInt(0) <= $input",
                     "exclusive": true,
                     "schema": {
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     }
                   }
                 ]

--- a/test/schemas/reflect/metadata/ConstantAtomicTagged.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicTagged.json
@@ -163,7 +163,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       },
                       {

--- a/test/schemas/reflect/metadata/DynamicTag.json
+++ b/test/schemas/reflect/metadata/DynamicTag.json
@@ -105,7 +105,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
+++ b/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
@@ -150,7 +150,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
@@ -165,7 +165,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       },
                       {

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
@@ -207,7 +207,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -335,7 +336,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
@@ -207,7 +207,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -335,7 +336,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
@@ -207,7 +207,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -335,7 +336,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagAtomicUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagAtomicUnion.json
@@ -136,27 +136,6 @@
               "functions": [],
               "atomics": [
                 {
-                  "type": "number",
-                  "tags": [
-                    [
-                      {
-                        "target": "number",
-                        "name": "Minimum<3>",
-                        "kind": "minimum",
-                        "value": 3,
-                        "validate": "3 <= $input",
-                        "exclusive": [
-                          "minimum",
-                          "exclusiveMinimum"
-                        ],
-                        "schema": {
-                          "minimum": 3
-                        }
-                      }
-                    ]
-                  ]
-                },
-                {
                   "type": "string",
                   "tags": [
                     [
@@ -180,6 +159,27 @@
                         "exclusive": true,
                         "schema": {
                           "maxLength": 7
+                        }
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "type": "number",
+                  "tags": [
+                    [
+                      {
+                        "target": "number",
+                        "name": "Minimum<3>",
+                        "kind": "minimum",
+                        "value": 3,
+                        "validate": "3 <= $input",
+                        "exclusive": [
+                          "minimum",
+                          "exclusiveMinimum"
+                        ],
+                        "schema": {
+                          "minimum": 3
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagType.json
+++ b/test/schemas/reflect/metadata/TypeTagType.json
@@ -218,7 +218,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -360,7 +361,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -502,7 +504,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
@@ -136,7 +136,8 @@
                         "validate": "BigInt(0) <= $input",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/schemas/reflect/metadata/TypeTagTypeUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeUnion.json
@@ -92,7 +92,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -260,7 +261,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -512,7 +514,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]
@@ -848,7 +851,8 @@
                         "validate": "$importInternal(\"isTypeUint32\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ],
@@ -900,7 +904,8 @@
                         "validate": "$importInternal(\"isTypeUint64\")($input)",
                         "exclusive": true,
                         "schema": {
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     ]

--- a/test/src/debug/schema.ts
+++ b/test/src/debug/schema.ts
@@ -1,9 +1,5 @@
-import typia from "typia";
+import typia, { tags } from "typia";
 
-import { TypeTagObjectUnion } from "../structures/TypeTagObjectUnion";
-
-const collection = typia.json.schemas<[TypeTagObjectUnion], "3.0">();
 console.log(
-  //JSON.stringify(collection, null, 2)
-  collection.components.schemas?.TypeTagObjectUnion,
+  typia.llm.schema<number & tags.Type<"uint32"> & tags.Minimum<10>, "3.0">(),
 );

--- a/test/src/debug/schema.ts
+++ b/test/src/debug/schema.ts
@@ -2,4 +2,8 @@ import typia, { tags } from "typia";
 
 console.log(
   typia.llm.schema<number & tags.Type<"uint32"> & tags.Minimum<10>, "3.0">(),
+  typia.llm.schema<
+    number & tags.Type<"uint32"> & tags.ExclusiveMinimum<10>,
+    "3.0"
+  >(),
 );


### PR DESCRIPTION
This pull request includes several updates to dependencies and schema definitions. The most important changes include updating the `@samchon/openapi` dependency version, adding minimum values to integer types in various schema files, and modifying the `Type.ts` file to include specific schema definitions for `uint32` and `uint64`.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R44): Updated the version of the `@samchon/openapi` dependency from `4.0.0-dev.20250405-3` to `4.0.0-dev.20250405-4`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13): Updated the `@samchon/openapi` dependency version in multiple places to `4.0.0-dev.20250405-4`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL828-R829) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4093-R4093)

Schema updates:

* [`src/tags/Type.ts`](diffhunk://#diff-5000940b4248b6ff40293c1ee4d32f54daf4c0137dd6bd37cb9c463d3b58b407L27-R32): Modified the `schema` property to include specific definitions for `uint32` and `uint64` types.
* Various schema files: Added a `minimum` value of `0` to integer types in multiple JSON schema files. [[1]](diffhunk://#diff-bf75082abce30e0838cd4655af8d29451d6796f29df6bf0a6f76f0ac7374239fR1744) [[2]](diffhunk://#diff-3b5645279e0fe4a1082d6d8a8eff4d15dea16aa8521cb1c807d9139e2b1f58a4R42) [[3]](diffhunk://#diff-e1dfd187f1fd4410862cb916a63887d44058f338f6fb9d76ec85a1af90ae4bbdR1744) [[4]](diffhunk://#diff-f33ba44ed8649fde416e034ff5284af6c06bd6e5d05f0579d94b1a2124240da0R19) [[5]](diffhunk://#diff-c71e2fec55e61c1aad96c223c30d1e2e6701374c9c6c1f6ced8ea5e1a0a33983L24-R31) [[6]](diffhunk://#diff-19a00b7cb04538d06f2a76d66e0857bfae8b4a8605a6ec5b255853ae2474e09aL26-R41) [[7]](diffhunk://#diff-8c787f89ccad740689641b23f233c2ed23161b2329a90291730e3b0457b1feeeR26) [[8]](diffhunk://#diff-10926afd7653348bd35b0b907c48fe2d1fbbb039727ad6da2ae28422ec05cfd3L24-R31) [[9]](diffhunk://#diff-4dc6555198459aae14a98b5f99b9e344f98ceffceee476485f6f4211e50b27d6L26-R41) [[10]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R28) [[11]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R73) [[12]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R106) [[13]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R146) [[14]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R185) [[15]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R218) [[16]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R251) [[17]](diffhunk://#diff-c69a6c7c1aa64dc293bc34c3e7317e84b601cccf9694119fa499179bd9ae9587R291) [[18]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL24-R31) [[19]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL72-R79) [[20]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL108-R115) [[21]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL151-R158) [[22]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL193-R200) [[23]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL229-R236) [[24]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL265-R272) [[25]](diffhunk://#diff-b613eb99328b40ea09ef33e829d4596592d48abc42f0f55bcaee59d055e8d67bL308-R315) [[26]](diffhunk://#diff-6ea7f94e5f81890a5d705cdb51f05fa0b3b0352a32738214368cc4221d9eb762L26-R41) [[27]](diffhunk://#diff-6ea7f94e5f81890a5d705cdb51f05fa0b3b0352a32738214368cc4221d9eb762L88-R106)