### PR TITLE
Upgrade `@samchon/openapi` only in `pnpm-lock.yaml`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: ^4.0.0
-        version: 4.0.0
+        version: 4.1.0
       commander:
         specifier: ^10.0.0
         version: 10.0.1
@@ -29,13 +29,13 @@ importers:
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^26.0.1
-        version: 26.0.3(rollup@4.37.0)
+        version: 26.0.3(rollup@4.40.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
-        version: 15.3.1(rollup@4.37.0)
+        version: 15.3.1(rollup@4.40.0)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.37.0)(tslib@2.8.1)(typescript@5.8.3)
+        version: 11.1.6(rollup@4.40.0)(tslib@2.8.1)(typescript@5.8.3)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
@@ -44,16 +44,16 @@ importers:
         version: 8.2.10
       '@types/node':
         specifier: ^18.15.12
-        version: 18.19.84
+        version: 18.19.86
       '@types/ts-expose-internals':
         specifier: npm:ts-expose-internals@5.5.4
         version: ts-expose-internals@5.5.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.1.0
-        version: 8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+        version: 8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^8.1.0
-        version: 8.28.0(eslint@8.57.1)(typescript@5.8.3)
+        version: 8.29.1(eslint@8.57.1)(typescript@5.8.3)
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -68,13 +68,13 @@ importers:
         version: 5.0.10
       rollup:
         specifier: ^4.18.0
-        version: 4.37.0
+        version: 4.40.0
       rollup-plugin-auto-external:
         specifier: ^2.0.0
-        version: 2.0.0(rollup@4.37.0)
+        version: 2.0.0(rollup@4.40.0)
       rollup-plugin-node-externals:
         specifier: ^8.0.0
-        version: 8.0.0(rollup@4.37.0)
+        version: 8.0.0(rollup@4.40.0)
       suppress-warnings:
         specifier: ^1.0.2
         version: 1.0.2
@@ -83,7 +83,7 @@ importers:
         version: 0.2.12
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.19.84)(typescript@5.8.3)
+        version: 10.9.2(@types/node@18.19.86)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -141,7 +141,7 @@ importers:
         version: 4.17.21
       '@types/node':
         specifier: ^18.15.12
-        version: 18.19.84
+        version: 18.19.86
       '@types/physical-cpu-count':
         specifier: ^2.0.0
         version: 2.0.2
@@ -201,13 +201,13 @@ importers:
         version: 0.10.3
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.84)(typescript@5.8.2)
+        version: 10.9.2(@types/node@18.19.86)(typescript@5.8.3)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
         specifier: ~5.8.2
-        version: 5.8.2
+        version: 5.8.3
       zod:
         specifier: ^3.19.1
         version: 3.24.2
@@ -216,7 +216,7 @@ importers:
     dependencies:
       openai:
         specifier: ^4.90.0
-        version: 4.90.0(ws@8.18.1)(zod@3.24.2)
+        version: 4.93.0(ws@8.18.1)(zod@3.24.2)
       typia:
         specifier: workspace:^
         version: link:..
@@ -226,7 +226,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.9.4
-        version: 20.17.28
+        version: 20.17.30
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -241,7 +241,7 @@ importers:
         version: 3.3.0
       typescript:
         specifier: ~5.8.2
-        version: 5.8.2
+        version: 5.8.3
 
   test:
     dependencies:
@@ -278,7 +278,7 @@ importers:
         version: 0.11.25
       '@types/node':
         specifier: ^20.9.4
-        version: 20.17.28
+        version: 20.17.30
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
@@ -290,7 +290,7 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.17.28)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.8.3)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -312,7 +312,7 @@ importers:
         version: 3.3.0
       typescript:
         specifier: ~5.8.2
-        version: 5.8.2
+        version: 5.8.3
 
   test-esm:
     dependencies:
@@ -325,13 +325,13 @@ importers:
         version: 0.11.25
       '@types/node':
         specifier: ^22.10.1
-        version: 22.13.14
+        version: 22.14.1
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
         specifier: ~5.8.2
-        version: 5.8.2
+        version: 5.8.3
 
 packages:
 
@@ -355,20 +355,20 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-cognito-identity@3.777.0':
-    resolution: {integrity: sha512-VGtFI3SH+jKfPln+9CM16F9zKieIqSxUSZNzQ6WZahPDVC79VmlG6QkXCqgm9Y4qZf4ebcdMhO23+FkR4s9vhA==}
+  '@aws-sdk/client-cognito-identity@3.787.0':
+    resolution: {integrity: sha512-7v6nywZ5wcQxX7qdZ5M1ld15QdkzLU6fAKiEqbvJKu4dM8cFW6As+DbS990Mg46pp1xM/yvme+51xZDTfTfJZA==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/client-sso@3.777.0':
-    resolution: {integrity: sha512-0+z6CiAYIQa7s6FJ+dpBYPi9zr9yY5jBg/4/FGcwYbmqWPXwL9Thdtr0FearYRZgKl7bhL3m3dILCCfWqr3teQ==}
+  '@aws-sdk/client-sso@3.787.0':
+    resolution: {integrity: sha512-L8R+Mh258G0DC73ktpSVrG4TT9i2vmDLecARTDR/4q5sRivdDQSL5bUp3LKcK80Bx+FRw3UETIlX6mYMLL9PJQ==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/core@3.775.0':
     resolution: {integrity: sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-cognito-identity@3.777.0':
-    resolution: {integrity: sha512-lNvz3v94TvEcBvQqVUyg+c/aL3Max+8wUMXvehWoQPv9y9cJAHciZqvA/G+yFo/JB+1Y4IBpMu09W2lfpT6Euw==}
+  '@aws-sdk/credential-provider-cognito-identity@3.787.0':
+    resolution: {integrity: sha512-nF5XjgvZHFuyttOeTjMgfEsg6slZPQ6uI34yzq12Kq4icFgcD4bQsijnQClMN7A0u5qR8Ad8kume4b7+I2++Ig==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-env@3.775.0':
@@ -379,28 +379,28 @@ packages:
     resolution: {integrity: sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.777.0':
-    resolution: {integrity: sha512-1X9mCuM9JSQPmQ+D2TODt4THy6aJWCNiURkmKmTIPRdno7EIKgAqrr/LLN++K5mBf54DZVKpqcJutXU2jwo01A==}
+  '@aws-sdk/credential-provider-ini@3.787.0':
+    resolution: {integrity: sha512-hc2taRoDlXn2uuNuHWDJljVWYrp3r9JF1a/8XmOAZhVUNY+ImeeStylHXhXXKEA4JOjW+5PdJj0f1UDkVCHJiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.777.0':
-    resolution: {integrity: sha512-ZD66ywx1Q0KyUSuBXZIQzBe3Q7MzX8lNwsrCU43H3Fww+Y+HB3Ncws9grhSdNhKQNeGmZ+MgKybuZYaaeLwJEQ==}
+  '@aws-sdk/credential-provider-node@3.787.0':
+    resolution: {integrity: sha512-JioVi44B1vDMaK2CdzqimwvJD3uzvzbQhaEWXsGMBcMcNHajXAXf08EF50JG3ZhLrhhUsT1ObXpbTaPINOhh+g==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-process@3.775.0':
     resolution: {integrity: sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.777.0':
-    resolution: {integrity: sha512-9mPz7vk9uE4PBVprfINv4tlTkyq1OonNevx2DiXC1LY4mCUCNN3RdBwAY0BTLzj0uyc3k5KxFFNbn3/8ZDQP7w==}
+  '@aws-sdk/credential-provider-sso@3.787.0':
+    resolution: {integrity: sha512-fHc08bsvwm4+dEMEQKnQ7c1irEQmmxbgS+Fq41y09pPvPh31nAhoMcjBSTWAaPHvvsRbTYvmP4Mf12ZGr8/nfg==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.777.0':
-    resolution: {integrity: sha512-uGCqr47fnthkqwq5luNl2dksgcpHHjSXz2jUra7TXtFOpqvnhOW8qXjoa1ivlkq8qhqlaZwCzPdbcN0lXpmLzQ==}
+  '@aws-sdk/credential-provider-web-identity@3.787.0':
+    resolution: {integrity: sha512-SobmCwNbk6TfEsF283mZPQEI5vV2j6eY5tOCj8Er4Lzraxu9fBPADV+Bib2A8F6jlB1lMPJzOuDCbEasSt/RIw==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-providers@3.777.0':
-    resolution: {integrity: sha512-t1UyC1dUa4aph+kFixR0+5naKtDYZEtN2+PrDig4l1IvxJlD5rRRGodcVqi1duQjqfvhBwa7UPiHz5M4eRli7g==}
+  '@aws-sdk/credential-providers@3.787.0':
+    resolution: {integrity: sha512-kR3RtI7drOc9pho13vWbUC2Bvrx9A0G4iizBDGmTs08NOdg4w3c1I4kdLG9tyPiIMeVnH+wYrsli5CM7xIfqiA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/middleware-host-header@3.775.0':
@@ -415,28 +415,28 @@ packages:
     resolution: {integrity: sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.775.0':
-    resolution: {integrity: sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==}
+  '@aws-sdk/middleware-user-agent@3.787.0':
+    resolution: {integrity: sha512-Lnfj8SmPLYtrDFthNIaNj66zZsBCam+E4XiUDr55DIHTGstH6qZ/q6vg0GfbukxwSmUcGMwSR4Qbn8rb8yd77g==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/nested-clients@3.777.0':
-    resolution: {integrity: sha512-bmmVRsCjuYlStYPt06hr+f8iEyWg7+AklKCA8ZLDEJujXhXIowgUIqXmqpTkXwkVvDQ9tzU7hxaONjyaQCGybA==}
+  '@aws-sdk/nested-clients@3.787.0':
+    resolution: {integrity: sha512-xk03q1xpKNHgbuo+trEf1dFrI239kuMmjKKsqLEsHlAZbuFq4yRGMlHBrVMnKYOPBhVFDS/VineM991XI52fKg==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/region-config-resolver@3.775.0':
     resolution: {integrity: sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/token-providers@3.777.0':
-    resolution: {integrity: sha512-Yc2cDONsHOa4dTSGOev6Ng2QgTKQUEjaUnsyKd13pc/nLLz/WLqHiQ/o7PcnKERJxXGs1g1C6l3sNXiX+kbnFQ==}
+  '@aws-sdk/token-providers@3.787.0':
+    resolution: {integrity: sha512-d7/NIqxq308Zg0RPMNrmn0QvzniL4Hx8Qdwzr6YZWLYAbUSvZYS2ppLR3BFWSkV6SsTJUx8BuDaj3P8vttkrog==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/types@3.775.0':
     resolution: {integrity: sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/util-endpoints@3.775.0':
-    resolution: {integrity: sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==}
+  '@aws-sdk/util-endpoints@3.787.0':
+    resolution: {integrity: sha512-fd3zkiOkwnbdbN0Xp9TsP5SWrmv0SpT70YEdbb8wAj2DWQwiCmFszaSs+YCvhoCdmlR3Wl9Spu0pGpSAGKeYvQ==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/util-locate-window@3.723.0':
@@ -446,8 +446,8 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.775.0':
     resolution: {integrity: sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==}
 
-  '@aws-sdk/util-user-agent-node@3.775.0':
-    resolution: {integrity: sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==}
+  '@aws-sdk/util-user-agent-node@3.787.0':
+    resolution: {integrity: sha512-mG7Lz8ydfG4SF9e8WSXiPQ/Lsn3n8A5B5jtPROidafi06I3ckV2WxyMLdwG14m919NoS6IOfWHyRGSqWIwbVKA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -563,8 +563,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@eslint-community/eslint-utils@4.5.1':
-    resolution: {integrity: sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==}
+  '@eslint-community/eslint-utils@4.6.0':
+    resolution: {integrity: sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -636,8 +636,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@mongodb-js/saslprep@1.2.0':
-    resolution: {integrity: sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==}
+  '@mongodb-js/saslprep@1.2.2':
+    resolution: {integrity: sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -725,108 +725,108 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.37.0':
-    resolution: {integrity: sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==}
+  '@rollup/rollup-android-arm-eabi@4.40.0':
+    resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.37.0':
-    resolution: {integrity: sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==}
+  '@rollup/rollup-android-arm64@4.40.0':
+    resolution: {integrity: sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.37.0':
-    resolution: {integrity: sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==}
+  '@rollup/rollup-darwin-arm64@4.40.0':
+    resolution: {integrity: sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.37.0':
-    resolution: {integrity: sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==}
+  '@rollup/rollup-darwin-x64@4.40.0':
+    resolution: {integrity: sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.37.0':
-    resolution: {integrity: sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==}
+  '@rollup/rollup-freebsd-arm64@4.40.0':
+    resolution: {integrity: sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.37.0':
-    resolution: {integrity: sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==}
+  '@rollup/rollup-freebsd-x64@4.40.0':
+    resolution: {integrity: sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
-    resolution: {integrity: sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.0':
+    resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
-    resolution: {integrity: sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==}
+  '@rollup/rollup-linux-arm-musleabihf@4.40.0':
+    resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.37.0':
-    resolution: {integrity: sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==}
+  '@rollup/rollup-linux-arm64-gnu@4.40.0':
+    resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.37.0':
-    resolution: {integrity: sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==}
+  '@rollup/rollup-linux-arm64-musl@4.40.0':
+    resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
-    resolution: {integrity: sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
+    resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
-    resolution: {integrity: sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
+    resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
-    resolution: {integrity: sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.40.0':
+    resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.37.0':
-    resolution: {integrity: sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==}
+  '@rollup/rollup-linux-riscv64-musl@4.40.0':
+    resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.37.0':
-    resolution: {integrity: sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==}
+  '@rollup/rollup-linux-s390x-gnu@4.40.0':
+    resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.37.0':
-    resolution: {integrity: sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==}
+  '@rollup/rollup-linux-x64-gnu@4.40.0':
+    resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.37.0':
-    resolution: {integrity: sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==}
+  '@rollup/rollup-linux-x64-musl@4.40.0':
+    resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.37.0':
-    resolution: {integrity: sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==}
+  '@rollup/rollup-win32-arm64-msvc@4.40.0':
+    resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.37.0':
-    resolution: {integrity: sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==}
+  '@rollup/rollup-win32-ia32-msvc@4.40.0':
+    resolution: {integrity: sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.37.0':
-    resolution: {integrity: sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==}
+  '@rollup/rollup-win32-x64-msvc@4.40.0':
+    resolution: {integrity: sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==}
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@4.0.0':
-    resolution: {integrity: sha512-fzji+KTrLqb3rD6RZID7N1cTN7aDwd0KAq0fP4rl2p1dHEy3uybqS7bP9BjMWP10k0DvFaS+P+g8+a/PA0FyZw==}
+  '@samchon/openapi@4.1.0':
+    resolution: {integrity: sha512-UUFBI6n8R9+V0xt4scGEaQ0rib04cOVARhu7DXBZuEG0ExiTFPoiW49+qYFwE44LjYpfxBIlNkd+rcpiRGhsNA==}
 
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
@@ -1143,9 +1143,6 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -1170,14 +1167,14 @@ packages:
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
-  '@types/node@18.19.84':
-    resolution: {integrity: sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==}
+  '@types/node@18.19.86':
+    resolution: {integrity: sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==}
 
-  '@types/node@20.17.28':
-    resolution: {integrity: sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==}
+  '@types/node@20.17.30':
+    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
 
-  '@types/node@22.13.14':
-    resolution: {integrity: sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==}
+  '@types/node@22.14.1':
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/physical-cpu-count@2.0.2':
     resolution: {integrity: sha512-dWrdOZd9fy8HGz77lN+yX3hBAsSDDSizGD5Ho/SNDUmm2hQlxmCR3rQbULOwV8+83RHiy8icF4D3urQSMy2Vaw==}
@@ -1224,16 +1221,16 @@ packages:
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
 
-  '@typescript-eslint/eslint-plugin@8.28.0':
-    resolution: {integrity: sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==}
+  '@typescript-eslint/eslint-plugin@8.29.1':
+    resolution: {integrity: sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/parser@8.28.0':
-    resolution: {integrity: sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==}
+  '@typescript-eslint/parser@8.29.1':
+    resolution: {integrity: sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1243,12 +1240,12 @@ packages:
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/scope-manager@8.28.0':
-    resolution: {integrity: sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==}
+  '@typescript-eslint/scope-manager@8.29.1':
+    resolution: {integrity: sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.28.0':
-    resolution: {integrity: sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==}
+  '@typescript-eslint/type-utils@8.29.1':
+    resolution: {integrity: sha512-DkDUSDwZVCYN71xA4wzySqqcZsHKic53A4BLqmrWFFpOpNSoxX233lwGu/2135ymTCR04PoKiEEEvN1gFYg4Tw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1258,8 +1255,8 @@ packages:
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/types@8.28.0':
-    resolution: {integrity: sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==}
+  '@typescript-eslint/types@8.29.1':
+    resolution: {integrity: sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
@@ -1271,8 +1268,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/typescript-estree@8.28.0':
-    resolution: {integrity: sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==}
+  '@typescript-eslint/typescript-estree@8.29.1':
+    resolution: {integrity: sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -1283,8 +1280,8 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
-  '@typescript-eslint/utils@8.28.0':
-    resolution: {integrity: sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==}
+  '@typescript-eslint/utils@8.29.1':
+    resolution: {integrity: sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1294,8 +1291,8 @@ packages:
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/visitor-keys@8.28.0':
-    resolution: {integrity: sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==}
+  '@typescript-eslint/visitor-keys@8.29.1':
+    resolution: {integrity: sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -1491,8 +1488,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001707:
-    resolution: {integrity: sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==}
+  caniuse-lite@1.0.30001713:
+    resolution: {integrity: sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1779,8 +1776,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.128:
-    resolution: {integrity: sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==}
+  electron-to-chromium@1.5.136:
+    resolution: {integrity: sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2127,8 +2124,8 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  http-parser-js@0.5.9:
-    resolution: {integrity: sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==}
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -2519,8 +2516,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openai@4.90.0:
-    resolution: {integrity: sha512-YCuHMMycqtCg1B8G9ezkOF0j8UnBWD3Al/zYaelpuXwU1yhCEv+Y4n9G20MnyGy6cH4GsFwOMrgstQ+bgG1PtA==}
+  openai@4.93.0:
+    resolution: {integrity: sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2792,8 +2789,8 @@ packages:
     peerDependencies:
       rollup: ^4.0.0
 
-  rollup@4.37.0:
-    resolution: {integrity: sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==}
+  rollup@4.40.0:
+    resolution: {integrity: sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3110,11 +3107,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -3126,8 +3118,8 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -3331,21 +3323,21 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/client-cognito-identity@3.777.0':
+  '@aws-sdk/client-cognito-identity@3.787.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.775.0
-      '@aws-sdk/credential-provider-node': 3.777.0
+      '@aws-sdk/credential-provider-node': 3.787.0
       '@aws-sdk/middleware-host-header': 3.775.0
       '@aws-sdk/middleware-logger': 3.775.0
       '@aws-sdk/middleware-recursion-detection': 3.775.0
-      '@aws-sdk/middleware-user-agent': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.787.0
       '@aws-sdk/region-config-resolver': 3.775.0
       '@aws-sdk/types': 3.775.0
-      '@aws-sdk/util-endpoints': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
       '@aws-sdk/util-user-agent-browser': 3.775.0
-      '@aws-sdk/util-user-agent-node': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.787.0
       '@smithy/config-resolver': 4.1.0
       '@smithy/core': 3.2.0
       '@smithy/fetch-http-handler': 5.0.2
@@ -3376,7 +3368,7 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/client-sso@3.777.0':
+  '@aws-sdk/client-sso@3.787.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -3384,12 +3376,12 @@ snapshots:
       '@aws-sdk/middleware-host-header': 3.775.0
       '@aws-sdk/middleware-logger': 3.775.0
       '@aws-sdk/middleware-recursion-detection': 3.775.0
-      '@aws-sdk/middleware-user-agent': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.787.0
       '@aws-sdk/region-config-resolver': 3.775.0
       '@aws-sdk/types': 3.775.0
-      '@aws-sdk/util-endpoints': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
       '@aws-sdk/util-user-agent-browser': 3.775.0
-      '@aws-sdk/util-user-agent-node': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.787.0
       '@smithy/config-resolver': 4.1.0
       '@smithy/core': 3.2.0
       '@smithy/fetch-http-handler': 5.0.2
@@ -3435,9 +3427,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/credential-provider-cognito-identity@3.777.0':
+  '@aws-sdk/credential-provider-cognito-identity@3.787.0':
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.777.0
+      '@aws-sdk/client-cognito-identity': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
@@ -3469,15 +3461,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/credential-provider-ini@3.777.0':
+  '@aws-sdk/credential-provider-ini@3.787.0':
     dependencies:
       '@aws-sdk/core': 3.775.0
       '@aws-sdk/credential-provider-env': 3.775.0
       '@aws-sdk/credential-provider-http': 3.775.0
       '@aws-sdk/credential-provider-process': 3.775.0
-      '@aws-sdk/credential-provider-sso': 3.777.0
-      '@aws-sdk/credential-provider-web-identity': 3.777.0
-      '@aws-sdk/nested-clients': 3.777.0
+      '@aws-sdk/credential-provider-sso': 3.787.0
+      '@aws-sdk/credential-provider-web-identity': 3.787.0
+      '@aws-sdk/nested-clients': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/credential-provider-imds': 4.0.2
       '@smithy/property-provider': 4.0.2
@@ -3488,14 +3480,14 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-provider-node@3.777.0':
+  '@aws-sdk/credential-provider-node@3.787.0':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.775.0
       '@aws-sdk/credential-provider-http': 3.775.0
-      '@aws-sdk/credential-provider-ini': 3.777.0
+      '@aws-sdk/credential-provider-ini': 3.787.0
       '@aws-sdk/credential-provider-process': 3.775.0
-      '@aws-sdk/credential-provider-sso': 3.777.0
-      '@aws-sdk/credential-provider-web-identity': 3.777.0
+      '@aws-sdk/credential-provider-sso': 3.787.0
+      '@aws-sdk/credential-provider-web-identity': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/credential-provider-imds': 4.0.2
       '@smithy/property-provider': 4.0.2
@@ -3516,11 +3508,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/credential-provider-sso@3.777.0':
+  '@aws-sdk/credential-provider-sso@3.787.0':
     dependencies:
-      '@aws-sdk/client-sso': 3.777.0
+      '@aws-sdk/client-sso': 3.787.0
       '@aws-sdk/core': 3.775.0
-      '@aws-sdk/token-providers': 3.777.0
+      '@aws-sdk/token-providers': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
@@ -3530,10 +3522,10 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-provider-web-identity@3.777.0':
+  '@aws-sdk/credential-provider-web-identity@3.787.0':
     dependencies:
       '@aws-sdk/core': 3.775.0
-      '@aws-sdk/nested-clients': 3.777.0
+      '@aws-sdk/nested-clients': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
@@ -3542,22 +3534,24 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-providers@3.777.0':
+  '@aws-sdk/credential-providers@3.787.0':
     dependencies:
-      '@aws-sdk/client-cognito-identity': 3.777.0
+      '@aws-sdk/client-cognito-identity': 3.787.0
       '@aws-sdk/core': 3.775.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.777.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.787.0
       '@aws-sdk/credential-provider-env': 3.775.0
       '@aws-sdk/credential-provider-http': 3.775.0
-      '@aws-sdk/credential-provider-ini': 3.777.0
-      '@aws-sdk/credential-provider-node': 3.777.0
+      '@aws-sdk/credential-provider-ini': 3.787.0
+      '@aws-sdk/credential-provider-node': 3.787.0
       '@aws-sdk/credential-provider-process': 3.775.0
-      '@aws-sdk/credential-provider-sso': 3.777.0
-      '@aws-sdk/credential-provider-web-identity': 3.777.0
-      '@aws-sdk/nested-clients': 3.777.0
+      '@aws-sdk/credential-provider-sso': 3.787.0
+      '@aws-sdk/credential-provider-web-identity': 3.787.0
+      '@aws-sdk/nested-clients': 3.787.0
       '@aws-sdk/types': 3.775.0
+      '@smithy/config-resolver': 4.1.0
       '@smithy/core': 3.2.0
       '@smithy/credential-provider-imds': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
       tslib: 2.8.1
@@ -3588,18 +3582,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/middleware-user-agent@3.775.0':
+  '@aws-sdk/middleware-user-agent@3.787.0':
     dependencies:
       '@aws-sdk/core': 3.775.0
       '@aws-sdk/types': 3.775.0
-      '@aws-sdk/util-endpoints': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
       '@smithy/core': 3.2.0
       '@smithy/protocol-http': 5.1.0
       '@smithy/types': 4.2.0
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/nested-clients@3.777.0':
+  '@aws-sdk/nested-clients@3.787.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -3607,12 +3601,12 @@ snapshots:
       '@aws-sdk/middleware-host-header': 3.775.0
       '@aws-sdk/middleware-logger': 3.775.0
       '@aws-sdk/middleware-recursion-detection': 3.775.0
-      '@aws-sdk/middleware-user-agent': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.787.0
       '@aws-sdk/region-config-resolver': 3.775.0
       '@aws-sdk/types': 3.775.0
-      '@aws-sdk/util-endpoints': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
       '@aws-sdk/util-user-agent-browser': 3.775.0
-      '@aws-sdk/util-user-agent-node': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.787.0
       '@smithy/config-resolver': 4.1.0
       '@smithy/core': 3.2.0
       '@smithy/fetch-http-handler': 5.0.2
@@ -3653,9 +3647,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/token-providers@3.777.0':
+  '@aws-sdk/token-providers@3.787.0':
     dependencies:
-      '@aws-sdk/nested-clients': 3.777.0
+      '@aws-sdk/nested-clients': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
@@ -3671,7 +3665,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/util-endpoints@3.775.0':
+  '@aws-sdk/util-endpoints@3.787.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/types': 4.2.0
@@ -3692,9 +3686,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/util-user-agent-node@3.775.0':
+  '@aws-sdk/util-user-agent-node@3.787.0':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.787.0
       '@aws-sdk/types': 3.775.0
       '@smithy/node-config-provider': 4.0.2
       '@smithy/types': 4.2.0
@@ -3868,7 +3862,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@8.57.1)':
+  '@eslint-community/eslint-utils@4.6.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
@@ -3954,7 +3948,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mongodb-js/saslprep@1.2.0':
+  '@mongodb-js/saslprep@1.2.2':
     dependencies:
       sparse-bitfield: 3.0.3
     optional: true
@@ -3997,105 +3991,105 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rollup/plugin-commonjs@26.0.3(rollup@4.37.0)':
+  '@rollup/plugin-commonjs@26.0.3(rollup@4.40.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 10.4.5
       is-reference: 1.2.1
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.37.0
+      rollup: 4.40.0
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.37.0)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.40.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.37.0
+      rollup: 4.40.0
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.37.0)(tslib@2.8.1)(typescript@5.8.3)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.40.0)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
       resolve: 1.22.10
       typescript: 5.8.3
     optionalDependencies:
-      rollup: 4.37.0
+      rollup: 4.40.0
       tslib: 2.8.1
 
-  '@rollup/pluginutils@5.1.4(rollup@4.37.0)':
+  '@rollup/pluginutils@5.1.4(rollup@4.40.0)':
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.37.0
+      rollup: 4.40.0
 
-  '@rollup/rollup-android-arm-eabi@4.37.0':
+  '@rollup/rollup-android-arm-eabi@4.40.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.37.0':
+  '@rollup/rollup-android-arm64@4.40.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.37.0':
+  '@rollup/rollup-darwin-arm64@4.40.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.37.0':
+  '@rollup/rollup-darwin-x64@4.40.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.37.0':
+  '@rollup/rollup-freebsd-arm64@4.40.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.37.0':
+  '@rollup/rollup-freebsd-x64@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.37.0':
+  '@rollup/rollup-linux-arm64-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.37.0':
+  '@rollup/rollup-linux-arm64-musl@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.37.0':
+  '@rollup/rollup-linux-riscv64-musl@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.37.0':
+  '@rollup/rollup-linux-s390x-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.37.0':
+  '@rollup/rollup-linux-x64-gnu@4.40.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.37.0':
+  '@rollup/rollup-linux-x64-musl@4.40.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.37.0':
+  '@rollup/rollup-win32-arm64-msvc@4.40.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.37.0':
+  '@rollup/rollup-win32-ia32-msvc@4.40.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.37.0':
+  '@rollup/rollup-win32-x64-msvc@4.40.0':
     optional: true
 
-  '@samchon/openapi@4.0.0': {}
+  '@samchon/openapi@4.1.0': {}
 
   '@sinclair/typebox@0.31.28': {}
 
@@ -4457,22 +4451,22 @@ snapshots:
 
   '@types/autocannon@7.12.6':
     dependencies:
-      '@types/node': 18.19.84
+      '@types/node': 18.19.86
 
   '@types/benchmark@2.1.5': {}
 
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.84
+      '@types/node': 18.19.86
 
   '@types/cli@0.11.25':
     dependencies:
-      '@types/node': 20.17.28
+      '@types/node': 20.17.30
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
 
   '@types/d3-array@3.2.1': {}
 
@@ -4591,13 +4585,11 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
-  '@types/estree@1.0.6': {}
-
   '@types/estree@1.0.7': {}
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -4622,20 +4614,20 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 20.17.30
       form-data: 4.0.2
 
-  '@types/node@18.19.84':
+  '@types/node@18.19.86':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.17.28':
+  '@types/node@20.17.30':
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.13.14':
+  '@types/node@22.14.1':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.21.0
 
   '@types/physical-cpu-count@2.0.2': {}
 
@@ -4648,17 +4640,17 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
       '@types/send': 0.17.4
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
 
   '@types/uuid@10.0.0': {}
 
@@ -4672,25 +4664,25 @@ snapshots:
 
   '@types/websocket@1.0.10':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
 
   '@types/whatwg-url@8.2.2':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 22.14.1
       '@types/webidl-conversions': 7.0.3
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 22.13.14
+      '@types/node': 18.19.86
 
-  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/type-utils': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.28.0
+      '@typescript-eslint/parser': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.29.1
+      '@typescript-eslint/type-utils': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.29.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -4700,12 +4692,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.28.0
+      '@typescript-eslint/scope-manager': 8.29.1
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.29.1
       debug: 4.4.0
       eslint: 8.57.1
       typescript: 5.8.3
@@ -4717,15 +4709,15 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
-  '@typescript-eslint/scope-manager@8.28.0':
+  '@typescript-eslint/scope-manager@8.29.1':
     dependencies:
-      '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/visitor-keys': 8.28.0
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/visitor-keys': 8.29.1
 
-  '@typescript-eslint/type-utils@8.28.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.29.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
       debug: 4.4.0
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.8.3)
@@ -4735,7 +4727,7 @@ snapshots:
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/types@8.28.0': {}
+  '@typescript-eslint/types@8.29.1': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.8.3)':
     dependencies:
@@ -4752,10 +4744,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.28.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.29.1(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/visitor-keys': 8.28.0
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/visitor-keys': 8.29.1
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -4768,7 +4760,7 @@ snapshots:
 
   '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
@@ -4777,12 +4769,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.28.0(eslint@8.57.1)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.29.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.29.1
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.8.3)
       eslint: 8.57.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -4793,9 +4785,9 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
-  '@typescript-eslint/visitor-keys@8.28.0':
+  '@typescript-eslint/visitor-keys@8.29.1':
     dependencies:
-      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/types': 8.29.1
       eslint-visitor-keys: 4.2.0
 
   '@ungap/structured-clone@1.3.0': {}
@@ -4931,7 +4923,7 @@ snapshots:
       has-async-hooks: 1.0.0
       hdr-histogram-js: 3.0.0
       hdr-histogram-percentiles-obj: 3.0.0
-      http-parser-js: 0.5.9
+      http-parser-js: 0.5.10
       hyperid: 3.3.0
       lodash.chunk: 4.2.0
       lodash.clonedeep: 4.5.0
@@ -5001,8 +4993,8 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001707
-      electron-to-chromium: 1.5.128
+      caniuse-lite: 1.0.30001713
+      electron-to-chromium: 1.5.136
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
 
@@ -5035,7 +5027,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001707: {}
+  caniuse-lite@1.0.30001713: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5341,7 +5333,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.128: {}
+  electron-to-chromium@1.5.136: {}
 
   emoji-regex@8.0.0: {}
 
@@ -5409,7 +5401,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.6.0(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
@@ -5776,7 +5768,7 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-parser-js@0.5.9: {}
+  http-parser-js@0.5.10: {}
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -6081,8 +6073,8 @@ snapshots:
       mongodb-connection-string-url: 2.6.0
       socks: 2.8.4
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.777.0
-      '@mongodb-js/saslprep': 1.2.0
+      '@aws-sdk/credential-providers': 3.787.0
+      '@mongodb-js/saslprep': 1.2.2
     transitivePeerDependencies:
       - aws-crt
 
@@ -6154,9 +6146,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.90.0(ws@8.18.1)(zod@3.24.2):
+  openai@4.93.0(ws@8.18.1)(zod@3.24.2):
     dependencies:
-      '@types/node': 18.19.84
+      '@types/node': 18.19.86
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -6308,7 +6300,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.17.28
+      '@types/node': 20.17.30
       long: 5.3.1
 
   proxy-addr@2.0.7:
@@ -6403,42 +6395,42 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
-  rollup-plugin-auto-external@2.0.0(rollup@4.37.0):
+  rollup-plugin-auto-external@2.0.0(rollup@4.40.0):
     dependencies:
       builtins: 2.0.1
       read-pkg: 3.0.0
-      rollup: 4.37.0
+      rollup: 4.40.0
       safe-resolve: 1.0.0
       semver: 5.7.2
 
-  rollup-plugin-node-externals@8.0.0(rollup@4.37.0):
+  rollup-plugin-node-externals@8.0.0(rollup@4.40.0):
     dependencies:
-      rollup: 4.37.0
+      rollup: 4.40.0
 
-  rollup@4.37.0:
+  rollup@4.40.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.37.0
-      '@rollup/rollup-android-arm64': 4.37.0
-      '@rollup/rollup-darwin-arm64': 4.37.0
-      '@rollup/rollup-darwin-x64': 4.37.0
-      '@rollup/rollup-freebsd-arm64': 4.37.0
-      '@rollup/rollup-freebsd-x64': 4.37.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.37.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.37.0
-      '@rollup/rollup-linux-arm64-gnu': 4.37.0
-      '@rollup/rollup-linux-arm64-musl': 4.37.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.37.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.37.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.37.0
-      '@rollup/rollup-linux-riscv64-musl': 4.37.0
-      '@rollup/rollup-linux-s390x-gnu': 4.37.0
-      '@rollup/rollup-linux-x64-gnu': 4.37.0
-      '@rollup/rollup-linux-x64-musl': 4.37.0
-      '@rollup/rollup-win32-arm64-msvc': 4.37.0
-      '@rollup/rollup-win32-ia32-msvc': 4.37.0
-      '@rollup/rollup-win32-x64-msvc': 4.37.0
+      '@rollup/rollup-android-arm-eabi': 4.40.0
+      '@rollup/rollup-android-arm64': 4.40.0
+      '@rollup/rollup-darwin-arm64': 4.40.0
+      '@rollup/rollup-darwin-x64': 4.40.0
+      '@rollup/rollup-freebsd-arm64': 4.40.0
+      '@rollup/rollup-freebsd-x64': 4.40.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.40.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.40.0
+      '@rollup/rollup-linux-arm64-gnu': 4.40.0
+      '@rollup/rollup-linux-arm64-musl': 4.40.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.40.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.40.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.40.0
+      '@rollup/rollup-linux-riscv64-musl': 4.40.0
+      '@rollup/rollup-linux-s390x-gnu': 4.40.0
+      '@rollup/rollup-linux-x64-gnu': 4.40.0
+      '@rollup/rollup-linux-x64-musl': 4.40.0
+      '@rollup/rollup-win32-arm64-msvc': 4.40.0
+      '@rollup/rollup-win32-ia32-msvc': 4.40.0
+      '@rollup/rollup-win32-x64-msvc': 4.40.0
       fsevents: 2.3.3
 
   rrweb-cssom@0.6.0: {}
@@ -6648,7 +6640,7 @@ snapshots:
 
   tgrid@0.10.3:
     dependencies:
-      '@types/node': 20.17.28
+      '@types/node': 20.17.30
       '@types/websocket': 1.0.10
       '@types/ws': 7.4.7
       import2: 1.0.3
@@ -6712,32 +6704,14 @@ snapshots:
 
   ts-expose-internals@5.5.4: {}
 
-  ts-node@10.9.2(@types/node@18.19.84)(typescript@5.8.2):
+  ts-node@10.9.2(@types/node@18.19.86)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.84
-      acorn: 8.14.1
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@18.19.84)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.84
+      '@types/node': 18.19.86
       acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -6748,14 +6722,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.17.28)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@20.17.30)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.28
+      '@types/node': 20.17.30
       acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -6792,15 +6766,13 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript@5.8.2: {}
-
   typescript@5.8.3: {}
 
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.21.0: {}
 
   universalify@0.2.0: {}
 

--- a/test-esm/generate/output/index.ts
+++ b/test-esm/generate/output/index.ts
@@ -17,7 +17,6 @@ const application: ILlmApplication<"chatgpt"> = {
     {
       name: "establishCompany",
       parameters: {
-        description: "",
         type: "object",
         properties: {
           company: {
@@ -28,7 +27,6 @@ const application: ILlmApplication<"chatgpt"> = {
         additionalProperties: false,
         $defs: {
           "default.o1": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -55,7 +53,6 @@ const application: ILlmApplication<"chatgpt"> = {
             required: ["id", "serial", "name", "established_at", "departments"],
           },
           "default.o2": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -400,7 +397,6 @@ const application: ILlmApplication<"chatgpt"> = {
     {
       name: "createDepartment",
       parameters: {
-        description: "",
         type: "object",
         properties: {
           company: {
@@ -414,7 +410,6 @@ const application: ILlmApplication<"chatgpt"> = {
         additionalProperties: false,
         $defs: {
           "default.o1": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -441,7 +436,6 @@ const application: ILlmApplication<"chatgpt"> = {
             required: ["id", "serial", "name", "established_at", "departments"],
           },
           "default.o2": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -806,7 +800,6 @@ const application: ILlmApplication<"chatgpt"> = {
     {
       name: "hire",
       parameters: {
-        description: "",
         type: "object",
         properties: {
           company: {
@@ -823,7 +816,6 @@ const application: ILlmApplication<"chatgpt"> = {
         additionalProperties: false,
         $defs: {
           "default.o1": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -850,7 +842,6 @@ const application: ILlmApplication<"chatgpt"> = {
             required: ["id", "serial", "name", "established_at", "departments"],
           },
           "default.o2": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -1232,7 +1223,6 @@ const application: ILlmApplication<"chatgpt"> = {
     {
       name: "erase",
       parameters: {
-        description: "",
         type: "object",
         properties: {
           entity: {
@@ -1250,7 +1240,6 @@ const application: ILlmApplication<"chatgpt"> = {
         additionalProperties: false,
         $defs: {
           "default.o1": {
-            description: "",
             type: "object",
             properties: {
               id: {
@@ -1277,7 +1266,6 @@ const application: ILlmApplication<"chatgpt"> = {
             required: ["id", "serial", "name", "established_at", "departments"],
           },
           "default.o2": {
-            description: "",
             type: "object",
             properties: {
               id: {

--- a/test/build/internal/TestJsonSchemaGenerator.ts
+++ b/test/build/internal/TestJsonSchemaGenerator.ts
@@ -6,7 +6,7 @@ export namespace TestJsonSchemaGenerator {
   export async function generate(
     structures: TestStructure<any>[],
   ): Promise<void> {
-    await mkdir(`${__dirname}/../../src/features/json.schema`);
+    await mkdir(`${__dirname}/../../src/features/json.schemas`);
     for (const version of ["3.0", "3.1"] as const)
       await functor(structures, version);
   }
@@ -16,7 +16,7 @@ export namespace TestJsonSchemaGenerator {
     version: "3.0" | "3.1",
   ): Promise<void> {
     const title: string = `v${version.replace(".", "_")}`;
-    const path: string = `${__dirname}/../../src/features/json.schema/${title}`;
+    const path: string = `${__dirname}/../../src/features/json.schemas/${title}`;
     await fs.promises.mkdir(path);
 
     for (const s of structures) {
@@ -42,7 +42,7 @@ export namespace TestJsonSchemaGenerator {
   }
 
   export async function schemas(): Promise<void> {
-    const location: string = `${__dirname}/../../schema/json.schema`;
+    const location: string = `${__dirname}/../../schemas/json.schema`;
     await mkdir(location);
 
     for (const version of ["3.0", "3.1"] as const) await iterate(version);
@@ -57,7 +57,7 @@ export namespace TestJsonSchemaGenerator {
   async function iterate(version: "3.0" | "3.1") {
     const title: string = `v${version.replace(".", "_")}`;
     const path: string = `${__dirname}/../../src/features/json.schema/${title}`;
-    const schemaPath: string = `${__dirname}/../../schema/json.schema/${title}`;
+    const schemaPath: string = `${__dirname}/../../schemas/json.schema/${title}`;
     await mkdir(schemaPath);
 
     for (const file of await fs.promises.readdir(path)) {

--- a/test/generate/output/generate_llm.ts
+++ b/test/generate/output/generate_llm.ts
@@ -13,7 +13,6 @@ export const schema = ((props: {
   if (undefined !== props?.$defs)
     Object.assign(props.$defs, {
       ICompany: {
-        description: "",
         type: "object",
         properties: {
           id: {
@@ -40,7 +39,6 @@ export const schema = ((props: {
         required: ["id", "serial", "name", "established_at", "departments"],
       },
       IDepartment: {
-        description: "",
         type: "object",
         properties: {
           id: {
@@ -80,7 +78,6 @@ export const schema = ((props: {
         ],
       },
       IEmployee: {
-        description: "",
         type: "object",
         properties: {
           id: {

--- a/test/schemas/llm.application/chatgpt/ArrayAny.json
+++ b/test/schemas/llm.application/chatgpt/ArrayAny.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -106,7 +105,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -377,7 +375,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayHierarchical.json
+++ b/test/schemas/llm.application/chatgpt/ArrayHierarchical.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -150,7 +149,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -553,7 +551,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayHierarchicalPointer.json
+++ b/test/schemas/llm.application/chatgpt/ArrayHierarchicalPointer.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -158,7 +157,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -585,7 +583,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayMatrix.json
+++ b/test/schemas/llm.application/chatgpt/ArrayMatrix.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -36,7 +35,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -97,7 +95,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayRecursive.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRecursive.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -22,7 +21,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursive.ICategory": {
-            "description": "",
             "type": "object",
             "properties": {
               "children": {
@@ -71,7 +69,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -95,7 +92,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursive.ICategory": {
-            "description": "",
             "type": "object",
             "properties": {
               "children": {
@@ -147,7 +143,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -188,7 +183,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursive.ICategory": {
-            "description": "",
             "type": "object",
             "properties": {
               "children": {

--- a/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionExplicit.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -170,7 +169,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -204,7 +202,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -247,7 +244,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -423,7 +419,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -457,7 +452,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -507,7 +501,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -704,7 +697,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -738,7 +730,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {

--- a/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionExplicitPointer.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionExplicitPointer.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -34,7 +33,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursiveUnionExplicitPointer.IBucket": {
-            "description": "",
             "type": "object",
             "properties": {
               "value": {
@@ -187,7 +185,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -221,7 +218,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -264,7 +260,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -312,7 +307,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursiveUnionExplicitPointer.IBucket": {
-            "description": "",
             "type": "object",
             "properties": {
               "value": {
@@ -465,7 +459,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -499,7 +492,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -557,7 +549,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -634,7 +625,6 @@
         "additionalProperties": false,
         "$defs": {
           "ArrayRecursiveUnionExplicitPointer.IBucket": {
-            "description": "",
             "type": "object",
             "properties": {
               "value": {
@@ -787,7 +777,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -821,7 +810,6 @@
             ]
           },
           "ArrayRecursiveUnionExplicitPointer.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {

--- a/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRecursiveUnionImplicit.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -131,7 +130,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -158,7 +156,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.ISharedDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "access": {
@@ -193,7 +190,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -222,7 +218,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -359,7 +354,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -386,7 +380,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.ISharedDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "access": {
@@ -421,7 +414,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -457,7 +449,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -615,7 +606,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -642,7 +632,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.ISharedDirectory": {
-            "description": "",
             "type": "object",
             "properties": {
               "access": {
@@ -677,7 +666,6 @@
             ]
           },
           "ArrayRecursiveUnionImplicit.IShortcut": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {

--- a/test/schemas/llm.application/chatgpt/ArrayRepeatedNullable.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRepeatedNullable.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -49,7 +48,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -96,7 +94,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayRepeatedRequired.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRepeatedRequired.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -46,7 +45,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -103,7 +101,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayRepeatedUnion.json
+++ b/test/schemas/llm.application/chatgpt/ArrayRepeatedUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -147,7 +146,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -406,7 +404,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArraySimple.json
+++ b/test/schemas/llm.application/chatgpt/ArraySimple.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -67,7 +66,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -221,7 +219,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ArrayUnion.json
+++ b/test/schemas/llm.application/chatgpt/ArrayUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -50,7 +49,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -153,7 +151,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/AtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/AtomicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -44,7 +43,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -129,7 +127,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ClassGetter.json
+++ b/test/schemas/llm.application/chatgpt/ClassGetter.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -50,7 +49,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -153,7 +151,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ClassMethod.json
+++ b/test/schemas/llm.application/chatgpt/ClassMethod.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -39,7 +38,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -109,7 +107,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/chatgpt/ClassPropertyAssignment.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -57,7 +56,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -181,7 +179,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagArray.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagArray.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -83,7 +82,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -285,7 +283,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagArrayUnion.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagArrayUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -74,7 +73,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -249,7 +247,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagAtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagAtomicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -56,7 +55,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -177,7 +175,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagDefault.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagDefault.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -142,7 +141,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -521,7 +519,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagFormat.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagFormat.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -141,7 +140,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -517,7 +515,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagLength.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagLength.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -68,7 +67,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -225,7 +223,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagObjectUnion.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagObjectUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -58,7 +57,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -185,7 +183,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagPattern.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagPattern.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -51,7 +50,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -157,7 +155,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagRange.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagRange.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -88,7 +87,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -305,7 +303,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/CommentTagType.json
+++ b/test/schemas/llm.application/chatgpt/CommentTagType.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -77,7 +76,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -261,7 +259,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicAbsorbed.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -40,7 +39,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -113,7 +111,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicTagged.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -54,7 +53,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -169,7 +167,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ConstantAtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/ConstantAtomicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -30,8 +29,7 @@
                   },
                   "required": [
                     "key"
-                  ],
-                  "description": ""
+                  ]
                 },
                 {
                   "type": "boolean",
@@ -67,7 +65,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -88,8 +85,7 @@
                   },
                   "required": [
                     "key"
-                  ],
-                  "description": ""
+                  ]
                 },
                 {
                   "type": "boolean",
@@ -136,8 +132,7 @@
                       },
                       "required": [
                         "key"
-                      ],
-                      "description": ""
+                      ]
                     },
                     {
                       "type": "boolean",
@@ -191,8 +186,7 @@
               },
               "required": [
                 "key"
-              ],
-              "description": ""
+              ]
             },
             {
               "type": "boolean",
@@ -221,7 +215,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -246,8 +239,7 @@
                       },
                       "required": [
                         "key"
-                      ],
-                      "description": ""
+                      ]
                     },
                     {
                       "type": "boolean",
@@ -297,8 +289,7 @@
                       },
                       "required": [
                         "key"
-                      ],
-                      "description": ""
+                      ]
                     },
                     {
                       "type": "boolean",
@@ -348,8 +339,7 @@
                       },
                       "required": [
                         "key"
-                      ],
-                      "description": ""
+                      ]
                     },
                     {
                       "type": "boolean",
@@ -407,8 +397,7 @@
                   },
                   "required": [
                     "key"
-                  ],
-                  "description": ""
+                  ]
                 },
                 {
                   "type": "boolean",

--- a/test/schemas/llm.application/chatgpt/ConstantConstEnumeration.json
+++ b/test/schemas/llm.application/chatgpt/ConstantConstEnumeration.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -47,7 +46,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -141,7 +139,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ConstantEnumeration.json
+++ b/test/schemas/llm.application/chatgpt/ConstantEnumeration.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -47,7 +46,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -141,7 +139,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/DynamicArray.json
+++ b/test/schemas/llm.application/chatgpt/DynamicArray.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -17,7 +16,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],
@@ -44,7 +42,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -52,7 +49,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],
@@ -77,7 +73,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -109,7 +104,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {},
             "required": [],
@@ -129,7 +123,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -141,7 +134,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -169,7 +161,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -197,7 +188,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -233,7 +223,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],

--- a/test/schemas/llm.application/chatgpt/DynamicComposite.json
+++ b/test/schemas/llm.application/chatgpt/DynamicComposite.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -52,7 +51,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -161,7 +159,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/DynamicConstant.json
+++ b/test/schemas/llm.application/chatgpt/DynamicConstant.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -17,7 +16,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "a": {
@@ -56,7 +54,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -64,7 +61,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "a": {
@@ -101,7 +97,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "a": {
@@ -145,7 +140,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "a": {
@@ -177,7 +171,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -189,7 +182,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "a": {
@@ -229,7 +221,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "a": {
@@ -269,7 +260,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "a": {
@@ -317,7 +307,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "a": {

--- a/test/schemas/llm.application/chatgpt/DynamicEnumeration.json
+++ b/test/schemas/llm.application/chatgpt/DynamicEnumeration.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -17,7 +16,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "ar": {
@@ -69,7 +67,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -77,7 +74,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "ar": {
@@ -127,7 +123,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "ar": {
@@ -184,7 +179,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "ar": {
@@ -229,7 +223,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -241,7 +234,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "ar": {
@@ -294,7 +286,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "ar": {
@@ -347,7 +338,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "ar": {
@@ -408,7 +398,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "ar": {

--- a/test/schemas/llm.application/chatgpt/DynamicNever.json
+++ b/test/schemas/llm.application/chatgpt/DynamicNever.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -29,7 +28,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -69,7 +67,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/DynamicSimple.json
+++ b/test/schemas/llm.application/chatgpt/DynamicSimple.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -17,7 +16,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],
@@ -41,7 +39,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -49,7 +46,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],
@@ -71,7 +67,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -100,7 +95,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {},
             "required": [],
@@ -117,7 +111,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -129,7 +122,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -154,7 +146,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -179,7 +170,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {},
                     "required": [],
@@ -212,7 +202,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {},
                 "required": [],

--- a/test/schemas/llm.application/chatgpt/DynamicTemplate.json
+++ b/test/schemas/llm.application/chatgpt/DynamicTemplate.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -42,7 +41,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -121,7 +119,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/DynamicTree.json
+++ b/test/schemas/llm.application/chatgpt/DynamicTree.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -22,7 +21,6 @@
         "additionalProperties": false,
         "$defs": {
           "DynamicTree": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -56,7 +54,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -80,7 +77,6 @@
         "additionalProperties": false,
         "$defs": {
           "DynamicTree": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -117,7 +113,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -158,7 +153,6 @@
         "additionalProperties": false,
         "$defs": {
           "DynamicTree": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {

--- a/test/schemas/llm.application/chatgpt/DynamicUndefined.json
+++ b/test/schemas/llm.application/chatgpt/DynamicUndefined.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -29,7 +28,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -69,7 +67,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/DynamicUnion.json
+++ b/test/schemas/llm.application/chatgpt/DynamicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -39,7 +38,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -109,7 +107,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectAlias.json
+++ b/test/schemas/llm.application/chatgpt/ObjectAlias.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -98,7 +97,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -345,7 +343,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectDate.json
+++ b/test/schemas/llm.application/chatgpt/ObjectDate.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -90,7 +89,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -313,7 +311,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectDescription.json
+++ b/test/schemas/llm.application/chatgpt/ObjectDescription.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -65,7 +64,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -213,7 +211,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectDynamic.json
+++ b/test/schemas/llm.application/chatgpt/ObjectDynamic.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -42,7 +41,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -121,7 +119,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectGenericAlias.json
+++ b/test/schemas/llm.application/chatgpt/ObjectGenericAlias.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -35,7 +34,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -93,7 +91,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectGenericArray.json
+++ b/test/schemas/llm.application/chatgpt/ObjectGenericArray.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -76,7 +75,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -257,7 +255,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectGenericUnion.json
+++ b/test/schemas/llm.application/chatgpt/ObjectGenericUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -381,7 +380,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -1477,7 +1475,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectInternal.json
+++ b/test/schemas/llm.application/chatgpt/ObjectInternal.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -39,7 +38,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -109,7 +107,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectIntersection.json
+++ b/test/schemas/llm.application/chatgpt/ObjectIntersection.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -43,7 +42,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -125,7 +123,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectJsonTag.json
+++ b/test/schemas/llm.application/chatgpt/ObjectJsonTag.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -54,7 +53,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -169,7 +167,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectLiteralProperty.json
+++ b/test/schemas/llm.application/chatgpt/ObjectLiteralProperty.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -39,7 +38,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -109,7 +107,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectLiteralType.json
+++ b/test/schemas/llm.application/chatgpt/ObjectLiteralType.json
@@ -9,11 +9,9 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -43,11 +41,9 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
-            "description": "",
             "type": "object",
             "properties": {
               "id": {
@@ -88,8 +84,7 @@
                   "id",
                   "name",
                   "age"
-                ],
-                "description": ""
+                ]
               }
             ]
           }
@@ -102,7 +97,6 @@
         "$defs": {}
       },
       "output": {
-        "description": "",
         "type": "object",
         "properties": {
           "id": {
@@ -125,7 +119,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -150,8 +143,7 @@
                   "id",
                   "name",
                   "age"
-                ],
-                "description": ""
+                ]
               }
             ]
           },
@@ -177,8 +169,7 @@
                   "id",
                   "name",
                   "age"
-                ],
-                "description": ""
+                ]
               }
             ]
           },
@@ -204,8 +195,7 @@
                   "id",
                   "name",
                   "age"
-                ],
-                "description": ""
+                ]
               }
             ]
           }
@@ -239,8 +229,7 @@
               "id",
               "name",
               "age"
-            ],
-            "description": ""
+            ]
           }
         ]
       }

--- a/test/schemas/llm.application/chatgpt/ObjectNullable.json
+++ b/test/schemas/llm.application/chatgpt/ObjectNullable.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -140,7 +139,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -513,7 +511,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectOptional.json
+++ b/test/schemas/llm.application/chatgpt/ObjectOptional.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -42,7 +41,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -121,7 +119,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectPartial.json
+++ b/test/schemas/llm.application/chatgpt/ObjectPartial.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -51,7 +50,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartial.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {
@@ -94,7 +92,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -176,7 +173,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartial.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {
@@ -251,7 +247,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -379,7 +374,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartial.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {

--- a/test/schemas/llm.application/chatgpt/ObjectPartialAndRequired.json
+++ b/test/schemas/llm.application/chatgpt/ObjectPartialAndRequired.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -22,7 +21,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartialAndRequired": {
-            "description": "",
             "type": "object",
             "properties": {
               "string": {
@@ -62,7 +60,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -86,7 +83,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartialAndRequired": {
-            "description": "",
             "type": "object",
             "properties": {
               "string": {
@@ -129,7 +125,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -170,7 +165,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectPartialAndRequired": {
-            "description": "",
             "type": "object",
             "properties": {
               "string": {

--- a/test/schemas/llm.application/chatgpt/ObjectPrimitive.json
+++ b/test/schemas/llm.application/chatgpt/ObjectPrimitive.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -92,7 +91,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -321,7 +319,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectRecursive.json
+++ b/test/schemas/llm.application/chatgpt/ObjectRecursive.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -22,7 +21,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRecursive.IDepartment": {
-            "description": "",
             "type": "object",
             "properties": {
               "parent": {
@@ -79,7 +77,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -103,7 +100,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRecursive.IDepartment": {
-            "description": "",
             "type": "object",
             "properties": {
               "parent": {
@@ -163,7 +159,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -204,7 +199,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRecursive.IDepartment": {
-            "description": "",
             "type": "object",
             "properties": {
               "parent": {

--- a/test/schemas/llm.application/chatgpt/ObjectRequired.json
+++ b/test/schemas/llm.application/chatgpt/ObjectRequired.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -57,7 +56,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRequired.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {
@@ -94,7 +92,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -188,7 +185,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRequired.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {
@@ -263,7 +259,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -409,7 +404,6 @@
         "additionalProperties": false,
         "$defs": {
           "ObjectRequired.IBase": {
-            "description": "",
             "type": "object",
             "properties": {
               "boolean": {

--- a/test/schemas/llm.application/chatgpt/ObjectSimple.json
+++ b/test/schemas/llm.application/chatgpt/ObjectSimple.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -115,7 +114,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -413,7 +411,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUndefined.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUndefined.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -70,7 +69,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -233,7 +231,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionComposite.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionComposite.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -395,7 +394,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -1533,7 +1531,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionCompositePointer.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionCompositePointer.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -412,7 +411,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -1601,7 +1599,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionDouble.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionDouble.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -22,7 +21,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -39,7 +37,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -60,7 +57,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -90,7 +86,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -107,7 +102,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -131,7 +125,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -171,7 +164,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -184,7 +176,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -201,7 +192,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -222,7 +212,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -252,7 +241,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -269,7 +257,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -293,7 +280,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -336,7 +322,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -353,7 +338,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -374,7 +358,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -404,7 +387,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -421,7 +403,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -445,7 +426,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -495,7 +475,6 @@
               "type": "object",
               "properties": {
                 "value": {
-                  "description": "",
                   "type": "object",
                   "properties": {
                     "x": {
@@ -512,7 +491,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -533,7 +511,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -563,7 +540,6 @@
               "type": "object",
               "properties": {
                 "value": {
-                  "description": "",
                   "type": "object",
                   "properties": {
                     "x": {
@@ -580,7 +556,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -604,7 +579,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -637,7 +611,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -654,7 +627,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -671,7 +643,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -692,7 +663,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -722,7 +692,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -739,7 +708,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -763,7 +731,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -809,7 +776,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -826,7 +792,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -847,7 +812,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -877,7 +841,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -894,7 +857,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -918,7 +880,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -964,7 +925,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -981,7 +941,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -1002,7 +961,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -1032,7 +990,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "x": {
@@ -1049,7 +1006,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -1073,7 +1029,6 @@
                               "type": "object",
                               "properties": {
                                 "value": {
-                                  "description": "",
                                   "type": "object",
                                   "properties": {
                                     "y": {
@@ -1127,7 +1082,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -1144,7 +1098,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -1165,7 +1118,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -1195,7 +1147,6 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "",
                       "type": "object",
                       "properties": {
                         "x": {
@@ -1212,7 +1163,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {
@@ -1236,7 +1186,6 @@
                           "type": "object",
                           "properties": {
                             "value": {
-                              "description": "",
                               "type": "object",
                               "properties": {
                                 "y": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionExplicit.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionExplicit.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -399,7 +398,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -1549,7 +1547,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionExplicitPointer.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionExplicitPointer.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -417,7 +416,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -1621,7 +1619,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionImplicit.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionImplicit.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -618,7 +617,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -2425,7 +2423,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ObjectUnionNonPredictable.json
+++ b/test/schemas/llm.application/chatgpt/ObjectUnionNonPredictable.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -121,7 +120,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -437,7 +435,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TemplateAtomic.json
+++ b/test/schemas/llm.application/chatgpt/TemplateAtomic.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -74,7 +73,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -249,7 +247,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TemplateConstant.json
+++ b/test/schemas/llm.application/chatgpt/TemplateConstant.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -76,7 +75,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -257,7 +255,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TemplateUnion.json
+++ b/test/schemas/llm.application/chatgpt/TemplateUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -63,8 +62,7 @@
                           },
                           "required": [
                             "name"
-                          ],
-                          "description": ""
+                          ]
                         }
                       ]
                     }
@@ -93,7 +91,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -147,8 +144,7 @@
                           },
                           "required": [
                             "name"
-                          ],
-                          "description": ""
+                          ]
                         }
                       ]
                     }
@@ -221,8 +217,7 @@
                               },
                               "required": [
                                 "name"
-                              ],
-                              "description": ""
+                              ]
                             }
                           ]
                         }
@@ -302,8 +297,7 @@
                       },
                       "required": [
                         "name"
-                      ],
-                      "description": ""
+                      ]
                     }
                   ]
                 }
@@ -325,7 +319,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -383,8 +376,7 @@
                               },
                               "required": [
                                 "name"
-                              ],
-                              "description": ""
+                              ]
                             }
                           ]
                         }
@@ -460,8 +452,7 @@
                               },
                               "required": [
                                 "name"
-                              ],
-                              "description": ""
+                              ]
                             }
                           ]
                         }
@@ -537,8 +528,7 @@
                               },
                               "required": [
                                 "name"
-                              ],
-                              "description": ""
+                              ]
                             }
                           ]
                         }
@@ -622,8 +612,7 @@
                           },
                           "required": [
                             "name"
-                          ],
-                          "description": ""
+                          ]
                         }
                       ]
                     }

--- a/test/schemas/llm.application/chatgpt/ToJsonAtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/ToJsonAtomicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -43,7 +42,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -125,7 +123,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ToJsonDouble.json
+++ b/test/schemas/llm.application/chatgpt/ToJsonDouble.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -39,7 +38,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -109,7 +107,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ToJsonNull.json
+++ b/test/schemas/llm.application/chatgpt/ToJsonNull.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -26,7 +25,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -57,7 +55,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/ToJsonUnion.json
+++ b/test/schemas/llm.application/chatgpt/ToJsonUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -100,7 +99,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -353,7 +351,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagArray.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagArray.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -87,7 +86,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -301,7 +299,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagArrayUnion.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagArrayUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -79,7 +78,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -269,7 +267,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagAtomicUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -56,7 +55,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -177,7 +175,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagCustom.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagCustom.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -51,7 +50,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -157,7 +155,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagDefault.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagDefault.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -122,7 +121,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -441,7 +439,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagFormat.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagFormat.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -141,7 +140,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -517,7 +515,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagLength.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagLength.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -68,7 +67,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -225,7 +223,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagMatrix.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagMatrix.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -44,7 +43,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -129,7 +127,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagObjectUnion.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagObjectUnion.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -58,7 +57,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -185,7 +183,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagPattern.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagPattern.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -51,7 +50,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -157,7 +155,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagRange.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -88,7 +87,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -305,7 +303,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.application/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.application/chatgpt/TypeTagType.json
@@ -9,7 +9,6 @@
     {
       "name": "insert",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -74,7 +73,6 @@
     {
       "name": "reduce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {
@@ -249,7 +247,6 @@
     {
       "name": "coalesce",
       "parameters": {
-        "description": "",
         "type": "object",
         "properties": {
           "first": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayAny.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayAny.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayHierarchical.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayHierarchical.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayHierarchicalPointer.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayHierarchicalPointer.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayMatrix.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayMatrix.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRecursive.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRecursive.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -43,7 +42,6 @@
   "additionalProperties": false,
   "$defs": {
     "ArrayRecursive.ICategory": {
-      "description": "",
       "type": "object",
       "properties": {
         "children": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionExplicit.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -207,7 +206,6 @@
       ]
     },
     "ArrayRecursiveUnionExplicit.IDirectory": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {
@@ -241,7 +239,6 @@
       ]
     },
     "ArrayRecursiveUnionExplicit.IShortcut": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionExplicitPointer.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionExplicitPointer.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -103,7 +102,6 @@
   "additionalProperties": false,
   "$defs": {
     "ArrayRecursiveUnionExplicitPointer.IBucket": {
-      "description": "",
       "type": "object",
       "properties": {
         "value": {
@@ -256,7 +254,6 @@
       ]
     },
     "ArrayRecursiveUnionExplicitPointer.IDirectory": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {
@@ -290,7 +287,6 @@
       ]
     },
     "ArrayRecursiveUnionExplicitPointer.IShortcut": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRecursiveUnionImplicit.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -168,7 +167,6 @@
       ]
     },
     "ArrayRecursiveUnionImplicit.IDirectory": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {
@@ -195,7 +193,6 @@
       ]
     },
     "ArrayRecursiveUnionImplicit.ISharedDirectory": {
-      "description": "",
       "type": "object",
       "properties": {
         "access": {
@@ -230,7 +227,6 @@
       ]
     },
     "ArrayRecursiveUnionImplicit.IShortcut": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRepeatedNullable.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRepeatedNullable.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRepeatedRequired.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRepeatedRequired.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayRepeatedUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayRepeatedUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArraySimple.json
+++ b/test/schemas/llm.parameters/chatgpt/ArraySimple.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ArrayUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ArrayUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/AtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/AtomicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ClassGetter.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassGetter.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ClassMethod.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassMethod.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassPropertyAssignment.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagArray.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagArray.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagArrayUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagArrayUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagAtomicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagDefault.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagDefault.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagFormat.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagFormat.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagLength.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagLength.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagObjectUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagObjectUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagPattern.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagPattern.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagRange.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagRange.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/CommentTagType.json
+++ b/test/schemas/llm.parameters/chatgpt/CommentTagType.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicAbsorbed.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicAbsorbed.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicTagged.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ConstantAtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantAtomicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -20,8 +19,7 @@
             },
             "required": [
               "key"
-            ],
-            "description": ""
+            ]
           },
           {
             "type": "boolean",
@@ -68,8 +66,7 @@
                 },
                 "required": [
                   "key"
-                ],
-                "description": ""
+                ]
               },
               {
                 "type": "boolean",
@@ -115,8 +112,7 @@
             },
             "required": [
               "key"
-            ],
-            "description": ""
+            ]
           },
           {
             "type": "boolean",
@@ -163,8 +159,7 @@
                 },
                 "required": [
                   "key"
-                ],
-                "description": ""
+                ]
               },
               {
                 "type": "boolean",
@@ -212,8 +207,7 @@
               },
               "required": [
                 "key"
-              ],
-              "description": ""
+              ]
             },
             {
               "type": "boolean",

--- a/test/schemas/llm.parameters/chatgpt/ConstantConstEnumeration.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantConstEnumeration.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ConstantEnumeration.json
+++ b/test/schemas/llm.parameters/chatgpt/ConstantEnumeration.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicArray.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicArray.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -7,7 +6,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {},
           "required": [],
@@ -32,7 +30,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {},
               "required": [],
@@ -56,7 +53,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {},
           "required": [],
@@ -81,7 +77,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {},
               "required": [],
@@ -107,7 +102,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {},
             "required": [],

--- a/test/schemas/llm.parameters/chatgpt/DynamicComposite.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicComposite.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicConstant.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicConstant.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -7,7 +6,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {
             "a": {
@@ -44,7 +42,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {
                 "a": {
@@ -80,7 +77,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {
             "a": {
@@ -117,7 +113,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {
                 "a": {
@@ -155,7 +150,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "a": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicEnumeration.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicEnumeration.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -7,7 +6,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {
             "ar": {
@@ -57,7 +55,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {
                 "ar": {
@@ -106,7 +103,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {
             "ar": {
@@ -156,7 +152,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {
                 "ar": {
@@ -207,7 +202,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "ar": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicNever.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicNever.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicSimple.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicSimple.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -7,7 +6,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {},
           "required": [],
@@ -29,7 +27,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {},
               "required": [],
@@ -50,7 +47,6 @@
       "type": "object",
       "properties": {
         "value": {
-          "description": "",
           "type": "object",
           "properties": {},
           "required": [],
@@ -72,7 +68,6 @@
           "type": "object",
           "properties": {
             "value": {
-              "description": "",
               "type": "object",
               "properties": {},
               "required": [],
@@ -95,7 +90,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {},
             "required": [],

--- a/test/schemas/llm.parameters/chatgpt/DynamicTemplate.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicTemplate.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicTree.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicTree.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -43,7 +42,6 @@
   "additionalProperties": false,
   "$defs": {
     "DynamicTree": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicUndefined.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicUndefined.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/DynamicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/DynamicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectAlias.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectAlias.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectDate.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectDate.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectDescription.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectDescription.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectDynamic.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectDynamic.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectGenericAlias.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectGenericAlias.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectGenericArray.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectGenericArray.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectGenericUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectGenericUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectInternal.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectInternal.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectIntersection.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectIntersection.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectJsonTag.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectJsonTag.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectLiteralProperty.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectLiteralProperty.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectLiteralType.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectLiteralType.json
@@ -1,9 +1,7 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {
@@ -44,13 +42,11 @@
             "id",
             "name",
             "age"
-          ],
-          "description": ""
+          ]
         }
       ]
     },
     "optional": {
-      "description": "",
       "type": "object",
       "properties": {
         "id": {
@@ -91,15 +87,13 @@
             "id",
             "name",
             "age"
-          ],
-          "description": ""
+          ]
         }
       ]
     },
     "array": {
       "type": "array",
       "items": {
-        "description": "",
         "type": "object",
         "properties": {
           "id": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectNullable.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectNullable.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectOptional.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectOptional.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectPartial.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectPartial.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -188,7 +187,6 @@
   "additionalProperties": false,
   "$defs": {
     "ObjectPartial.IBase": {
-      "description": "",
       "type": "object",
       "properties": {
         "boolean": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectPartialAndRequired.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectPartialAndRequired.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -43,7 +42,6 @@
   "additionalProperties": false,
   "$defs": {
     "ObjectPartialAndRequired": {
-      "description": "",
       "type": "object",
       "properties": {
         "string": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectPrimitive.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectPrimitive.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectRecursive.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectRecursive.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -43,7 +42,6 @@
   "additionalProperties": false,
   "$defs": {
     "ObjectRecursive.IDepartment": {
-      "description": "",
       "type": "object",
       "properties": {
         "parent": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectRequired.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectRequired.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -218,7 +217,6 @@
   "additionalProperties": false,
   "$defs": {
     "ObjectRequired.IBase": {
-      "description": "",
       "type": "object",
       "properties": {
         "boolean": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectSimple.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectSimple.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUndefined.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUndefined.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionComposite.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionComposite.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionCompositePointer.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionCompositePointer.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionDouble.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionDouble.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -12,7 +11,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "x": {
@@ -29,7 +27,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -50,7 +47,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -80,7 +76,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "x": {
@@ -97,7 +92,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -121,7 +115,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -164,7 +157,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "x": {
@@ -181,7 +173,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -202,7 +193,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -232,7 +222,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "x": {
@@ -249,7 +238,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -273,7 +261,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -315,7 +302,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "x": {
@@ -332,7 +318,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -353,7 +338,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -383,7 +367,6 @@
             "type": "object",
             "properties": {
               "value": {
-                "description": "",
                 "type": "object",
                 "properties": {
                   "x": {
@@ -400,7 +383,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -424,7 +406,6 @@
                     "type": "object",
                     "properties": {
                       "value": {
-                        "description": "",
                         "type": "object",
                         "properties": {
                           "y": {
@@ -467,7 +448,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "x": {
@@ -484,7 +464,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -505,7 +484,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -535,7 +513,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "x": {
@@ -552,7 +529,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -576,7 +552,6 @@
                         "type": "object",
                         "properties": {
                           "value": {
-                            "description": "",
                             "type": "object",
                             "properties": {
                               "y": {
@@ -620,7 +595,6 @@
               "type": "object",
               "properties": {
                 "value": {
-                  "description": "",
                   "type": "object",
                   "properties": {
                     "x": {
@@ -637,7 +611,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -658,7 +631,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -688,7 +660,6 @@
               "type": "object",
               "properties": {
                 "value": {
-                  "description": "",
                   "type": "object",
                   "properties": {
                     "x": {
@@ -705,7 +676,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {
@@ -729,7 +699,6 @@
                       "type": "object",
                       "properties": {
                         "value": {
-                          "description": "",
                           "type": "object",
                           "properties": {
                             "y": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionExplicit.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionExplicit.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionExplicitPointer.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionExplicitPointer.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionImplicit.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionImplicit.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ObjectUnionNonPredictable.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectUnionNonPredictable.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TemplateAtomic.json
+++ b/test/schemas/llm.parameters/chatgpt/TemplateAtomic.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TemplateConstant.json
+++ b/test/schemas/llm.parameters/chatgpt/TemplateConstant.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TemplateUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/TemplateUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {
@@ -53,8 +52,7 @@
                     },
                     "required": [
                       "name"
-                    ],
-                    "description": ""
+                    ]
                   }
                 ]
               }
@@ -127,8 +125,7 @@
                         },
                         "required": [
                           "name"
-                        ],
-                        "description": ""
+                        ]
                       }
                     ]
                   }
@@ -200,8 +197,7 @@
                     },
                     "required": [
                       "name"
-                    ],
-                    "description": ""
+                    ]
                   }
                 ]
               }
@@ -274,8 +270,7 @@
                         },
                         "required": [
                           "name"
-                        ],
-                        "description": ""
+                        ]
                       }
                     ]
                   }
@@ -349,8 +344,7 @@
                       },
                       "required": [
                         "name"
-                      ],
-                      "description": ""
+                      ]
                     }
                   ]
                 }

--- a/test/schemas/llm.parameters/chatgpt/ToJsonAtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ToJsonAtomicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/chatgpt/ToJsonDouble.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ToJsonNull.json
+++ b/test/schemas/llm.parameters/chatgpt/ToJsonNull.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/ToJsonUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/ToJsonUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagArray.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagArray.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagArrayUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagArrayUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagAtomicUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagAtomicUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagCustom.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagCustom.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagDefault.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagDefault.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagFormat.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagFormat.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagLength.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagLength.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagMatrix.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagMatrix.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagObjectUnion.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagObjectUnion.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagPattern.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagPattern.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagRange.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.parameters/chatgpt/TypeTagType.json
+++ b/test/schemas/llm.parameters/chatgpt/TypeTagType.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "regular": {

--- a/test/schemas/llm.schema/chatgpt/ConstantAtomicUnion.json
+++ b/test/schemas/llm.schema/chatgpt/ConstantAtomicUnion.json
@@ -16,8 +16,7 @@
         },
         "required": [
           "key"
-        ],
-        "description": ""
+        ]
       },
       {
         "type": "boolean",

--- a/test/schemas/llm.schema/chatgpt/DynamicArray.json
+++ b/test/schemas/llm.schema/chatgpt/DynamicArray.json
@@ -3,7 +3,6 @@
   "type": "object",
   "properties": {
     "value": {
-      "description": "",
       "type": "object",
       "properties": {},
       "required": [],

--- a/test/schemas/llm.schema/chatgpt/DynamicConstant.json
+++ b/test/schemas/llm.schema/chatgpt/DynamicConstant.json
@@ -3,7 +3,6 @@
   "type": "object",
   "properties": {
     "value": {
-      "description": "",
       "type": "object",
       "properties": {
         "a": {

--- a/test/schemas/llm.schema/chatgpt/DynamicEnumeration.json
+++ b/test/schemas/llm.schema/chatgpt/DynamicEnumeration.json
@@ -3,7 +3,6 @@
   "type": "object",
   "properties": {
     "value": {
-      "description": "",
       "type": "object",
       "properties": {
         "ar": {

--- a/test/schemas/llm.schema/chatgpt/DynamicSimple.json
+++ b/test/schemas/llm.schema/chatgpt/DynamicSimple.json
@@ -3,7 +3,6 @@
   "type": "object",
   "properties": {
     "value": {
-      "description": "",
       "type": "object",
       "properties": {},
       "required": [],

--- a/test/schemas/llm.schema/chatgpt/ObjectLiteralType.json
+++ b/test/schemas/llm.schema/chatgpt/ObjectLiteralType.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "type": "object",
   "properties": {
     "id": {

--- a/test/schemas/llm.schema/chatgpt/ObjectUnionDouble.json
+++ b/test/schemas/llm.schema/chatgpt/ObjectUnionDouble.json
@@ -8,7 +8,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "x": {
@@ -25,7 +24,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "y": {
@@ -46,7 +44,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "y": {
@@ -76,7 +73,6 @@
         "type": "object",
         "properties": {
           "value": {
-            "description": "",
             "type": "object",
             "properties": {
               "x": {
@@ -93,7 +89,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "y": {
@@ -117,7 +112,6 @@
                 "type": "object",
                 "properties": {
                   "value": {
-                    "description": "",
                     "type": "object",
                     "properties": {
                       "y": {

--- a/test/schemas/llm.schema/chatgpt/TemplateUnion.json
+++ b/test/schemas/llm.schema/chatgpt/TemplateUnion.json
@@ -49,8 +49,7 @@
                 },
                 "required": [
                   "name"
-                ],
-                "description": ""
+                ]
               }
             ]
           }

--- a/test/src/features/assert/test_assert_ArrayAny.ts
+++ b/test/src/features/assert/test_assert_ArrayAny.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayAny } from "../../structures/ArrayAny";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayAny = _test_assert(TypeGuardError)(
-  "ArrayAny",
-)<ArrayAny>(ArrayAny)((input) => typia.assert<ArrayAny>(input));
+    "ArrayAny",
+)<ArrayAny>(
+    ArrayAny
+)((input) => typia.assert<ArrayAny>(input));

--- a/test/src/features/assert/test_assert_ArrayAtomicAlias.ts
+++ b/test/src/features/assert/test_assert_ArrayAtomicAlias.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayAtomicAlias } from "../../structures/ArrayAtomicAlias";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayAtomicAlias = _test_assert(TypeGuardError)(
-  "ArrayAtomicAlias",
-)<ArrayAtomicAlias>(ArrayAtomicAlias)((input) =>
-  typia.assert<ArrayAtomicAlias>(input),
-);
+    "ArrayAtomicAlias",
+)<ArrayAtomicAlias>(
+    ArrayAtomicAlias
+)((input) => typia.assert<ArrayAtomicAlias>(input));

--- a/test/src/features/assert/test_assert_ArrayAtomicSimple.ts
+++ b/test/src/features/assert/test_assert_ArrayAtomicSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayAtomicSimple } from "../../structures/ArrayAtomicSimple";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayAtomicSimple = _test_assert(TypeGuardError)(
-  "ArrayAtomicSimple",
-)<ArrayAtomicSimple>(ArrayAtomicSimple)((input) =>
-  typia.assert<ArrayAtomicSimple>(input),
-);
+    "ArrayAtomicSimple",
+)<ArrayAtomicSimple>(
+    ArrayAtomicSimple
+)((input) => typia.assert<ArrayAtomicSimple>(input));

--- a/test/src/features/assert/test_assert_ArrayHierarchical.ts
+++ b/test/src/features/assert/test_assert_ArrayHierarchical.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayHierarchical } from "../../structures/ArrayHierarchical";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayHierarchical = _test_assert(TypeGuardError)(
-  "ArrayHierarchical",
-)<ArrayHierarchical>(ArrayHierarchical)((input) =>
-  typia.assert<ArrayHierarchical>(input),
-);
+    "ArrayHierarchical",
+)<ArrayHierarchical>(
+    ArrayHierarchical
+)((input) => typia.assert<ArrayHierarchical>(input));

--- a/test/src/features/assert/test_assert_ArrayHierarchicalPointer.ts
+++ b/test/src/features/assert/test_assert_ArrayHierarchicalPointer.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayHierarchicalPointer } from "../../structures/ArrayHierarchicalPointer";
 
-export const test_assert_ArrayHierarchicalPointer = _test_assert(
-  TypeGuardError,
-)("ArrayHierarchicalPointer")<ArrayHierarchicalPointer>(
-  ArrayHierarchicalPointer,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArrayHierarchicalPointer = _test_assert(TypeGuardError)(
+    "ArrayHierarchicalPointer",
+)<ArrayHierarchicalPointer>(
+    ArrayHierarchicalPointer
 )((input) => typia.assert<ArrayHierarchicalPointer>(input));

--- a/test/src/features/assert/test_assert_ArrayMatrix.ts
+++ b/test/src/features/assert/test_assert_ArrayMatrix.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayMatrix } from "../../structures/ArrayMatrix";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayMatrix = _test_assert(TypeGuardError)(
-  "ArrayMatrix",
-)<ArrayMatrix>(ArrayMatrix)((input) => typia.assert<ArrayMatrix>(input));
+    "ArrayMatrix",
+)<ArrayMatrix>(
+    ArrayMatrix
+)((input) => typia.assert<ArrayMatrix>(input));

--- a/test/src/features/assert/test_assert_ArrayRecursive.ts
+++ b/test/src/features/assert/test_assert_ArrayRecursive.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRecursive } from "../../structures/ArrayRecursive";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayRecursive = _test_assert(TypeGuardError)(
-  "ArrayRecursive",
-)<ArrayRecursive>(ArrayRecursive)((input) =>
-  typia.assert<ArrayRecursive>(input),
-);
+    "ArrayRecursive",
+)<ArrayRecursive>(
+    ArrayRecursive
+)((input) => typia.assert<ArrayRecursive>(input));

--- a/test/src/features/assert/test_assert_ArrayRecursiveUnionExplicit.ts
+++ b/test/src/features/assert/test_assert_ArrayRecursiveUnionExplicit.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRecursiveUnionExplicit } from "../../structures/ArrayRecursiveUnionExplicit";
 
-export const test_assert_ArrayRecursiveUnionExplicit = _test_assert(
-  TypeGuardError,
-)("ArrayRecursiveUnionExplicit")<ArrayRecursiveUnionExplicit>(
-  ArrayRecursiveUnionExplicit,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArrayRecursiveUnionExplicit = _test_assert(TypeGuardError)(
+    "ArrayRecursiveUnionExplicit",
+)<ArrayRecursiveUnionExplicit>(
+    ArrayRecursiveUnionExplicit
 )((input) => typia.assert<ArrayRecursiveUnionExplicit>(input));

--- a/test/src/features/assert/test_assert_ArrayRecursiveUnionExplicitPointer.ts
+++ b/test/src/features/assert/test_assert_ArrayRecursiveUnionExplicitPointer.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRecursiveUnionExplicitPointer } from "../../structures/ArrayRecursiveUnionExplicitPointer";
 
-export const test_assert_ArrayRecursiveUnionExplicitPointer = _test_assert(
-  TypeGuardError,
-)("ArrayRecursiveUnionExplicitPointer")<ArrayRecursiveUnionExplicitPointer>(
-  ArrayRecursiveUnionExplicitPointer,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArrayRecursiveUnionExplicitPointer = _test_assert(TypeGuardError)(
+    "ArrayRecursiveUnionExplicitPointer",
+)<ArrayRecursiveUnionExplicitPointer>(
+    ArrayRecursiveUnionExplicitPointer
 )((input) => typia.assert<ArrayRecursiveUnionExplicitPointer>(input));

--- a/test/src/features/assert/test_assert_ArrayRecursiveUnionImplicit.ts
+++ b/test/src/features/assert/test_assert_ArrayRecursiveUnionImplicit.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRecursiveUnionImplicit } from "../../structures/ArrayRecursiveUnionImplicit";
 
-export const test_assert_ArrayRecursiveUnionImplicit = _test_assert(
-  TypeGuardError,
-)("ArrayRecursiveUnionImplicit")<ArrayRecursiveUnionImplicit>(
-  ArrayRecursiveUnionImplicit,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArrayRecursiveUnionImplicit = _test_assert(TypeGuardError)(
+    "ArrayRecursiveUnionImplicit",
+)<ArrayRecursiveUnionImplicit>(
+    ArrayRecursiveUnionImplicit
 )((input) => typia.assert<ArrayRecursiveUnionImplicit>(input));

--- a/test/src/features/assert/test_assert_ArrayRepeatedNullable.ts
+++ b/test/src/features/assert/test_assert_ArrayRepeatedNullable.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRepeatedNullable } from "../../structures/ArrayRepeatedNullable";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayRepeatedNullable = _test_assert(TypeGuardError)(
-  "ArrayRepeatedNullable",
-)<ArrayRepeatedNullable>(ArrayRepeatedNullable)((input) =>
-  typia.assert<ArrayRepeatedNullable>(input),
-);
+    "ArrayRepeatedNullable",
+)<ArrayRepeatedNullable>(
+    ArrayRepeatedNullable
+)((input) => typia.assert<ArrayRepeatedNullable>(input));

--- a/test/src/features/assert/test_assert_ArrayRepeatedOptional.ts
+++ b/test/src/features/assert/test_assert_ArrayRepeatedOptional.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRepeatedOptional } from "../../structures/ArrayRepeatedOptional";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayRepeatedOptional = _test_assert(TypeGuardError)(
-  "ArrayRepeatedOptional",
-)<ArrayRepeatedOptional>(ArrayRepeatedOptional)((input) =>
-  typia.assert<ArrayRepeatedOptional>(input),
-);
+    "ArrayRepeatedOptional",
+)<ArrayRepeatedOptional>(
+    ArrayRepeatedOptional
+)((input) => typia.assert<ArrayRepeatedOptional>(input));

--- a/test/src/features/assert/test_assert_ArrayRepeatedRequired.ts
+++ b/test/src/features/assert/test_assert_ArrayRepeatedRequired.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRepeatedRequired } from "../../structures/ArrayRepeatedRequired";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayRepeatedRequired = _test_assert(TypeGuardError)(
-  "ArrayRepeatedRequired",
-)<ArrayRepeatedRequired>(ArrayRepeatedRequired)((input) =>
-  typia.assert<ArrayRepeatedRequired>(input),
-);
+    "ArrayRepeatedRequired",
+)<ArrayRepeatedRequired>(
+    ArrayRepeatedRequired
+)((input) => typia.assert<ArrayRepeatedRequired>(input));

--- a/test/src/features/assert/test_assert_ArrayRepeatedUnion.ts
+++ b/test/src/features/assert/test_assert_ArrayRepeatedUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRepeatedUnion } from "../../structures/ArrayRepeatedUnion";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayRepeatedUnion = _test_assert(TypeGuardError)(
-  "ArrayRepeatedUnion",
-)<ArrayRepeatedUnion>(ArrayRepeatedUnion)((input) =>
-  typia.assert<ArrayRepeatedUnion>(input),
-);
+    "ArrayRepeatedUnion",
+)<ArrayRepeatedUnion>(
+    ArrayRepeatedUnion
+)((input) => typia.assert<ArrayRepeatedUnion>(input));

--- a/test/src/features/assert/test_assert_ArrayRepeatedUnionWithTuple.ts
+++ b/test/src/features/assert/test_assert_ArrayRepeatedUnionWithTuple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayRepeatedUnionWithTuple } from "../../structures/ArrayRepeatedUnionWithTuple";
 
-export const test_assert_ArrayRepeatedUnionWithTuple = _test_assert(
-  TypeGuardError,
-)("ArrayRepeatedUnionWithTuple")<ArrayRepeatedUnionWithTuple>(
-  ArrayRepeatedUnionWithTuple,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArrayRepeatedUnionWithTuple = _test_assert(TypeGuardError)(
+    "ArrayRepeatedUnionWithTuple",
+)<ArrayRepeatedUnionWithTuple>(
+    ArrayRepeatedUnionWithTuple
 )((input) => typia.assert<ArrayRepeatedUnionWithTuple>(input));

--- a/test/src/features/assert/test_assert_ArraySimple.ts
+++ b/test/src/features/assert/test_assert_ArraySimple.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArraySimple } from "../../structures/ArraySimple";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArraySimple = _test_assert(TypeGuardError)(
-  "ArraySimple",
-)<ArraySimple>(ArraySimple)((input) => typia.assert<ArraySimple>(input));
+    "ArraySimple",
+)<ArraySimple>(
+    ArraySimple
+)((input) => typia.assert<ArraySimple>(input));

--- a/test/src/features/assert/test_assert_ArraySimpleProtobuf.ts
+++ b/test/src/features/assert/test_assert_ArraySimpleProtobuf.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArraySimpleProtobuf } from "../../structures/ArraySimpleProtobuf";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArraySimpleProtobuf = _test_assert(TypeGuardError)(
-  "ArraySimpleProtobuf",
-)<ArraySimpleProtobuf>(ArraySimpleProtobuf)((input) =>
-  typia.assert<ArraySimpleProtobuf>(input),
-);
+    "ArraySimpleProtobuf",
+)<ArraySimpleProtobuf>(
+    ArraySimpleProtobuf
+)((input) => typia.assert<ArraySimpleProtobuf>(input));

--- a/test/src/features/assert/test_assert_ArraySimpleProtobufNullable.ts
+++ b/test/src/features/assert/test_assert_ArraySimpleProtobufNullable.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArraySimpleProtobufNullable } from "../../structures/ArraySimpleProtobufNullable";
 
-export const test_assert_ArraySimpleProtobufNullable = _test_assert(
-  TypeGuardError,
-)("ArraySimpleProtobufNullable")<ArraySimpleProtobufNullable>(
-  ArraySimpleProtobufNullable,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArraySimpleProtobufNullable = _test_assert(TypeGuardError)(
+    "ArraySimpleProtobufNullable",
+)<ArraySimpleProtobufNullable>(
+    ArraySimpleProtobufNullable
 )((input) => typia.assert<ArraySimpleProtobufNullable>(input));

--- a/test/src/features/assert/test_assert_ArraySimpleProtobufOptional.ts
+++ b/test/src/features/assert/test_assert_ArraySimpleProtobufOptional.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArraySimpleProtobufOptional } from "../../structures/ArraySimpleProtobufOptional";
 
-export const test_assert_ArraySimpleProtobufOptional = _test_assert(
-  TypeGuardError,
-)("ArraySimpleProtobufOptional")<ArraySimpleProtobufOptional>(
-  ArraySimpleProtobufOptional,
+import { TypeGuardError } from "typia";
+
+export const test_assert_ArraySimpleProtobufOptional = _test_assert(TypeGuardError)(
+    "ArraySimpleProtobufOptional",
+)<ArraySimpleProtobufOptional>(
+    ArraySimpleProtobufOptional
 )((input) => typia.assert<ArraySimpleProtobufOptional>(input));

--- a/test/src/features/assert/test_assert_ArrayUnion.ts
+++ b/test/src/features/assert/test_assert_ArrayUnion.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { ArrayUnion } from "../../structures/ArrayUnion";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_ArrayUnion = _test_assert(TypeGuardError)(
-  "ArrayUnion",
-)<ArrayUnion>(ArrayUnion)((input) => typia.assert<ArrayUnion>(input));
+    "ArrayUnion",
+)<ArrayUnion>(
+    ArrayUnion
+)((input) => typia.assert<ArrayUnion>(input));

--- a/test/src/features/assert/test_assert_AtomicAlias.ts
+++ b/test/src/features/assert/test_assert_AtomicAlias.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { AtomicAlias } from "../../structures/AtomicAlias";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_AtomicAlias = _test_assert(TypeGuardError)(
-  "AtomicAlias",
-)<AtomicAlias>(AtomicAlias)((input) => typia.assert<AtomicAlias>(input));
+    "AtomicAlias",
+)<AtomicAlias>(
+    AtomicAlias
+)((input) => typia.assert<AtomicAlias>(input));

--- a/test/src/features/assert/test_assert_AtomicClass.ts
+++ b/test/src/features/assert/test_assert_AtomicClass.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { AtomicClass } from "../../structures/AtomicClass";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_AtomicClass = _test_assert(TypeGuardError)(
-  "AtomicClass",
-)<AtomicClass>(AtomicClass)((input) => typia.assert<AtomicClass>(input));
+    "AtomicClass",
+)<AtomicClass>(
+    AtomicClass
+)((input) => typia.assert<AtomicClass>(input));

--- a/test/src/features/assert/test_assert_AtomicIntersection.ts
+++ b/test/src/features/assert/test_assert_AtomicIntersection.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { AtomicIntersection } from "../../structures/AtomicIntersection";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_AtomicIntersection = _test_assert(TypeGuardError)(
-  "AtomicIntersection",
-)<AtomicIntersection>(AtomicIntersection)((input) =>
-  typia.assert<AtomicIntersection>(input),
-);
+    "AtomicIntersection",
+)<AtomicIntersection>(
+    AtomicIntersection
+)((input) => typia.assert<AtomicIntersection>(input));

--- a/test/src/features/assert/test_assert_AtomicSimple.ts
+++ b/test/src/features/assert/test_assert_AtomicSimple.ts
@@ -1,9 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_assert } from "../../internal/_test_assert";
 import { AtomicSimple } from "../../structures/AtomicSimple";
 
+import { TypeGuardError } from "typia";
+
 export const test_assert_AtomicSimple = _test_assert(TypeGuardError)(
-  "AtomicSimple",
-)<AtomicSimple>(AtomicSimple)((input) => typia.assert<AtomicSimple>(input));
+    "AtomicSimple",
+)<AtomicSimple>(
+    AtomicSimple
+)((input) => typia.assert<AtomicSimple>(input));

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicIntersection.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { AtomicIntersection } from "../../structures/AtomicIntersection";
 
-export const test_functional_assertParametersCustom_AtomicIntersection =
-  _test_functional_assertParameters(CustomGuardError)("AtomicIntersection")(
-    AtomicIntersection,
-  )((p: (input: AtomicIntersection) => AtomicIntersection) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_AtomicIntersection = _test_functional_assertParameters(CustomGuardError)(
+  "AtomicIntersection"
+)(AtomicIntersection)(
+  (p: (input: AtomicIntersection) => AtomicIntersection) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { AtomicSimple } from "../../structures/AtomicSimple";
 
-export const test_functional_assertParametersCustom_AtomicSimple =
-  _test_functional_assertParameters(CustomGuardError)("AtomicSimple")(
-    AtomicSimple,
-  )((p: (input: AtomicSimple) => AtomicSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_AtomicSimple = _test_functional_assertParameters(CustomGuardError)(
+  "AtomicSimple"
+)(AtomicSimple)(
+  (p: (input: AtomicSimple) => AtomicSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_AtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { AtomicUnion } from "../../structures/AtomicUnion";
 
-export const test_functional_assertParametersCustom_AtomicUnion =
-  _test_functional_assertParameters(CustomGuardError)("AtomicUnion")(
-    AtomicUnion,
-  )((p: (input: AtomicUnion) => AtomicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_AtomicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "AtomicUnion"
+)(AtomicUnion)(
+  (p: (input: AtomicUnion) => AtomicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassClosure.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassClosure.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ClassClosure } from "../../structures/ClassClosure";
 
-export const test_functional_assertParametersCustom_ClassClosure =
-  _test_functional_assertParameters(CustomGuardError)("ClassClosure")(
-    ClassClosure,
-  )((p: (input: ClassClosure) => ClassClosure) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ClassClosure = _test_functional_assertParameters(CustomGuardError)(
+  "ClassClosure"
+)(ClassClosure)(
+  (p: (input: ClassClosure) => ClassClosure) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassGetter.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassGetter.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ClassGetter } from "../../structures/ClassGetter";
 
-export const test_functional_assertParametersCustom_ClassGetter =
-  _test_functional_assertParameters(CustomGuardError)("ClassGetter")(
-    ClassGetter,
-  )((p: (input: ClassGetter) => ClassGetter) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ClassGetter = _test_functional_assertParameters(CustomGuardError)(
+  "ClassGetter"
+)(ClassGetter)(
+  (p: (input: ClassGetter) => ClassGetter) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassMethod.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassMethod.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ClassMethod } from "../../structures/ClassMethod";
 
-export const test_functional_assertParametersCustom_ClassMethod =
-  _test_functional_assertParameters(CustomGuardError)("ClassMethod")(
-    ClassMethod,
-  )((p: (input: ClassMethod) => ClassMethod) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ClassMethod = _test_functional_assertParameters(CustomGuardError)(
+  "ClassMethod"
+)(ClassMethod)(
+  (p: (input: ClassMethod) => ClassMethod) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassNonPublic.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassNonPublic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ClassNonPublic } from "../../structures/ClassNonPublic";
 
-export const test_functional_assertParametersCustom_ClassNonPublic =
-  _test_functional_assertParameters(CustomGuardError)("ClassNonPublic")(
-    ClassNonPublic,
-  )((p: (input: ClassNonPublic) => ClassNonPublic) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ClassNonPublic = _test_functional_assertParameters(CustomGuardError)(
+  "ClassNonPublic"
+)(ClassNonPublic)(
+  (p: (input: ClassNonPublic) => ClassNonPublic) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassPropertyAssignment.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ClassPropertyAssignment.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ClassPropertyAssignment } from "../../structures/ClassPropertyAssignment";
 
-export const test_functional_assertParametersCustom_ClassPropertyAssignment =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ClassPropertyAssignment",
-  )(ClassPropertyAssignment)(
-    (p: (input: ClassPropertyAssignment) => ClassPropertyAssignment) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ClassPropertyAssignment = _test_functional_assertParameters(CustomGuardError)(
+  "ClassPropertyAssignment"
+)(ClassPropertyAssignment)(
+  (p: (input: ClassPropertyAssignment) => ClassPropertyAssignment) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagArray } from "../../structures/CommentTagArray";
 
-export const test_functional_assertParametersCustom_CommentTagArray =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagArray")(
-    CommentTagArray,
-  )((p: (input: CommentTagArray) => CommentTagArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagArray = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagArray"
+)(CommentTagArray)(
+  (p: (input: CommentTagArray) => CommentTagArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagArrayUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagArrayUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagArrayUnion } from "../../structures/CommentTagArrayUnion";
 
-export const test_functional_assertParametersCustom_CommentTagArrayUnion =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagArrayUnion")(
-    CommentTagArrayUnion,
-  )((p: (input: CommentTagArrayUnion) => CommentTagArrayUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagArrayUnion = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagArrayUnion"
+)(CommentTagArrayUnion)(
+  (p: (input: CommentTagArrayUnion) => CommentTagArrayUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagAtomicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagAtomicUnion } from "../../structures/CommentTagAtomicUnion";
 
-export const test_functional_assertParametersCustom_CommentTagAtomicUnion =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagAtomicUnion")(
-    CommentTagAtomicUnion,
-  )((p: (input: CommentTagAtomicUnion) => CommentTagAtomicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagAtomicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagAtomicUnion"
+)(CommentTagAtomicUnion)(
+  (p: (input: CommentTagAtomicUnion) => CommentTagAtomicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagBigInt } from "../../structures/CommentTagBigInt";
 
-export const test_functional_assertParametersCustom_CommentTagBigInt =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagBigInt")(
-    CommentTagBigInt,
-  )((p: (input: CommentTagBigInt) => CommentTagBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagBigInt"
+)(CommentTagBigInt)(
+  (p: (input: CommentTagBigInt) => CommentTagBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagDefault.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagDefault.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagDefault } from "../../structures/CommentTagDefault";
 
-export const test_functional_assertParametersCustom_CommentTagDefault =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagDefault")(
-    CommentTagDefault,
-  )((p: (input: CommentTagDefault) => CommentTagDefault) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagDefault = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagDefault"
+)(CommentTagDefault)(
+  (p: (input: CommentTagDefault) => CommentTagDefault) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagFormat.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagFormat.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagFormat } from "../../structures/CommentTagFormat";
 
-export const test_functional_assertParametersCustom_CommentTagFormat =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagFormat")(
-    CommentTagFormat,
-  )((p: (input: CommentTagFormat) => CommentTagFormat) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagFormat = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagFormat"
+)(CommentTagFormat)(
+  (p: (input: CommentTagFormat) => CommentTagFormat) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagInfinite.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagInfinite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagInfinite } from "../../structures/CommentTagInfinite";
 
-export const test_functional_assertParametersCustom_CommentTagInfinite =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagInfinite")(
-    CommentTagInfinite,
-  )((p: (input: CommentTagInfinite) => CommentTagInfinite) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagInfinite = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagInfinite"
+)(CommentTagInfinite)(
+  (p: (input: CommentTagInfinite) => CommentTagInfinite) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagLength.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagLength.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagLength } from "../../structures/CommentTagLength";
 
-export const test_functional_assertParametersCustom_CommentTagLength =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagLength")(
-    CommentTagLength,
-  )((p: (input: CommentTagLength) => CommentTagLength) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagLength = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagLength"
+)(CommentTagLength)(
+  (p: (input: CommentTagLength) => CommentTagLength) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagNaN.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagNaN.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagNaN } from "../../structures/CommentTagNaN";
 
-export const test_functional_assertParametersCustom_CommentTagNaN =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagNaN")(
-    CommentTagNaN,
-  )((p: (input: CommentTagNaN) => CommentTagNaN) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagNaN = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagNaN"
+)(CommentTagNaN)(
+  (p: (input: CommentTagNaN) => CommentTagNaN) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagObjectUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagObjectUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagObjectUnion } from "../../structures/CommentTagObjectUnion";
 
-export const test_functional_assertParametersCustom_CommentTagObjectUnion =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagObjectUnion")(
-    CommentTagObjectUnion,
-  )((p: (input: CommentTagObjectUnion) => CommentTagObjectUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagObjectUnion = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagObjectUnion"
+)(CommentTagObjectUnion)(
+  (p: (input: CommentTagObjectUnion) => CommentTagObjectUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagPattern.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagPattern.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagPattern } from "../../structures/CommentTagPattern";
 
-export const test_functional_assertParametersCustom_CommentTagPattern =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagPattern")(
-    CommentTagPattern,
-  )((p: (input: CommentTagPattern) => CommentTagPattern) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagPattern = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagPattern"
+)(CommentTagPattern)(
+  (p: (input: CommentTagPattern) => CommentTagPattern) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagRange.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagRange.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagRange } from "../../structures/CommentTagRange";
 
-export const test_functional_assertParametersCustom_CommentTagRange =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagRange")(
-    CommentTagRange,
-  )((p: (input: CommentTagRange) => CommentTagRange) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagRange = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagRange"
+)(CommentTagRange)(
+  (p: (input: CommentTagRange) => CommentTagRange) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagRangeBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagRangeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagRangeBigInt } from "../../structures/CommentTagRangeBigInt";
 
-export const test_functional_assertParametersCustom_CommentTagRangeBigInt =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagRangeBigInt")(
-    CommentTagRangeBigInt,
-  )((p: (input: CommentTagRangeBigInt) => CommentTagRangeBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagRangeBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagRangeBigInt"
+)(CommentTagRangeBigInt)(
+  (p: (input: CommentTagRangeBigInt) => CommentTagRangeBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagType.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagType.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagType } from "../../structures/CommentTagType";
 
-export const test_functional_assertParametersCustom_CommentTagType =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagType")(
-    CommentTagType,
-  )((p: (input: CommentTagType) => CommentTagType) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagType = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagType"
+)(CommentTagType)(
+  (p: (input: CommentTagType) => CommentTagType) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagTypeBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_CommentTagTypeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { CommentTagTypeBigInt } from "../../structures/CommentTagTypeBigInt";
 
-export const test_functional_assertParametersCustom_CommentTagTypeBigInt =
-  _test_functional_assertParameters(CustomGuardError)("CommentTagTypeBigInt")(
-    CommentTagTypeBigInt,
-  )((p: (input: CommentTagTypeBigInt) => CommentTagTypeBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_CommentTagTypeBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "CommentTagTypeBigInt"
+)(CommentTagTypeBigInt)(
+  (p: (input: CommentTagTypeBigInt) => CommentTagTypeBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicAbsorbed.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicAbsorbed.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantAtomicAbsorbed } from "../../structures/ConstantAtomicAbsorbed";
 
-export const test_functional_assertParametersCustom_ConstantAtomicAbsorbed =
-  _test_functional_assertParameters(CustomGuardError)("ConstantAtomicAbsorbed")(
-    ConstantAtomicAbsorbed,
-  )((p: (input: ConstantAtomicAbsorbed) => ConstantAtomicAbsorbed) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantAtomicAbsorbed = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantAtomicAbsorbed"
+)(ConstantAtomicAbsorbed)(
+  (p: (input: ConstantAtomicAbsorbed) => ConstantAtomicAbsorbed) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantAtomicSimple } from "../../structures/ConstantAtomicSimple";
 
-export const test_functional_assertParametersCustom_ConstantAtomicSimple =
-  _test_functional_assertParameters(CustomGuardError)("ConstantAtomicSimple")(
-    ConstantAtomicSimple,
-  )((p: (input: ConstantAtomicSimple) => ConstantAtomicSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantAtomicSimple = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantAtomicSimple"
+)(ConstantAtomicSimple)(
+  (p: (input: ConstantAtomicSimple) => ConstantAtomicSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicTagged.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicTagged.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantAtomicTagged } from "../../structures/ConstantAtomicTagged";
 
-export const test_functional_assertParametersCustom_ConstantAtomicTagged =
-  _test_functional_assertParameters(CustomGuardError)("ConstantAtomicTagged")(
-    ConstantAtomicTagged,
-  )((p: (input: ConstantAtomicTagged) => ConstantAtomicTagged) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantAtomicTagged = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantAtomicTagged"
+)(ConstantAtomicTagged)(
+  (p: (input: ConstantAtomicTagged) => ConstantAtomicTagged) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantAtomicUnion } from "../../structures/ConstantAtomicUnion";
 
-export const test_functional_assertParametersCustom_ConstantAtomicUnion =
-  _test_functional_assertParameters(CustomGuardError)("ConstantAtomicUnion")(
-    ConstantAtomicUnion,
-  )((p: (input: ConstantAtomicUnion) => ConstantAtomicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantAtomicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantAtomicUnion"
+)(ConstantAtomicUnion)(
+  (p: (input: ConstantAtomicUnion) => ConstantAtomicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicWrapper.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantAtomicWrapper.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantAtomicWrapper } from "../../structures/ConstantAtomicWrapper";
 
-export const test_functional_assertParametersCustom_ConstantAtomicWrapper =
-  _test_functional_assertParameters(CustomGuardError)("ConstantAtomicWrapper")(
-    ConstantAtomicWrapper,
-  )((p: (input: ConstantAtomicWrapper) => ConstantAtomicWrapper) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantAtomicWrapper = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantAtomicWrapper"
+)(ConstantAtomicWrapper)(
+  (p: (input: ConstantAtomicWrapper) => ConstantAtomicWrapper) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantConstEnumeration.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantConstEnumeration.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantConstEnumeration } from "../../structures/ConstantConstEnumeration";
 
-export const test_functional_assertParametersCustom_ConstantConstEnumeration =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ConstantConstEnumeration",
-  )(ConstantConstEnumeration)(
-    (p: (input: ConstantConstEnumeration) => ConstantConstEnumeration) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantConstEnumeration = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantConstEnumeration"
+)(ConstantConstEnumeration)(
+  (p: (input: ConstantConstEnumeration) => ConstantConstEnumeration) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantEnumeration.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantEnumeration.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantEnumeration } from "../../structures/ConstantEnumeration";
 
-export const test_functional_assertParametersCustom_ConstantEnumeration =
-  _test_functional_assertParameters(CustomGuardError)("ConstantEnumeration")(
-    ConstantEnumeration,
-  )((p: (input: ConstantEnumeration) => ConstantEnumeration) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantEnumeration = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantEnumeration"
+)(ConstantEnumeration)(
+  (p: (input: ConstantEnumeration) => ConstantEnumeration) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantIntersection.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ConstantIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ConstantIntersection } from "../../structures/ConstantIntersection";
 
-export const test_functional_assertParametersCustom_ConstantIntersection =
-  _test_functional_assertParameters(CustomGuardError)("ConstantIntersection")(
-    ConstantIntersection,
-  )((p: (input: ConstantIntersection) => ConstantIntersection) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ConstantIntersection = _test_functional_assertParameters(CustomGuardError)(
+  "ConstantIntersection"
+)(ConstantIntersection)(
+  (p: (input: ConstantIntersection) => ConstantIntersection) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicArray } from "../../structures/DynamicArray";
 
-export const test_functional_assertParametersCustom_DynamicArray =
-  _test_functional_assertParameters(CustomGuardError)("DynamicArray")(
-    DynamicArray,
-  )((p: (input: DynamicArray) => DynamicArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicArray = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicArray"
+)(DynamicArray)(
+  (p: (input: DynamicArray) => DynamicArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicComposite.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicComposite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicComposite } from "../../structures/DynamicComposite";
 
-export const test_functional_assertParametersCustom_DynamicComposite =
-  _test_functional_assertParameters(CustomGuardError)("DynamicComposite")(
-    DynamicComposite,
-  )((p: (input: DynamicComposite) => DynamicComposite) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicComposite = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicComposite"
+)(DynamicComposite)(
+  (p: (input: DynamicComposite) => DynamicComposite) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicConstant.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicConstant } from "../../structures/DynamicConstant";
 
-export const test_functional_assertParametersCustom_DynamicConstant =
-  _test_functional_assertParameters(CustomGuardError)("DynamicConstant")(
-    DynamicConstant,
-  )((p: (input: DynamicConstant) => DynamicConstant) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicConstant = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicConstant"
+)(DynamicConstant)(
+  (p: (input: DynamicConstant) => DynamicConstant) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicEnumeration.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicEnumeration.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicEnumeration } from "../../structures/DynamicEnumeration";
 
-export const test_functional_assertParametersCustom_DynamicEnumeration =
-  _test_functional_assertParameters(CustomGuardError)("DynamicEnumeration")(
-    DynamicEnumeration,
-  )((p: (input: DynamicEnumeration) => DynamicEnumeration) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicEnumeration = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicEnumeration"
+)(DynamicEnumeration)(
+  (p: (input: DynamicEnumeration) => DynamicEnumeration) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicJsonValue.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicJsonValue.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicJsonValue } from "../../structures/DynamicJsonValue";
 
-export const test_functional_assertParametersCustom_DynamicJsonValue =
-  _test_functional_assertParameters(CustomGuardError)("DynamicJsonValue")(
-    DynamicJsonValue,
-  )((p: (input: DynamicJsonValue) => DynamicJsonValue) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicJsonValue = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicJsonValue"
+)(DynamicJsonValue)(
+  (p: (input: DynamicJsonValue) => DynamicJsonValue) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicNever.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicNever.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicNever } from "../../structures/DynamicNever";
 
-export const test_functional_assertParametersCustom_DynamicNever =
-  _test_functional_assertParameters(CustomGuardError)("DynamicNever")(
-    DynamicNever,
-  )((p: (input: DynamicNever) => DynamicNever) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicNever = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicNever"
+)(DynamicNever)(
+  (p: (input: DynamicNever) => DynamicNever) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicSimple } from "../../structures/DynamicSimple";
 
-export const test_functional_assertParametersCustom_DynamicSimple =
-  _test_functional_assertParameters(CustomGuardError)("DynamicSimple")(
-    DynamicSimple,
-  )((p: (input: DynamicSimple) => DynamicSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicSimple = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicSimple"
+)(DynamicSimple)(
+  (p: (input: DynamicSimple) => DynamicSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTag.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTag.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicTag } from "../../structures/DynamicTag";
 
-export const test_functional_assertParametersCustom_DynamicTag =
-  _test_functional_assertParameters(CustomGuardError)("DynamicTag")(DynamicTag)(
-    (p: (input: DynamicTag) => DynamicTag) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicTag = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicTag"
+)(DynamicTag)(
+  (p: (input: DynamicTag) => DynamicTag) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTemplate.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTemplate.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicTemplate } from "../../structures/DynamicTemplate";
 
-export const test_functional_assertParametersCustom_DynamicTemplate =
-  _test_functional_assertParameters(CustomGuardError)("DynamicTemplate")(
-    DynamicTemplate,
-  )((p: (input: DynamicTemplate) => DynamicTemplate) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicTemplate = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicTemplate"
+)(DynamicTemplate)(
+  (p: (input: DynamicTemplate) => DynamicTemplate) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTree.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicTree.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicTree } from "../../structures/DynamicTree";
 
-export const test_functional_assertParametersCustom_DynamicTree =
-  _test_functional_assertParameters(CustomGuardError)("DynamicTree")(
-    DynamicTree,
-  )((p: (input: DynamicTree) => DynamicTree) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicTree = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicTree"
+)(DynamicTree)(
+  (p: (input: DynamicTree) => DynamicTree) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicUndefined.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicUndefined.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicUndefined } from "../../structures/DynamicUndefined";
 
-export const test_functional_assertParametersCustom_DynamicUndefined =
-  _test_functional_assertParameters(CustomGuardError)("DynamicUndefined")(
-    DynamicUndefined,
-  )((p: (input: DynamicUndefined) => DynamicUndefined) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicUndefined = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicUndefined"
+)(DynamicUndefined)(
+  (p: (input: DynamicUndefined) => DynamicUndefined) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_DynamicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { DynamicUnion } from "../../structures/DynamicUnion";
 
-export const test_functional_assertParametersCustom_DynamicUnion =
-  _test_functional_assertParameters(CustomGuardError)("DynamicUnion")(
-    DynamicUnion,
-  )((p: (input: DynamicUnion) => DynamicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_DynamicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "DynamicUnion"
+)(DynamicUnion)(
+  (p: (input: DynamicUnion) => DynamicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalArray } from "../../structures/FunctionalArray";
 
-export const test_functional_assertParametersCustom_FunctionalArray =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalArray")(
-    FunctionalArray,
-  )((p: (input: FunctionalArray) => FunctionalArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalArray = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalArray"
+)(FunctionalArray)(
+  (p: (input: FunctionalArray) => FunctionalArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalArrayUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalArrayUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalArrayUnion } from "../../structures/FunctionalArrayUnion";
 
-export const test_functional_assertParametersCustom_FunctionalArrayUnion =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalArrayUnion")(
-    FunctionalArrayUnion,
-  )((p: (input: FunctionalArrayUnion) => FunctionalArrayUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalArrayUnion = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalArrayUnion"
+)(FunctionalArrayUnion)(
+  (p: (input: FunctionalArrayUnion) => FunctionalArrayUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalObjectUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalObjectUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalObjectUnion } from "../../structures/FunctionalObjectUnion";
 
-export const test_functional_assertParametersCustom_FunctionalObjectUnion =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalObjectUnion")(
-    FunctionalObjectUnion,
-  )((p: (input: FunctionalObjectUnion) => FunctionalObjectUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalObjectUnion = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalObjectUnion"
+)(FunctionalObjectUnion)(
+  (p: (input: FunctionalObjectUnion) => FunctionalObjectUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalProperty.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalProperty.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalProperty } from "../../structures/FunctionalProperty";
 
-export const test_functional_assertParametersCustom_FunctionalProperty =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalProperty")(
-    FunctionalProperty,
-  )((p: (input: FunctionalProperty) => FunctionalProperty) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalProperty = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalProperty"
+)(FunctionalProperty)(
+  (p: (input: FunctionalProperty) => FunctionalProperty) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalPropertyUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalPropertyUnion.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalPropertyUnion } from "../../structures/FunctionalPropertyUnion";
 
-export const test_functional_assertParametersCustom_FunctionalPropertyUnion =
-  _test_functional_assertParameters(CustomGuardError)(
-    "FunctionalPropertyUnion",
-  )(FunctionalPropertyUnion)(
-    (p: (input: FunctionalPropertyUnion) => FunctionalPropertyUnion) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalPropertyUnion = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalPropertyUnion"
+)(FunctionalPropertyUnion)(
+  (p: (input: FunctionalPropertyUnion) => FunctionalPropertyUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalTuple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalTuple } from "../../structures/FunctionalTuple";
 
-export const test_functional_assertParametersCustom_FunctionalTuple =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalTuple")(
-    FunctionalTuple,
-  )((p: (input: FunctionalTuple) => FunctionalTuple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalTuple = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalTuple"
+)(FunctionalTuple)(
+  (p: (input: FunctionalTuple) => FunctionalTuple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalTupleUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalTupleUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalTupleUnion } from "../../structures/FunctionalTupleUnion";
 
-export const test_functional_assertParametersCustom_FunctionalTupleUnion =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalTupleUnion")(
-    FunctionalTupleUnion,
-  )((p: (input: FunctionalTupleUnion) => FunctionalTupleUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalTupleUnion = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalTupleUnion"
+)(FunctionalTupleUnion)(
+  (p: (input: FunctionalTupleUnion) => FunctionalTupleUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalValue.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalValue.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalValue } from "../../structures/FunctionalValue";
 
-export const test_functional_assertParametersCustom_FunctionalValue =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalValue")(
-    FunctionalValue,
-  )((p: (input: FunctionalValue) => FunctionalValue) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalValue = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalValue"
+)(FunctionalValue)(
+  (p: (input: FunctionalValue) => FunctionalValue) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalValueUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_FunctionalValueUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { FunctionalValueUnion } from "../../structures/FunctionalValueUnion";
 
-export const test_functional_assertParametersCustom_FunctionalValueUnion =
-  _test_functional_assertParameters(CustomGuardError)("FunctionalValueUnion")(
-    FunctionalValueUnion,
-  )((p: (input: FunctionalValueUnion) => FunctionalValueUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_FunctionalValueUnion = _test_functional_assertParameters(CustomGuardError)(
+  "FunctionalValueUnion"
+)(FunctionalValueUnion)(
+  (p: (input: FunctionalValueUnion) => FunctionalValueUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_InstanceUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_InstanceUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { InstanceUnion } from "../../structures/InstanceUnion";
 
-export const test_functional_assertParametersCustom_InstanceUnion =
-  _test_functional_assertParameters(CustomGuardError)("InstanceUnion")(
-    InstanceUnion,
-  )((p: (input: InstanceUnion) => InstanceUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_InstanceUnion = _test_functional_assertParameters(CustomGuardError)(
+  "InstanceUnion"
+)(InstanceUnion)(
+  (p: (input: InstanceUnion) => InstanceUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapAlias.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapAlias.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapAlias } from "../../structures/MapAlias";
 
-export const test_functional_assertParametersCustom_MapAlias =
-  _test_functional_assertParameters(CustomGuardError)("MapAlias")(MapAlias)(
-    (p: (input: MapAlias) => MapAlias) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapAlias = _test_functional_assertParameters(CustomGuardError)(
+  "MapAlias"
+)(MapAlias)(
+  (p: (input: MapAlias) => MapAlias) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapSimple } from "../../structures/MapSimple";
 
-export const test_functional_assertParametersCustom_MapSimple =
-  _test_functional_assertParameters(CustomGuardError)("MapSimple")(MapSimple)(
-    (p: (input: MapSimple) => MapSimple) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapSimple = _test_functional_assertParameters(CustomGuardError)(
+  "MapSimple"
+)(MapSimple)(
+  (p: (input: MapSimple) => MapSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobuf.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapSimpleProtobuf } from "../../structures/MapSimpleProtobuf";
 
-export const test_functional_assertParametersCustom_MapSimpleProtobuf =
-  _test_functional_assertParameters(CustomGuardError)("MapSimpleProtobuf")(
-    MapSimpleProtobuf,
-  )((p: (input: MapSimpleProtobuf) => MapSimpleProtobuf) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapSimpleProtobuf = _test_functional_assertParameters(CustomGuardError)(
+  "MapSimpleProtobuf"
+)(MapSimpleProtobuf)(
+  (p: (input: MapSimpleProtobuf) => MapSimpleProtobuf) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobufNullable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobufNullable.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapSimpleProtobufNullable } from "../../structures/MapSimpleProtobufNullable";
 
-export const test_functional_assertParametersCustom_MapSimpleProtobufNullable =
-  _test_functional_assertParameters(CustomGuardError)(
-    "MapSimpleProtobufNullable",
-  )(MapSimpleProtobufNullable)(
-    (p: (input: MapSimpleProtobufNullable) => MapSimpleProtobufNullable) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapSimpleProtobufNullable = _test_functional_assertParameters(CustomGuardError)(
+  "MapSimpleProtobufNullable"
+)(MapSimpleProtobufNullable)(
+  (p: (input: MapSimpleProtobufNullable) => MapSimpleProtobufNullable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobufOptional.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapSimpleProtobufOptional.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapSimpleProtobufOptional } from "../../structures/MapSimpleProtobufOptional";
 
-export const test_functional_assertParametersCustom_MapSimpleProtobufOptional =
-  _test_functional_assertParameters(CustomGuardError)(
-    "MapSimpleProtobufOptional",
-  )(MapSimpleProtobufOptional)(
-    (p: (input: MapSimpleProtobufOptional) => MapSimpleProtobufOptional) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapSimpleProtobufOptional = _test_functional_assertParameters(CustomGuardError)(
+  "MapSimpleProtobufOptional"
+)(MapSimpleProtobufOptional)(
+  (p: (input: MapSimpleProtobufOptional) => MapSimpleProtobufOptional) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_MapUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { MapUnion } from "../../structures/MapUnion";
 
-export const test_functional_assertParametersCustom_MapUnion =
-  _test_functional_assertParameters(CustomGuardError)("MapUnion")(MapUnion)(
-    (p: (input: MapUnion) => MapUnion) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_MapUnion = _test_functional_assertParameters(CustomGuardError)(
+  "MapUnion"
+)(MapUnion)(
+  (p: (input: MapUnion) => MapUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_NativeSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_NativeSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { NativeSimple } from "../../structures/NativeSimple";
 
-export const test_functional_assertParametersCustom_NativeSimple =
-  _test_functional_assertParameters(CustomGuardError)("NativeSimple")(
-    NativeSimple,
-  )((p: (input: NativeSimple) => NativeSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_NativeSimple = _test_functional_assertParameters(CustomGuardError)(
+  "NativeSimple"
+)(NativeSimple)(
+  (p: (input: NativeSimple) => NativeSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_NativeUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_NativeUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { NativeUnion } from "../../structures/NativeUnion";
 
-export const test_functional_assertParametersCustom_NativeUnion =
-  _test_functional_assertParameters(CustomGuardError)("NativeUnion")(
-    NativeUnion,
-  )((p: (input: NativeUnion) => NativeUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_NativeUnion = _test_functional_assertParameters(CustomGuardError)(
+  "NativeUnion"
+)(NativeUnion)(
+  (p: (input: NativeUnion) => NativeUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectAlias.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectAlias.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectAlias } from "../../structures/ObjectAlias";
 
-export const test_functional_assertParametersCustom_ObjectAlias =
-  _test_functional_assertParameters(CustomGuardError)("ObjectAlias")(
-    ObjectAlias,
-  )((p: (input: ObjectAlias) => ObjectAlias) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectAlias = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectAlias"
+)(ObjectAlias)(
+  (p: (input: ObjectAlias) => ObjectAlias) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectClosure.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectClosure.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectClosure } from "../../structures/ObjectClosure";
 
-export const test_functional_assertParametersCustom_ObjectClosure =
-  _test_functional_assertParameters(CustomGuardError)("ObjectClosure")(
-    ObjectClosure,
-  )((p: (input: ObjectClosure) => ObjectClosure) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectClosure = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectClosure"
+)(ObjectClosure)(
+  (p: (input: ObjectClosure) => ObjectClosure) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDate.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDate.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectDate } from "../../structures/ObjectDate";
 
-export const test_functional_assertParametersCustom_ObjectDate =
-  _test_functional_assertParameters(CustomGuardError)("ObjectDate")(ObjectDate)(
-    (p: (input: ObjectDate) => ObjectDate) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectDate = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectDate"
+)(ObjectDate)(
+  (p: (input: ObjectDate) => ObjectDate) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDescription.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDescription.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectDescription } from "../../structures/ObjectDescription";
 
-export const test_functional_assertParametersCustom_ObjectDescription =
-  _test_functional_assertParameters(CustomGuardError)("ObjectDescription")(
-    ObjectDescription,
-  )((p: (input: ObjectDescription) => ObjectDescription) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectDescription = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectDescription"
+)(ObjectDescription)(
+  (p: (input: ObjectDescription) => ObjectDescription) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDynamic.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectDynamic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectDynamic } from "../../structures/ObjectDynamic";
 
-export const test_functional_assertParametersCustom_ObjectDynamic =
-  _test_functional_assertParameters(CustomGuardError)("ObjectDynamic")(
-    ObjectDynamic,
-  )((p: (input: ObjectDynamic) => ObjectDynamic) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectDynamic = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectDynamic"
+)(ObjectDynamic)(
+  (p: (input: ObjectDynamic) => ObjectDynamic) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGeneric.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGeneric.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectGeneric } from "../../structures/ObjectGeneric";
 
-export const test_functional_assertParametersCustom_ObjectGeneric =
-  _test_functional_assertParameters(CustomGuardError)("ObjectGeneric")(
-    ObjectGeneric,
-  )((p: (input: ObjectGeneric) => ObjectGeneric) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectGeneric = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectGeneric"
+)(ObjectGeneric)(
+  (p: (input: ObjectGeneric) => ObjectGeneric) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericAlias.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericAlias.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectGenericAlias } from "../../structures/ObjectGenericAlias";
 
-export const test_functional_assertParametersCustom_ObjectGenericAlias =
-  _test_functional_assertParameters(CustomGuardError)("ObjectGenericAlias")(
-    ObjectGenericAlias,
-  )((p: (input: ObjectGenericAlias) => ObjectGenericAlias) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectGenericAlias = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectGenericAlias"
+)(ObjectGenericAlias)(
+  (p: (input: ObjectGenericAlias) => ObjectGenericAlias) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectGenericArray } from "../../structures/ObjectGenericArray";
 
-export const test_functional_assertParametersCustom_ObjectGenericArray =
-  _test_functional_assertParameters(CustomGuardError)("ObjectGenericArray")(
-    ObjectGenericArray,
-  )((p: (input: ObjectGenericArray) => ObjectGenericArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectGenericArray = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectGenericArray"
+)(ObjectGenericArray)(
+  (p: (input: ObjectGenericArray) => ObjectGenericArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectGenericUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectGenericUnion } from "../../structures/ObjectGenericUnion";
 
-export const test_functional_assertParametersCustom_ObjectGenericUnion =
-  _test_functional_assertParameters(CustomGuardError)("ObjectGenericUnion")(
-    ObjectGenericUnion,
-  )((p: (input: ObjectGenericUnion) => ObjectGenericUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectGenericUnion = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectGenericUnion"
+)(ObjectGenericUnion)(
+  (p: (input: ObjectGenericUnion) => ObjectGenericUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHierarchical.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHierarchical.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHierarchical } from "../../structures/ObjectHierarchical";
 
-export const test_functional_assertParametersCustom_ObjectHierarchical =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHierarchical")(
-    ObjectHierarchical,
-  )((p: (input: ObjectHierarchical) => ObjectHierarchical) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHierarchical = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHierarchical"
+)(ObjectHierarchical)(
+  (p: (input: ObjectHierarchical) => ObjectHierarchical) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpArray } from "../../structures/ObjectHttpArray";
 
-export const test_functional_assertParametersCustom_ObjectHttpArray =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpArray")(
-    ObjectHttpArray,
-  )((p: (input: ObjectHttpArray) => ObjectHttpArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpArray = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpArray"
+)(ObjectHttpArray)(
+  (p: (input: ObjectHttpArray) => ObjectHttpArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpAtomic.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpAtomic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpAtomic } from "../../structures/ObjectHttpAtomic";
 
-export const test_functional_assertParametersCustom_ObjectHttpAtomic =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpAtomic")(
-    ObjectHttpAtomic,
-  )((p: (input: ObjectHttpAtomic) => ObjectHttpAtomic) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpAtomic = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpAtomic"
+)(ObjectHttpAtomic)(
+  (p: (input: ObjectHttpAtomic) => ObjectHttpAtomic) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpCommentTag.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpCommentTag.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpCommentTag } from "../../structures/ObjectHttpCommentTag";
 
-export const test_functional_assertParametersCustom_ObjectHttpCommentTag =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpCommentTag")(
-    ObjectHttpCommentTag,
-  )((p: (input: ObjectHttpCommentTag) => ObjectHttpCommentTag) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpCommentTag = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpCommentTag"
+)(ObjectHttpCommentTag)(
+  (p: (input: ObjectHttpCommentTag) => ObjectHttpCommentTag) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpConstant.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpConstant } from "../../structures/ObjectHttpConstant";
 
-export const test_functional_assertParametersCustom_ObjectHttpConstant =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpConstant")(
-    ObjectHttpConstant,
-  )((p: (input: ObjectHttpConstant) => ObjectHttpConstant) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpConstant = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpConstant"
+)(ObjectHttpConstant)(
+  (p: (input: ObjectHttpConstant) => ObjectHttpConstant) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpFormData.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpFormData.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpFormData } from "../../structures/ObjectHttpFormData";
 
-export const test_functional_assertParametersCustom_ObjectHttpFormData =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpFormData")(
-    ObjectHttpFormData,
-  )((p: (input: ObjectHttpFormData) => ObjectHttpFormData) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpFormData = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpFormData"
+)(ObjectHttpFormData)(
+  (p: (input: ObjectHttpFormData) => ObjectHttpFormData) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpNullable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpNullable } from "../../structures/ObjectHttpNullable";
 
-export const test_functional_assertParametersCustom_ObjectHttpNullable =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpNullable")(
-    ObjectHttpNullable,
-  )((p: (input: ObjectHttpNullable) => ObjectHttpNullable) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpNullable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpNullable"
+)(ObjectHttpNullable)(
+  (p: (input: ObjectHttpNullable) => ObjectHttpNullable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpTypeTag.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpTypeTag.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpTypeTag } from "../../structures/ObjectHttpTypeTag";
 
-export const test_functional_assertParametersCustom_ObjectHttpTypeTag =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpTypeTag")(
-    ObjectHttpTypeTag,
-  )((p: (input: ObjectHttpTypeTag) => ObjectHttpTypeTag) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpTypeTag = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpTypeTag"
+)(ObjectHttpTypeTag)(
+  (p: (input: ObjectHttpTypeTag) => ObjectHttpTypeTag) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpUndefindable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectHttpUndefindable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectHttpUndefindable } from "../../structures/ObjectHttpUndefindable";
 
-export const test_functional_assertParametersCustom_ObjectHttpUndefindable =
-  _test_functional_assertParameters(CustomGuardError)("ObjectHttpUndefindable")(
-    ObjectHttpUndefindable,
-  )((p: (input: ObjectHttpUndefindable) => ObjectHttpUndefindable) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectHttpUndefindable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectHttpUndefindable"
+)(ObjectHttpUndefindable)(
+  (p: (input: ObjectHttpUndefindable) => ObjectHttpUndefindable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectInternal.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectInternal.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectInternal } from "../../structures/ObjectInternal";
 
-export const test_functional_assertParametersCustom_ObjectInternal =
-  _test_functional_assertParameters(CustomGuardError)("ObjectInternal")(
-    ObjectInternal,
-  )((p: (input: ObjectInternal) => ObjectInternal) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectInternal = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectInternal"
+)(ObjectInternal)(
+  (p: (input: ObjectInternal) => ObjectInternal) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectIntersection.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectIntersection } from "../../structures/ObjectIntersection";
 
-export const test_functional_assertParametersCustom_ObjectIntersection =
-  _test_functional_assertParameters(CustomGuardError)("ObjectIntersection")(
-    ObjectIntersection,
-  )((p: (input: ObjectIntersection) => ObjectIntersection) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectIntersection = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectIntersection"
+)(ObjectIntersection)(
+  (p: (input: ObjectIntersection) => ObjectIntersection) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectJsonTag.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectJsonTag.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectJsonTag } from "../../structures/ObjectJsonTag";
 
-export const test_functional_assertParametersCustom_ObjectJsonTag =
-  _test_functional_assertParameters(CustomGuardError)("ObjectJsonTag")(
-    ObjectJsonTag,
-  )((p: (input: ObjectJsonTag) => ObjectJsonTag) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectJsonTag = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectJsonTag"
+)(ObjectJsonTag)(
+  (p: (input: ObjectJsonTag) => ObjectJsonTag) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectLiteralProperty.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectLiteralProperty.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectLiteralProperty } from "../../structures/ObjectLiteralProperty";
 
-export const test_functional_assertParametersCustom_ObjectLiteralProperty =
-  _test_functional_assertParameters(CustomGuardError)("ObjectLiteralProperty")(
-    ObjectLiteralProperty,
-  )((p: (input: ObjectLiteralProperty) => ObjectLiteralProperty) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectLiteralProperty = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectLiteralProperty"
+)(ObjectLiteralProperty)(
+  (p: (input: ObjectLiteralProperty) => ObjectLiteralProperty) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectLiteralType.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectLiteralType.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectLiteralType } from "../../structures/ObjectLiteralType";
 
-export const test_functional_assertParametersCustom_ObjectLiteralType =
-  _test_functional_assertParameters(CustomGuardError)("ObjectLiteralType")(
-    ObjectLiteralType,
-  )((p: (input: ObjectLiteralType) => ObjectLiteralType) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectLiteralType = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectLiteralType"
+)(ObjectLiteralType)(
+  (p: (input: ObjectLiteralType) => ObjectLiteralType) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectNullable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectNullable } from "../../structures/ObjectNullable";
 
-export const test_functional_assertParametersCustom_ObjectNullable =
-  _test_functional_assertParameters(CustomGuardError)("ObjectNullable")(
-    ObjectNullable,
-  )((p: (input: ObjectNullable) => ObjectNullable) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectNullable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectNullable"
+)(ObjectNullable)(
+  (p: (input: ObjectNullable) => ObjectNullable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectOptional.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectOptional } from "../../structures/ObjectOptional";
 
-export const test_functional_assertParametersCustom_ObjectOptional =
-  _test_functional_assertParameters(CustomGuardError)("ObjectOptional")(
-    ObjectOptional,
-  )((p: (input: ObjectOptional) => ObjectOptional) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectOptional = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectOptional"
+)(ObjectOptional)(
+  (p: (input: ObjectOptional) => ObjectOptional) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPartial.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPartial.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectPartial } from "../../structures/ObjectPartial";
 
-export const test_functional_assertParametersCustom_ObjectPartial =
-  _test_functional_assertParameters(CustomGuardError)("ObjectPartial")(
-    ObjectPartial,
-  )((p: (input: ObjectPartial) => ObjectPartial) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectPartial = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectPartial"
+)(ObjectPartial)(
+  (p: (input: ObjectPartial) => ObjectPartial) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPartialAndRequired.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPartialAndRequired.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
 
-export const test_functional_assertParametersCustom_ObjectPartialAndRequired =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectPartialAndRequired",
-  )(ObjectPartialAndRequired)(
-    (p: (input: ObjectPartialAndRequired) => ObjectPartialAndRequired) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectPartialAndRequired = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectPartialAndRequired"
+)(ObjectPartialAndRequired)(
+  (p: (input: ObjectPartialAndRequired) => ObjectPartialAndRequired) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPrimitive.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPrimitive.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectPrimitive } from "../../structures/ObjectPrimitive";
 
-export const test_functional_assertParametersCustom_ObjectPrimitive =
-  _test_functional_assertParameters(CustomGuardError)("ObjectPrimitive")(
-    ObjectPrimitive,
-  )((p: (input: ObjectPrimitive) => ObjectPrimitive) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectPrimitive = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectPrimitive"
+)(ObjectPrimitive)(
+  (p: (input: ObjectPrimitive) => ObjectPrimitive) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPropertyNullable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectPropertyNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectPropertyNullable } from "../../structures/ObjectPropertyNullable";
 
-export const test_functional_assertParametersCustom_ObjectPropertyNullable =
-  _test_functional_assertParameters(CustomGuardError)("ObjectPropertyNullable")(
-    ObjectPropertyNullable,
-  )((p: (input: ObjectPropertyNullable) => ObjectPropertyNullable) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectPropertyNullable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectPropertyNullable"
+)(ObjectPropertyNullable)(
+  (p: (input: ObjectPropertyNullable) => ObjectPropertyNullable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectRecursive.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectRecursive.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectRecursive } from "../../structures/ObjectRecursive";
 
-export const test_functional_assertParametersCustom_ObjectRecursive =
-  _test_functional_assertParameters(CustomGuardError)("ObjectRecursive")(
-    ObjectRecursive,
-  )((p: (input: ObjectRecursive) => ObjectRecursive) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectRecursive = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectRecursive"
+)(ObjectRecursive)(
+  (p: (input: ObjectRecursive) => ObjectRecursive) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectRequired.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectRequired.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectRequired } from "../../structures/ObjectRequired";
 
-export const test_functional_assertParametersCustom_ObjectRequired =
-  _test_functional_assertParameters(CustomGuardError)("ObjectRequired")(
-    ObjectRequired,
-  )((p: (input: ObjectRequired) => ObjectRequired) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectRequired = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectRequired"
+)(ObjectRequired)(
+  (p: (input: ObjectRequired) => ObjectRequired) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSequenceProtobuf.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSequenceProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectSequenceProtobuf } from "../../structures/ObjectSequenceProtobuf";
 
-export const test_functional_assertParametersCustom_ObjectSequenceProtobuf =
-  _test_functional_assertParameters(CustomGuardError)("ObjectSequenceProtobuf")(
-    ObjectSequenceProtobuf,
-  )((p: (input: ObjectSequenceProtobuf) => ObjectSequenceProtobuf) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectSequenceProtobuf = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectSequenceProtobuf"
+)(ObjectSequenceProtobuf)(
+  (p: (input: ObjectSequenceProtobuf) => ObjectSequenceProtobuf) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectSimple } from "../../structures/ObjectSimple";
 
-export const test_functional_assertParametersCustom_ObjectSimple =
-  _test_functional_assertParameters(CustomGuardError)("ObjectSimple")(
-    ObjectSimple,
-  )((p: (input: ObjectSimple) => ObjectSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectSimple = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectSimple"
+)(ObjectSimple)(
+  (p: (input: ObjectSimple) => ObjectSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobuf.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectSimpleProtobuf } from "../../structures/ObjectSimpleProtobuf";
 
-export const test_functional_assertParametersCustom_ObjectSimpleProtobuf =
-  _test_functional_assertParameters(CustomGuardError)("ObjectSimpleProtobuf")(
-    ObjectSimpleProtobuf,
-  )((p: (input: ObjectSimpleProtobuf) => ObjectSimpleProtobuf) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectSimpleProtobuf = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectSimpleProtobuf"
+)(ObjectSimpleProtobuf)(
+  (p: (input: ObjectSimpleProtobuf) => ObjectSimpleProtobuf) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobufNullable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobufNullable.ts
@@ -1,14 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectSimpleProtobufNullable } from "../../structures/ObjectSimpleProtobufNullable";
 
-export const test_functional_assertParametersCustom_ObjectSimpleProtobufNullable =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectSimpleProtobufNullable",
-  )(ObjectSimpleProtobufNullable)(
-    (
-      p: (input: ObjectSimpleProtobufNullable) => ObjectSimpleProtobufNullable,
-    ) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectSimpleProtobufNullable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectSimpleProtobufNullable"
+)(ObjectSimpleProtobufNullable)(
+  (p: (input: ObjectSimpleProtobufNullable) => ObjectSimpleProtobufNullable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobufOptional.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectSimpleProtobufOptional.ts
@@ -1,14 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectSimpleProtobufOptional } from "../../structures/ObjectSimpleProtobufOptional";
 
-export const test_functional_assertParametersCustom_ObjectSimpleProtobufOptional =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectSimpleProtobufOptional",
-  )(ObjectSimpleProtobufOptional)(
-    (
-      p: (input: ObjectSimpleProtobufOptional) => ObjectSimpleProtobufOptional,
-    ) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectSimpleProtobufOptional = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectSimpleProtobufOptional"
+)(ObjectSimpleProtobufOptional)(
+  (p: (input: ObjectSimpleProtobufOptional) => ObjectSimpleProtobufOptional) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectTuple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectTuple } from "../../structures/ObjectTuple";
 
-export const test_functional_assertParametersCustom_ObjectTuple =
-  _test_functional_assertParameters(CustomGuardError)("ObjectTuple")(
-    ObjectTuple,
-  )((p: (input: ObjectTuple) => ObjectTuple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectTuple = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectTuple"
+)(ObjectTuple)(
+  (p: (input: ObjectTuple) => ObjectTuple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUndefined.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUndefined.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUndefined } from "../../structures/ObjectUndefined";
 
-export const test_functional_assertParametersCustom_ObjectUndefined =
-  _test_functional_assertParameters(CustomGuardError)("ObjectUndefined")(
-    ObjectUndefined,
-  )((p: (input: ObjectUndefined) => ObjectUndefined) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUndefined = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUndefined"
+)(ObjectUndefined)(
+  (p: (input: ObjectUndefined) => ObjectUndefined) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionComposite.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionComposite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionComposite } from "../../structures/ObjectUnionComposite";
 
-export const test_functional_assertParametersCustom_ObjectUnionComposite =
-  _test_functional_assertParameters(CustomGuardError)("ObjectUnionComposite")(
-    ObjectUnionComposite,
-  )((p: (input: ObjectUnionComposite) => ObjectUnionComposite) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionComposite = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionComposite"
+)(ObjectUnionComposite)(
+  (p: (input: ObjectUnionComposite) => ObjectUnionComposite) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionCompositePointer.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionCompositePointer.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionCompositePointer } from "../../structures/ObjectUnionCompositePointer";
 
-export const test_functional_assertParametersCustom_ObjectUnionCompositePointer =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectUnionCompositePointer",
-  )(ObjectUnionCompositePointer)(
-    (p: (input: ObjectUnionCompositePointer) => ObjectUnionCompositePointer) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionCompositePointer = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionCompositePointer"
+)(ObjectUnionCompositePointer)(
+  (p: (input: ObjectUnionCompositePointer) => ObjectUnionCompositePointer) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionDouble.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionDouble.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionDouble } from "../../structures/ObjectUnionDouble";
 
-export const test_functional_assertParametersCustom_ObjectUnionDouble =
-  _test_functional_assertParameters(CustomGuardError)("ObjectUnionDouble")(
-    ObjectUnionDouble,
-  )((p: (input: ObjectUnionDouble) => ObjectUnionDouble) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionDouble = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionDouble"
+)(ObjectUnionDouble)(
+  (p: (input: ObjectUnionDouble) => ObjectUnionDouble) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionExplicit.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionExplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionExplicit } from "../../structures/ObjectUnionExplicit";
 
-export const test_functional_assertParametersCustom_ObjectUnionExplicit =
-  _test_functional_assertParameters(CustomGuardError)("ObjectUnionExplicit")(
-    ObjectUnionExplicit,
-  )((p: (input: ObjectUnionExplicit) => ObjectUnionExplicit) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionExplicit = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionExplicit"
+)(ObjectUnionExplicit)(
+  (p: (input: ObjectUnionExplicit) => ObjectUnionExplicit) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionExplicitPointer.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionExplicitPointer.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionExplicitPointer } from "../../structures/ObjectUnionExplicitPointer";
 
-export const test_functional_assertParametersCustom_ObjectUnionExplicitPointer =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectUnionExplicitPointer",
-  )(ObjectUnionExplicitPointer)(
-    (p: (input: ObjectUnionExplicitPointer) => ObjectUnionExplicitPointer) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionExplicitPointer = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionExplicitPointer"
+)(ObjectUnionExplicitPointer)(
+  (p: (input: ObjectUnionExplicitPointer) => ObjectUnionExplicitPointer) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionImplicit.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionImplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionImplicit } from "../../structures/ObjectUnionImplicit";
 
-export const test_functional_assertParametersCustom_ObjectUnionImplicit =
-  _test_functional_assertParameters(CustomGuardError)("ObjectUnionImplicit")(
-    ObjectUnionImplicit,
-  )((p: (input: ObjectUnionImplicit) => ObjectUnionImplicit) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionImplicit = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionImplicit"
+)(ObjectUnionImplicit)(
+  (p: (input: ObjectUnionImplicit) => ObjectUnionImplicit) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionNonPredictable.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ObjectUnionNonPredictable.ts
@@ -1,13 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ObjectUnionNonPredictable } from "../../structures/ObjectUnionNonPredictable";
 
-export const test_functional_assertParametersCustom_ObjectUnionNonPredictable =
-  _test_functional_assertParameters(CustomGuardError)(
-    "ObjectUnionNonPredictable",
-  )(ObjectUnionNonPredictable)(
-    (p: (input: ObjectUnionNonPredictable) => ObjectUnionNonPredictable) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ObjectUnionNonPredictable = _test_functional_assertParameters(CustomGuardError)(
+  "ObjectUnionNonPredictable"
+)(ObjectUnionNonPredictable)(
+  (p: (input: ObjectUnionNonPredictable) => ObjectUnionNonPredictable) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetAlias.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetAlias.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { SetAlias } from "../../structures/SetAlias";
 
-export const test_functional_assertParametersCustom_SetAlias =
-  _test_functional_assertParameters(CustomGuardError)("SetAlias")(SetAlias)(
-    (p: (input: SetAlias) => SetAlias) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_SetAlias = _test_functional_assertParameters(CustomGuardError)(
+  "SetAlias"
+)(SetAlias)(
+  (p: (input: SetAlias) => SetAlias) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { SetSimple } from "../../structures/SetSimple";
 
-export const test_functional_assertParametersCustom_SetSimple =
-  _test_functional_assertParameters(CustomGuardError)("SetSimple")(SetSimple)(
-    (p: (input: SetSimple) => SetSimple) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_SetSimple = _test_functional_assertParameters(CustomGuardError)(
+  "SetSimple"
+)(SetSimple)(
+  (p: (input: SetSimple) => SetSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_SetUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { SetUnion } from "../../structures/SetUnion";
 
-export const test_functional_assertParametersCustom_SetUnion =
-  _test_functional_assertParameters(CustomGuardError)("SetUnion")(SetUnion)(
-    (p: (input: SetUnion) => SetUnion) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_SetUnion = _test_functional_assertParameters(CustomGuardError)(
+  "SetUnion"
+)(SetUnion)(
+  (p: (input: SetUnion) => SetUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateAtomic.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateAtomic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TemplateAtomic } from "../../structures/TemplateAtomic";
 
-export const test_functional_assertParametersCustom_TemplateAtomic =
-  _test_functional_assertParameters(CustomGuardError)("TemplateAtomic")(
-    TemplateAtomic,
-  )((p: (input: TemplateAtomic) => TemplateAtomic) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TemplateAtomic = _test_functional_assertParameters(CustomGuardError)(
+  "TemplateAtomic"
+)(TemplateAtomic)(
+  (p: (input: TemplateAtomic) => TemplateAtomic) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateConstant.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TemplateConstant } from "../../structures/TemplateConstant";
 
-export const test_functional_assertParametersCustom_TemplateConstant =
-  _test_functional_assertParameters(CustomGuardError)("TemplateConstant")(
-    TemplateConstant,
-  )((p: (input: TemplateConstant) => TemplateConstant) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TemplateConstant = _test_functional_assertParameters(CustomGuardError)(
+  "TemplateConstant"
+)(TemplateConstant)(
+  (p: (input: TemplateConstant) => TemplateConstant) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TemplateUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TemplateUnion } from "../../structures/TemplateUnion";
 
-export const test_functional_assertParametersCustom_TemplateUnion =
-  _test_functional_assertParameters(CustomGuardError)("TemplateUnion")(
-    TemplateUnion,
-  )((p: (input: TemplateUnion) => TemplateUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TemplateUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TemplateUnion"
+)(TemplateUnion)(
+  (p: (input: TemplateUnion) => TemplateUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonArray } from "../../structures/ToJsonArray";
 
-export const test_functional_assertParametersCustom_ToJsonArray =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonArray")(
-    ToJsonArray,
-  )((p: (input: ToJsonArray) => ToJsonArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonArray = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonArray"
+)(ToJsonArray)(
+  (p: (input: ToJsonArray) => ToJsonArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonAtomicSimple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonAtomicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonAtomicSimple } from "../../structures/ToJsonAtomicSimple";
 
-export const test_functional_assertParametersCustom_ToJsonAtomicSimple =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonAtomicSimple")(
-    ToJsonAtomicSimple,
-  )((p: (input: ToJsonAtomicSimple) => ToJsonAtomicSimple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonAtomicSimple = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonAtomicSimple"
+)(ToJsonAtomicSimple)(
+  (p: (input: ToJsonAtomicSimple) => ToJsonAtomicSimple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonAtomicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonAtomicUnion } from "../../structures/ToJsonAtomicUnion";
 
-export const test_functional_assertParametersCustom_ToJsonAtomicUnion =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonAtomicUnion")(
-    ToJsonAtomicUnion,
-  )((p: (input: ToJsonAtomicUnion) => ToJsonAtomicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonAtomicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonAtomicUnion"
+)(ToJsonAtomicUnion)(
+  (p: (input: ToJsonAtomicUnion) => ToJsonAtomicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonDouble.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonDouble.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonDouble } from "../../structures/ToJsonDouble";
 
-export const test_functional_assertParametersCustom_ToJsonDouble =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonDouble")(
-    ToJsonDouble,
-  )((p: (input: ToJsonDouble) => ToJsonDouble) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonDouble = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonDouble"
+)(ToJsonDouble)(
+  (p: (input: ToJsonDouble) => ToJsonDouble) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonNull.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonNull.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonNull } from "../../structures/ToJsonNull";
 
-export const test_functional_assertParametersCustom_ToJsonNull =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonNull")(ToJsonNull)(
-    (p: (input: ToJsonNull) => ToJsonNull) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonNull = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonNull"
+)(ToJsonNull)(
+  (p: (input: ToJsonNull) => ToJsonNull) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonTuple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonTuple } from "../../structures/ToJsonTuple";
 
-export const test_functional_assertParametersCustom_ToJsonTuple =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonTuple")(
-    ToJsonTuple,
-  )((p: (input: ToJsonTuple) => ToJsonTuple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonTuple = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonTuple"
+)(ToJsonTuple)(
+  (p: (input: ToJsonTuple) => ToJsonTuple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_ToJsonUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { ToJsonUnion } from "../../structures/ToJsonUnion";
 
-export const test_functional_assertParametersCustom_ToJsonUnion =
-  _test_functional_assertParameters(CustomGuardError)("ToJsonUnion")(
-    ToJsonUnion,
-  )((p: (input: ToJsonUnion) => ToJsonUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_ToJsonUnion = _test_functional_assertParameters(CustomGuardError)(
+  "ToJsonUnion"
+)(ToJsonUnion)(
+  (p: (input: ToJsonUnion) => ToJsonUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleHierarchical.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleHierarchical.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleHierarchical } from "../../structures/TupleHierarchical";
 
-export const test_functional_assertParametersCustom_TupleHierarchical =
-  _test_functional_assertParameters(CustomGuardError)("TupleHierarchical")(
-    TupleHierarchical,
-  )((p: (input: TupleHierarchical) => TupleHierarchical) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleHierarchical = _test_functional_assertParameters(CustomGuardError)(
+  "TupleHierarchical"
+)(TupleHierarchical)(
+  (p: (input: TupleHierarchical) => TupleHierarchical) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleOptional.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleOptional } from "../../structures/TupleOptional";
 
-export const test_functional_assertParametersCustom_TupleOptional =
-  _test_functional_assertParameters(CustomGuardError)("TupleOptional")(
-    TupleOptional,
-  )((p: (input: TupleOptional) => TupleOptional) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleOptional = _test_functional_assertParameters(CustomGuardError)(
+  "TupleOptional"
+)(TupleOptional)(
+  (p: (input: TupleOptional) => TupleOptional) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleRestArray } from "../../structures/TupleRestArray";
 
-export const test_functional_assertParametersCustom_TupleRestArray =
-  _test_functional_assertParameters(CustomGuardError)("TupleRestArray")(
-    TupleRestArray,
-  )((p: (input: TupleRestArray) => TupleRestArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleRestArray = _test_functional_assertParameters(CustomGuardError)(
+  "TupleRestArray"
+)(TupleRestArray)(
+  (p: (input: TupleRestArray) => TupleRestArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestAtomic.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestAtomic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleRestAtomic } from "../../structures/TupleRestAtomic";
 
-export const test_functional_assertParametersCustom_TupleRestAtomic =
-  _test_functional_assertParameters(CustomGuardError)("TupleRestAtomic")(
-    TupleRestAtomic,
-  )((p: (input: TupleRestAtomic) => TupleRestAtomic) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleRestAtomic = _test_functional_assertParameters(CustomGuardError)(
+  "TupleRestAtomic"
+)(TupleRestAtomic)(
+  (p: (input: TupleRestAtomic) => TupleRestAtomic) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestObject.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleRestObject.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleRestObject } from "../../structures/TupleRestObject";
 
-export const test_functional_assertParametersCustom_TupleRestObject =
-  _test_functional_assertParameters(CustomGuardError)("TupleRestObject")(
-    TupleRestObject,
-  )((p: (input: TupleRestObject) => TupleRestObject) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleRestObject = _test_functional_assertParameters(CustomGuardError)(
+  "TupleRestObject"
+)(TupleRestObject)(
+  (p: (input: TupleRestObject) => TupleRestObject) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TupleUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TupleUnion } from "../../structures/TupleUnion";
 
-export const test_functional_assertParametersCustom_TupleUnion =
-  _test_functional_assertParameters(CustomGuardError)("TupleUnion")(TupleUnion)(
-    (p: (input: TupleUnion) => TupleUnion) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TupleUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TupleUnion"
+)(TupleUnion)(
+  (p: (input: TupleUnion) => TupleUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagArray.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagArray } from "../../structures/TypeTagArray";
 
-export const test_functional_assertParametersCustom_TypeTagArray =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagArray")(
-    TypeTagArray,
-  )((p: (input: TypeTagArray) => TypeTagArray) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagArray = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagArray"
+)(TypeTagArray)(
+  (p: (input: TypeTagArray) => TypeTagArray) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagArrayUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagArrayUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagArrayUnion } from "../../structures/TypeTagArrayUnion";
 
-export const test_functional_assertParametersCustom_TypeTagArrayUnion =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagArrayUnion")(
-    TypeTagArrayUnion,
-  )((p: (input: TypeTagArrayUnion) => TypeTagArrayUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagArrayUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagArrayUnion"
+)(TypeTagArrayUnion)(
+  (p: (input: TypeTagArrayUnion) => TypeTagArrayUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagAtomicUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagAtomicUnion } from "../../structures/TypeTagAtomicUnion";
 
-export const test_functional_assertParametersCustom_TypeTagAtomicUnion =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagAtomicUnion")(
-    TypeTagAtomicUnion,
-  )((p: (input: TypeTagAtomicUnion) => TypeTagAtomicUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagAtomicUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagAtomicUnion"
+)(TypeTagAtomicUnion)(
+  (p: (input: TypeTagAtomicUnion) => TypeTagAtomicUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagBigInt } from "../../structures/TypeTagBigInt";
 
-export const test_functional_assertParametersCustom_TypeTagBigInt =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagBigInt")(
-    TypeTagBigInt,
-  )((p: (input: TypeTagBigInt) => TypeTagBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagBigInt"
+)(TypeTagBigInt)(
+  (p: (input: TypeTagBigInt) => TypeTagBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagCustom.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagCustom.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagCustom } from "../../structures/TypeTagCustom";
 
-export const test_functional_assertParametersCustom_TypeTagCustom =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagCustom")(
-    TypeTagCustom,
-  )((p: (input: TypeTagCustom) => TypeTagCustom) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagCustom = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagCustom"
+)(TypeTagCustom)(
+  (p: (input: TypeTagCustom) => TypeTagCustom) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagDefault.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagDefault.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagDefault } from "../../structures/TypeTagDefault";
 
-export const test_functional_assertParametersCustom_TypeTagDefault =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagDefault")(
-    TypeTagDefault,
-  )((p: (input: TypeTagDefault) => TypeTagDefault) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagDefault = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagDefault"
+)(TypeTagDefault)(
+  (p: (input: TypeTagDefault) => TypeTagDefault) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagFormat.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagFormat.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagFormat } from "../../structures/TypeTagFormat";
 
-export const test_functional_assertParametersCustom_TypeTagFormat =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagFormat")(
-    TypeTagFormat,
-  )((p: (input: TypeTagFormat) => TypeTagFormat) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagFormat = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagFormat"
+)(TypeTagFormat)(
+  (p: (input: TypeTagFormat) => TypeTagFormat) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagInfinite.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagInfinite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagInfinite } from "../../structures/TypeTagInfinite";
 
-export const test_functional_assertParametersCustom_TypeTagInfinite =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagInfinite")(
-    TypeTagInfinite,
-  )((p: (input: TypeTagInfinite) => TypeTagInfinite) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagInfinite = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagInfinite"
+)(TypeTagInfinite)(
+  (p: (input: TypeTagInfinite) => TypeTagInfinite) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagLength.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagLength.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagLength } from "../../structures/TypeTagLength";
 
-export const test_functional_assertParametersCustom_TypeTagLength =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagLength")(
-    TypeTagLength,
-  )((p: (input: TypeTagLength) => TypeTagLength) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagLength = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagLength"
+)(TypeTagLength)(
+  (p: (input: TypeTagLength) => TypeTagLength) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagMatrix.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagMatrix.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagMatrix } from "../../structures/TypeTagMatrix";
 
-export const test_functional_assertParametersCustom_TypeTagMatrix =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagMatrix")(
-    TypeTagMatrix,
-  )((p: (input: TypeTagMatrix) => TypeTagMatrix) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagMatrix = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagMatrix"
+)(TypeTagMatrix)(
+  (p: (input: TypeTagMatrix) => TypeTagMatrix) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagNaN.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagNaN.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagNaN } from "../../structures/TypeTagNaN";
 
-export const test_functional_assertParametersCustom_TypeTagNaN =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagNaN")(TypeTagNaN)(
-    (p: (input: TypeTagNaN) => TypeTagNaN) =>
-      typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagNaN = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagNaN"
+)(TypeTagNaN)(
+  (p: (input: TypeTagNaN) => TypeTagNaN) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagObjectUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagObjectUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagObjectUnion } from "../../structures/TypeTagObjectUnion";
 
-export const test_functional_assertParametersCustom_TypeTagObjectUnion =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagObjectUnion")(
-    TypeTagObjectUnion,
-  )((p: (input: TypeTagObjectUnion) => TypeTagObjectUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagObjectUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagObjectUnion"
+)(TypeTagObjectUnion)(
+  (p: (input: TypeTagObjectUnion) => TypeTagObjectUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagPattern.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagPattern.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagPattern } from "../../structures/TypeTagPattern";
 
-export const test_functional_assertParametersCustom_TypeTagPattern =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagPattern")(
-    TypeTagPattern,
-  )((p: (input: TypeTagPattern) => TypeTagPattern) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagPattern = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagPattern"
+)(TypeTagPattern)(
+  (p: (input: TypeTagPattern) => TypeTagPattern) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagRange.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagRange.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagRange } from "../../structures/TypeTagRange";
 
-export const test_functional_assertParametersCustom_TypeTagRange =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagRange")(
-    TypeTagRange,
-  )((p: (input: TypeTagRange) => TypeTagRange) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagRange = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagRange"
+)(TypeTagRange)(
+  (p: (input: TypeTagRange) => TypeTagRange) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagRangeBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagRangeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagRangeBigInt } from "../../structures/TypeTagRangeBigInt";
 
-export const test_functional_assertParametersCustom_TypeTagRangeBigInt =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagRangeBigInt")(
-    TypeTagRangeBigInt,
-  )((p: (input: TypeTagRangeBigInt) => TypeTagRangeBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagRangeBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagRangeBigInt"
+)(TypeTagRangeBigInt)(
+  (p: (input: TypeTagRangeBigInt) => TypeTagRangeBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTuple.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagTuple } from "../../structures/TypeTagTuple";
 
-export const test_functional_assertParametersCustom_TypeTagTuple =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagTuple")(
-    TypeTagTuple,
-  )((p: (input: TypeTagTuple) => TypeTagTuple) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagTuple = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagTuple"
+)(TypeTagTuple)(
+  (p: (input: TypeTagTuple) => TypeTagTuple) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagType.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagType.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagType } from "../../structures/TypeTagType";
 
-export const test_functional_assertParametersCustom_TypeTagType =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagType")(
-    TypeTagType,
-  )((p: (input: TypeTagType) => TypeTagType) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagType = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagType"
+)(TypeTagType)(
+  (p: (input: TypeTagType) => TypeTagType) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTypeBigInt.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTypeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagTypeBigInt } from "../../structures/TypeTagTypeBigInt";
 
-export const test_functional_assertParametersCustom_TypeTagTypeBigInt =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagTypeBigInt")(
-    TypeTagTypeBigInt,
-  )((p: (input: TypeTagTypeBigInt) => TypeTagTypeBigInt) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagTypeBigInt = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagTypeBigInt"
+)(TypeTagTypeBigInt)(
+  (p: (input: TypeTagTypeBigInt) => TypeTagTypeBigInt) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTypeUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_TypeTagTypeUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { TypeTagTypeUnion } from "../../structures/TypeTagTypeUnion";
 
-export const test_functional_assertParametersCustom_TypeTagTypeUnion =
-  _test_functional_assertParameters(CustomGuardError)("TypeTagTypeUnion")(
-    TypeTagTypeUnion,
-  )((p: (input: TypeTagTypeUnion) => TypeTagTypeUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_TypeTagTypeUnion = _test_functional_assertParameters(CustomGuardError)(
+  "TypeTagTypeUnion"
+)(TypeTagTypeUnion)(
+  (p: (input: TypeTagTypeUnion) => TypeTagTypeUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_UltimateUnion.ts
+++ b/test/src/features/functional.assertParametersCustom/test_functional_assertParametersCustom_UltimateUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
 
-import { CustomGuardError } from "../../internal/CustomGuardError";
 import { _test_functional_assertParameters } from "../../internal/_test_functional_assertParameters";
 import { UltimateUnion } from "../../structures/UltimateUnion";
 
-export const test_functional_assertParametersCustom_UltimateUnion =
-  _test_functional_assertParameters(CustomGuardError)("UltimateUnion")(
-    UltimateUnion,
-  )((p: (input: UltimateUnion) => UltimateUnion) =>
-    typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
-  );
+import { CustomGuardError } from "../../internal/CustomGuardError";
+
+export const test_functional_assertParametersCustom_UltimateUnion = _test_functional_assertParameters(CustomGuardError)(
+  "UltimateUnion"
+)(UltimateUnion)(
+  (p: (input: UltimateUnion) => UltimateUnion) => typia.functional.assertParameters(p, (p) => new CustomGuardError(p)),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAny.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAny.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayAny } from "../../structures/ArrayAny";
 
-export const test_functional_assertReturn_ArrayAny =
-  _test_functional_assertReturn(TypeGuardError)("ArrayAny")(ArrayAny)(
-    (p: (input: ArrayAny) => ArrayAny) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayAny = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayAny"
+)(ArrayAny)(
+  (p: (input: ArrayAny) => ArrayAny) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAtomicAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAtomicAlias.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayAtomicAlias } from "../../structures/ArrayAtomicAlias";
 
-export const test_functional_assertReturn_ArrayAtomicAlias =
-  _test_functional_assertReturn(TypeGuardError)("ArrayAtomicAlias")(
-    ArrayAtomicAlias,
-  )((p: (input: ArrayAtomicAlias) => ArrayAtomicAlias) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayAtomicAlias = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayAtomicAlias"
+)(ArrayAtomicAlias)(
+  (p: (input: ArrayAtomicAlias) => ArrayAtomicAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAtomicSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayAtomicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayAtomicSimple } from "../../structures/ArrayAtomicSimple";
 
-export const test_functional_assertReturn_ArrayAtomicSimple =
-  _test_functional_assertReturn(TypeGuardError)("ArrayAtomicSimple")(
-    ArrayAtomicSimple,
-  )((p: (input: ArrayAtomicSimple) => ArrayAtomicSimple) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayAtomicSimple = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayAtomicSimple"
+)(ArrayAtomicSimple)(
+  (p: (input: ArrayAtomicSimple) => ArrayAtomicSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayHierarchical.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayHierarchical.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayHierarchical } from "../../structures/ArrayHierarchical";
 
-export const test_functional_assertReturn_ArrayHierarchical =
-  _test_functional_assertReturn(TypeGuardError)("ArrayHierarchical")(
-    ArrayHierarchical,
-  )((p: (input: ArrayHierarchical) => ArrayHierarchical) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayHierarchical = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayHierarchical"
+)(ArrayHierarchical)(
+  (p: (input: ArrayHierarchical) => ArrayHierarchical) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayHierarchicalPointer.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayHierarchicalPointer.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayHierarchicalPointer } from "../../structures/ArrayHierarchicalPointer";
 
-export const test_functional_assertReturn_ArrayHierarchicalPointer =
-  _test_functional_assertReturn(TypeGuardError)("ArrayHierarchicalPointer")(
-    ArrayHierarchicalPointer,
-  )((p: (input: ArrayHierarchicalPointer) => ArrayHierarchicalPointer) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayHierarchicalPointer = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayHierarchicalPointer"
+)(ArrayHierarchicalPointer)(
+  (p: (input: ArrayHierarchicalPointer) => ArrayHierarchicalPointer) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayMatrix.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayMatrix.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayMatrix } from "../../structures/ArrayMatrix";
 
-export const test_functional_assertReturn_ArrayMatrix =
-  _test_functional_assertReturn(TypeGuardError)("ArrayMatrix")(ArrayMatrix)(
-    (p: (input: ArrayMatrix) => ArrayMatrix) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayMatrix = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayMatrix"
+)(ArrayMatrix)(
+  (p: (input: ArrayMatrix) => ArrayMatrix) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursive.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursive.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRecursive } from "../../structures/ArrayRecursive";
 
-export const test_functional_assertReturn_ArrayRecursive =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRecursive")(
-    ArrayRecursive,
-  )((p: (input: ArrayRecursive) => ArrayRecursive) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRecursive = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRecursive"
+)(ArrayRecursive)(
+  (p: (input: ArrayRecursive) => ArrayRecursive) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionExplicit.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionExplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRecursiveUnionExplicit } from "../../structures/ArrayRecursiveUnionExplicit";
 
-export const test_functional_assertReturn_ArrayRecursiveUnionExplicit =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRecursiveUnionExplicit")(
-    ArrayRecursiveUnionExplicit,
-  )((p: (input: ArrayRecursiveUnionExplicit) => ArrayRecursiveUnionExplicit) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRecursiveUnionExplicit = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRecursiveUnionExplicit"
+)(ArrayRecursiveUnionExplicit)(
+  (p: (input: ArrayRecursiveUnionExplicit) => ArrayRecursiveUnionExplicit) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionExplicitPointer.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionExplicitPointer.ts
@@ -1,16 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRecursiveUnionExplicitPointer } from "../../structures/ArrayRecursiveUnionExplicitPointer";
 
-export const test_functional_assertReturn_ArrayRecursiveUnionExplicitPointer =
-  _test_functional_assertReturn(TypeGuardError)(
-    "ArrayRecursiveUnionExplicitPointer",
-  )(ArrayRecursiveUnionExplicitPointer)(
-    (
-      p: (
-        input: ArrayRecursiveUnionExplicitPointer,
-      ) => ArrayRecursiveUnionExplicitPointer,
-    ) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRecursiveUnionExplicitPointer = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRecursiveUnionExplicitPointer"
+)(ArrayRecursiveUnionExplicitPointer)(
+  (p: (input: ArrayRecursiveUnionExplicitPointer) => ArrayRecursiveUnionExplicitPointer) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionImplicit.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRecursiveUnionImplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRecursiveUnionImplicit } from "../../structures/ArrayRecursiveUnionImplicit";
 
-export const test_functional_assertReturn_ArrayRecursiveUnionImplicit =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRecursiveUnionImplicit")(
-    ArrayRecursiveUnionImplicit,
-  )((p: (input: ArrayRecursiveUnionImplicit) => ArrayRecursiveUnionImplicit) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRecursiveUnionImplicit = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRecursiveUnionImplicit"
+)(ArrayRecursiveUnionImplicit)(
+  (p: (input: ArrayRecursiveUnionImplicit) => ArrayRecursiveUnionImplicit) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRepeatedNullable } from "../../structures/ArrayRepeatedNullable";
 
-export const test_functional_assertReturn_ArrayRepeatedNullable =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRepeatedNullable")(
-    ArrayRepeatedNullable,
-  )((p: (input: ArrayRepeatedNullable) => ArrayRepeatedNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRepeatedNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRepeatedNullable"
+)(ArrayRepeatedNullable)(
+  (p: (input: ArrayRepeatedNullable) => ArrayRepeatedNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedOptional.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRepeatedOptional } from "../../structures/ArrayRepeatedOptional";
 
-export const test_functional_assertReturn_ArrayRepeatedOptional =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRepeatedOptional")(
-    ArrayRepeatedOptional,
-  )((p: (input: ArrayRepeatedOptional) => ArrayRepeatedOptional) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRepeatedOptional = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRepeatedOptional"
+)(ArrayRepeatedOptional)(
+  (p: (input: ArrayRepeatedOptional) => ArrayRepeatedOptional) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedRequired.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedRequired.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRepeatedRequired } from "../../structures/ArrayRepeatedRequired";
 
-export const test_functional_assertReturn_ArrayRepeatedRequired =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRepeatedRequired")(
-    ArrayRepeatedRequired,
-  )((p: (input: ArrayRepeatedRequired) => ArrayRepeatedRequired) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRepeatedRequired = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRepeatedRequired"
+)(ArrayRepeatedRequired)(
+  (p: (input: ArrayRepeatedRequired) => ArrayRepeatedRequired) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRepeatedUnion } from "../../structures/ArrayRepeatedUnion";
 
-export const test_functional_assertReturn_ArrayRepeatedUnion =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRepeatedUnion")(
-    ArrayRepeatedUnion,
-  )((p: (input: ArrayRepeatedUnion) => ArrayRepeatedUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRepeatedUnion = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRepeatedUnion"
+)(ArrayRepeatedUnion)(
+  (p: (input: ArrayRepeatedUnion) => ArrayRepeatedUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedUnionWithTuple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayRepeatedUnionWithTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayRepeatedUnionWithTuple } from "../../structures/ArrayRepeatedUnionWithTuple";
 
-export const test_functional_assertReturn_ArrayRepeatedUnionWithTuple =
-  _test_functional_assertReturn(TypeGuardError)("ArrayRepeatedUnionWithTuple")(
-    ArrayRepeatedUnionWithTuple,
-  )((p: (input: ArrayRepeatedUnionWithTuple) => ArrayRepeatedUnionWithTuple) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayRepeatedUnionWithTuple = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayRepeatedUnionWithTuple"
+)(ArrayRepeatedUnionWithTuple)(
+  (p: (input: ArrayRepeatedUnionWithTuple) => ArrayRepeatedUnionWithTuple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArraySimple } from "../../structures/ArraySimple";
 
-export const test_functional_assertReturn_ArraySimple =
-  _test_functional_assertReturn(TypeGuardError)("ArraySimple")(ArraySimple)(
-    (p: (input: ArraySimple) => ArraySimple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArraySimple = _test_functional_assertReturn(TypeGuardError)(
+  "ArraySimple"
+)(ArraySimple)(
+  (p: (input: ArraySimple) => ArraySimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobuf.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArraySimpleProtobuf } from "../../structures/ArraySimpleProtobuf";
 
-export const test_functional_assertReturn_ArraySimpleProtobuf =
-  _test_functional_assertReturn(TypeGuardError)("ArraySimpleProtobuf")(
-    ArraySimpleProtobuf,
-  )((p: (input: ArraySimpleProtobuf) => ArraySimpleProtobuf) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArraySimpleProtobuf = _test_functional_assertReturn(TypeGuardError)(
+  "ArraySimpleProtobuf"
+)(ArraySimpleProtobuf)(
+  (p: (input: ArraySimpleProtobuf) => ArraySimpleProtobuf) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobufNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobufNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArraySimpleProtobufNullable } from "../../structures/ArraySimpleProtobufNullable";
 
-export const test_functional_assertReturn_ArraySimpleProtobufNullable =
-  _test_functional_assertReturn(TypeGuardError)("ArraySimpleProtobufNullable")(
-    ArraySimpleProtobufNullable,
-  )((p: (input: ArraySimpleProtobufNullable) => ArraySimpleProtobufNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArraySimpleProtobufNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ArraySimpleProtobufNullable"
+)(ArraySimpleProtobufNullable)(
+  (p: (input: ArraySimpleProtobufNullable) => ArraySimpleProtobufNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobufOptional.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArraySimpleProtobufOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArraySimpleProtobufOptional } from "../../structures/ArraySimpleProtobufOptional";
 
-export const test_functional_assertReturn_ArraySimpleProtobufOptional =
-  _test_functional_assertReturn(TypeGuardError)("ArraySimpleProtobufOptional")(
-    ArraySimpleProtobufOptional,
-  )((p: (input: ArraySimpleProtobufOptional) => ArraySimpleProtobufOptional) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArraySimpleProtobufOptional = _test_functional_assertReturn(TypeGuardError)(
+  "ArraySimpleProtobufOptional"
+)(ArraySimpleProtobufOptional)(
+  (p: (input: ArraySimpleProtobufOptional) => ArraySimpleProtobufOptional) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ArrayUnion.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ArrayUnion } from "../../structures/ArrayUnion";
 
-export const test_functional_assertReturn_ArrayUnion =
-  _test_functional_assertReturn(TypeGuardError)("ArrayUnion")(ArrayUnion)(
-    (p: (input: ArrayUnion) => ArrayUnion) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ArrayUnion = _test_functional_assertReturn(TypeGuardError)(
+  "ArrayUnion"
+)(ArrayUnion)(
+  (p: (input: ArrayUnion) => ArrayUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicAlias.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { AtomicAlias } from "../../structures/AtomicAlias";
 
-export const test_functional_assertReturn_AtomicAlias =
-  _test_functional_assertReturn(TypeGuardError)("AtomicAlias")(AtomicAlias)(
-    (p: (input: AtomicAlias) => AtomicAlias) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_AtomicAlias = _test_functional_assertReturn(TypeGuardError)(
+  "AtomicAlias"
+)(AtomicAlias)(
+  (p: (input: AtomicAlias) => AtomicAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicClass.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicClass.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { AtomicClass } from "../../structures/AtomicClass";
 
-export const test_functional_assertReturn_AtomicClass =
-  _test_functional_assertReturn(TypeGuardError)("AtomicClass")(AtomicClass)(
-    (p: (input: AtomicClass) => AtomicClass) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_AtomicClass = _test_functional_assertReturn(TypeGuardError)(
+  "AtomicClass"
+)(AtomicClass)(
+  (p: (input: AtomicClass) => AtomicClass) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicIntersection.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { AtomicIntersection } from "../../structures/AtomicIntersection";
 
-export const test_functional_assertReturn_AtomicIntersection =
-  _test_functional_assertReturn(TypeGuardError)("AtomicIntersection")(
-    AtomicIntersection,
-  )((p: (input: AtomicIntersection) => AtomicIntersection) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_AtomicIntersection = _test_functional_assertReturn(TypeGuardError)(
+  "AtomicIntersection"
+)(AtomicIntersection)(
+  (p: (input: AtomicIntersection) => AtomicIntersection) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { AtomicSimple } from "../../structures/AtomicSimple";
 
-export const test_functional_assertReturn_AtomicSimple =
-  _test_functional_assertReturn(TypeGuardError)("AtomicSimple")(AtomicSimple)(
-    (p: (input: AtomicSimple) => AtomicSimple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_AtomicSimple = _test_functional_assertReturn(TypeGuardError)(
+  "AtomicSimple"
+)(AtomicSimple)(
+  (p: (input: AtomicSimple) => AtomicSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_AtomicUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { AtomicUnion } from "../../structures/AtomicUnion";
 
-export const test_functional_assertReturn_AtomicUnion =
-  _test_functional_assertReturn(TypeGuardError)("AtomicUnion")(AtomicUnion)(
-    (p: (input: AtomicUnion) => AtomicUnion) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_AtomicUnion = _test_functional_assertReturn(TypeGuardError)(
+  "AtomicUnion"
+)(AtomicUnion)(
+  (p: (input: AtomicUnion) => AtomicUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassClosure.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassClosure.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ClassClosure } from "../../structures/ClassClosure";
 
-export const test_functional_assertReturn_ClassClosure =
-  _test_functional_assertReturn(TypeGuardError)("ClassClosure")(ClassClosure)(
-    (p: (input: ClassClosure) => ClassClosure) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ClassClosure = _test_functional_assertReturn(TypeGuardError)(
+  "ClassClosure"
+)(ClassClosure)(
+  (p: (input: ClassClosure) => ClassClosure) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassGetter.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassGetter.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ClassGetter } from "../../structures/ClassGetter";
 
-export const test_functional_assertReturn_ClassGetter =
-  _test_functional_assertReturn(TypeGuardError)("ClassGetter")(ClassGetter)(
-    (p: (input: ClassGetter) => ClassGetter) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ClassGetter = _test_functional_assertReturn(TypeGuardError)(
+  "ClassGetter"
+)(ClassGetter)(
+  (p: (input: ClassGetter) => ClassGetter) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassMethod.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassMethod.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ClassMethod } from "../../structures/ClassMethod";
 
-export const test_functional_assertReturn_ClassMethod =
-  _test_functional_assertReturn(TypeGuardError)("ClassMethod")(ClassMethod)(
-    (p: (input: ClassMethod) => ClassMethod) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ClassMethod = _test_functional_assertReturn(TypeGuardError)(
+  "ClassMethod"
+)(ClassMethod)(
+  (p: (input: ClassMethod) => ClassMethod) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassNonPublic.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassNonPublic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ClassNonPublic } from "../../structures/ClassNonPublic";
 
-export const test_functional_assertReturn_ClassNonPublic =
-  _test_functional_assertReturn(TypeGuardError)("ClassNonPublic")(
-    ClassNonPublic,
-  )((p: (input: ClassNonPublic) => ClassNonPublic) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ClassNonPublic = _test_functional_assertReturn(TypeGuardError)(
+  "ClassNonPublic"
+)(ClassNonPublic)(
+  (p: (input: ClassNonPublic) => ClassNonPublic) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassPropertyAssignment.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ClassPropertyAssignment.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ClassPropertyAssignment } from "../../structures/ClassPropertyAssignment";
 
-export const test_functional_assertReturn_ClassPropertyAssignment =
-  _test_functional_assertReturn(TypeGuardError)("ClassPropertyAssignment")(
-    ClassPropertyAssignment,
-  )((p: (input: ClassPropertyAssignment) => ClassPropertyAssignment) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ClassPropertyAssignment = _test_functional_assertReturn(TypeGuardError)(
+  "ClassPropertyAssignment"
+)(ClassPropertyAssignment)(
+  (p: (input: ClassPropertyAssignment) => ClassPropertyAssignment) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagArray.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagArray } from "../../structures/CommentTagArray";
 
-export const test_functional_assertReturn_CommentTagArray =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagArray")(
-    CommentTagArray,
-  )((p: (input: CommentTagArray) => CommentTagArray) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagArray = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagArray"
+)(CommentTagArray)(
+  (p: (input: CommentTagArray) => CommentTagArray) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagArrayUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagArrayUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagArrayUnion } from "../../structures/CommentTagArrayUnion";
 
-export const test_functional_assertReturn_CommentTagArrayUnion =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagArrayUnion")(
-    CommentTagArrayUnion,
-  )((p: (input: CommentTagArrayUnion) => CommentTagArrayUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagArrayUnion = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagArrayUnion"
+)(CommentTagArrayUnion)(
+  (p: (input: CommentTagArrayUnion) => CommentTagArrayUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagAtomicUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagAtomicUnion } from "../../structures/CommentTagAtomicUnion";
 
-export const test_functional_assertReturn_CommentTagAtomicUnion =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagAtomicUnion")(
-    CommentTagAtomicUnion,
-  )((p: (input: CommentTagAtomicUnion) => CommentTagAtomicUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagAtomicUnion = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagAtomicUnion"
+)(CommentTagAtomicUnion)(
+  (p: (input: CommentTagAtomicUnion) => CommentTagAtomicUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagBigInt.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagBigInt } from "../../structures/CommentTagBigInt";
 
-export const test_functional_assertReturn_CommentTagBigInt =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagBigInt")(
-    CommentTagBigInt,
-  )((p: (input: CommentTagBigInt) => CommentTagBigInt) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagBigInt = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagBigInt"
+)(CommentTagBigInt)(
+  (p: (input: CommentTagBigInt) => CommentTagBigInt) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagDefault.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagDefault.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagDefault } from "../../structures/CommentTagDefault";
 
-export const test_functional_assertReturn_CommentTagDefault =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagDefault")(
-    CommentTagDefault,
-  )((p: (input: CommentTagDefault) => CommentTagDefault) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagDefault = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagDefault"
+)(CommentTagDefault)(
+  (p: (input: CommentTagDefault) => CommentTagDefault) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagFormat.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagFormat.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagFormat } from "../../structures/CommentTagFormat";
 
-export const test_functional_assertReturn_CommentTagFormat =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagFormat")(
-    CommentTagFormat,
-  )((p: (input: CommentTagFormat) => CommentTagFormat) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagFormat = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagFormat"
+)(CommentTagFormat)(
+  (p: (input: CommentTagFormat) => CommentTagFormat) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagInfinite.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagInfinite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagInfinite } from "../../structures/CommentTagInfinite";
 
-export const test_functional_assertReturn_CommentTagInfinite =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagInfinite")(
-    CommentTagInfinite,
-  )((p: (input: CommentTagInfinite) => CommentTagInfinite) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagInfinite = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagInfinite"
+)(CommentTagInfinite)(
+  (p: (input: CommentTagInfinite) => CommentTagInfinite) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagLength.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagLength.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagLength } from "../../structures/CommentTagLength";
 
-export const test_functional_assertReturn_CommentTagLength =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagLength")(
-    CommentTagLength,
-  )((p: (input: CommentTagLength) => CommentTagLength) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagLength = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagLength"
+)(CommentTagLength)(
+  (p: (input: CommentTagLength) => CommentTagLength) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagNaN.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagNaN.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagNaN } from "../../structures/CommentTagNaN";
 
-export const test_functional_assertReturn_CommentTagNaN =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagNaN")(CommentTagNaN)(
-    (p: (input: CommentTagNaN) => CommentTagNaN) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagNaN = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagNaN"
+)(CommentTagNaN)(
+  (p: (input: CommentTagNaN) => CommentTagNaN) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagObjectUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagObjectUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagObjectUnion } from "../../structures/CommentTagObjectUnion";
 
-export const test_functional_assertReturn_CommentTagObjectUnion =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagObjectUnion")(
-    CommentTagObjectUnion,
-  )((p: (input: CommentTagObjectUnion) => CommentTagObjectUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagObjectUnion = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagObjectUnion"
+)(CommentTagObjectUnion)(
+  (p: (input: CommentTagObjectUnion) => CommentTagObjectUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagPattern.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagPattern.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagPattern } from "../../structures/CommentTagPattern";
 
-export const test_functional_assertReturn_CommentTagPattern =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagPattern")(
-    CommentTagPattern,
-  )((p: (input: CommentTagPattern) => CommentTagPattern) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagPattern = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagPattern"
+)(CommentTagPattern)(
+  (p: (input: CommentTagPattern) => CommentTagPattern) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagRange.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagRange.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagRange } from "../../structures/CommentTagRange";
 
-export const test_functional_assertReturn_CommentTagRange =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagRange")(
-    CommentTagRange,
-  )((p: (input: CommentTagRange) => CommentTagRange) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagRange = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagRange"
+)(CommentTagRange)(
+  (p: (input: CommentTagRange) => CommentTagRange) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagRangeBigInt.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagRangeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagRangeBigInt } from "../../structures/CommentTagRangeBigInt";
 
-export const test_functional_assertReturn_CommentTagRangeBigInt =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagRangeBigInt")(
-    CommentTagRangeBigInt,
-  )((p: (input: CommentTagRangeBigInt) => CommentTagRangeBigInt) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagRangeBigInt = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagRangeBigInt"
+)(CommentTagRangeBigInt)(
+  (p: (input: CommentTagRangeBigInt) => CommentTagRangeBigInt) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagType.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagType.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagType } from "../../structures/CommentTagType";
 
-export const test_functional_assertReturn_CommentTagType =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagType")(
-    CommentTagType,
-  )((p: (input: CommentTagType) => CommentTagType) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagType = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagType"
+)(CommentTagType)(
+  (p: (input: CommentTagType) => CommentTagType) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagTypeBigInt.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_CommentTagTypeBigInt.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { CommentTagTypeBigInt } from "../../structures/CommentTagTypeBigInt";
 
-export const test_functional_assertReturn_CommentTagTypeBigInt =
-  _test_functional_assertReturn(TypeGuardError)("CommentTagTypeBigInt")(
-    CommentTagTypeBigInt,
-  )((p: (input: CommentTagTypeBigInt) => CommentTagTypeBigInt) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_CommentTagTypeBigInt = _test_functional_assertReturn(TypeGuardError)(
+  "CommentTagTypeBigInt"
+)(CommentTagTypeBigInt)(
+  (p: (input: CommentTagTypeBigInt) => CommentTagTypeBigInt) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicAbsorbed.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicAbsorbed.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantAtomicAbsorbed } from "../../structures/ConstantAtomicAbsorbed";
 
-export const test_functional_assertReturn_ConstantAtomicAbsorbed =
-  _test_functional_assertReturn(TypeGuardError)("ConstantAtomicAbsorbed")(
-    ConstantAtomicAbsorbed,
-  )((p: (input: ConstantAtomicAbsorbed) => ConstantAtomicAbsorbed) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantAtomicAbsorbed = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantAtomicAbsorbed"
+)(ConstantAtomicAbsorbed)(
+  (p: (input: ConstantAtomicAbsorbed) => ConstantAtomicAbsorbed) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicSimple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantAtomicSimple } from "../../structures/ConstantAtomicSimple";
 
-export const test_functional_assertReturn_ConstantAtomicSimple =
-  _test_functional_assertReturn(TypeGuardError)("ConstantAtomicSimple")(
-    ConstantAtomicSimple,
-  )((p: (input: ConstantAtomicSimple) => ConstantAtomicSimple) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantAtomicSimple = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantAtomicSimple"
+)(ConstantAtomicSimple)(
+  (p: (input: ConstantAtomicSimple) => ConstantAtomicSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicTagged.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicTagged.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantAtomicTagged } from "../../structures/ConstantAtomicTagged";
 
-export const test_functional_assertReturn_ConstantAtomicTagged =
-  _test_functional_assertReturn(TypeGuardError)("ConstantAtomicTagged")(
-    ConstantAtomicTagged,
-  )((p: (input: ConstantAtomicTagged) => ConstantAtomicTagged) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantAtomicTagged = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantAtomicTagged"
+)(ConstantAtomicTagged)(
+  (p: (input: ConstantAtomicTagged) => ConstantAtomicTagged) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantAtomicUnion } from "../../structures/ConstantAtomicUnion";
 
-export const test_functional_assertReturn_ConstantAtomicUnion =
-  _test_functional_assertReturn(TypeGuardError)("ConstantAtomicUnion")(
-    ConstantAtomicUnion,
-  )((p: (input: ConstantAtomicUnion) => ConstantAtomicUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantAtomicUnion = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantAtomicUnion"
+)(ConstantAtomicUnion)(
+  (p: (input: ConstantAtomicUnion) => ConstantAtomicUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicWrapper.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantAtomicWrapper.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantAtomicWrapper } from "../../structures/ConstantAtomicWrapper";
 
-export const test_functional_assertReturn_ConstantAtomicWrapper =
-  _test_functional_assertReturn(TypeGuardError)("ConstantAtomicWrapper")(
-    ConstantAtomicWrapper,
-  )((p: (input: ConstantAtomicWrapper) => ConstantAtomicWrapper) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantAtomicWrapper = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantAtomicWrapper"
+)(ConstantAtomicWrapper)(
+  (p: (input: ConstantAtomicWrapper) => ConstantAtomicWrapper) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantConstEnumeration.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantConstEnumeration.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantConstEnumeration } from "../../structures/ConstantConstEnumeration";
 
-export const test_functional_assertReturn_ConstantConstEnumeration =
-  _test_functional_assertReturn(TypeGuardError)("ConstantConstEnumeration")(
-    ConstantConstEnumeration,
-  )((p: (input: ConstantConstEnumeration) => ConstantConstEnumeration) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantConstEnumeration = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantConstEnumeration"
+)(ConstantConstEnumeration)(
+  (p: (input: ConstantConstEnumeration) => ConstantConstEnumeration) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantEnumeration.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantEnumeration.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantEnumeration } from "../../structures/ConstantEnumeration";
 
-export const test_functional_assertReturn_ConstantEnumeration =
-  _test_functional_assertReturn(TypeGuardError)("ConstantEnumeration")(
-    ConstantEnumeration,
-  )((p: (input: ConstantEnumeration) => ConstantEnumeration) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantEnumeration = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantEnumeration"
+)(ConstantEnumeration)(
+  (p: (input: ConstantEnumeration) => ConstantEnumeration) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantIntersection.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ConstantIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ConstantIntersection } from "../../structures/ConstantIntersection";
 
-export const test_functional_assertReturn_ConstantIntersection =
-  _test_functional_assertReturn(TypeGuardError)("ConstantIntersection")(
-    ConstantIntersection,
-  )((p: (input: ConstantIntersection) => ConstantIntersection) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ConstantIntersection = _test_functional_assertReturn(TypeGuardError)(
+  "ConstantIntersection"
+)(ConstantIntersection)(
+  (p: (input: ConstantIntersection) => ConstantIntersection) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicArray.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicArray.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicArray } from "../../structures/DynamicArray";
 
-export const test_functional_assertReturn_DynamicArray =
-  _test_functional_assertReturn(TypeGuardError)("DynamicArray")(DynamicArray)(
-    (p: (input: DynamicArray) => DynamicArray) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicArray = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicArray"
+)(DynamicArray)(
+  (p: (input: DynamicArray) => DynamicArray) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicComposite.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicComposite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicComposite } from "../../structures/DynamicComposite";
 
-export const test_functional_assertReturn_DynamicComposite =
-  _test_functional_assertReturn(TypeGuardError)("DynamicComposite")(
-    DynamicComposite,
-  )((p: (input: DynamicComposite) => DynamicComposite) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicComposite = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicComposite"
+)(DynamicComposite)(
+  (p: (input: DynamicComposite) => DynamicComposite) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicConstant.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicConstant } from "../../structures/DynamicConstant";
 
-export const test_functional_assertReturn_DynamicConstant =
-  _test_functional_assertReturn(TypeGuardError)("DynamicConstant")(
-    DynamicConstant,
-  )((p: (input: DynamicConstant) => DynamicConstant) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicConstant = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicConstant"
+)(DynamicConstant)(
+  (p: (input: DynamicConstant) => DynamicConstant) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicEnumeration.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicEnumeration.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicEnumeration } from "../../structures/DynamicEnumeration";
 
-export const test_functional_assertReturn_DynamicEnumeration =
-  _test_functional_assertReturn(TypeGuardError)("DynamicEnumeration")(
-    DynamicEnumeration,
-  )((p: (input: DynamicEnumeration) => DynamicEnumeration) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicEnumeration = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicEnumeration"
+)(DynamicEnumeration)(
+  (p: (input: DynamicEnumeration) => DynamicEnumeration) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicJsonValue.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicJsonValue.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicJsonValue } from "../../structures/DynamicJsonValue";
 
-export const test_functional_assertReturn_DynamicJsonValue =
-  _test_functional_assertReturn(TypeGuardError)("DynamicJsonValue")(
-    DynamicJsonValue,
-  )((p: (input: DynamicJsonValue) => DynamicJsonValue) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicJsonValue = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicJsonValue"
+)(DynamicJsonValue)(
+  (p: (input: DynamicJsonValue) => DynamicJsonValue) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicNever.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicNever.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicNever } from "../../structures/DynamicNever";
 
-export const test_functional_assertReturn_DynamicNever =
-  _test_functional_assertReturn(TypeGuardError)("DynamicNever")(DynamicNever)(
-    (p: (input: DynamicNever) => DynamicNever) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicNever = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicNever"
+)(DynamicNever)(
+  (p: (input: DynamicNever) => DynamicNever) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicSimple } from "../../structures/DynamicSimple";
 
-export const test_functional_assertReturn_DynamicSimple =
-  _test_functional_assertReturn(TypeGuardError)("DynamicSimple")(DynamicSimple)(
-    (p: (input: DynamicSimple) => DynamicSimple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicSimple = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicSimple"
+)(DynamicSimple)(
+  (p: (input: DynamicSimple) => DynamicSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTag.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTag.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicTag } from "../../structures/DynamicTag";
 
-export const test_functional_assertReturn_DynamicTag =
-  _test_functional_assertReturn(TypeGuardError)("DynamicTag")(DynamicTag)(
-    (p: (input: DynamicTag) => DynamicTag) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicTag = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicTag"
+)(DynamicTag)(
+  (p: (input: DynamicTag) => DynamicTag) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTemplate.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTemplate.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicTemplate } from "../../structures/DynamicTemplate";
 
-export const test_functional_assertReturn_DynamicTemplate =
-  _test_functional_assertReturn(TypeGuardError)("DynamicTemplate")(
-    DynamicTemplate,
-  )((p: (input: DynamicTemplate) => DynamicTemplate) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicTemplate = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicTemplate"
+)(DynamicTemplate)(
+  (p: (input: DynamicTemplate) => DynamicTemplate) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTree.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicTree.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicTree } from "../../structures/DynamicTree";
 
-export const test_functional_assertReturn_DynamicTree =
-  _test_functional_assertReturn(TypeGuardError)("DynamicTree")(DynamicTree)(
-    (p: (input: DynamicTree) => DynamicTree) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicTree = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicTree"
+)(DynamicTree)(
+  (p: (input: DynamicTree) => DynamicTree) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicUndefined.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicUndefined.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicUndefined } from "../../structures/DynamicUndefined";
 
-export const test_functional_assertReturn_DynamicUndefined =
-  _test_functional_assertReturn(TypeGuardError)("DynamicUndefined")(
-    DynamicUndefined,
-  )((p: (input: DynamicUndefined) => DynamicUndefined) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicUndefined = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicUndefined"
+)(DynamicUndefined)(
+  (p: (input: DynamicUndefined) => DynamicUndefined) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_DynamicUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { DynamicUnion } from "../../structures/DynamicUnion";
 
-export const test_functional_assertReturn_DynamicUnion =
-  _test_functional_assertReturn(TypeGuardError)("DynamicUnion")(DynamicUnion)(
-    (p: (input: DynamicUnion) => DynamicUnion) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_DynamicUnion = _test_functional_assertReturn(TypeGuardError)(
+  "DynamicUnion"
+)(DynamicUnion)(
+  (p: (input: DynamicUnion) => DynamicUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalArray.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalArray } from "../../structures/FunctionalArray";
 
-export const test_functional_assertReturn_FunctionalArray =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalArray")(
-    FunctionalArray,
-  )((p: (input: FunctionalArray) => FunctionalArray) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalArray = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalArray"
+)(FunctionalArray)(
+  (p: (input: FunctionalArray) => FunctionalArray) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalArrayUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalArrayUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalArrayUnion } from "../../structures/FunctionalArrayUnion";
 
-export const test_functional_assertReturn_FunctionalArrayUnion =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalArrayUnion")(
-    FunctionalArrayUnion,
-  )((p: (input: FunctionalArrayUnion) => FunctionalArrayUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalArrayUnion = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalArrayUnion"
+)(FunctionalArrayUnion)(
+  (p: (input: FunctionalArrayUnion) => FunctionalArrayUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalObjectUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalObjectUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalObjectUnion } from "../../structures/FunctionalObjectUnion";
 
-export const test_functional_assertReturn_FunctionalObjectUnion =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalObjectUnion")(
-    FunctionalObjectUnion,
-  )((p: (input: FunctionalObjectUnion) => FunctionalObjectUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalObjectUnion = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalObjectUnion"
+)(FunctionalObjectUnion)(
+  (p: (input: FunctionalObjectUnion) => FunctionalObjectUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalProperty.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalProperty.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalProperty } from "../../structures/FunctionalProperty";
 
-export const test_functional_assertReturn_FunctionalProperty =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalProperty")(
-    FunctionalProperty,
-  )((p: (input: FunctionalProperty) => FunctionalProperty) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalProperty = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalProperty"
+)(FunctionalProperty)(
+  (p: (input: FunctionalProperty) => FunctionalProperty) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalPropertyUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalPropertyUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalPropertyUnion } from "../../structures/FunctionalPropertyUnion";
 
-export const test_functional_assertReturn_FunctionalPropertyUnion =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalPropertyUnion")(
-    FunctionalPropertyUnion,
-  )((p: (input: FunctionalPropertyUnion) => FunctionalPropertyUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalPropertyUnion = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalPropertyUnion"
+)(FunctionalPropertyUnion)(
+  (p: (input: FunctionalPropertyUnion) => FunctionalPropertyUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalTuple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalTuple.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalTuple } from "../../structures/FunctionalTuple";
 
-export const test_functional_assertReturn_FunctionalTuple =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalTuple")(
-    FunctionalTuple,
-  )((p: (input: FunctionalTuple) => FunctionalTuple) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalTuple = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalTuple"
+)(FunctionalTuple)(
+  (p: (input: FunctionalTuple) => FunctionalTuple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalTupleUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalTupleUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalTupleUnion } from "../../structures/FunctionalTupleUnion";
 
-export const test_functional_assertReturn_FunctionalTupleUnion =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalTupleUnion")(
-    FunctionalTupleUnion,
-  )((p: (input: FunctionalTupleUnion) => FunctionalTupleUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalTupleUnion = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalTupleUnion"
+)(FunctionalTupleUnion)(
+  (p: (input: FunctionalTupleUnion) => FunctionalTupleUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalValue.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalValue.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalValue } from "../../structures/FunctionalValue";
 
-export const test_functional_assertReturn_FunctionalValue =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalValue")(
-    FunctionalValue,
-  )((p: (input: FunctionalValue) => FunctionalValue) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalValue = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalValue"
+)(FunctionalValue)(
+  (p: (input: FunctionalValue) => FunctionalValue) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalValueUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_FunctionalValueUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { FunctionalValueUnion } from "../../structures/FunctionalValueUnion";
 
-export const test_functional_assertReturn_FunctionalValueUnion =
-  _test_functional_assertReturn(TypeGuardError)("FunctionalValueUnion")(
-    FunctionalValueUnion,
-  )((p: (input: FunctionalValueUnion) => FunctionalValueUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_FunctionalValueUnion = _test_functional_assertReturn(TypeGuardError)(
+  "FunctionalValueUnion"
+)(FunctionalValueUnion)(
+  (p: (input: FunctionalValueUnion) => FunctionalValueUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_InstanceUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_InstanceUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { InstanceUnion } from "../../structures/InstanceUnion";
 
-export const test_functional_assertReturn_InstanceUnion =
-  _test_functional_assertReturn(TypeGuardError)("InstanceUnion")(InstanceUnion)(
-    (p: (input: InstanceUnion) => InstanceUnion) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_InstanceUnion = _test_functional_assertReturn(TypeGuardError)(
+  "InstanceUnion"
+)(InstanceUnion)(
+  (p: (input: InstanceUnion) => InstanceUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapAlias.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapAlias } from "../../structures/MapAlias";
 
-export const test_functional_assertReturn_MapAlias =
-  _test_functional_assertReturn(TypeGuardError)("MapAlias")(MapAlias)(
-    (p: (input: MapAlias) => MapAlias) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapAlias = _test_functional_assertReturn(TypeGuardError)(
+  "MapAlias"
+)(MapAlias)(
+  (p: (input: MapAlias) => MapAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimple.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapSimple } from "../../structures/MapSimple";
 
-export const test_functional_assertReturn_MapSimple =
-  _test_functional_assertReturn(TypeGuardError)("MapSimple")(MapSimple)(
-    (p: (input: MapSimple) => MapSimple) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapSimple = _test_functional_assertReturn(TypeGuardError)(
+  "MapSimple"
+)(MapSimple)(
+  (p: (input: MapSimple) => MapSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobuf.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapSimpleProtobuf } from "../../structures/MapSimpleProtobuf";
 
-export const test_functional_assertReturn_MapSimpleProtobuf =
-  _test_functional_assertReturn(TypeGuardError)("MapSimpleProtobuf")(
-    MapSimpleProtobuf,
-  )((p: (input: MapSimpleProtobuf) => MapSimpleProtobuf) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapSimpleProtobuf = _test_functional_assertReturn(TypeGuardError)(
+  "MapSimpleProtobuf"
+)(MapSimpleProtobuf)(
+  (p: (input: MapSimpleProtobuf) => MapSimpleProtobuf) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobufNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobufNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapSimpleProtobufNullable } from "../../structures/MapSimpleProtobufNullable";
 
-export const test_functional_assertReturn_MapSimpleProtobufNullable =
-  _test_functional_assertReturn(TypeGuardError)("MapSimpleProtobufNullable")(
-    MapSimpleProtobufNullable,
-  )((p: (input: MapSimpleProtobufNullable) => MapSimpleProtobufNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapSimpleProtobufNullable = _test_functional_assertReturn(TypeGuardError)(
+  "MapSimpleProtobufNullable"
+)(MapSimpleProtobufNullable)(
+  (p: (input: MapSimpleProtobufNullable) => MapSimpleProtobufNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobufOptional.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapSimpleProtobufOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapSimpleProtobufOptional } from "../../structures/MapSimpleProtobufOptional";
 
-export const test_functional_assertReturn_MapSimpleProtobufOptional =
-  _test_functional_assertReturn(TypeGuardError)("MapSimpleProtobufOptional")(
-    MapSimpleProtobufOptional,
-  )((p: (input: MapSimpleProtobufOptional) => MapSimpleProtobufOptional) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapSimpleProtobufOptional = _test_functional_assertReturn(TypeGuardError)(
+  "MapSimpleProtobufOptional"
+)(MapSimpleProtobufOptional)(
+  (p: (input: MapSimpleProtobufOptional) => MapSimpleProtobufOptional) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_MapUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_MapUnion.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { MapUnion } from "../../structures/MapUnion";
 
-export const test_functional_assertReturn_MapUnion =
-  _test_functional_assertReturn(TypeGuardError)("MapUnion")(MapUnion)(
-    (p: (input: MapUnion) => MapUnion) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_MapUnion = _test_functional_assertReturn(TypeGuardError)(
+  "MapUnion"
+)(MapUnion)(
+  (p: (input: MapUnion) => MapUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_NativeSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_NativeSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { NativeSimple } from "../../structures/NativeSimple";
 
-export const test_functional_assertReturn_NativeSimple =
-  _test_functional_assertReturn(TypeGuardError)("NativeSimple")(NativeSimple)(
-    (p: (input: NativeSimple) => NativeSimple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_NativeSimple = _test_functional_assertReturn(TypeGuardError)(
+  "NativeSimple"
+)(NativeSimple)(
+  (p: (input: NativeSimple) => NativeSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_NativeUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_NativeUnion.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { NativeUnion } from "../../structures/NativeUnion";
 
-export const test_functional_assertReturn_NativeUnion =
-  _test_functional_assertReturn(TypeGuardError)("NativeUnion")(NativeUnion)(
-    (p: (input: NativeUnion) => NativeUnion) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_NativeUnion = _test_functional_assertReturn(TypeGuardError)(
+  "NativeUnion"
+)(NativeUnion)(
+  (p: (input: NativeUnion) => NativeUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectAlias.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectAlias } from "../../structures/ObjectAlias";
 
-export const test_functional_assertReturn_ObjectAlias =
-  _test_functional_assertReturn(TypeGuardError)("ObjectAlias")(ObjectAlias)(
-    (p: (input: ObjectAlias) => ObjectAlias) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectAlias = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectAlias"
+)(ObjectAlias)(
+  (p: (input: ObjectAlias) => ObjectAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectClosure.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectClosure.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectClosure } from "../../structures/ObjectClosure";
 
-export const test_functional_assertReturn_ObjectClosure =
-  _test_functional_assertReturn(TypeGuardError)("ObjectClosure")(ObjectClosure)(
-    (p: (input: ObjectClosure) => ObjectClosure) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectClosure = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectClosure"
+)(ObjectClosure)(
+  (p: (input: ObjectClosure) => ObjectClosure) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDate.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDate.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectDate } from "../../structures/ObjectDate";
 
-export const test_functional_assertReturn_ObjectDate =
-  _test_functional_assertReturn(TypeGuardError)("ObjectDate")(ObjectDate)(
-    (p: (input: ObjectDate) => ObjectDate) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectDate = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectDate"
+)(ObjectDate)(
+  (p: (input: ObjectDate) => ObjectDate) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDescription.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDescription.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectDescription } from "../../structures/ObjectDescription";
 
-export const test_functional_assertReturn_ObjectDescription =
-  _test_functional_assertReturn(TypeGuardError)("ObjectDescription")(
-    ObjectDescription,
-  )((p: (input: ObjectDescription) => ObjectDescription) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectDescription = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectDescription"
+)(ObjectDescription)(
+  (p: (input: ObjectDescription) => ObjectDescription) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDynamic.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectDynamic.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectDynamic } from "../../structures/ObjectDynamic";
 
-export const test_functional_assertReturn_ObjectDynamic =
-  _test_functional_assertReturn(TypeGuardError)("ObjectDynamic")(ObjectDynamic)(
-    (p: (input: ObjectDynamic) => ObjectDynamic) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectDynamic = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectDynamic"
+)(ObjectDynamic)(
+  (p: (input: ObjectDynamic) => ObjectDynamic) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGeneric.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGeneric.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectGeneric } from "../../structures/ObjectGeneric";
 
-export const test_functional_assertReturn_ObjectGeneric =
-  _test_functional_assertReturn(TypeGuardError)("ObjectGeneric")(ObjectGeneric)(
-    (p: (input: ObjectGeneric) => ObjectGeneric) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectGeneric = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectGeneric"
+)(ObjectGeneric)(
+  (p: (input: ObjectGeneric) => ObjectGeneric) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericAlias.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectGenericAlias } from "../../structures/ObjectGenericAlias";
 
-export const test_functional_assertReturn_ObjectGenericAlias =
-  _test_functional_assertReturn(TypeGuardError)("ObjectGenericAlias")(
-    ObjectGenericAlias,
-  )((p: (input: ObjectGenericAlias) => ObjectGenericAlias) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectGenericAlias = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectGenericAlias"
+)(ObjectGenericAlias)(
+  (p: (input: ObjectGenericAlias) => ObjectGenericAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericArray.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectGenericArray } from "../../structures/ObjectGenericArray";
 
-export const test_functional_assertReturn_ObjectGenericArray =
-  _test_functional_assertReturn(TypeGuardError)("ObjectGenericArray")(
-    ObjectGenericArray,
-  )((p: (input: ObjectGenericArray) => ObjectGenericArray) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectGenericArray = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectGenericArray"
+)(ObjectGenericArray)(
+  (p: (input: ObjectGenericArray) => ObjectGenericArray) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectGenericUnion.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectGenericUnion } from "../../structures/ObjectGenericUnion";
 
-export const test_functional_assertReturn_ObjectGenericUnion =
-  _test_functional_assertReturn(TypeGuardError)("ObjectGenericUnion")(
-    ObjectGenericUnion,
-  )((p: (input: ObjectGenericUnion) => ObjectGenericUnion) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectGenericUnion = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectGenericUnion"
+)(ObjectGenericUnion)(
+  (p: (input: ObjectGenericUnion) => ObjectGenericUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHierarchical.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHierarchical.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHierarchical } from "../../structures/ObjectHierarchical";
 
-export const test_functional_assertReturn_ObjectHierarchical =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHierarchical")(
-    ObjectHierarchical,
-  )((p: (input: ObjectHierarchical) => ObjectHierarchical) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHierarchical = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHierarchical"
+)(ObjectHierarchical)(
+  (p: (input: ObjectHierarchical) => ObjectHierarchical) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpArray.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpArray.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpArray } from "../../structures/ObjectHttpArray";
 
-export const test_functional_assertReturn_ObjectHttpArray =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpArray")(
-    ObjectHttpArray,
-  )((p: (input: ObjectHttpArray) => ObjectHttpArray) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpArray = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpArray"
+)(ObjectHttpArray)(
+  (p: (input: ObjectHttpArray) => ObjectHttpArray) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpAtomic.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpAtomic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpAtomic } from "../../structures/ObjectHttpAtomic";
 
-export const test_functional_assertReturn_ObjectHttpAtomic =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpAtomic")(
-    ObjectHttpAtomic,
-  )((p: (input: ObjectHttpAtomic) => ObjectHttpAtomic) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpAtomic = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpAtomic"
+)(ObjectHttpAtomic)(
+  (p: (input: ObjectHttpAtomic) => ObjectHttpAtomic) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpCommentTag.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpCommentTag.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpCommentTag } from "../../structures/ObjectHttpCommentTag";
 
-export const test_functional_assertReturn_ObjectHttpCommentTag =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpCommentTag")(
-    ObjectHttpCommentTag,
-  )((p: (input: ObjectHttpCommentTag) => ObjectHttpCommentTag) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpCommentTag = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpCommentTag"
+)(ObjectHttpCommentTag)(
+  (p: (input: ObjectHttpCommentTag) => ObjectHttpCommentTag) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpConstant.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpConstant } from "../../structures/ObjectHttpConstant";
 
-export const test_functional_assertReturn_ObjectHttpConstant =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpConstant")(
-    ObjectHttpConstant,
-  )((p: (input: ObjectHttpConstant) => ObjectHttpConstant) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpConstant = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpConstant"
+)(ObjectHttpConstant)(
+  (p: (input: ObjectHttpConstant) => ObjectHttpConstant) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpFormData.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpFormData.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpFormData } from "../../structures/ObjectHttpFormData";
 
-export const test_functional_assertReturn_ObjectHttpFormData =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpFormData")(
-    ObjectHttpFormData,
-  )((p: (input: ObjectHttpFormData) => ObjectHttpFormData) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpFormData = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpFormData"
+)(ObjectHttpFormData)(
+  (p: (input: ObjectHttpFormData) => ObjectHttpFormData) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpNullable } from "../../structures/ObjectHttpNullable";
 
-export const test_functional_assertReturn_ObjectHttpNullable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpNullable")(
-    ObjectHttpNullable,
-  )((p: (input: ObjectHttpNullable) => ObjectHttpNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpNullable"
+)(ObjectHttpNullable)(
+  (p: (input: ObjectHttpNullable) => ObjectHttpNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpTypeTag.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpTypeTag.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpTypeTag } from "../../structures/ObjectHttpTypeTag";
 
-export const test_functional_assertReturn_ObjectHttpTypeTag =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpTypeTag")(
-    ObjectHttpTypeTag,
-  )((p: (input: ObjectHttpTypeTag) => ObjectHttpTypeTag) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpTypeTag = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpTypeTag"
+)(ObjectHttpTypeTag)(
+  (p: (input: ObjectHttpTypeTag) => ObjectHttpTypeTag) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpUndefindable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectHttpUndefindable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectHttpUndefindable } from "../../structures/ObjectHttpUndefindable";
 
-export const test_functional_assertReturn_ObjectHttpUndefindable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectHttpUndefindable")(
-    ObjectHttpUndefindable,
-  )((p: (input: ObjectHttpUndefindable) => ObjectHttpUndefindable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectHttpUndefindable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectHttpUndefindable"
+)(ObjectHttpUndefindable)(
+  (p: (input: ObjectHttpUndefindable) => ObjectHttpUndefindable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectInternal.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectInternal.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectInternal } from "../../structures/ObjectInternal";
 
-export const test_functional_assertReturn_ObjectInternal =
-  _test_functional_assertReturn(TypeGuardError)("ObjectInternal")(
-    ObjectInternal,
-  )((p: (input: ObjectInternal) => ObjectInternal) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectInternal = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectInternal"
+)(ObjectInternal)(
+  (p: (input: ObjectInternal) => ObjectInternal) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectIntersection.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectIntersection.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectIntersection } from "../../structures/ObjectIntersection";
 
-export const test_functional_assertReturn_ObjectIntersection =
-  _test_functional_assertReturn(TypeGuardError)("ObjectIntersection")(
-    ObjectIntersection,
-  )((p: (input: ObjectIntersection) => ObjectIntersection) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectIntersection = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectIntersection"
+)(ObjectIntersection)(
+  (p: (input: ObjectIntersection) => ObjectIntersection) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectJsonTag.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectJsonTag.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectJsonTag } from "../../structures/ObjectJsonTag";
 
-export const test_functional_assertReturn_ObjectJsonTag =
-  _test_functional_assertReturn(TypeGuardError)("ObjectJsonTag")(ObjectJsonTag)(
-    (p: (input: ObjectJsonTag) => ObjectJsonTag) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectJsonTag = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectJsonTag"
+)(ObjectJsonTag)(
+  (p: (input: ObjectJsonTag) => ObjectJsonTag) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectLiteralProperty.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectLiteralProperty.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectLiteralProperty } from "../../structures/ObjectLiteralProperty";
 
-export const test_functional_assertReturn_ObjectLiteralProperty =
-  _test_functional_assertReturn(TypeGuardError)("ObjectLiteralProperty")(
-    ObjectLiteralProperty,
-  )((p: (input: ObjectLiteralProperty) => ObjectLiteralProperty) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectLiteralProperty = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectLiteralProperty"
+)(ObjectLiteralProperty)(
+  (p: (input: ObjectLiteralProperty) => ObjectLiteralProperty) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectLiteralType.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectLiteralType.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectLiteralType } from "../../structures/ObjectLiteralType";
 
-export const test_functional_assertReturn_ObjectLiteralType =
-  _test_functional_assertReturn(TypeGuardError)("ObjectLiteralType")(
-    ObjectLiteralType,
-  )((p: (input: ObjectLiteralType) => ObjectLiteralType) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectLiteralType = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectLiteralType"
+)(ObjectLiteralType)(
+  (p: (input: ObjectLiteralType) => ObjectLiteralType) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectNullable } from "../../structures/ObjectNullable";
 
-export const test_functional_assertReturn_ObjectNullable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectNullable")(
-    ObjectNullable,
-  )((p: (input: ObjectNullable) => ObjectNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectNullable"
+)(ObjectNullable)(
+  (p: (input: ObjectNullable) => ObjectNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectOptional.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectOptional.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectOptional } from "../../structures/ObjectOptional";
 
-export const test_functional_assertReturn_ObjectOptional =
-  _test_functional_assertReturn(TypeGuardError)("ObjectOptional")(
-    ObjectOptional,
-  )((p: (input: ObjectOptional) => ObjectOptional) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectOptional = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectOptional"
+)(ObjectOptional)(
+  (p: (input: ObjectOptional) => ObjectOptional) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPartial.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPartial.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectPartial } from "../../structures/ObjectPartial";
 
-export const test_functional_assertReturn_ObjectPartial =
-  _test_functional_assertReturn(TypeGuardError)("ObjectPartial")(ObjectPartial)(
-    (p: (input: ObjectPartial) => ObjectPartial) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectPartial = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectPartial"
+)(ObjectPartial)(
+  (p: (input: ObjectPartial) => ObjectPartial) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPartialAndRequired.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPartialAndRequired.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectPartialAndRequired } from "../../structures/ObjectPartialAndRequired";
 
-export const test_functional_assertReturn_ObjectPartialAndRequired =
-  _test_functional_assertReturn(TypeGuardError)("ObjectPartialAndRequired")(
-    ObjectPartialAndRequired,
-  )((p: (input: ObjectPartialAndRequired) => ObjectPartialAndRequired) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectPartialAndRequired = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectPartialAndRequired"
+)(ObjectPartialAndRequired)(
+  (p: (input: ObjectPartialAndRequired) => ObjectPartialAndRequired) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPrimitive.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPrimitive.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectPrimitive } from "../../structures/ObjectPrimitive";
 
-export const test_functional_assertReturn_ObjectPrimitive =
-  _test_functional_assertReturn(TypeGuardError)("ObjectPrimitive")(
-    ObjectPrimitive,
-  )((p: (input: ObjectPrimitive) => ObjectPrimitive) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectPrimitive = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectPrimitive"
+)(ObjectPrimitive)(
+  (p: (input: ObjectPrimitive) => ObjectPrimitive) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPropertyNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectPropertyNullable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectPropertyNullable } from "../../structures/ObjectPropertyNullable";
 
-export const test_functional_assertReturn_ObjectPropertyNullable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectPropertyNullable")(
-    ObjectPropertyNullable,
-  )((p: (input: ObjectPropertyNullable) => ObjectPropertyNullable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectPropertyNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectPropertyNullable"
+)(ObjectPropertyNullable)(
+  (p: (input: ObjectPropertyNullable) => ObjectPropertyNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectRecursive.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectRecursive.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectRecursive } from "../../structures/ObjectRecursive";
 
-export const test_functional_assertReturn_ObjectRecursive =
-  _test_functional_assertReturn(TypeGuardError)("ObjectRecursive")(
-    ObjectRecursive,
-  )((p: (input: ObjectRecursive) => ObjectRecursive) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectRecursive = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectRecursive"
+)(ObjectRecursive)(
+  (p: (input: ObjectRecursive) => ObjectRecursive) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectRequired.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectRequired.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectRequired } from "../../structures/ObjectRequired";
 
-export const test_functional_assertReturn_ObjectRequired =
-  _test_functional_assertReturn(TypeGuardError)("ObjectRequired")(
-    ObjectRequired,
-  )((p: (input: ObjectRequired) => ObjectRequired) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectRequired = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectRequired"
+)(ObjectRequired)(
+  (p: (input: ObjectRequired) => ObjectRequired) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSequenceProtobuf.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSequenceProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectSequenceProtobuf } from "../../structures/ObjectSequenceProtobuf";
 
-export const test_functional_assertReturn_ObjectSequenceProtobuf =
-  _test_functional_assertReturn(TypeGuardError)("ObjectSequenceProtobuf")(
-    ObjectSequenceProtobuf,
-  )((p: (input: ObjectSequenceProtobuf) => ObjectSequenceProtobuf) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectSequenceProtobuf = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectSequenceProtobuf"
+)(ObjectSequenceProtobuf)(
+  (p: (input: ObjectSequenceProtobuf) => ObjectSequenceProtobuf) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectSimple } from "../../structures/ObjectSimple";
 
-export const test_functional_assertReturn_ObjectSimple =
-  _test_functional_assertReturn(TypeGuardError)("ObjectSimple")(ObjectSimple)(
-    (p: (input: ObjectSimple) => ObjectSimple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectSimple = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectSimple"
+)(ObjectSimple)(
+  (p: (input: ObjectSimple) => ObjectSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobuf.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobuf.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectSimpleProtobuf } from "../../structures/ObjectSimpleProtobuf";
 
-export const test_functional_assertReturn_ObjectSimpleProtobuf =
-  _test_functional_assertReturn(TypeGuardError)("ObjectSimpleProtobuf")(
-    ObjectSimpleProtobuf,
-  )((p: (input: ObjectSimpleProtobuf) => ObjectSimpleProtobuf) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectSimpleProtobuf = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectSimpleProtobuf"
+)(ObjectSimpleProtobuf)(
+  (p: (input: ObjectSimpleProtobuf) => ObjectSimpleProtobuf) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobufNullable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobufNullable.ts
@@ -1,14 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectSimpleProtobufNullable } from "../../structures/ObjectSimpleProtobufNullable";
 
-export const test_functional_assertReturn_ObjectSimpleProtobufNullable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectSimpleProtobufNullable")(
-    ObjectSimpleProtobufNullable,
-  )(
-    (
-      p: (input: ObjectSimpleProtobufNullable) => ObjectSimpleProtobufNullable,
-    ) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectSimpleProtobufNullable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectSimpleProtobufNullable"
+)(ObjectSimpleProtobufNullable)(
+  (p: (input: ObjectSimpleProtobufNullable) => ObjectSimpleProtobufNullable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobufOptional.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectSimpleProtobufOptional.ts
@@ -1,14 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectSimpleProtobufOptional } from "../../structures/ObjectSimpleProtobufOptional";
 
-export const test_functional_assertReturn_ObjectSimpleProtobufOptional =
-  _test_functional_assertReturn(TypeGuardError)("ObjectSimpleProtobufOptional")(
-    ObjectSimpleProtobufOptional,
-  )(
-    (
-      p: (input: ObjectSimpleProtobufOptional) => ObjectSimpleProtobufOptional,
-    ) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectSimpleProtobufOptional = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectSimpleProtobufOptional"
+)(ObjectSimpleProtobufOptional)(
+  (p: (input: ObjectSimpleProtobufOptional) => ObjectSimpleProtobufOptional) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectTuple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectTuple.ts
@@ -1,11 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectTuple } from "../../structures/ObjectTuple";
 
-export const test_functional_assertReturn_ObjectTuple =
-  _test_functional_assertReturn(TypeGuardError)("ObjectTuple")(ObjectTuple)(
-    (p: (input: ObjectTuple) => ObjectTuple) =>
-      typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectTuple = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectTuple"
+)(ObjectTuple)(
+  (p: (input: ObjectTuple) => ObjectTuple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUndefined.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUndefined.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUndefined } from "../../structures/ObjectUndefined";
 
-export const test_functional_assertReturn_ObjectUndefined =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUndefined")(
-    ObjectUndefined,
-  )((p: (input: ObjectUndefined) => ObjectUndefined) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUndefined = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUndefined"
+)(ObjectUndefined)(
+  (p: (input: ObjectUndefined) => ObjectUndefined) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionComposite.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionComposite.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionComposite } from "../../structures/ObjectUnionComposite";
 
-export const test_functional_assertReturn_ObjectUnionComposite =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionComposite")(
-    ObjectUnionComposite,
-  )((p: (input: ObjectUnionComposite) => ObjectUnionComposite) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionComposite = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionComposite"
+)(ObjectUnionComposite)(
+  (p: (input: ObjectUnionComposite) => ObjectUnionComposite) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionCompositePointer.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionCompositePointer.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionCompositePointer } from "../../structures/ObjectUnionCompositePointer";
 
-export const test_functional_assertReturn_ObjectUnionCompositePointer =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionCompositePointer")(
-    ObjectUnionCompositePointer,
-  )((p: (input: ObjectUnionCompositePointer) => ObjectUnionCompositePointer) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionCompositePointer = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionCompositePointer"
+)(ObjectUnionCompositePointer)(
+  (p: (input: ObjectUnionCompositePointer) => ObjectUnionCompositePointer) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionDouble.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionDouble.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionDouble } from "../../structures/ObjectUnionDouble";
 
-export const test_functional_assertReturn_ObjectUnionDouble =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionDouble")(
-    ObjectUnionDouble,
-  )((p: (input: ObjectUnionDouble) => ObjectUnionDouble) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionDouble = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionDouble"
+)(ObjectUnionDouble)(
+  (p: (input: ObjectUnionDouble) => ObjectUnionDouble) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionExplicit.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionExplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionExplicit } from "../../structures/ObjectUnionExplicit";
 
-export const test_functional_assertReturn_ObjectUnionExplicit =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionExplicit")(
-    ObjectUnionExplicit,
-  )((p: (input: ObjectUnionExplicit) => ObjectUnionExplicit) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionExplicit = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionExplicit"
+)(ObjectUnionExplicit)(
+  (p: (input: ObjectUnionExplicit) => ObjectUnionExplicit) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionExplicitPointer.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionExplicitPointer.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionExplicitPointer } from "../../structures/ObjectUnionExplicitPointer";
 
-export const test_functional_assertReturn_ObjectUnionExplicitPointer =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionExplicitPointer")(
-    ObjectUnionExplicitPointer,
-  )((p: (input: ObjectUnionExplicitPointer) => ObjectUnionExplicitPointer) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionExplicitPointer = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionExplicitPointer"
+)(ObjectUnionExplicitPointer)(
+  (p: (input: ObjectUnionExplicitPointer) => ObjectUnionExplicitPointer) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionImplicit.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionImplicit.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionImplicit } from "../../structures/ObjectUnionImplicit";
 
-export const test_functional_assertReturn_ObjectUnionImplicit =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionImplicit")(
-    ObjectUnionImplicit,
-  )((p: (input: ObjectUnionImplicit) => ObjectUnionImplicit) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionImplicit = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionImplicit"
+)(ObjectUnionImplicit)(
+  (p: (input: ObjectUnionImplicit) => ObjectUnionImplicit) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionNonPredictable.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_ObjectUnionNonPredictable.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { ObjectUnionNonPredictable } from "../../structures/ObjectUnionNonPredictable";
 
-export const test_functional_assertReturn_ObjectUnionNonPredictable =
-  _test_functional_assertReturn(TypeGuardError)("ObjectUnionNonPredictable")(
-    ObjectUnionNonPredictable,
-  )((p: (input: ObjectUnionNonPredictable) => ObjectUnionNonPredictable) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_ObjectUnionNonPredictable = _test_functional_assertReturn(TypeGuardError)(
+  "ObjectUnionNonPredictable"
+)(ObjectUnionNonPredictable)(
+  (p: (input: ObjectUnionNonPredictable) => ObjectUnionNonPredictable) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_SetAlias.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_SetAlias.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { SetAlias } from "../../structures/SetAlias";
 
-export const test_functional_assertReturn_SetAlias =
-  _test_functional_assertReturn(TypeGuardError)("SetAlias")(SetAlias)(
-    (p: (input: SetAlias) => SetAlias) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_SetAlias = _test_functional_assertReturn(TypeGuardError)(
+  "SetAlias"
+)(SetAlias)(
+  (p: (input: SetAlias) => SetAlias) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_SetSimple.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_SetSimple.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { SetSimple } from "../../structures/SetSimple";
 
-export const test_functional_assertReturn_SetSimple =
-  _test_functional_assertReturn(TypeGuardError)("SetSimple")(SetSimple)(
-    (p: (input: SetSimple) => SetSimple) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_SetSimple = _test_functional_assertReturn(TypeGuardError)(
+  "SetSimple"
+)(SetSimple)(
+  (p: (input: SetSimple) => SetSimple) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_SetUnion.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_SetUnion.ts
@@ -1,10 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { SetUnion } from "../../structures/SetUnion";
 
-export const test_functional_assertReturn_SetUnion =
-  _test_functional_assertReturn(TypeGuardError)("SetUnion")(SetUnion)(
-    (p: (input: SetUnion) => SetUnion) => typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_SetUnion = _test_functional_assertReturn(TypeGuardError)(
+  "SetUnion"
+)(SetUnion)(
+  (p: (input: SetUnion) => SetUnion) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_TemplateAtomic.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_TemplateAtomic.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { TemplateAtomic } from "../../structures/TemplateAtomic";
 
-export const test_functional_assertReturn_TemplateAtomic =
-  _test_functional_assertReturn(TypeGuardError)("TemplateAtomic")(
-    TemplateAtomic,
-  )((p: (input: TemplateAtomic) => TemplateAtomic) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_TemplateAtomic = _test_functional_assertReturn(TypeGuardError)(
+  "TemplateAtomic"
+)(TemplateAtomic)(
+  (p: (input: TemplateAtomic) => TemplateAtomic) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/functional.assertReturn/test_functional_assertReturn_TemplateConstant.ts
+++ b/test/src/features/functional.assertReturn/test_functional_assertReturn_TemplateConstant.ts
@@ -1,12 +1,12 @@
 import typia from "typia";
-import { TypeGuardError } from "typia";
 
 import { _test_functional_assertReturn } from "../../internal/_test_functional_assertReturn";
 import { TemplateConstant } from "../../structures/TemplateConstant";
 
-export const test_functional_assertReturn_TemplateConstant =
-  _test_functional_assertReturn(TypeGuardError)("TemplateConstant")(
-    TemplateConstant,
-  )((p: (input: TemplateConstant) => TemplateConstant) =>
-    typia.functional.assertReturn(p),
-  );
+import { TypeGuardError } from "typia";
+
+export const test_functional_assertReturn_TemplateConstant = _test_functional_assertReturn(TypeGuardError)(
+  "TemplateConstant"
+)(TemplateConstant)(
+  (p: (input: TemplateConstant) => TemplateConstant) => typia.functional.assertReturn(p),
+)

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonAtomicUnion.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonAtomicUnion.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonAtomicUnion } from "../../../structures/ToJsonAtomicUnion";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_ToJsonAtomicUnion =
+export const test_llm_parameters_claude_ToJsonAtomicUnion = 
   _test_llm_parameters({
     model: "claude",
     name: "ToJsonAtomicUnion",
-  })(typia.llm.parameters<ToJsonAtomicUnionParameters, "claude">());
+  })(
+    typia.llm.parameters<ToJsonAtomicUnionParameters, "claude">(),
+  );
 
 interface ToJsonAtomicUnionParameters {
   regular: ToJsonAtomicUnion;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonDouble.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonDouble.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonDouble } from "../../../structures/ToJsonDouble";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_ToJsonDouble = _test_llm_parameters({
-  model: "claude",
-  name: "ToJsonDouble",
-})(typia.llm.parameters<ToJsonDoubleParameters, "claude">());
+export const test_llm_parameters_claude_ToJsonDouble = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "ToJsonDouble",
+  })(
+    typia.llm.parameters<ToJsonDoubleParameters, "claude">(),
+  );
 
 interface ToJsonDoubleParameters {
   regular: ToJsonDouble;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonNull.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonNull.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonNull } from "../../../structures/ToJsonNull";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_ToJsonNull = _test_llm_parameters({
-  model: "claude",
-  name: "ToJsonNull",
-})(typia.llm.parameters<ToJsonNullParameters, "claude">());
+export const test_llm_parameters_claude_ToJsonNull = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "ToJsonNull",
+  })(
+    typia.llm.parameters<ToJsonNullParameters, "claude">(),
+  );
 
 interface ToJsonNullParameters {
   regular: ToJsonNull;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonUnion.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_ToJsonUnion.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonUnion } from "../../../structures/ToJsonUnion";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_ToJsonUnion = _test_llm_parameters({
-  model: "claude",
-  name: "ToJsonUnion",
-})(typia.llm.parameters<ToJsonUnionParameters, "claude">());
+export const test_llm_parameters_claude_ToJsonUnion = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "ToJsonUnion",
+  })(
+    typia.llm.parameters<ToJsonUnionParameters, "claude">(),
+  );
 
 interface ToJsonUnionParameters {
   regular: ToJsonUnion;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagArray.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagArray.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagArray } from "../../../structures/TypeTagArray";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagArray = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagArray",
-})(typia.llm.parameters<TypeTagArrayParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagArray = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagArray",
+  })(
+    typia.llm.parameters<TypeTagArrayParameters, "claude">(),
+  );
 
 interface TypeTagArrayParameters {
   regular: TypeTagArray;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagArrayUnion.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagArrayUnion.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagArrayUnion } from "../../../structures/TypeTagArrayUnion";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagArrayUnion =
+export const test_llm_parameters_claude_TypeTagArrayUnion = 
   _test_llm_parameters({
     model: "claude",
     name: "TypeTagArrayUnion",
-  })(typia.llm.parameters<TypeTagArrayUnionParameters, "claude">());
+  })(
+    typia.llm.parameters<TypeTagArrayUnionParameters, "claude">(),
+  );
 
 interface TypeTagArrayUnionParameters {
   regular: TypeTagArrayUnion;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagAtomicUnion.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagAtomicUnion.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagAtomicUnion } from "../../../structures/TypeTagAtomicUnion";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagAtomicUnion =
+export const test_llm_parameters_claude_TypeTagAtomicUnion = 
   _test_llm_parameters({
     model: "claude",
     name: "TypeTagAtomicUnion",
-  })(typia.llm.parameters<TypeTagAtomicUnionParameters, "claude">());
+  })(
+    typia.llm.parameters<TypeTagAtomicUnionParameters, "claude">(),
+  );
 
 interface TypeTagAtomicUnionParameters {
   regular: TypeTagAtomicUnion;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagCustom.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagCustom.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagCustom } from "../../../structures/TypeTagCustom";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagCustom = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagCustom",
-})(typia.llm.parameters<TypeTagCustomParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagCustom = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagCustom",
+  })(
+    typia.llm.parameters<TypeTagCustomParameters, "claude">(),
+  );
 
 interface TypeTagCustomParameters {
   regular: TypeTagCustom;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagDefault.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagDefault.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagDefault } from "../../../structures/TypeTagDefault";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagDefault = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagDefault",
-})(typia.llm.parameters<TypeTagDefaultParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagDefault = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagDefault",
+  })(
+    typia.llm.parameters<TypeTagDefaultParameters, "claude">(),
+  );
 
 interface TypeTagDefaultParameters {
   regular: TypeTagDefault;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagFormat.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagFormat.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagFormat } from "../../../structures/TypeTagFormat";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagFormat = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagFormat",
-})(typia.llm.parameters<TypeTagFormatParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagFormat = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagFormat",
+  })(
+    typia.llm.parameters<TypeTagFormatParameters, "claude">(),
+  );
 
 interface TypeTagFormatParameters {
   regular: TypeTagFormat;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagLength.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagLength.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagLength } from "../../../structures/TypeTagLength";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagLength = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagLength",
-})(typia.llm.parameters<TypeTagLengthParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagLength = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagLength",
+  })(
+    typia.llm.parameters<TypeTagLengthParameters, "claude">(),
+  );
 
 interface TypeTagLengthParameters {
   regular: TypeTagLength;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagMatrix.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagMatrix.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagMatrix } from "../../../structures/TypeTagMatrix";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagMatrix = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagMatrix",
-})(typia.llm.parameters<TypeTagMatrixParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagMatrix = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagMatrix",
+  })(
+    typia.llm.parameters<TypeTagMatrixParameters, "claude">(),
+  );
 
 interface TypeTagMatrixParameters {
   regular: TypeTagMatrix;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagObjectUnion.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagObjectUnion.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagObjectUnion } from "../../../structures/TypeTagObjectUnion";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagObjectUnion =
+export const test_llm_parameters_claude_TypeTagObjectUnion = 
   _test_llm_parameters({
     model: "claude",
     name: "TypeTagObjectUnion",
-  })(typia.llm.parameters<TypeTagObjectUnionParameters, "claude">());
+  })(
+    typia.llm.parameters<TypeTagObjectUnionParameters, "claude">(),
+  );
 
 interface TypeTagObjectUnionParameters {
   regular: TypeTagObjectUnion;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagPattern.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagPattern.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagPattern } from "../../../structures/TypeTagPattern";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagPattern = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagPattern",
-})(typia.llm.parameters<TypeTagPatternParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagPattern = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagPattern",
+  })(
+    typia.llm.parameters<TypeTagPatternParameters, "claude">(),
+  );
 
 interface TypeTagPatternParameters {
   regular: TypeTagPattern;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagRange.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagRange.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagRange } from "../../../structures/TypeTagRange";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagRange = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagRange",
-})(typia.llm.parameters<TypeTagRangeParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagRange = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagRange",
+  })(
+    typia.llm.parameters<TypeTagRangeParameters, "claude">(),
+  );
 
 interface TypeTagRangeParameters {
   regular: TypeTagRange;

--- a/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagType.ts
+++ b/test/src/features/llm.parameters/claude/test_llm_parameters_claude_TypeTagType.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagType } from "../../../structures/TypeTagType";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_claude_TypeTagType = _test_llm_parameters({
-  model: "claude",
-  name: "TypeTagType",
-})(typia.llm.parameters<TypeTagTypeParameters, "claude">());
+export const test_llm_parameters_claude_TypeTagType = 
+  _test_llm_parameters({
+    model: "claude",
+    name: "TypeTagType",
+  })(
+    typia.llm.parameters<TypeTagTypeParameters, "claude">(),
+  );
 
 interface TypeTagTypeParameters {
   regular: TypeTagType;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayAny.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayAny.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayAny } from "../../../structures/ArrayAny";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArrayAny = _test_llm_parameters({
-  model: "gemini",
-  name: "ArrayAny",
-})(typia.llm.parameters<ArrayAnyParameters, "gemini">());
+export const test_llm_parameters_gemini_ArrayAny = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ArrayAny",
+  })(
+    typia.llm.parameters<ArrayAnyParameters, "gemini">(),
+  );
 
 interface ArrayAnyParameters {
   regular: ArrayAny;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayHierarchical.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayHierarchical.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayHierarchical } from "../../../structures/ArrayHierarchical";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArrayHierarchical =
+export const test_llm_parameters_gemini_ArrayHierarchical = 
   _test_llm_parameters({
     model: "gemini",
     name: "ArrayHierarchical",
-  })(typia.llm.parameters<ArrayHierarchicalParameters, "gemini">());
+  })(
+    typia.llm.parameters<ArrayHierarchicalParameters, "gemini">(),
+  );
 
 interface ArrayHierarchicalParameters {
   regular: ArrayHierarchical;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayHierarchicalPointer.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayHierarchicalPointer.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayHierarchicalPointer } from "../../../structures/ArrayHierarchicalPointer";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArrayHierarchicalPointer =
+export const test_llm_parameters_gemini_ArrayHierarchicalPointer = 
   _test_llm_parameters({
     model: "gemini",
     name: "ArrayHierarchicalPointer",
-  })(typia.llm.parameters<ArrayHierarchicalPointerParameters, "gemini">());
+  })(
+    typia.llm.parameters<ArrayHierarchicalPointerParameters, "gemini">(),
+  );
 
 interface ArrayHierarchicalPointerParameters {
   regular: ArrayHierarchicalPointer;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayMatrix.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayMatrix.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayMatrix } from "../../../structures/ArrayMatrix";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArrayMatrix = _test_llm_parameters({
-  model: "gemini",
-  name: "ArrayMatrix",
-})(typia.llm.parameters<ArrayMatrixParameters, "gemini">());
+export const test_llm_parameters_gemini_ArrayMatrix = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ArrayMatrix",
+  })(
+    typia.llm.parameters<ArrayMatrixParameters, "gemini">(),
+  );
 
 interface ArrayMatrixParameters {
   regular: ArrayMatrix;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayRecursive.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArrayRecursive.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayRecursive } from "../../../structures/ArrayRecursive";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArrayRecursive = _test_llm_parameters({
-  model: "gemini",
-  name: "ArrayRecursive",
-})(typia.llm.parameters<ArrayRecursiveParameters, "gemini">());
+export const test_llm_parameters_gemini_ArrayRecursive = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ArrayRecursive",
+  })(
+    typia.llm.parameters<ArrayRecursiveParameters, "gemini">(),
+  );
 
 interface ArrayRecursiveParameters {
   regular: ArrayRecursive;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArraySimple.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ArraySimple.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArraySimple } from "../../../structures/ArraySimple";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ArraySimple = _test_llm_parameters({
-  model: "gemini",
-  name: "ArraySimple",
-})(typia.llm.parameters<ArraySimpleParameters, "gemini">());
+export const test_llm_parameters_gemini_ArraySimple = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ArraySimple",
+  })(
+    typia.llm.parameters<ArraySimpleParameters, "gemini">(),
+  );
 
 interface ArraySimpleParameters {
   regular: ArraySimple;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassGetter.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassGetter.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ClassGetter } from "../../../structures/ClassGetter";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ClassGetter = _test_llm_parameters({
-  model: "gemini",
-  name: "ClassGetter",
-})(typia.llm.parameters<ClassGetterParameters, "gemini">());
+export const test_llm_parameters_gemini_ClassGetter = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ClassGetter",
+  })(
+    typia.llm.parameters<ClassGetterParameters, "gemini">(),
+  );
 
 interface ClassGetterParameters {
   regular: ClassGetter;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassMethod.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassMethod.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ClassMethod } from "../../../structures/ClassMethod";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ClassMethod = _test_llm_parameters({
-  model: "gemini",
-  name: "ClassMethod",
-})(typia.llm.parameters<ClassMethodParameters, "gemini">());
+export const test_llm_parameters_gemini_ClassMethod = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ClassMethod",
+  })(
+    typia.llm.parameters<ClassMethodParameters, "gemini">(),
+  );
 
 interface ClassMethodParameters {
   regular: ClassMethod;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassPropertyAssignment.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ClassPropertyAssignment.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ClassPropertyAssignment } from "../../../structures/ClassPropertyAssignment";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ClassPropertyAssignment =
+export const test_llm_parameters_gemini_ClassPropertyAssignment = 
   _test_llm_parameters({
     model: "gemini",
     name: "ClassPropertyAssignment",
-  })(typia.llm.parameters<ClassPropertyAssignmentParameters, "gemini">());
+  })(
+    typia.llm.parameters<ClassPropertyAssignmentParameters, "gemini">(),
+  );
 
 interface ClassPropertyAssignmentParameters {
   regular: ClassPropertyAssignment;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagArray.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagArray.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagArray } from "../../../structures/CommentTagArray";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagArray = _test_llm_parameters({
-  model: "gemini",
-  name: "CommentTagArray",
-})(typia.llm.parameters<CommentTagArrayParameters, "gemini">());
+export const test_llm_parameters_gemini_CommentTagArray = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "CommentTagArray",
+  })(
+    typia.llm.parameters<CommentTagArrayParameters, "gemini">(),
+  );
 
 interface CommentTagArrayParameters {
   regular: CommentTagArray;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagFormat.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagFormat.ts
@@ -1,14 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagFormat } from "../../../structures/CommentTagFormat";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagFormat = _test_llm_parameters(
-  {
+export const test_llm_parameters_gemini_CommentTagFormat = 
+  _test_llm_parameters({
     model: "gemini",
     name: "CommentTagFormat",
-  },
-)(typia.llm.parameters<CommentTagFormatParameters, "gemini">());
+  })(
+    typia.llm.parameters<CommentTagFormatParameters, "gemini">(),
+  );
 
 interface CommentTagFormatParameters {
   regular: CommentTagFormat;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagLength.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagLength.ts
@@ -1,14 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagLength } from "../../../structures/CommentTagLength";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagLength = _test_llm_parameters(
-  {
+export const test_llm_parameters_gemini_CommentTagLength = 
+  _test_llm_parameters({
     model: "gemini",
     name: "CommentTagLength",
-  },
-)(typia.llm.parameters<CommentTagLengthParameters, "gemini">());
+  })(
+    typia.llm.parameters<CommentTagLengthParameters, "gemini">(),
+  );
 
 interface CommentTagLengthParameters {
   regular: CommentTagLength;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagPattern.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagPattern.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagPattern } from "../../../structures/CommentTagPattern";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagPattern =
+export const test_llm_parameters_gemini_CommentTagPattern = 
   _test_llm_parameters({
     model: "gemini",
     name: "CommentTagPattern",
-  })(typia.llm.parameters<CommentTagPatternParameters, "gemini">());
+  })(
+    typia.llm.parameters<CommentTagPatternParameters, "gemini">(),
+  );
 
 interface CommentTagPatternParameters {
   regular: CommentTagPattern;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagRange.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagRange.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagRange } from "../../../structures/CommentTagRange";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagRange = _test_llm_parameters({
-  model: "gemini",
-  name: "CommentTagRange",
-})(typia.llm.parameters<CommentTagRangeParameters, "gemini">());
+export const test_llm_parameters_gemini_CommentTagRange = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "CommentTagRange",
+  })(
+    typia.llm.parameters<CommentTagRangeParameters, "gemini">(),
+  );
 
 interface CommentTagRangeParameters {
   regular: CommentTagRange;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagType.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_CommentTagType.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { CommentTagType } from "../../../structures/CommentTagType";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_CommentTagType = _test_llm_parameters({
-  model: "gemini",
-  name: "CommentTagType",
-})(typia.llm.parameters<CommentTagTypeParameters, "gemini">());
+export const test_llm_parameters_gemini_CommentTagType = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "CommentTagType",
+  })(
+    typia.llm.parameters<CommentTagTypeParameters, "gemini">(),
+  );
 
 interface CommentTagTypeParameters {
   regular: CommentTagType;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ConstantAtomicAbsorbed.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ConstantAtomicAbsorbed.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ConstantAtomicAbsorbed } from "../../../structures/ConstantAtomicAbsorbed";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ConstantAtomicAbsorbed =
+export const test_llm_parameters_gemini_ConstantAtomicAbsorbed = 
   _test_llm_parameters({
     model: "gemini",
     name: "ConstantAtomicAbsorbed",
-  })(typia.llm.parameters<ConstantAtomicAbsorbedParameters, "gemini">());
+  })(
+    typia.llm.parameters<ConstantAtomicAbsorbedParameters, "gemini">(),
+  );
 
 interface ConstantAtomicAbsorbedParameters {
   regular: ConstantAtomicAbsorbed;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicConstant.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicConstant.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { DynamicConstant } from "../../../structures/DynamicConstant";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_DynamicConstant = _test_llm_parameters({
-  model: "gemini",
-  name: "DynamicConstant",
-})(typia.llm.parameters<DynamicConstantParameters, "gemini">());
+export const test_llm_parameters_gemini_DynamicConstant = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "DynamicConstant",
+  })(
+    typia.llm.parameters<DynamicConstantParameters, "gemini">(),
+  );
 
 interface DynamicConstantParameters {
   regular: DynamicConstant;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicEnumeration.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicEnumeration.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { DynamicEnumeration } from "../../../structures/DynamicEnumeration";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_DynamicEnumeration =
+export const test_llm_parameters_gemini_DynamicEnumeration = 
   _test_llm_parameters({
     model: "gemini",
     name: "DynamicEnumeration",
-  })(typia.llm.parameters<DynamicEnumerationParameters, "gemini">());
+  })(
+    typia.llm.parameters<DynamicEnumerationParameters, "gemini">(),
+  );
 
 interface DynamicEnumerationParameters {
   regular: DynamicEnumeration;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicNever.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicNever.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { DynamicNever } from "../../../structures/DynamicNever";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_DynamicNever = _test_llm_parameters({
-  model: "gemini",
-  name: "DynamicNever",
-})(typia.llm.parameters<DynamicNeverParameters, "gemini">());
+export const test_llm_parameters_gemini_DynamicNever = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "DynamicNever",
+  })(
+    typia.llm.parameters<DynamicNeverParameters, "gemini">(),
+  );
 
 interface DynamicNeverParameters {
   regular: DynamicNever;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicUndefined.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_DynamicUndefined.ts
@@ -1,14 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { DynamicUndefined } from "../../../structures/DynamicUndefined";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_DynamicUndefined = _test_llm_parameters(
-  {
+export const test_llm_parameters_gemini_DynamicUndefined = 
+  _test_llm_parameters({
     model: "gemini",
     name: "DynamicUndefined",
-  },
-)(typia.llm.parameters<DynamicUndefinedParameters, "gemini">());
+  })(
+    typia.llm.parameters<DynamicUndefinedParameters, "gemini">(),
+  );
 
 interface DynamicUndefinedParameters {
   regular: DynamicUndefined;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectDate.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectDate.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectDate } from "../../../structures/ObjectDate";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectDate = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectDate",
-})(typia.llm.parameters<ObjectDateParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectDate = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectDate",
+  })(
+    typia.llm.parameters<ObjectDateParameters, "gemini">(),
+  );
 
 interface ObjectDateParameters {
   regular: ObjectDate;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectDescription.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectDescription.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectDescription } from "../../../structures/ObjectDescription";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectDescription =
+export const test_llm_parameters_gemini_ObjectDescription = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectDescription",
-  })(typia.llm.parameters<ObjectDescriptionParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectDescriptionParameters, "gemini">(),
+  );
 
 interface ObjectDescriptionParameters {
   regular: ObjectDescription;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectGenericAlias.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectGenericAlias.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectGenericAlias } from "../../../structures/ObjectGenericAlias";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectGenericAlias =
+export const test_llm_parameters_gemini_ObjectGenericAlias = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectGenericAlias",
-  })(typia.llm.parameters<ObjectGenericAliasParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectGenericAliasParameters, "gemini">(),
+  );
 
 interface ObjectGenericAliasParameters {
   regular: ObjectGenericAlias;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectGenericArray.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectGenericArray.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectGenericArray } from "../../../structures/ObjectGenericArray";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectGenericArray =
+export const test_llm_parameters_gemini_ObjectGenericArray = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectGenericArray",
-  })(typia.llm.parameters<ObjectGenericArrayParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectGenericArrayParameters, "gemini">(),
+  );
 
 interface ObjectGenericArrayParameters {
   regular: ObjectGenericArray;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectInternal.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectInternal.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectInternal } from "../../../structures/ObjectInternal";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectInternal = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectInternal",
-})(typia.llm.parameters<ObjectInternalParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectInternal = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectInternal",
+  })(
+    typia.llm.parameters<ObjectInternalParameters, "gemini">(),
+  );
 
 interface ObjectInternalParameters {
   regular: ObjectInternal;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectIntersection.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectIntersection.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectIntersection } from "../../../structures/ObjectIntersection";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectIntersection =
+export const test_llm_parameters_gemini_ObjectIntersection = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectIntersection",
-  })(typia.llm.parameters<ObjectIntersectionParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectIntersectionParameters, "gemini">(),
+  );
 
 interface ObjectIntersectionParameters {
   regular: ObjectIntersection;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectJsonTag.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectJsonTag.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectJsonTag } from "../../../structures/ObjectJsonTag";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectJsonTag = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectJsonTag",
-})(typia.llm.parameters<ObjectJsonTagParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectJsonTag = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectJsonTag",
+  })(
+    typia.llm.parameters<ObjectJsonTagParameters, "gemini">(),
+  );
 
 interface ObjectJsonTagParameters {
   regular: ObjectJsonTag;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectLiteralProperty.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectLiteralProperty.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectLiteralProperty } from "../../../structures/ObjectLiteralProperty";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectLiteralProperty =
+export const test_llm_parameters_gemini_ObjectLiteralProperty = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectLiteralProperty",
-  })(typia.llm.parameters<ObjectLiteralPropertyParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectLiteralPropertyParameters, "gemini">(),
+  );
 
 interface ObjectLiteralPropertyParameters {
   regular: ObjectLiteralProperty;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectLiteralType.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectLiteralType.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectLiteralType } from "../../../structures/ObjectLiteralType";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectLiteralType =
+export const test_llm_parameters_gemini_ObjectLiteralType = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectLiteralType",
-  })(typia.llm.parameters<ObjectLiteralTypeParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectLiteralTypeParameters, "gemini">(),
+  );
 
 interface ObjectLiteralTypeParameters {
   regular: ObjectLiteralType;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectOptional.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectOptional.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectOptional } from "../../../structures/ObjectOptional";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectOptional = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectOptional",
-})(typia.llm.parameters<ObjectOptionalParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectOptional = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectOptional",
+  })(
+    typia.llm.parameters<ObjectOptionalParameters, "gemini">(),
+  );
 
 interface ObjectOptionalParameters {
   regular: ObjectOptional;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPartial.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPartial.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectPartial } from "../../../structures/ObjectPartial";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectPartial = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectPartial",
-})(typia.llm.parameters<ObjectPartialParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectPartial = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectPartial",
+  })(
+    typia.llm.parameters<ObjectPartialParameters, "gemini">(),
+  );
 
 interface ObjectPartialParameters {
   regular: ObjectPartial;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPartialAndRequired.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPartialAndRequired.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectPartialAndRequired } from "../../../structures/ObjectPartialAndRequired";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectPartialAndRequired =
+export const test_llm_parameters_gemini_ObjectPartialAndRequired = 
   _test_llm_parameters({
     model: "gemini",
     name: "ObjectPartialAndRequired",
-  })(typia.llm.parameters<ObjectPartialAndRequiredParameters, "gemini">());
+  })(
+    typia.llm.parameters<ObjectPartialAndRequiredParameters, "gemini">(),
+  );
 
 interface ObjectPartialAndRequiredParameters {
   regular: ObjectPartialAndRequired;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPrimitive.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectPrimitive.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectPrimitive } from "../../../structures/ObjectPrimitive";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectPrimitive = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectPrimitive",
-})(typia.llm.parameters<ObjectPrimitiveParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectPrimitive = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectPrimitive",
+  })(
+    typia.llm.parameters<ObjectPrimitiveParameters, "gemini">(),
+  );
 
 interface ObjectPrimitiveParameters {
   regular: ObjectPrimitive;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectRecursive.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectRecursive.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectRecursive } from "../../../structures/ObjectRecursive";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectRecursive = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectRecursive",
-})(typia.llm.parameters<ObjectRecursiveParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectRecursive = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectRecursive",
+  })(
+    typia.llm.parameters<ObjectRecursiveParameters, "gemini">(),
+  );
 
 interface ObjectRecursiveParameters {
   regular: ObjectRecursive;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectRequired.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectRequired.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectRequired } from "../../../structures/ObjectRequired";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectRequired = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectRequired",
-})(typia.llm.parameters<ObjectRequiredParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectRequired = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectRequired",
+  })(
+    typia.llm.parameters<ObjectRequiredParameters, "gemini">(),
+  );
 
 interface ObjectRequiredParameters {
   regular: ObjectRequired;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectSimple.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ObjectSimple.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ObjectSimple } from "../../../structures/ObjectSimple";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ObjectSimple = _test_llm_parameters({
-  model: "gemini",
-  name: "ObjectSimple",
-})(typia.llm.parameters<ObjectSimpleParameters, "gemini">());
+export const test_llm_parameters_gemini_ObjectSimple = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ObjectSimple",
+  })(
+    typia.llm.parameters<ObjectSimpleParameters, "gemini">(),
+  );
 
 interface ObjectSimpleParameters {
   regular: ObjectSimple;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TemplateAtomic.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TemplateAtomic.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TemplateAtomic } from "../../../structures/TemplateAtomic";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TemplateAtomic = _test_llm_parameters({
-  model: "gemini",
-  name: "TemplateAtomic",
-})(typia.llm.parameters<TemplateAtomicParameters, "gemini">());
+export const test_llm_parameters_gemini_TemplateAtomic = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TemplateAtomic",
+  })(
+    typia.llm.parameters<TemplateAtomicParameters, "gemini">(),
+  );
 
 interface TemplateAtomicParameters {
   regular: TemplateAtomic;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TemplateConstant.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TemplateConstant.ts
@@ -1,14 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TemplateConstant } from "../../../structures/TemplateConstant";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TemplateConstant = _test_llm_parameters(
-  {
+export const test_llm_parameters_gemini_TemplateConstant = 
+  _test_llm_parameters({
     model: "gemini",
     name: "TemplateConstant",
-  },
-)(typia.llm.parameters<TemplateConstantParameters, "gemini">());
+  })(
+    typia.llm.parameters<TemplateConstantParameters, "gemini">(),
+  );
 
 interface TemplateConstantParameters {
   regular: TemplateConstant;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ToJsonDouble.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ToJsonDouble.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonDouble } from "../../../structures/ToJsonDouble";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ToJsonDouble = _test_llm_parameters({
-  model: "gemini",
-  name: "ToJsonDouble",
-})(typia.llm.parameters<ToJsonDoubleParameters, "gemini">());
+export const test_llm_parameters_gemini_ToJsonDouble = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ToJsonDouble",
+  })(
+    typia.llm.parameters<ToJsonDoubleParameters, "gemini">(),
+  );
 
 interface ToJsonDoubleParameters {
   regular: ToJsonDouble;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ToJsonNull.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_ToJsonNull.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ToJsonNull } from "../../../structures/ToJsonNull";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_ToJsonNull = _test_llm_parameters({
-  model: "gemini",
-  name: "ToJsonNull",
-})(typia.llm.parameters<ToJsonNullParameters, "gemini">());
+export const test_llm_parameters_gemini_ToJsonNull = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "ToJsonNull",
+  })(
+    typia.llm.parameters<ToJsonNullParameters, "gemini">(),
+  );
 
 interface ToJsonNullParameters {
   regular: ToJsonNull;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagArray.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagArray.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagArray } from "../../../structures/TypeTagArray";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagArray = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagArray",
-})(typia.llm.parameters<TypeTagArrayParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagArray = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagArray",
+  })(
+    typia.llm.parameters<TypeTagArrayParameters, "gemini">(),
+  );
 
 interface TypeTagArrayParameters {
   regular: TypeTagArray;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagCustom.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagCustom.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagCustom } from "../../../structures/TypeTagCustom";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagCustom = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagCustom",
-})(typia.llm.parameters<TypeTagCustomParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagCustom = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagCustom",
+  })(
+    typia.llm.parameters<TypeTagCustomParameters, "gemini">(),
+  );
 
 interface TypeTagCustomParameters {
   regular: TypeTagCustom;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagFormat.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagFormat.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagFormat } from "../../../structures/TypeTagFormat";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagFormat = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagFormat",
-})(typia.llm.parameters<TypeTagFormatParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagFormat = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagFormat",
+  })(
+    typia.llm.parameters<TypeTagFormatParameters, "gemini">(),
+  );
 
 interface TypeTagFormatParameters {
   regular: TypeTagFormat;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagLength.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagLength.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagLength } from "../../../structures/TypeTagLength";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagLength = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagLength",
-})(typia.llm.parameters<TypeTagLengthParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagLength = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagLength",
+  })(
+    typia.llm.parameters<TypeTagLengthParameters, "gemini">(),
+  );
 
 interface TypeTagLengthParameters {
   regular: TypeTagLength;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagMatrix.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagMatrix.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagMatrix } from "../../../structures/TypeTagMatrix";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagMatrix = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagMatrix",
-})(typia.llm.parameters<TypeTagMatrixParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagMatrix = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagMatrix",
+  })(
+    typia.llm.parameters<TypeTagMatrixParameters, "gemini">(),
+  );
 
 interface TypeTagMatrixParameters {
   regular: TypeTagMatrix;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagPattern.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagPattern.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagPattern } from "../../../structures/TypeTagPattern";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagPattern = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagPattern",
-})(typia.llm.parameters<TypeTagPatternParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagPattern = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagPattern",
+  })(
+    typia.llm.parameters<TypeTagPatternParameters, "gemini">(),
+  );
 
 interface TypeTagPatternParameters {
   regular: TypeTagPattern;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagRange.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagRange.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagRange } from "../../../structures/TypeTagRange";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagRange = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagRange",
-})(typia.llm.parameters<TypeTagRangeParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagRange = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagRange",
+  })(
+    typia.llm.parameters<TypeTagRangeParameters, "gemini">(),
+  );
 
 interface TypeTagRangeParameters {
   regular: TypeTagRange;

--- a/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagType.ts
+++ b/test/src/features/llm.parameters/gemini/test_llm_parameters_gemini_TypeTagType.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { TypeTagType } from "../../../structures/TypeTagType";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_gemini_TypeTagType = _test_llm_parameters({
-  model: "gemini",
-  name: "TypeTagType",
-})(typia.llm.parameters<TypeTagTypeParameters, "gemini">());
+export const test_llm_parameters_gemini_TypeTagType = 
+  _test_llm_parameters({
+    model: "gemini",
+    name: "TypeTagType",
+  })(
+    typia.llm.parameters<TypeTagTypeParameters, "gemini">(),
+  );
 
 interface TypeTagTypeParameters {
   regular: TypeTagType;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayAny.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayAny.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayAny } from "../../../structures/ArrayAny";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayAny = _test_llm_parameters({
-  model: "llama",
-  name: "ArrayAny",
-})(typia.llm.parameters<ArrayAnyParameters, "llama">());
+export const test_llm_parameters_llama_ArrayAny = 
+  _test_llm_parameters({
+    model: "llama",
+    name: "ArrayAny",
+  })(
+    typia.llm.parameters<ArrayAnyParameters, "llama">(),
+  );
 
 interface ArrayAnyParameters {
   regular: ArrayAny;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayHierarchical.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayHierarchical.ts
@@ -1,14 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayHierarchical } from "../../../structures/ArrayHierarchical";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayHierarchical = _test_llm_parameters(
-  {
+export const test_llm_parameters_llama_ArrayHierarchical = 
+  _test_llm_parameters({
     model: "llama",
     name: "ArrayHierarchical",
-  },
-)(typia.llm.parameters<ArrayHierarchicalParameters, "llama">());
+  })(
+    typia.llm.parameters<ArrayHierarchicalParameters, "llama">(),
+  );
 
 interface ArrayHierarchicalParameters {
   regular: ArrayHierarchical;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayHierarchicalPointer.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayHierarchicalPointer.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayHierarchicalPointer } from "../../../structures/ArrayHierarchicalPointer";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayHierarchicalPointer =
+export const test_llm_parameters_llama_ArrayHierarchicalPointer = 
   _test_llm_parameters({
     model: "llama",
     name: "ArrayHierarchicalPointer",
-  })(typia.llm.parameters<ArrayHierarchicalPointerParameters, "llama">());
+  })(
+    typia.llm.parameters<ArrayHierarchicalPointerParameters, "llama">(),
+  );
 
 interface ArrayHierarchicalPointerParameters {
   regular: ArrayHierarchicalPointer;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayMatrix.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayMatrix.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayMatrix } from "../../../structures/ArrayMatrix";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayMatrix = _test_llm_parameters({
-  model: "llama",
-  name: "ArrayMatrix",
-})(typia.llm.parameters<ArrayMatrixParameters, "llama">());
+export const test_llm_parameters_llama_ArrayMatrix = 
+  _test_llm_parameters({
+    model: "llama",
+    name: "ArrayMatrix",
+  })(
+    typia.llm.parameters<ArrayMatrixParameters, "llama">(),
+  );
 
 interface ArrayMatrixParameters {
   regular: ArrayMatrix;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursive.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursive.ts
@@ -1,12 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayRecursive } from "../../../structures/ArrayRecursive";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayRecursive = _test_llm_parameters({
-  model: "llama",
-  name: "ArrayRecursive",
-})(typia.llm.parameters<ArrayRecursiveParameters, "llama">());
+export const test_llm_parameters_llama_ArrayRecursive = 
+  _test_llm_parameters({
+    model: "llama",
+    name: "ArrayRecursive",
+  })(
+    typia.llm.parameters<ArrayRecursiveParameters, "llama">(),
+  );
 
 interface ArrayRecursiveParameters {
   regular: ArrayRecursive;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursiveUnionExplicit.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursiveUnionExplicit.ts
@@ -1,13 +1,14 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayRecursiveUnionExplicit } from "../../../structures/ArrayRecursiveUnionExplicit";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayRecursiveUnionExplicit =
+export const test_llm_parameters_llama_ArrayRecursiveUnionExplicit = 
   _test_llm_parameters({
     model: "llama",
     name: "ArrayRecursiveUnionExplicit",
-  })(typia.llm.parameters<ArrayRecursiveUnionExplicitParameters, "llama">());
+  })(
+    typia.llm.parameters<ArrayRecursiveUnionExplicitParameters, "llama">(),
+  );
 
 interface ArrayRecursiveUnionExplicitParameters {
   regular: ArrayRecursiveUnionExplicit;

--- a/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursiveUnionExplicitPointer.ts
+++ b/test/src/features/llm.parameters/llama/test_llm_parameters_llama_ArrayRecursiveUnionExplicitPointer.ts
@@ -1,17 +1,13 @@
 import typia from "typia";
-
-import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 import { ArrayRecursiveUnionExplicitPointer } from "../../../structures/ArrayRecursiveUnionExplicitPointer";
+import { _test_llm_parameters } from "../../../internal/_test_llm_parameters";
 
-export const test_llm_parameters_llama_ArrayRecursiveUnionExplicitPointer =
+export const test_llm_parameters_llama_ArrayRecursiveUnionExplicitPointer = 
   _test_llm_parameters({
     model: "llama",
     name: "ArrayRecursiveUnionExplicitPointer",
   })(
-    typia.llm.parameters<
-      ArrayRecursiveUnionExplicitPointerParameters,
-      "llama"
-    >(),
+    typia.llm.parameters<ArrayRecursiveUnionExplicitPointerParameters, "llama">(),
   );
 
 interface ArrayRecursiveUnionExplicitPointerParameters {


### PR DESCRIPTION
This pull request includes several changes to remove empty `description` fields from various JSON schema definitions and updates file paths related to JSON schema generation.

### Removal of empty `description` fields:

* [`test-esm/generate/output/index.ts`](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L20): Removed empty `description` fields from multiple objects and properties. [[1]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L20) [[2]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L31) [[3]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L58) [[4]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L403) [[5]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L417) [[6]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L444) [[7]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L809) [[8]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L826) [[9]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L853) [[10]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L1235) [[11]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L1253) [[12]](diffhunk://#diff-1385862c0ce03c3314132f04d8ed3c6f40ef14b7b5eaf5fb3846f8e858a99233L1280)
* [`test/generate/output/generate_llm.ts`](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L16): Removed empty `description` fields from multiple schema definitions. [[1]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L16) [[2]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L43) [[3]](diffhunk://#diff-7755786417697df9098161c9a2c9c991e6eac213e55297ce9fc7be2cbe798fe0L83)
* [`test/schemas/llm.application/chatgpt/ArrayAny.json`](diffhunk://#diff-60d3bef11f76218e6f28730e15cb0e0bd74fa9bc45e8ec32b8c8f2ae016e8651L12): Removed empty `description` fields from multiple parameters. [[1]](diffhunk://#diff-60d3bef11f76218e6f28730e15cb0e0bd74fa9bc45e8ec32b8c8f2ae016e8651L12) [[2]](diffhunk://#diff-60d3bef11f76218e6f28730e15cb0e0bd74fa9bc45e8ec32b8c8f2ae016e8651L109) [[3]](diffhunk://#diff-60d3bef11f76218e6f28730e15cb0e0bd74fa9bc45e8ec32b8c8f2ae016e8651L380)
* [`test/schemas/llm.application/chatgpt/ArrayHierarchical.json`](diffhunk://#diff-8e02636838ecdf05d6a3a89c3205bdefcfb293fb4cca2d6336eb26f3c4fa17fbL12): Removed empty `description` fields from multiple parameters. [[1]](diffhunk://#diff-8e02636838ecdf05d6a3a89c3205bdefcfb293fb4cca2d6336eb26f3c4fa17fbL12) [[2]](diffhunk://#diff-8e02636838ecdf05d6a3a89c3205bdefcfb293fb4cca2d6336eb26f3c4fa17fbL153) [[3]](diffhunk://#diff-8e02636838ecdf05d6a3a89c3205bdefcfb293fb4cca2d6336eb26f3c4fa17fbL556)
* [`test/schemas/llm.application/chatgpt/ArrayHierarchicalPointer.json`](diffhunk://#diff-43e7d4f6b3ab478a21aaf77ee56cd987a223a104fab8fc88dbb9fd5298581d06L12): Removed empty `description` fields from multiple parameters. [[1]](diffhunk://#diff-43e7d4f6b3ab478a21aaf77ee56cd987a223a104fab8fc88dbb9fd5298581d06L12) [[2]](diffhunk://#diff-43e7d4f6b3ab478a21aaf77ee56cd987a223a104fab8fc88dbb9fd5298581d06L161) [[3]](diffhunk://#diff-43e7d4f6b3ab478a21aaf77ee56cd987a223a104fab8fc88dbb9fd5298581d06L588)
* [`test/schemas/llm.application/chatgpt/ArrayMatrix.json`](diffhunk://#diff-419a4834c61ca84521488699805b4557adfb043628aec9cb200db68c91a38dc7L12): Removed empty `description` fields from multiple parameters. [[1]](diffhunk://#diff-419a4834c61ca84521488699805b4557adfb043628aec9cb200db68c91a38dc7L12) [[2]](diffhunk://#diff-419a4834c61ca84521488699805b4557adfb043628aec9cb200db68c91a38dc7L39) [[3]](diffhunk://#diff-419a4834c61ca84521488699805b4557adfb043628aec9cb200db68c91a38dc7L100)
* [`test/schemas/llm.application/chatgpt/ArrayRecursive.json`](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L12): Removed empty `description` fields from multiple parameters and properties. [[1]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L12) [[2]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L25) [[3]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L74) [[4]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L98) [[5]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L150) [[6]](diffhunk://#diff-56923dad11476fe6b3459682d603d01888a92fa579e1838ecb6fea85e4b10d56L191)
* [`test/schemas/llm.application/chatgpt/ArrayRecursiveUnionExplicit.json`](diffhunk://#diff-2f9a59e2b4bf6b16dc954beb658ba0f2b4a864e4ce5c7f679329853bc16f49cdL12): Removed empty `description` fields from multiple parameters and properties. [[1]](diffhunk://#diff-2f9a59e2b4bf6b16dc954beb658ba0f2b4a864e4ce5c7f679329853bc16f49cdL12) [[2]](diffhunk://#diff-2f9a59e2b4bf6b16dc954beb658ba0f2b4a864e4ce5c7f679329853bc16f49cdL173) [[3]](diffhunk://#diff-2f9a59e2b4bf6b16dc954beb658ba0f2b4a864e4ce5c7f679329853bc16f49cdL207) [[4]](diffhunk://#diff-2f9a59e2b4bf6b16dc954beb658ba0f2b4a864e4ce5c7f679329853bc16f49cdL250)

### Updates to JSON schema generation file paths:

* [`test/build/internal/TestJsonSchemaGenerator.ts`](diffhunk://#diff-43f12ecc282f921e323b80a4690c6213b6bb294f5f1dfad3b1615ef388f30287L9-R9): Updated file paths from `json.schema` to `json.schemas` to reflect the correct directory structure. [[1]](diffhunk://#diff-43f12ecc282f921e323b80a4690c6213b6bb294f5f1dfad3b1615ef388f30287L9-R9) [[2]](diffhunk://#diff-43f12ecc282f921e323b80a4690c6213b6bb294f5f1dfad3b1615ef388f30287L19-R19) [[3]](diffhunk://#diff-43f12ecc282f921e323b80a4690c6213b6bb294f5f1dfad3b1615ef388f30287L45-R45) [[4]](diffhunk://#diff-43f12ecc282f921e323b80a4690c6213b6bb294f5f1dfad3b1615ef388f30287L60-R60)