### PR TITLE
Close #1568: native type from `@types/node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/factories/internal/metadata/iterate_metadata_native.ts
+++ b/src/factories/internal/metadata/iterate_metadata_native.ts
@@ -10,12 +10,13 @@ import { IMetadataIteratorProps } from "./IMetadataIteratorProps";
 export const iterate_metadata_native = (
   props: IMetadataIteratorProps,
 ): boolean => {
-  const name: string =
+  const name: string = getNativeName(
     TypeFactory.getFullName({
       checker: props.checker,
       type: props.type,
       symbol: props.type.getSymbol(),
-    }).split("<")?.[0] ?? "";
+    }),
+  );
   const simple: IClassInfo | undefined = SIMPLES.get(name);
   if (
     simple !== undefined &&
@@ -114,6 +115,14 @@ const getBinaryProps = (className: string): IClassInfo => ({
     }),
   ),
 });
+
+const getNativeName = (name: string): string => {
+  name = name.split("<")?.[0] ?? "";
+  if (name.startsWith('"') && name.slice(0).includes('".'))
+    name = name.slice(name.indexOf('".', 1) + 2);
+  return name;
+};
+
 const SIMPLES: Map<string, IClassInfo> = new Map([
   [
     "Date",

--- a/test/src/features/issues/test_issue_1568_native_class_from_node.ts
+++ b/test/src/features/issues/test_issue_1568_native_class_from_node.ts
@@ -3,7 +3,7 @@ import typia from "typia";
 
 import { TestValidator } from "../../helpers/TestValidator";
 
-export const test_issue_1588_native_class_from_node = (): void => {
+export const test_issue_1568_native_class_from_node = (): void => {
   TestValidator.equals("native")(
     typia.reflect
       .metadata<[Blob | File]>()

--- a/test/src/features/issues/test_issue_1588_native_class_from_node.ts
+++ b/test/src/features/issues/test_issue_1588_native_class_from_node.ts
@@ -1,0 +1,13 @@
+import { Blob, File } from "node:buffer";
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_1588_native_class_from_node = (): void => {
+  TestValidator.equals("native")(
+    typia.reflect
+      .metadata<[Blob | File]>()
+      .metadatas[0]?.natives.map((n) => n.name)
+      .sort(),
+  )(["Blob", "File"]);
+};


### PR DESCRIPTION
This pull request includes several changes to improve functionality and add new features. The most important changes include a version update in `package.json`, a refactor in `iterate_metadata_native.ts`, and a new test case for native class handling.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `9.1.0` to `9.1.1`.

Refactors and new functions:

* [`src/factories/internal/metadata/iterate_metadata_native.ts`](diffhunk://#diff-1984eb78e45cb2d8b1d0d02874ec3cf483cc6babcbe85d9c33b24b7568e0b41fL13-R19): Refactored the `name` variable assignment to use the new `getNativeName` function. Added the `getNativeName` function to handle name processing. [[1]](diffhunk://#diff-1984eb78e45cb2d8b1d0d02874ec3cf483cc6babcbe85d9c33b24b7568e0b41fL13-R19) [[2]](diffhunk://#diff-1984eb78e45cb2d8b1d0d02874ec3cf483cc6babcbe85d9c33b24b7568e0b41fR118-R125)

New test case:

* [`test/src/features/issues/test_issue_1588_native_class_from_node.ts`](diffhunk://#diff-84d9e4da96e16bcf6d384533a0b7144083f7a3930dcda0c19c1cffa1a958ef5bR1-R13): Added a new test case to validate the handling of native classes `Blob` and `File` from the `node:buffer` module.