### PR TITLE
Fix #1583: alias type problem of Map and Set cases.

### DIFF
--- a/src/factories/TypeFactory.ts
+++ b/src/factories/TypeFactory.ts
@@ -45,6 +45,7 @@ export namespace TypeFactory {
     checker: ts.TypeChecker;
     type: ts.Type;
     symbol?: ts.Symbol;
+    aliasTypeArguments?: boolean; // default: true
   }): string => {
     // PRIMITIVE
     const symbol =
@@ -73,9 +74,10 @@ export namespace TypeFactory {
     const name: string = get_name(symbol);
 
     // CHECK GENERIC
-    const generic: readonly ts.Type[] = props.type.aliasSymbol
-      ? (props.type.aliasTypeArguments ?? [])
-      : props.checker.getTypeArguments(props.type as ts.TypeReference);
+    const generic: readonly ts.Type[] =
+      props.type.aliasSymbol && props.aliasTypeArguments !== false
+        ? (props.type.aliasTypeArguments ?? [])
+        : props.checker.getTypeArguments(props.type as ts.TypeReference);
     return generic.length
       ? name === "Promise"
         ? getFullName({

--- a/src/factories/internal/metadata/iterate_metadata_map.ts
+++ b/src/factories/internal/metadata/iterate_metadata_map.ts
@@ -17,10 +17,10 @@ export const iterate_metadata_map = (
     checker: props.checker,
     type,
     symbol: type.getSymbol(),
+    aliasTypeArguments: false,
   });
-  const generic: readonly ts.Type[] | undefined = type.aliasSymbol
-    ? type.aliasTypeArguments
-    : props.checker.getTypeArguments(type as ts.TypeReference);
+  const generic: readonly ts.Type[] | undefined =
+    props.checker.getTypeArguments(type as ts.TypeReference);
   if (name.substring(0, 4) !== "Map<" || generic?.length !== 2) return false;
 
   const key: ts.Type = generic[0]!;

--- a/src/factories/internal/metadata/iterate_metadata_set.ts
+++ b/src/factories/internal/metadata/iterate_metadata_set.ts
@@ -18,10 +18,9 @@ export const iterate_metadata_set = (
     checker: props.checker,
     type: type,
     symbol: type.getSymbol(),
+    aliasTypeArguments: false,
   });
-  const generic = type.aliasSymbol
-    ? type.aliasTypeArguments
-    : props.checker.getTypeArguments(type as ts.TypeReference);
+  const generic = props.checker.getTypeArguments(type as ts.TypeReference);
   if (name.substring(0, 4) !== "Set<" || generic?.length !== 1) return false;
 
   const key: ts.Type = generic[0]!;

--- a/test/src/debug/map.ts
+++ b/test/src/debug/map.ts
@@ -1,0 +1,12 @@
+import typia from "typia";
+
+import { TypeTagRange } from "../structures/TypeTagRange";
+
+type M = Map<string, string>;
+type S = Set<number>;
+
+typia.createIs<M>();
+
+typia.createIs<S>();
+
+console.log(JSON.stringify(typia.json.schema<TypeTagRange>(), null, 2));

--- a/test/src/features/issues/test_issue_1583_set_map_alias_validate.ts
+++ b/test/src/features/issues/test_issue_1583_set_map_alias_validate.ts
@@ -5,7 +5,7 @@ export const test_issue_1583_set_map_alias_validate = (): void => {
   m.set("first", 1);
 
   const s: S = new Set();
-  s.set("someothing");
+  s.add("someothing");
 
   typia.assert(m);
   typia.assert(s);

--- a/test/src/features/issues/test_issue_1583_set_map_alias_validate.ts
+++ b/test/src/features/issues/test_issue_1583_set_map_alias_validate.ts
@@ -1,6 +1,6 @@
 import typia from "typia";
 
-export const test_issue_1629_set_map_alias_validate = (): void => {
+export const test_issue_1583_set_map_alias_validate = (): void => {
   const m: M = new Map();
   m.set("first", 1);
 

--- a/test/src/features/issues/test_issue_1629_set_map_alias_validate.ts
+++ b/test/src/features/issues/test_issue_1629_set_map_alias_validate.ts
@@ -1,0 +1,15 @@
+import typia from "typia";
+
+export const test_issue_1629_set_map_alias_validate = (): void => {
+  const m: M = new Map();
+  m.set("first", 1);
+
+  const s: S = new Set();
+  s.set("someothing");
+
+  typia.assert(m);
+  typia.assert(s);
+};
+
+type M = Map<string, number>;
+type S = Set<string>;


### PR DESCRIPTION
This pull request refines how generic type arguments are handled for `Map` and `Set` type aliases in the type factory logic, ensuring more accurate type resolution and validation. The main change is disabling the use of alias type arguments when processing `Map` and `Set`, which improves compatibility with TypeScript's type checker and fixes related validation issues. New tests have been added to verify these improvements.

**Type Resolution Improvements:**

* Added an `aliasTypeArguments` option to the `TypeFactory.getFullName` method, allowing callers to control whether alias type arguments are used when resolving generic types.
* Updated the logic in `TypeFactory.getFullName` to respect the new `aliasTypeArguments` flag, defaulting to true unless explicitly set to false.

**Bug Fixes for Map and Set Aliases:**

* Modified `iterate_metadata_map.ts` and `iterate_metadata_set.ts` to set `aliasTypeArguments: false` when calling `TypeFactory.getFullName`, ensuring that generic type arguments are always retrieved via the type checker for these structures. [[1]](diffhunk://#diff-153d56546b751e173342cf50babdd195d3de0e556baff99b1bcda7ff7fbb1d42R20-R23) [[2]](diffhunk://#diff-497ba8ff6549a1bf589a3701c60467d65c39086d0a997cc8c0237c0c592d9dbbR21-R23)

**Testing and Validation:**

* Added a new test file `test_issue_1629_set_map_alias_validate.ts` to confirm correct validation of `Map` and `Set` aliases using `typia.assert`.
* Introduced a debug test in `map.ts` to exercise the schema generation and validation for `Map`, `Set`, and a custom structure.