### PR TITLE
feat: modify typia.llm.application non-object error message

### DIFF
--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -117,37 +117,37 @@ export namespace LlmApplicationProgrammer {
     const prefix: string = `LLM application's function (${JSON.stringify(name)})`;
     if (func.output.size() && func.output.isRequired() === false)
       output.push(
-        `${prefix}'s return type must not be union type with undefined.`,
+        `${prefix} return type cannot be optional (union with undefined).`,
       );
     if (/^[0-9]/.test(name[0] ?? "") === true)
-      output.push(`${prefix} name must not start with a number.`);
+      output.push(`${prefix} name cannot start with a number.`);
     if (/^[a-zA-Z0-9_-]+$/.test(name) === false)
       output.push(
-        `${prefix} name must be alphanumeric with underscore or hyphen.`,
+        `${prefix} name must contain only alphanumeric characters, underscores, or hyphens.`,
       );
     if (name.length > 64)
-      output.push(`${prefix} name must not exceed 64 characters.`);
+      output.push(`${prefix} name cannot exceed 64 characters.`);
     if (func.parameters.length !== 0 && func.parameters.length !== 1)
-      output.push(`${prefix} must have a single parameter.`);
+      output.push(
+        `${prefix} must have exactly one parameter or no parameters.`,
+      );
     if (func.parameters.length !== 0) {
       const type: Metadata = func.parameters[0]!.type;
       if (type.size() !== 1 || type.objects.length !== 1)
-        output.push(
-          `${prefix}'s parameter must be an object type. Union types ${type.getName()} are not supported.`,
-        );
+        output.push(`${prefix} parameter must be a single object type.`);
       else {
         if (
           type.objects[0]!.type.properties.some(
             (p) => p.key.isSoleLiteral() === false,
           )
         )
-          output.push(`${prefix}'s parameter must not have dynamic keys.`);
+          output.push(`${prefix} parameter cannot have dynamic property keys.`);
         if (type.isRequired() === false)
           output.push(
-            `${prefix}'s parameter must not be union type with undefined.`,
+            `${prefix} parameter cannot be optional (union with undefined).`,
           );
         if (type.nullable === true)
-          output.push(`${prefix}'s parameter must not be nullable.`);
+          output.push(`${prefix} parameter cannot be nullable.`);
       }
     }
     return output;

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -133,7 +133,7 @@ export namespace LlmApplicationProgrammer {
       const type: Metadata = func.parameters[0]!.type;
       if (type.size() !== 1 || type.objects.length !== 1)
         output.push(
-          `${prefix}'s parameter must be an object type. Union types (e.g., string | object) are not supported.`,
+          `${prefix}'s parameter must be an object type. Union types ${type.getName()} are not supported.`,
         );
       else {
         if (

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -132,7 +132,9 @@ export namespace LlmApplicationProgrammer {
     if (func.parameters.length !== 0) {
       const type: Metadata = func.parameters[0]!.type;
       if (type.size() !== 1 || type.objects.length !== 1)
-        output.push(`${prefix}'s parameter must be an object type.`);
+        output.push(
+          `${prefix}'s parameter must be an object type. Union types (e.g., string | object) are not supported.`,
+        );
       else {
         if (
           type.objects[0]!.type.properties.some(


### PR DESCRIPTION
Change Error Message by #1555 

> eg. before
```json
{
  "code": "typia.llm.application",
  "message": "unsupported type detected\n\n- PickNotionServicegetDatabaseInfo.getDatabaseInfo: unknown\n  - LLM application's function (\"getDatabaseInfo\")'s parameter must be an object type.",
  "name": "Error"
}
```

> eg. after

```json
{
  "code": "typia.llm.application",
  "message": "unsupported type detected\n\n- PickNotionServicegetDatabaseInfo.getDatabaseInfo: unknown\n  - LLM application's function (\"getDatabaseInfo\")'s parameter must be an object type. Union types (e.g., string | object) are not supported.",
  "name": "Error"
}
```