### PR TITLE
Remove `@samchon/openapi` from `peerDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "randexp": "^0.5.3"
   },
   "peerDependencies": {
-    "@samchon/openapi": ">=4.5.0 <5.0.0",
     "typescript": ">=4.8.0 <5.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
If restriction of the `@samchon/openapi` version range is required for the AI agent development reason, it must be from the AI agent project.
