### PR TITLE
Complement #1625: refactoring with safe conditions

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -50,7 +50,7 @@
     "fast-json-stringify": "^5.8.0",
     "fastify": "^4.9.2",
     "io-ts": "^2.2.19",
-    "jsdom": "^21.1.1",
+    "jsdom": "^26.1.0",
     "physical-cpu-count": "^2.0.0",
     "prettier": "^2.6.2",
     "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
@@ -32,31 +32,31 @@ importers:
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^26.0.1
-        version: 26.0.3(rollup@4.46.2)
+        version: 26.0.3(rollup@4.40.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
-        version: 15.3.1(rollup@4.46.2)
+        version: 15.3.1(rollup@4.40.0)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.46.2)(typescript@5.9.2)
+        version: 11.1.6(rollup@4.40.0)(tslib@2.8.1)(typescript@5.9.2)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.6.2)
+        version: 4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
       '@types/inquirer':
         specifier: ^8.2.5
-        version: 8.2.12
+        version: 8.2.10
       '@types/node':
         specifier: ^18.15.12
-        version: 18.19.121
+        version: 18.19.86
       '@types/ts-expose-internals':
         specifier: npm:ts-expose-internals@5.6.3
-        version: /ts-expose-internals@5.6.3
+        version: ts-expose-internals@5.6.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.1.0
-        version: 8.39.0(@typescript-eslint/parser@8.39.0)(eslint@8.57.1)(typescript@5.9.2)
+        version: 8.30.1(@typescript-eslint/parser@8.30.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.1.0
-        version: 8.39.0(eslint@8.57.1)(typescript@5.9.2)
+        version: 8.30.1(eslint@8.57.1)(typescript@5.9.2)
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -65,28 +65,28 @@ importers:
         version: 3.0.0(eslint@8.57.1)(typescript@5.9.2)
       prettier:
         specifier: ^3.2.5
-        version: 3.6.2
+        version: 3.5.3
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
       rollup:
         specifier: ^4.18.0
-        version: 4.46.2
+        version: 4.40.0
       rollup-plugin-auto-external:
         specifier: ^2.0.0
-        version: 2.0.0(rollup@4.46.2)
+        version: 2.0.0(rollup@4.40.0)
       rollup-plugin-node-externals:
         specifier: ^8.0.0
-        version: 8.0.1(rollup@4.46.2)
+        version: 8.0.0(rollup@4.40.0)
       suppress-warnings:
         specifier: ^1.0.2
         version: 1.0.2
       tinyglobby:
         specifier: ^0.2.12
-        version: 0.2.14
+        version: 0.2.13
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.19.121)(typescript@5.9.2)
+        version: 10.9.2(@types/node@18.19.86)(typescript@5.9.2)
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -129,22 +129,22 @@ importers:
         version: 10.6.0(mongoose@6.13.8)
       '@types/autocannon':
         specifier: ^7.9.0
-        version: 7.12.7
+        version: 7.12.6
       '@types/benchmark':
         specifier: ^2.1.2
         version: 2.1.5
       '@types/body-parser':
         specifier: ^1.19.5
-        version: 1.19.6
+        version: 1.19.5
       '@types/d3':
         specifier: ^7.4.0
         version: 7.4.3
       '@types/express':
         specifier: ^4.17.14
-        version: 4.17.23
+        version: 4.17.21
       '@types/node':
         specifier: ^18.15.12
-        version: 18.19.121
+        version: 18.19.86
       '@types/physical-cpu-count':
         specifier: ^2.0.0
         version: 2.0.2
@@ -168,7 +168,7 @@ importers:
         version: 0.5.1
       class-validator:
         specifier: ^0.14.0
-        version: 0.14.2
+        version: 0.14.1
       d3:
         specifier: ^5.16.0
         version: 5.16.0
@@ -180,7 +180,7 @@ importers:
         version: 5.16.1
       fastify:
         specifier: ^4.9.2
-        version: 4.29.1
+        version: 4.29.0
       io-ts:
         specifier: ^2.2.19
         version: 2.2.22(fp-ts@2.16.10)
@@ -204,7 +204,7 @@ importers:
         version: 0.10.3
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.121)(typescript@5.9.2)
+        version: 10.9.2(@types/node@18.19.86)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -213,13 +213,13 @@ importers:
         version: 5.9.2
       zod:
         specifier: ^3.19.1
-        version: 3.25.76
+        version: 3.24.3
 
   examples:
     dependencies:
       openai:
         specifier: ^4.90.0
-        version: 4.104.0
+        version: 4.95.1(ws@8.18.1)(zod@3.24.3)
       typia:
         specifier: workspace:^
         version: link:..
@@ -229,13 +229,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.9.4
-        version: 20.19.9
+        version: 20.17.30
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
       prettier:
         specifier: ^3.2.5
-        version: 3.6.2
+        version: 3.5.3
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
@@ -275,25 +275,25 @@ importers:
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.6.2)
+        version: 4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
       '@types/cli':
         specifier: ^0.11.25
         version: 0.11.25
       '@types/node':
         specifier: ^20.9.4
-        version: 20.19.9
+        version: 20.17.30
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
       prettier:
         specifier: ^3.2.5
-        version: 3.6.2
+        version: 3.5.3
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.9)(typescript@5.9.2)
+        version: 10.9.2(@types/node@20.17.30)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -328,7 +328,7 @@ importers:
         version: 0.11.25
       '@types/node':
         specifier: ^22.10.1
-        version: 22.17.0
+        version: 22.14.1
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
@@ -338,1017 +338,357 @@ importers:
 
 packages:
 
-  /@ampproject/remapping@2.3.0:
+  '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-    dev: true
 
-  /@assemblyscript/loader@0.19.23:
+  '@assemblyscript/loader@0.19.23':
     resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
-    dev: true
 
-  /@aws-crypto/sha256-browser@5.2.0:
+  '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-locate-window': 3.804.0
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-crypto/sha256-js@5.2.0:
+  '@aws-crypto/sha256-js@5.2.0':
     resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
     engines: {node: '>=16.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.862.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-crypto/supports-web-crypto@5.2.0:
+  '@aws-crypto/supports-web-crypto@5.2.0':
     resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-crypto/util@5.2.0:
+  '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/client-cognito-identity@3.863.0:
-    resolution: {integrity: sha512-Dhtrr5K6GdxzAGyVUaxvqg+mDPuHhPhMTAYufY6dR3b33azNcJc21aGVFbNhCnAWuswlR/OMHnAeB9DGPYz2Gg==}
+  '@aws-sdk/client-cognito-identity@3.797.0':
+    resolution: {integrity: sha512-IzpwVFYpLOV7Anm2CvihMb+qx/2OFjd47BWVOtMtMBDeYbygYKmTWQ2XdqWMlTwKub/gwzn0yRoXSeGuKl/yEQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/credential-provider-node': 3.863.0
-      '@aws-sdk/middleware-host-header': 3.862.0
-      '@aws-sdk/middleware-logger': 3.862.0
-      '@aws-sdk/middleware-recursion-detection': 3.862.0
-      '@aws-sdk/middleware-user-agent': 3.863.0
-      '@aws-sdk/region-config-resolver': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-endpoints': 3.862.0
-      '@aws-sdk/util-user-agent-browser': 3.862.0
-      '@aws-sdk/util-user-agent-node': 3.863.0
-      '@smithy/config-resolver': 4.1.5
-      '@smithy/core': 3.8.0
-      '@smithy/fetch-http-handler': 5.1.1
-      '@smithy/hash-node': 4.0.5
-      '@smithy/invalid-dependency': 4.0.5
-      '@smithy/middleware-content-length': 4.0.5
-      '@smithy/middleware-endpoint': 4.1.18
-      '@smithy/middleware-retry': 4.1.19
-      '@smithy/middleware-serde': 4.0.9
-      '@smithy/middleware-stack': 4.0.5
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/node-http-handler': 4.1.1
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-body-length-browser': 4.0.0
-      '@smithy/util-body-length-node': 4.0.0
-      '@smithy/util-defaults-mode-browser': 4.0.26
-      '@smithy/util-defaults-mode-node': 4.0.26
-      '@smithy/util-endpoints': 3.0.7
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-retry': 4.0.7
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/client-sso@3.863.0:
-    resolution: {integrity: sha512-3DZE5lx5A+MgTVS8yRBz/Ne8pWvwc7tDy4KBx5sDd93wvnDYjZW28g7W73d1dD7jfN8ZIC0REtiuNj00Ty0PBg==}
+  '@aws-sdk/client-sso@3.797.0':
+    resolution: {integrity: sha512-9xuR918p7tShR67ZL+AOSbydpJxSHAOdXcQswxxWR/hKCF7tULX7tyL3gNo3l/ETp0CDcStvorOdH/nCbzEOjw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/middleware-host-header': 3.862.0
-      '@aws-sdk/middleware-logger': 3.862.0
-      '@aws-sdk/middleware-recursion-detection': 3.862.0
-      '@aws-sdk/middleware-user-agent': 3.863.0
-      '@aws-sdk/region-config-resolver': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-endpoints': 3.862.0
-      '@aws-sdk/util-user-agent-browser': 3.862.0
-      '@aws-sdk/util-user-agent-node': 3.863.0
-      '@smithy/config-resolver': 4.1.5
-      '@smithy/core': 3.8.0
-      '@smithy/fetch-http-handler': 5.1.1
-      '@smithy/hash-node': 4.0.5
-      '@smithy/invalid-dependency': 4.0.5
-      '@smithy/middleware-content-length': 4.0.5
-      '@smithy/middleware-endpoint': 4.1.18
-      '@smithy/middleware-retry': 4.1.19
-      '@smithy/middleware-serde': 4.0.9
-      '@smithy/middleware-stack': 4.0.5
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/node-http-handler': 4.1.1
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-body-length-browser': 4.0.0
-      '@smithy/util-body-length-node': 4.0.0
-      '@smithy/util-defaults-mode-browser': 4.0.26
-      '@smithy/util-defaults-mode-node': 4.0.26
-      '@smithy/util-endpoints': 3.0.7
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-retry': 4.0.7
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/core@3.863.0:
-    resolution: {integrity: sha512-6KUD82jb8Z+PWRoAwqpjFcrhcCvUlKNfUKKdkhj2yEdugem36d29avTpTPa6RiOEsfUi7CM4Yh60Qrj0pNI4xQ==}
+  '@aws-sdk/core@3.796.0':
+    resolution: {integrity: sha512-tH8Sp7lCxISVoLnkyv4AouuXs2CDlMhTuesWa0lq2NX1f+DXsMwSBtN37ttZdpFMw3F8mWdsJt27X9h2Oq868A==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/xml-builder': 3.862.0
-      '@smithy/core': 3.8.0
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/property-provider': 4.0.5
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/signature-v4': 5.1.3
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-body-length-browser': 4.0.0
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-utf8': 4.0.0
-      fast-xml-parser: 5.2.5
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-cognito-identity@3.863.0:
-    resolution: {integrity: sha512-0lhAalLvONf9hnDbWQP2Dsbdnh7iLcMfz9c8YD2vyZTFqrooy4EX8ryhZO97gycTeg2b0gaQQVLSFCCWGJcWKw==}
+  '@aws-sdk/credential-provider-cognito-identity@3.797.0':
+    resolution: {integrity: sha512-hE/fOgFIToJKuMz8hxUZ9PqqyG9xkjig4my6JxE+dcKxefoK3gT2ELrDjw/MOnjqeUorzJ8O5PjJxa1zzIzchw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-env@3.863.0:
-    resolution: {integrity: sha512-KmA5cjJU5ihR+oFJtraraeQ7aDSp3GtogSoBUKaHBsiSP7awgxuVcAWSr8wCxi0kPUjCE7kHSLTv4i9UC4soYw==}
+  '@aws-sdk/credential-provider-env@3.796.0':
+    resolution: {integrity: sha512-kQzGKm4IOYYO6vUrai2JocNwhJm4Aml2BsAV+tBhFhhkutE7khf9PUucoVjB78b0J48nF+kdSacqzY+gB81/Uw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-http@3.863.0:
-    resolution: {integrity: sha512-AsMgQgYG5YwBFHAuB5y/ngwT9K2axBqJm1ZM+wBMTqPvyQ7cjnfsliCAGEY2QPIxE2prX85Bc50s1OPQVPROHg==}
+  '@aws-sdk/credential-provider-http@3.796.0':
+    resolution: {integrity: sha512-wWOT6VAHIKOuHdKFGm1iyKvx7f6+Kc/YTzFWJPuT+l+CPlXR6ylP1UMIDsHHLKpMzsrh3CH77QDsjkhQrnKkfg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/fetch-http-handler': 5.1.1
-      '@smithy/node-http-handler': 4.1.1
-      '@smithy/property-provider': 4.0.5
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/util-stream': 4.2.4
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-ini@3.863.0:
-    resolution: {integrity: sha512-RyyUZ7onXQdcjTnnmX3LvO3/tKsmYR9PJrLCnQQUVYlUzwref4E0ytBgk/mycxx6KHCJNVUzY4QV7s9VaUxcZA==}
+  '@aws-sdk/credential-provider-ini@3.797.0':
+    resolution: {integrity: sha512-Zpj6pJ2hnebrhLDr+x61ArMUkjHG6mfJRfamHxeVTgZkhLcwHjC5aM4u9pWTVugIaPY+VBtgkKPbi3TRbHlt2g==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/credential-provider-env': 3.863.0
-      '@aws-sdk/credential-provider-http': 3.863.0
-      '@aws-sdk/credential-provider-process': 3.863.0
-      '@aws-sdk/credential-provider-sso': 3.863.0
-      '@aws-sdk/credential-provider-web-identity': 3.863.0
-      '@aws-sdk/nested-clients': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/credential-provider-imds': 4.0.7
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-node@3.863.0:
-    resolution: {integrity: sha512-ApRpvgB+DN4BHVmiLvXIdpFN21wBdL5p81G5cXmipJHStThAkk2N9SSG0XxhMaCpzdRWt+4JPRwR5pHiPvnxug==}
+  '@aws-sdk/credential-provider-node@3.797.0':
+    resolution: {integrity: sha512-xJSWvvnmzEfHbqbpN4F3E3mI9+zJ/VWLGiKOjzX1Inbspa5WqNn2GoMamolZR2TvvZS4F3Hp73TD1WoBzkIjuw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.863.0
-      '@aws-sdk/credential-provider-http': 3.863.0
-      '@aws-sdk/credential-provider-ini': 3.863.0
-      '@aws-sdk/credential-provider-process': 3.863.0
-      '@aws-sdk/credential-provider-sso': 3.863.0
-      '@aws-sdk/credential-provider-web-identity': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/credential-provider-imds': 4.0.7
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-process@3.863.0:
-    resolution: {integrity: sha512-UN8AfjFvLGIHg2lMr4SNiOhCsDUv6uaD/XbAiRpt/u0z/xMsICxwkOawnKtHj24xGRAh+GgefMirl6QiTkbJ4Q==}
+  '@aws-sdk/credential-provider-process@3.796.0':
+    resolution: {integrity: sha512-r4e8/4AdKn/qQbRVocW7oXkpoiuXdTv0qty8AASNLnbQnT1vjD1bvmP6kp4fbHPWgwY8I9h0Dqjp49uy9Bqyuw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-sso@3.863.0:
-    resolution: {integrity: sha512-oV4F1zY0o/txR9ruTCH+UlRf7LAKBiwkthsHplNJT0kVq98RtBIMrzk9DgibvjfBsJH1572wozDIc4yOpcB4YA==}
+  '@aws-sdk/credential-provider-sso@3.797.0':
+    resolution: {integrity: sha512-VlyWnjTsTnBXqXcEW0nw3S7nj00n9fYwF6uU6HPO9t860yIySG01lNPAWTvAt3DfVL5SRS0GANriCZF6ohcMcQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/client-sso': 3.863.0
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/token-providers': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-provider-web-identity@3.863.0:
-    resolution: {integrity: sha512-INN5BNFalw68BxBFT+9sj2Yxia1XvS0+ZG0dkfFAmo8iXb2mw0o52PgqOiKlQfxnjbyOH7LgTB2hfbuuEwpKjw==}
+  '@aws-sdk/credential-provider-web-identity@3.797.0':
+    resolution: {integrity: sha512-DIb05FEmdOX7bNsqSVEAB3UkaDgrYHonQ2+gcBLqZ7LoDNnovHIlvC5jii93usgEStxITZstnzw+49keNEgVWw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/nested-clients': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/credential-providers@3.863.0:
-    resolution: {integrity: sha512-BBCrdtfGUFunOYFJiOUs9VdcXajJBGrWVb7zMCL1pADd/cOWM1Ozpskh+g+yh6LXXW43lhf1DcoMkACkNbFnIg==}
+  '@aws-sdk/credential-providers@3.797.0':
+    resolution: {integrity: sha512-UBsPtUql1q22kMNKcUKhpRKlZXHW1ESbcrv0Z/BekwHEu8fuxgS8aRsfminUcLaBLPjBJjEy6AhY/rXUpX6lsg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.863.0
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.863.0
-      '@aws-sdk/credential-provider-env': 3.863.0
-      '@aws-sdk/credential-provider-http': 3.863.0
-      '@aws-sdk/credential-provider-ini': 3.863.0
-      '@aws-sdk/credential-provider-node': 3.863.0
-      '@aws-sdk/credential-provider-process': 3.863.0
-      '@aws-sdk/credential-provider-sso': 3.863.0
-      '@aws-sdk/credential-provider-web-identity': 3.863.0
-      '@aws-sdk/nested-clients': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/config-resolver': 4.1.5
-      '@smithy/core': 3.8.0
-      '@smithy/credential-provider-imds': 4.0.7
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/property-provider': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/middleware-host-header@3.862.0:
-    resolution: {integrity: sha512-jDje8dCFeFHfuCAxMDXBs8hy8q9NCTlyK4ThyyfAj3U4Pixly2mmzY2u7b7AyGhWsjJNx8uhTjlYq5zkQPQCYw==}
+  '@aws-sdk/middleware-host-header@3.775.0':
+    resolution: {integrity: sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/middleware-logger@3.862.0:
-    resolution: {integrity: sha512-N/bXSJznNBR/i7Ofmf9+gM6dx/SPBK09ZWLKsW5iQjqKxAKn/2DozlnE54uiEs1saHZWoNDRg69Ww4XYYSlG1Q==}
+  '@aws-sdk/middleware-logger@3.775.0':
+    resolution: {integrity: sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/middleware-recursion-detection@3.862.0:
-    resolution: {integrity: sha512-KVoo3IOzEkTq97YKM4uxZcYFSNnMkhW/qj22csofLegZi5fk90ztUnnaeKfaEJHfHp/tm1Y3uSoOXH45s++kKQ==}
+  '@aws-sdk/middleware-recursion-detection@3.775.0':
+    resolution: {integrity: sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/middleware-user-agent@3.863.0:
-    resolution: {integrity: sha512-AqXzUUpHM51E/cmq/h3yja+GFff7zxQFj6Fq1bVkkc4vzXBCGpyTmaMcUv4rrR/OmmWfidyzbxdy7PuhMNAspg==}
+  '@aws-sdk/middleware-user-agent@3.796.0':
+    resolution: {integrity: sha512-IeNg+3jNWT37J45opi5Jx89hGF0lOnZjiNwlMp3rKq7PlOqy8kWq5J1Gxk0W3tIkPpuf68CtBs/QFrRXWOjsZw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-endpoints': 3.862.0
-      '@smithy/core': 3.8.0
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/nested-clients@3.863.0:
-    resolution: {integrity: sha512-TgVr6d1MmJz7H6RehaFevZlJ+d1KSmyftp8oi2V5FCQ4OR22ITsTxmm5cIODYk8VInaie2ZABlPCN5fs+glJuA==}
+  '@aws-sdk/nested-clients@3.797.0':
+    resolution: {integrity: sha512-xCsRKdsv0GAg9E28fvYBdC3JR2xdtZ2o41MVknOs+pSFtMsZm3SsgxObN35p1OTMk/o/V0LORGVLnFQMlc5QiA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/middleware-host-header': 3.862.0
-      '@aws-sdk/middleware-logger': 3.862.0
-      '@aws-sdk/middleware-recursion-detection': 3.862.0
-      '@aws-sdk/middleware-user-agent': 3.863.0
-      '@aws-sdk/region-config-resolver': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-endpoints': 3.862.0
-      '@aws-sdk/util-user-agent-browser': 3.862.0
-      '@aws-sdk/util-user-agent-node': 3.863.0
-      '@smithy/config-resolver': 4.1.5
-      '@smithy/core': 3.8.0
-      '@smithy/fetch-http-handler': 5.1.1
-      '@smithy/hash-node': 4.0.5
-      '@smithy/invalid-dependency': 4.0.5
-      '@smithy/middleware-content-length': 4.0.5
-      '@smithy/middleware-endpoint': 4.1.18
-      '@smithy/middleware-retry': 4.1.19
-      '@smithy/middleware-serde': 4.0.9
-      '@smithy/middleware-stack': 4.0.5
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/node-http-handler': 4.1.1
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-body-length-browser': 4.0.0
-      '@smithy/util-body-length-node': 4.0.0
-      '@smithy/util-defaults-mode-browser': 4.0.26
-      '@smithy/util-defaults-mode-node': 4.0.26
-      '@smithy/util-endpoints': 3.0.7
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-retry': 4.0.7
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/region-config-resolver@3.862.0:
-    resolution: {integrity: sha512-VisR+/HuVFICrBPY+q9novEiE4b3mvDofWqyvmxHcWM7HumTz9ZQSuEtnlB/92GVM3KDUrR9EmBHNRrfXYZkcQ==}
+  '@aws-sdk/region-config-resolver@3.775.0':
+    resolution: {integrity: sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/types': 4.3.2
-      '@smithy/util-config-provider': 4.0.0
-      '@smithy/util-middleware': 4.0.5
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/token-providers@3.863.0:
-    resolution: {integrity: sha512-rGZ8QsnLWa725etzdPW2rH6+LN9eCcGsTIcxcCyh59cSgZLxT913q84WaUj6fOA7ElCOEU+WrV4Jiz4qwZI2DA==}
+  '@aws-sdk/token-providers@3.797.0':
+    resolution: {integrity: sha512-TLFkP4BBdkH2zCXhG3JjaYrRft25MMZ+6/YDz1C/ikq2Zk8krUbVoSmhtYMVz10JtxAPiQ++w0vI/qbz2JSDXg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/core': 3.863.0
-      '@aws-sdk/nested-clients': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-    optional: true
 
-  /@aws-sdk/types@3.862.0:
-    resolution: {integrity: sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==}
+  '@aws-sdk/types@3.775.0':
+    resolution: {integrity: sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/util-endpoints@3.862.0:
-    resolution: {integrity: sha512-eCZuScdE9MWWkHGM2BJxm726MCmWk/dlHjOKvkM0sN1zxBellBMw5JohNss1Z8/TUmnW2gb9XHTOiHuGjOdksA==}
+  '@aws-sdk/util-endpoints@3.787.0':
+    resolution: {integrity: sha512-fd3zkiOkwnbdbN0Xp9TsP5SWrmv0SpT70YEdbb8wAj2DWQwiCmFszaSs+YCvhoCdmlR3Wl9Spu0pGpSAGKeYvQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      '@smithy/util-endpoints': 3.0.7
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/util-locate-window@3.804.0:
-    resolution: {integrity: sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==}
+  '@aws-sdk/util-locate-window@3.723.0':
+    resolution: {integrity: sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/util-user-agent-browser@3.862.0:
-    resolution: {integrity: sha512-BmPTlm0r9/10MMr5ND9E92r8KMZbq5ltYXYpVcUbAsnB1RJ8ASJuRoLne5F7mB3YMx0FJoOTuSq7LdQM3LgW3Q==}
-    requiresBuild: true
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/types': 4.3.2
-      bowser: 2.11.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
+  '@aws-sdk/util-user-agent-browser@3.775.0':
+    resolution: {integrity: sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==}
 
-  /@aws-sdk/util-user-agent-node@3.863.0:
-    resolution: {integrity: sha512-qoYXCe07xs0z+MjcDGuNBbP8P47i6h13BiHsXxiMKKiCihB3w2slvRbJYwUwc2fzZWSk0isKbdDmsdNZBKyBHg==}
+  '@aws-sdk/util-user-agent-node@3.796.0':
+    resolution: {integrity: sha512-9fQpNcHgVFitf1tbTT8V1xGRoRHSmOAWjrhevo6Tc0WoINMAKz+4JNqfVGWRE5Tmtpq0oHKo1RmvxXQQtJYciA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
     peerDependencies:
       aws-crt: '>=1.0.0'
     peerDependenciesMeta:
       aws-crt:
         optional: true
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.863.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@aws-sdk/xml-builder@3.862.0:
-    resolution: {integrity: sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==}
-    engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
-
-  /@babel/code-frame@7.27.1:
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-    dev: true
 
-  /@babel/compat-data@7.28.0:
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+  '@babel/compat-data@7.26.8':
+    resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/core@7.17.8:
+  '@babel/core@7.17.8':
     resolution: {integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.17.7
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.17.8)
-      '@babel/helpers': 7.28.2
-      '@babel/parser': 7.18.9
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      convert-source-map: 1.9.0
-      debug: 4.4.1
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/generator@7.17.7:
+  '@babel/generator@7.17.7':
     resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.17.0
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: true
 
-  /@babel/generator@7.28.0:
-    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+  '@babel/generator@7.27.0':
+    resolution: {integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-      jsesc: 3.1.0
-    dev: true
 
-  /@babel/helper-compilation-targets@7.27.2:
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.27.0':
+    resolution: {integrity: sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-    dev: true
 
-  /@babel/helper-environment-visitor@7.24.7:
+  '@babel/helper-environment-visitor@7.24.7':
     resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/helper-function-name@7.24.7:
+  '@babel/helper-function-name@7.24.7':
     resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/helper-globals@7.28.0:
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-hoist-variables@7.24.7:
+  '@babel/helper-hoist-variables@7.24.7':
     resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/helper-module-imports@7.27.1:
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/helper-module-transforms@7.27.3(@babel/core@7.17.8):
-    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/helper-split-export-declaration@7.24.7:
+  '@babel/helper-split-export-declaration@7.24.7':
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/helper-string-parser@7.27.1:
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/helper-validator-identifier@7.27.1:
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/helper-validator-option@7.27.1:
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/helpers@7.28.2:
-    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
+  '@babel/helpers@7.27.0':
+    resolution: {integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/parser@7.18.9:
+  '@babel/parser@7.18.9':
     resolution: {integrity: sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
 
-  /@babel/parser@7.28.0:
-    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dependencies:
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/template@7.27.2:
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.27.0':
+    resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
-    dev: true
 
-  /@babel/traverse@7.17.3:
+  '@babel/traverse@7.17.3':
     resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.17.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.18.9
-      '@babel/types': 7.17.0
-      debug: 4.4.1
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/traverse@7.23.2:
+  '@babel/traverse@7.23.2':
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.2
-      debug: 4.4.1
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/traverse@7.28.0:
-    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@babel/types@7.17.0:
+  '@babel/types@7.17.0':
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
-      to-fast-properties: 2.0.0
-    dev: true
 
-  /@babel/types@7.28.2:
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+  '@babel/types@7.27.0':
+    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-    dev: true
 
-  /@colors/colors@1.5.0:
+  '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@cspotcode/source-map-support@0.8.1:
+  '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-    dev: true
 
-  /@eslint-community/eslint-utils@4.7.0(eslint@8.57.1):
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+  '@eslint-community/eslint-utils@4.6.1':
+    resolution: {integrity: sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-    dev: true
 
-  /@eslint-community/regexpp@4.12.1:
+  '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
 
-  /@eslint/eslintrc@2.1.4:
+  '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.1
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@eslint/js@8.57.1:
+  '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
-  /@fastify/ajv-compiler@3.6.0:
+  '@fastify/ajv-compiler@3.6.0':
     resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
-    dependencies:
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      fast-uri: 2.4.0
-    dev: true
 
-  /@fastify/error@3.4.1:
+  '@fastify/error@3.4.1':
     resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
-    dev: true
 
-  /@fastify/fast-json-stringify-compiler@4.3.0:
+  '@fastify/fast-json-stringify-compiler@4.3.0':
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
-    dependencies:
-      fast-json-stringify: 5.16.1
-    dev: true
 
-  /@fastify/merge-json-schemas@0.1.1:
+  '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-    dev: true
 
-  /@fastify/type-provider-typebox@3.6.0(@sinclair/typebox@0.31.28):
+  '@fastify/type-provider-typebox@3.6.0':
     resolution: {integrity: sha512-HTeOLvirfGg0u1KGao3iXn5rZpYNqlrOmyDnXSXAbWVPa+mDQTTBNs/x5uZzOB6vFAqr0Xcf7x1lxOamNSYKjw==}
     peerDependencies:
       '@sinclair/typebox': '>=0.26 <=0.32'
-    dependencies:
-      '@sinclair/typebox': 0.31.28
-    dev: true
 
-  /@humanwhocodes/config-array@0.13.0:
+  '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@humanwhocodes/module-importer@1.0.1:
+  '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-    dev: true
 
-  /@humanwhocodes/object-schema@2.0.3:
+  '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
-    dev: true
 
-  /@isaacs/cliui@8.0.2:
+  '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: /strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
-  /@jridgewell/gen-mapping@0.3.12:
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-      '@jridgewell/trace-mapping': 0.3.29
-    dev: true
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
+    engines: {node: '>=6.0.0'}
 
-  /@jridgewell/resolve-uri@3.1.2:
+  '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
-  /@jridgewell/sourcemap-codec@1.5.4:
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
-    dev: true
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
 
-  /@jridgewell/trace-mapping@0.3.29:
-    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
-    dev: true
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  /@jridgewell/trace-mapping@0.3.9:
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
-    dev: true
 
-  /@mongodb-js/saslprep@1.3.0:
-    resolution: {integrity: sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==}
-    requiresBuild: true
-    dependencies:
-      sparse-bitfield: 3.0.3
-    dev: true
-    optional: true
+  '@mongodb-js/saslprep@1.2.2':
+    resolution: {integrity: sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==}
 
-  /@nodelib/fs.scandir@2.1.5:
+  '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-    dev: true
 
-  /@nodelib/fs.stat@2.0.5:
+  '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
-  /@nodelib/fs.walk@1.2.8:
+  '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
-    dev: true
 
-  /@pkgjs/parseargs@0.11.0:
+  '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@protobufjs/aspromise@1.1.2:
+  '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-    dev: false
 
-  /@protobufjs/base64@1.1.2:
+  '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-    dev: false
 
-  /@protobufjs/codegen@2.0.4:
+  '@protobufjs/codegen@2.0.4':
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-    dev: false
 
-  /@protobufjs/eventemitter@1.1.0:
+  '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-    dev: false
 
-  /@protobufjs/fetch@1.1.0:
+  '@protobufjs/fetch@1.1.0':
     resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
-    dev: false
 
-  /@protobufjs/float@1.0.2:
+  '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-    dev: false
 
-  /@protobufjs/inquire@1.1.0:
+  '@protobufjs/inquire@1.1.0':
     resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
-    dev: false
 
-  /@protobufjs/path@1.1.2:
+  '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-    dev: false
 
-  /@protobufjs/pool@1.1.0:
+  '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-    dev: false
 
-  /@protobufjs/utf8@1.1.0:
+  '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
-    dev: false
 
-  /@rollup/plugin-commonjs@26.0.3(rollup@4.46.2):
+  '@rollup/plugin-commonjs@26.0.3':
     resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
@@ -1356,17 +696,8 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      glob: 10.4.5
-      is-reference: 1.2.1
-      magic-string: 0.30.17
-      rollup: 4.46.2
-    dev: true
 
-  /@rollup/plugin-node-resolve@15.3.1(rollup@4.46.2):
+  '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1374,16 +705,8 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.10
-      rollup: 4.46.2
-    dev: true
 
-  /@rollup/plugin-typescript@11.1.6(rollup@4.46.2)(typescript@5.9.2):
+  '@rollup/plugin-typescript@11.1.6':
     resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1395,706 +718,303 @@ packages:
         optional: true
       tslib:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      resolve: 1.22.10
-      rollup: 4.46.2
-      typescript: 5.9.2
-    dev: true
 
-  /@rollup/pluginutils@5.2.0(rollup@4.46.2):
-    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
+  '@rollup/pluginutils@5.1.4':
+    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-      rollup: 4.46.2
-    dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.46.2:
-    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
+  '@rollup/rollup-android-arm-eabi@4.40.0':
+    resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-android-arm64@4.46.2:
-    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
+  '@rollup/rollup-android-arm64@4.40.0':
+    resolution: {integrity: sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-arm64@4.46.2:
-    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
+  '@rollup/rollup-darwin-arm64@4.40.0':
+    resolution: {integrity: sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-x64@4.46.2:
-    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
+  '@rollup/rollup-darwin-x64@4.40.0':
+    resolution: {integrity: sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-arm64@4.46.2:
-    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
+  '@rollup/rollup-freebsd-arm64@4.40.0':
+    resolution: {integrity: sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-x64@4.46.2:
-    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
+  '@rollup/rollup-freebsd-x64@4.40.0':
+    resolution: {integrity: sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.46.2:
-    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.0':
+    resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.46.2:
-    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.40.0':
+    resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.46.2:
-    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
+  '@rollup/rollup-linux-arm64-gnu@4.40.0':
+    resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.46.2:
-    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
+  '@rollup/rollup-linux-arm64-musl@4.40.0':
+    resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-loongarch64-gnu@4.46.2:
-    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
+    resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-ppc64-gnu@4.46.2:
-    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
+    resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.46.2:
-    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
+  '@rollup/rollup-linux-riscv64-gnu@4.40.0':
+    resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-musl@4.46.2:
-    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
+  '@rollup/rollup-linux-riscv64-musl@4.40.0':
+    resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.46.2:
-    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
+  '@rollup/rollup-linux-s390x-gnu@4.40.0':
+    resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.46.2:
-    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
+  '@rollup/rollup-linux-x64-gnu@4.40.0':
+    resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.46.2:
-    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
+  '@rollup/rollup-linux-x64-musl@4.40.0':
+    resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.46.2:
-    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
+  '@rollup/rollup-win32-arm64-msvc@4.40.0':
+    resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.46.2:
-    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.40.0':
+    resolution: {integrity: sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.46.2:
-    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
+  '@rollup/rollup-win32-x64-msvc@4.40.0':
+    resolution: {integrity: sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@samchon/openapi@4.7.1:
+  '@samchon/openapi@4.7.1':
     resolution: {integrity: sha512-+rkMlSKMt7l3KGWJVWUle1CXEm0vA8FIF2rufHl+T1gN/gGrTEhL1gDK3FHYf8Nl5XReK0r1vL6Q2QTMwQN7xQ==}
-    dev: false
 
-  /@sinclair/typebox@0.31.28:
+  '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
-    dev: true
 
-  /@smithy/abort-controller@4.0.5:
-    resolution: {integrity: sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==}
+  '@smithy/abort-controller@4.0.2':
+    resolution: {integrity: sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/config-resolver@4.1.5:
-    resolution: {integrity: sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==}
+  '@smithy/config-resolver@4.1.0':
+    resolution: {integrity: sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/types': 4.3.2
-      '@smithy/util-config-provider': 4.0.0
-      '@smithy/util-middleware': 4.0.5
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/core@3.8.0:
-    resolution: {integrity: sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==}
+  '@smithy/core@3.2.0':
+    resolution: {integrity: sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/middleware-serde': 4.0.9
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-body-length-browser': 4.0.0
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-stream': 4.2.4
-      '@smithy/util-utf8': 4.0.0
-      '@types/uuid': 9.0.8
-      tslib: 2.8.1
-      uuid: 9.0.1
-    dev: true
-    optional: true
 
-  /@smithy/credential-provider-imds@4.0.7:
-    resolution: {integrity: sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==}
+  '@smithy/credential-provider-imds@4.0.2':
+    resolution: {integrity: sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/property-provider': 4.0.5
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/fetch-http-handler@5.1.1:
-    resolution: {integrity: sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==}
+  '@smithy/fetch-http-handler@5.0.2':
+    resolution: {integrity: sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/querystring-builder': 4.0.5
-      '@smithy/types': 4.3.2
-      '@smithy/util-base64': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/hash-node@4.0.5:
-    resolution: {integrity: sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==}
+  '@smithy/hash-node@4.0.2':
+    resolution: {integrity: sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      '@smithy/util-buffer-from': 4.0.0
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/invalid-dependency@4.0.5:
-    resolution: {integrity: sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==}
+  '@smithy/invalid-dependency@4.0.2':
+    resolution: {integrity: sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/is-array-buffer@2.2.0:
+  '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/is-array-buffer@4.0.0:
+  '@smithy/is-array-buffer@4.0.0':
     resolution: {integrity: sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/middleware-content-length@4.0.5:
-    resolution: {integrity: sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==}
+  '@smithy/middleware-content-length@4.0.2':
+    resolution: {integrity: sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/middleware-endpoint@4.1.18:
-    resolution: {integrity: sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==}
+  '@smithy/middleware-endpoint@4.1.0':
+    resolution: {integrity: sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/core': 3.8.0
-      '@smithy/middleware-serde': 4.0.9
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      '@smithy/url-parser': 4.0.5
-      '@smithy/util-middleware': 4.0.5
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/middleware-retry@4.1.19:
-    resolution: {integrity: sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==}
+  '@smithy/middleware-retry@4.1.0':
+    resolution: {integrity: sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/service-error-classification': 4.0.7
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-retry': 4.0.7
-      '@types/uuid': 9.0.8
-      tslib: 2.8.1
-      uuid: 9.0.1
-    dev: true
-    optional: true
 
-  /@smithy/middleware-serde@4.0.9:
-    resolution: {integrity: sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==}
+  '@smithy/middleware-serde@4.0.3':
+    resolution: {integrity: sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/middleware-stack@4.0.5:
-    resolution: {integrity: sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==}
+  '@smithy/middleware-stack@4.0.2':
+    resolution: {integrity: sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/node-config-provider@4.1.4:
-    resolution: {integrity: sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==}
+  '@smithy/node-config-provider@4.0.2':
+    resolution: {integrity: sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/property-provider': 4.0.5
-      '@smithy/shared-ini-file-loader': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/node-http-handler@4.1.1:
-    resolution: {integrity: sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==}
+  '@smithy/node-http-handler@4.0.4':
+    resolution: {integrity: sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/abort-controller': 4.0.5
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/querystring-builder': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/property-provider@4.0.5:
-    resolution: {integrity: sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==}
+  '@smithy/property-provider@4.0.2':
+    resolution: {integrity: sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/protocol-http@5.1.3:
-    resolution: {integrity: sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==}
+  '@smithy/protocol-http@5.1.0':
+    resolution: {integrity: sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/querystring-builder@4.0.5:
-    resolution: {integrity: sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==}
+  '@smithy/querystring-builder@4.0.2':
+    resolution: {integrity: sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      '@smithy/util-uri-escape': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/querystring-parser@4.0.5:
-    resolution: {integrity: sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==}
+  '@smithy/querystring-parser@4.0.2':
+    resolution: {integrity: sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/service-error-classification@4.0.7:
-    resolution: {integrity: sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==}
+  '@smithy/service-error-classification@4.0.2':
+    resolution: {integrity: sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-    dev: true
-    optional: true
 
-  /@smithy/shared-ini-file-loader@4.0.5:
-    resolution: {integrity: sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==}
+  '@smithy/shared-ini-file-loader@4.0.2':
+    resolution: {integrity: sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/signature-v4@5.1.3:
-    resolution: {integrity: sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==}
+  '@smithy/signature-v4@5.1.0':
+    resolution: {integrity: sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/is-array-buffer': 4.0.0
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      '@smithy/util-hex-encoding': 4.0.0
-      '@smithy/util-middleware': 4.0.5
-      '@smithy/util-uri-escape': 4.0.0
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/smithy-client@4.4.10:
-    resolution: {integrity: sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==}
+  '@smithy/smithy-client@4.2.0':
+    resolution: {integrity: sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/core': 3.8.0
-      '@smithy/middleware-endpoint': 4.1.18
-      '@smithy/middleware-stack': 4.0.5
-      '@smithy/protocol-http': 5.1.3
-      '@smithy/types': 4.3.2
-      '@smithy/util-stream': 4.2.4
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/types@4.3.2:
-    resolution: {integrity: sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==}
+  '@smithy/types@4.2.0':
+    resolution: {integrity: sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/url-parser@4.0.5:
-    resolution: {integrity: sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==}
+  '@smithy/url-parser@4.0.2':
+    resolution: {integrity: sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/querystring-parser': 4.0.5
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-base64@4.0.0:
+  '@smithy/util-base64@4.0.0':
     resolution: {integrity: sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/util-buffer-from': 4.0.0
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-body-length-browser@4.0.0:
+  '@smithy/util-body-length-browser@4.0.0':
     resolution: {integrity: sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-body-length-node@4.0.0:
+  '@smithy/util-body-length-node@4.0.0':
     resolution: {integrity: sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-buffer-from@2.2.0:
+  '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-buffer-from@4.0.0:
+  '@smithy/util-buffer-from@4.0.0':
     resolution: {integrity: sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/is-array-buffer': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-config-provider@4.0.0:
+  '@smithy/util-config-provider@4.0.0':
     resolution: {integrity: sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-defaults-mode-browser@4.0.26:
-    resolution: {integrity: sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==}
+  '@smithy/util-defaults-mode-browser@4.0.8':
+    resolution: {integrity: sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/property-provider': 4.0.5
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      bowser: 2.11.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-defaults-mode-node@4.0.26:
-    resolution: {integrity: sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==}
+  '@smithy/util-defaults-mode-node@4.0.8':
+    resolution: {integrity: sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/config-resolver': 4.1.5
-      '@smithy/credential-provider-imds': 4.0.7
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/property-provider': 4.0.5
-      '@smithy/smithy-client': 4.4.10
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-endpoints@3.0.7:
-    resolution: {integrity: sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==}
+  '@smithy/util-endpoints@3.0.2':
+    resolution: {integrity: sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/node-config-provider': 4.1.4
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-hex-encoding@4.0.0:
+  '@smithy/util-hex-encoding@4.0.0':
     resolution: {integrity: sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-middleware@4.0.5:
-    resolution: {integrity: sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==}
+  '@smithy/util-middleware@4.0.2':
+    resolution: {integrity: sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-retry@4.0.7:
-    resolution: {integrity: sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==}
+  '@smithy/util-retry@4.0.2':
+    resolution: {integrity: sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/service-error-classification': 4.0.7
-      '@smithy/types': 4.3.2
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-stream@4.2.4:
-    resolution: {integrity: sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==}
+  '@smithy/util-stream@4.2.0':
+    resolution: {integrity: sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/fetch-http-handler': 5.1.1
-      '@smithy/node-http-handler': 4.1.1
-      '@smithy/types': 4.3.2
-      '@smithy/util-base64': 4.0.0
-      '@smithy/util-buffer-from': 4.0.0
-      '@smithy/util-hex-encoding': 4.0.0
-      '@smithy/util-utf8': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-uri-escape@4.0.0:
+  '@smithy/util-uri-escape@4.0.0':
     resolution: {integrity: sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-utf8@2.3.0:
+  '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@smithy/util-utf8@4.0.0:
+  '@smithy/util-utf8@4.0.0':
     resolution: {integrity: sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==}
     engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/util-buffer-from': 4.0.0
-      tslib: 2.8.1
-    dev: true
-    optional: true
 
-  /@standard-schema/spec@1.0.0:
+  '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-    dev: false
 
-  /@tootallnate/once@2.0.0:
+  '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-    dev: true
 
-  /@trivago/prettier-plugin-sort-imports@3.4.0(prettier@2.8.8):
+  '@trivago/prettier-plugin-sort-imports@3.4.0':
     resolution: {integrity: sha512-485Iailw8X5f7KetzRka20RF1kPBEINR5LJMNwlBZWY1gRAlVnv5dZzyNPnLxSP0Qcia8HETa9Cdd8LlX9o+pg==}
     peerDependencies:
       prettier: 2.x
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/generator': 7.17.7
-      '@babel/parser': 7.18.9
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      '@vue/compiler-sfc': 3.5.18
-      javascript-natural-sort: 0.7.1
-      lodash: 4.17.21
-      prettier: 2.8.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.6.2):
+  '@trivago/prettier-plugin-sort-imports@4.3.0':
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
     peerDependencies:
       '@vue/compiler-sfc': 3.x
@@ -2102,223 +1022,3546 @@ packages:
     peerDependenciesMeta:
       '@vue/compiler-sfc':
         optional: true
-    dependencies:
-      '@babel/generator': 7.17.7
-      '@babel/parser': 7.28.0
-      '@babel/traverse': 7.23.2
-      '@babel/types': 7.17.0
-      javascript-natural-sort: 0.7.1
-      lodash: 4.17.21
-      prettier: 3.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
-  /@tsconfig/node10@1.0.11:
+  '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-    dev: true
 
-  /@tsconfig/node12@1.0.11:
+  '@tsconfig/node12@1.0.11':
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-    dev: true
 
-  /@tsconfig/node14@1.0.3:
+  '@tsconfig/node14@1.0.3':
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-    dev: true
 
-  /@tsconfig/node16@1.0.4:
+  '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-    dev: true
 
-  /@typegoose/typegoose@10.6.0(mongoose@6.13.8):
+  '@typegoose/typegoose@10.6.0':
     resolution: {integrity: sha512-wlBppt2TcbZzeUaeyqtckM9BzZihS2wrOmxnrwDiBaDyeG64F5gfIV5t5JgnmzG0J6/gbgNJ4Ytok715O+bEvA==}
     engines: {node: '>=14.17.0'}
     peerDependencies:
       mongoose: ~6.13.0
+
+  '@types/autocannon@7.12.6':
+    resolution: {integrity: sha512-eBluTewWVKr1XlCPz3hYuzs+5JPme+Jh01sKpGPSnWg4wep1Oz2hpGn+dmcITl+uxYoV+rnhA+8LMengL+zcVw==}
+
+  '@types/benchmark@2.1.5':
+    resolution: {integrity: sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==}
+
+  '@types/body-parser@1.19.5':
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+
+  '@types/cli@0.11.25':
+    resolution: {integrity: sha512-dO7U6Q+6f7IIDtPwFe3RGIC7QBKEq6zPmQ2UaNt6NskhrupafbrftJ+PzzfMnxCL+y1oGKMJb7vC6vvSGEIElg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.6':
+    resolution: {integrity: sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/express-serve-static-core@4.19.6':
+    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+
+  '@types/express@4.17.21':
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/http-errors@2.0.4':
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/inquirer@8.2.10':
+    resolution: {integrity: sha512-IdD5NmHyVjWM8SHWo/kPBgtzXatwPkfwzyP3fN1jF2g9BWt5WO+8hL2F4o2GKIYsU40PpqeevuUWvkS/roXJkA==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/node-fetch@2.6.12':
+    resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
+
+  '@types/node@18.19.86':
+    resolution: {integrity: sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==}
+
+  '@types/node@20.17.30':
+    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
+
+  '@types/node@22.14.1':
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
+
+  '@types/physical-cpu-count@2.0.2':
+    resolution: {integrity: sha512-dWrdOZd9fy8HGz77lN+yX3hBAsSDDSizGD5Ho/SNDUmm2hQlxmCR3rQbULOwV8+83RHiy8icF4D3urQSMy2Vaw==}
+
+  '@types/qs@6.9.18':
+    resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/send@0.17.4':
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serve-static@1.15.7':
+    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  '@types/through@0.0.33':
+    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/uuid@8.3.4':
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
+  '@types/validator@13.15.0':
+    resolution: {integrity: sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/websocket@1.0.10':
+    resolution: {integrity: sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==}
+
+  '@types/whatwg-url@8.2.2':
+    resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@typescript-eslint/eslint-plugin@8.30.1':
+    resolution: {integrity: sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.30.1':
+    resolution: {integrity: sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/scope-manager@7.18.0':
+    resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.30.1':
+    resolution: {integrity: sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/type-utils@8.30.1':
+    resolution: {integrity: sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/types@7.18.0':
+    resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.30.1':
+    resolution: {integrity: sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@7.18.0':
+    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@8.30.1':
+    resolution: {integrity: sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@7.18.0':
+    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
+  '@typescript-eslint/utils@8.30.1':
+    resolution: {integrity: sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@7.18.0':
+    resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.30.1':
+    resolution: {integrity: sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vue/compiler-core@3.5.13':
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+
+  '@vue/compiler-dom@3.5.13':
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-sfc@3.5.13':
+    resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
+
+  '@vue/compiler-ssr@3.5.13':
+    resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/shared@3.5.13':
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
+  abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  acorn-globals@7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  autocannon@7.15.0:
+    resolution: {integrity: sha512-NaP2rQyA+tcubOJMFv2+oeW9jv2pq/t+LM6BL3cfJic0HEfscEcnWgAyU5YovE/oTHUzAgTliGdLPR+RQAWUbg==}
+    hasBin: true
+
+  avvio@8.4.0:
+    resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  benchmark@2.1.4:
+    resolution: {integrity: sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bowser@2.11.0:
+    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
+
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.24.4:
+    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bson@4.7.2:
+    resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
+    engines: {node: '>=6.9.0'}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  builtins@2.0.1:
+    resolution: {integrity: sha512-XkkVe5QAb6guWPXTzpSrYpSlN3nqEmrrE2TkAr/tp7idSF6+MONh9WvKrAuR3HiKLvoSgmbs8l1U9IPmMrIoLw==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001715:
+    resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  char-spinner@1.0.1:
+    resolution: {integrity: sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==}
+
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.14.1:
+    resolution: {integrity: sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==}
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+
+  cli@1.0.1:
+    resolution: {integrity: sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==}
+    engines: {node: '>=0.2.5'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  comment-json@4.2.5:
+    resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
+    engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-argv@2.0.0:
+    resolution: {integrity: sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  cssstyle@3.0.0:
+    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
+    engines: {node: '>=14'}
+
+  d3-array@1.2.4:
+    resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
+
+  d3-axis@1.0.12:
+    resolution: {integrity: sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==}
+
+  d3-brush@1.1.6:
+    resolution: {integrity: sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==}
+
+  d3-chord@1.0.6:
+    resolution: {integrity: sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==}
+
+  d3-collection@1.0.7:
+    resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
+
+  d3-color@1.4.1:
+    resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
+
+  d3-contour@1.3.2:
+    resolution: {integrity: sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==}
+
+  d3-dispatch@1.0.6:
+    resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
+
+  d3-drag@1.2.5:
+    resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
+
+  d3-dsv@1.2.0:
+    resolution: {integrity: sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==}
+    hasBin: true
+
+  d3-ease@1.0.7:
+    resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
+
+  d3-fetch@1.2.0:
+    resolution: {integrity: sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==}
+
+  d3-force@1.2.1:
+    resolution: {integrity: sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==}
+
+  d3-format@1.4.5:
+    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
+
+  d3-geo@1.12.1:
+    resolution: {integrity: sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==}
+
+  d3-hierarchy@1.1.9:
+    resolution: {integrity: sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==}
+
+  d3-interpolate@1.4.0:
+    resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-polygon@1.0.6:
+    resolution: {integrity: sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==}
+
+  d3-quadtree@1.0.7:
+    resolution: {integrity: sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==}
+
+  d3-random@1.1.2:
+    resolution: {integrity: sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==}
+
+  d3-scale-chromatic@1.5.0:
+    resolution: {integrity: sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==}
+
+  d3-scale@2.2.2:
+    resolution: {integrity: sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==}
+
+  d3-selection@1.4.2:
+    resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-time-format@2.3.0:
+    resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
+
+  d3-time@1.1.0:
+    resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
+
+  d3-timer@1.0.10:
+    resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
+
+  d3-transition@1.3.2:
+    resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
+
+  d3-voronoi@1.1.4:
+    resolution: {integrity: sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==}
+
+  d3-zoom@1.8.3:
+    resolution: {integrity: sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==}
+
+  d3@5.16.0:
+    resolution: {integrity: sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==}
+
+  data-urls@4.0.0:
+    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
+    engines: {node: '>=14'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
+
+  drange@1.1.1:
+    resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
+    engines: {node: '>=4'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.139:
+    resolution: {integrity: sha512-GGnRYOTdN5LYpwbIr0rwP/ZHOQSvAF6TG0LSzp28uCBb9JiXHJGmaaKw29qjNJc5bGnnp6kXJqRnGMQoELwi5w==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  eslint-plugin-deprecation@3.0.0:
+    resolution: {integrity: sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==}
+    peerDependencies:
+      eslint: ^8.0.0
+      typescript: ^4.2.4 || ^5.0.0
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
+  fast-content-type-parse@1.1.0:
+    resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-json-stringify@5.16.1:
+    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
+
+  fast-uri@2.4.0:
+    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-xml-parser@4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+    hasBin: true
+
+  fastify@4.29.0:
+    resolution: {integrity: sha512-MaaUHUGcCgC8fXQDsDtioaCcag1fmPJ9j64vAKunqZF4aSub040ZGi/ag8NGE2714yREPOKZuHCfpPzuUD3UQQ==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
+  find-my-way@8.2.2:
+    resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
+    engines: {node: '>=14'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fp-ts@2.16.10:
+    resolution: {integrity: sha512-vuROzbNVfCmUkZSUbnWSltR1sbheyQbTzug7LB/46fEa1c0EucLeBaCEUE0gF3ZGUGBt9lVUiziGOhhj6K1ORA==}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  global-prefix@4.0.0:
+    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
+    engines: {node: '>=16'}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-async-hooks@1.0.0:
+    resolution: {integrity: sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-own-prop@2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hdr-histogram-js@3.0.0:
+    resolution: {integrity: sha512-/EpvQI2/Z98mNFYEnlqJ8Ogful8OpArLG/6Tf2bPnkutBVLIeMVNHjk1ZDfshF2BUweipzbk+dB1hgSB7SIakw==}
+    engines: {node: '>=14'}
+
+  hdr-histogram-percentiles-obj@3.0.0:
+    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import2@1.0.3:
+    resolution: {integrity: sha512-X7KHNp1fovFaiah9Q+njdxXJKIV9/XippWGZwHL9ZdJYnQPBs+4wLd4PuCigbxz2IWNm5YvFycSjRA/1lgmdGw==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  inquirer@8.2.6:
+    resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
+    engines: {node: '>=12.0.0'}
+
+  io-ts@2.2.22:
+    resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
+    peerDependencies:
+      fp-ts: ^2.5.0
+
+  ip-address@9.0.5:
+    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  jsbn@1.1.0:
+    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
+  jsdom@21.1.2:
+    resolution: {integrity: sha512-sCpFmK2jv+1sjff4u7fzft+pUh2KSUbUrEHYHyfSIbGTIcmnjyp83qg6qLwdJ/I3LpTXx33ACxeRL7Lsyc6lGQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-better-errors@1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+
+  json-schema-ref-resolver@1.0.1:
+    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  kareem@2.5.1:
+    resolution: {integrity: sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==}
+    engines: {node: '>=12.0.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.12.7:
+    resolution: {integrity: sha512-0nYZSNj/QEikyhcM5RZFXGlCB/mr4PVamnT1C2sKBnDDTYndrvbybYjvg+PMqAndQHlLbwQ3socolnL3WWTUFA==}
+
+  light-my-request@5.14.0:
+    resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
+
+  load-json-file@4.0.0:
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.chunk@4.2.0:
+    resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  manage-path@2.0.0:
+    resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mongodb-connection-string-url@2.6.0:
+    resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
+
+  mongodb@4.17.2:
+    resolution: {integrity: sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==}
+    engines: {node: '>=12.9.0'}
+
+  mongoose@6.13.8:
+    resolution: {integrity: sha512-JHKco/533CyVrqCbyQsnqMpLn8ZCiKrPDTd2mvo2W7ygIvhygWjX2wj+RPjn6upZZgw0jC6U51RD7kUsyK8NBg==}
+    engines: {node: '>=12.0.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@4.0.3:
+    resolution: {integrity: sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==}
+    engines: {node: '>=12.0.0'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-net-listen@1.1.2:
+    resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
+    engines: {node: '>=9.4.0 || ^8.9.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  openai@4.95.1:
+    resolution: {integrity: sha512-IqJy+ymeW+k/Wq+2YVN3693OQMMcODRtHEYOlz263MdUwnN/Dwdl9c2EXSxLLtGEHkSHAfvzpDMHI5MaWJKXjQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-type@3.0.0:
+    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
+    engines: {node: '>=4'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  physical-cpu-count@2.0.0:
+    resolution: {integrity: sha512-rxJOljMuWtYlvREBmd6TZYanfcPhNUKtGDZBjBBS8WG1dpN2iwPsRJZgQqN/OtJuiQckdRFOfzogqJClTrsi7g==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.6.0:
+    resolution: {integrity: sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==}
+    hasBin: true
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+
+  process-warning@3.0.0:
+    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  protobufjs@7.2.5:
+    resolution: {integrity: sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
+  quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  randexp@0.5.3:
+    resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
+    engines: {node: '>=4'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  read-pkg@3.0.0:
+    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
+    engines: {node: '>=4'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  reflect-metadata@0.1.14:
+    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
+
+  reinterval@1.1.0:
+    resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
+  ret@0.2.2:
+    resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
+    engines: {node: '>=4'}
+
+  ret@0.4.3:
+    resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
+    engines: {node: '>=10'}
+
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  rollup-plugin-auto-external@2.0.0:
+    resolution: {integrity: sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      rollup: '>=0.45.2'
+
+  rollup-plugin-node-externals@8.0.0:
+    resolution: {integrity: sha512-2HIOpWsWn5DqBoYl6iCAmB4kd5GoGbF68PR4xKR1YBPvywiqjtYvDEjHFodyqRL51iAMDITP074Zxs0OKs6F+g==}
+    engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
+    peerDependencies:
+      rollup: ^4.0.0
+
+  rollup@4.40.0:
+    resolution: {integrity: sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@3.1.0:
+    resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
+
+  safe-resolve@1.0.0:
+    resolution: {integrity: sha512-aQpRvfxoi1y0UxKEU0tNO327kb0/LMo8Xrk64M2u172UqOOLCCM0khxN2OTClDiTqTJz5864GMD1X92j4YiHTg==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  sift@16.0.1:
+    resolution: {integrity: sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks@2.8.4:
+    resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.21:
+    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+
+  subarg@1.0.0:
+    resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  suppress-warnings@1.0.2:
+    resolution: {integrity: sha512-zrKSiWJ7BNG14YfGd6BzgKN4wBPrjviMP3EYIGdQNDjDI8qbKcnxdbKL2C6ODAmonj63JTH+d7/l0MPqaqQLHg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tgrid@0.10.3:
+    resolution: {integrity: sha512-EWIdHvc1BOX0p88P/lg8wXk1nnNmXCc6wf2mm7S/wxAWUXdAfk1klBBbM7FC+//tSlLHy6ITlmZHWxe+XmrNJg==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  timestring@6.0.0:
+    resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
+    engines: {node: '>=8'}
+
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
+  to-fast-properties@2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
+
+  tr46@4.1.1:
+    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
+    engines: {node: '>=14'}
+
+  ts-api-utils@1.4.3:
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-expose-internals@5.6.3:
+    resolution: {integrity: sha512-reb+7TXGaC0odGjywnLocM4f2i8mBhSEjc3gnKqdM21wDy8FcGGVjKbtMNjn17hka34CrwvqNREs0R7CGIeH3w==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  ts-patch@3.3.0:
+    resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tstl@3.0.0:
+    resolution: {integrity: sha512-pR83y6/tbJx6jeGRqGJXk2t/eCUynaHEE6zsOLB0Zga8ej61LXtPfoeiROdhezpoCT15+1QMbqKB1Um5kasSKg==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validator@13.15.0:
+    resolution: {integrity: sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==}
+    engines: {node: '>= 0.10'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  whatwg-url@11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
+
+  whatwg-url@12.0.1:
+    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
+    engines: {node: '>=14'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod@3.24.3:
+    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@assemblyscript/loader@0.19.23': {}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.775.0
+      '@aws-sdk/util-locate-window': 3.723.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.775.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/client-cognito-identity@3.797.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/credential-provider-node': 3.797.0
+      '@aws-sdk/middleware-host-header': 3.775.0
+      '@aws-sdk/middleware-logger': 3.775.0
+      '@aws-sdk/middleware-recursion-detection': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.796.0
+      '@aws-sdk/region-config-resolver': 3.775.0
+      '@aws-sdk/types': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
+      '@aws-sdk/util-user-agent-browser': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.796.0
+      '@smithy/config-resolver': 4.1.0
+      '@smithy/core': 3.2.0
+      '@smithy/fetch-http-handler': 5.0.2
+      '@smithy/hash-node': 4.0.2
+      '@smithy/invalid-dependency': 4.0.2
+      '@smithy/middleware-content-length': 4.0.2
+      '@smithy/middleware-endpoint': 4.1.0
+      '@smithy/middleware-retry': 4.1.0
+      '@smithy/middleware-serde': 4.0.3
+      '@smithy/middleware-stack': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/node-http-handler': 4.0.4
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/url-parser': 4.0.2
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.8
+      '@smithy/util-defaults-mode-node': 4.0.8
+      '@smithy/util-endpoints': 3.0.2
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-retry': 4.0.2
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/client-sso@3.797.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/middleware-host-header': 3.775.0
+      '@aws-sdk/middleware-logger': 3.775.0
+      '@aws-sdk/middleware-recursion-detection': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.796.0
+      '@aws-sdk/region-config-resolver': 3.775.0
+      '@aws-sdk/types': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
+      '@aws-sdk/util-user-agent-browser': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.796.0
+      '@smithy/config-resolver': 4.1.0
+      '@smithy/core': 3.2.0
+      '@smithy/fetch-http-handler': 5.0.2
+      '@smithy/hash-node': 4.0.2
+      '@smithy/invalid-dependency': 4.0.2
+      '@smithy/middleware-content-length': 4.0.2
+      '@smithy/middleware-endpoint': 4.1.0
+      '@smithy/middleware-retry': 4.1.0
+      '@smithy/middleware-serde': 4.0.3
+      '@smithy/middleware-stack': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/node-http-handler': 4.0.4
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/url-parser': 4.0.2
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.8
+      '@smithy/util-defaults-mode-node': 4.0.8
+      '@smithy/util-endpoints': 3.0.2
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-retry': 4.0.2
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/core@3.796.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/core': 3.2.0
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/signature-v4': 5.1.0
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-middleware': 4.0.2
+      fast-xml-parser: 4.4.1
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-cognito-identity@3.797.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-env@3.796.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-http@3.796.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/fetch-http-handler': 5.0.2
+      '@smithy/node-http-handler': 4.0.4
+      '@smithy/property-provider': 4.0.2
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-stream': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-ini@3.797.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/credential-provider-env': 3.796.0
+      '@aws-sdk/credential-provider-http': 3.796.0
+      '@aws-sdk/credential-provider-process': 3.796.0
+      '@aws-sdk/credential-provider-sso': 3.797.0
+      '@aws-sdk/credential-provider-web-identity': 3.797.0
+      '@aws-sdk/nested-clients': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/credential-provider-imds': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-node@3.797.0':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.796.0
+      '@aws-sdk/credential-provider-http': 3.796.0
+      '@aws-sdk/credential-provider-ini': 3.797.0
+      '@aws-sdk/credential-provider-process': 3.796.0
+      '@aws-sdk/credential-provider-sso': 3.797.0
+      '@aws-sdk/credential-provider-web-identity': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/credential-provider-imds': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-process@3.796.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-sso@3.797.0':
+    dependencies:
+      '@aws-sdk/client-sso': 3.797.0
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/token-providers': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-web-identity@3.797.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/nested-clients': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-providers@3.797.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.797.0
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.797.0
+      '@aws-sdk/credential-provider-env': 3.796.0
+      '@aws-sdk/credential-provider-http': 3.796.0
+      '@aws-sdk/credential-provider-ini': 3.797.0
+      '@aws-sdk/credential-provider-node': 3.797.0
+      '@aws-sdk/credential-provider-process': 3.796.0
+      '@aws-sdk/credential-provider-sso': 3.797.0
+      '@aws-sdk/credential-provider-web-identity': 3.797.0
+      '@aws-sdk/nested-clients': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/config-resolver': 4.1.0
+      '@smithy/core': 3.2.0
+      '@smithy/credential-provider-imds': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/middleware-host-header@3.775.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-logger@3.775.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-recursion-detection@3.775.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-user-agent@3.796.0':
+    dependencies:
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/types': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
+      '@smithy/core': 3.2.0
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/nested-clients@3.797.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.796.0
+      '@aws-sdk/middleware-host-header': 3.775.0
+      '@aws-sdk/middleware-logger': 3.775.0
+      '@aws-sdk/middleware-recursion-detection': 3.775.0
+      '@aws-sdk/middleware-user-agent': 3.796.0
+      '@aws-sdk/region-config-resolver': 3.775.0
+      '@aws-sdk/types': 3.775.0
+      '@aws-sdk/util-endpoints': 3.787.0
+      '@aws-sdk/util-user-agent-browser': 3.775.0
+      '@aws-sdk/util-user-agent-node': 3.796.0
+      '@smithy/config-resolver': 4.1.0
+      '@smithy/core': 3.2.0
+      '@smithy/fetch-http-handler': 5.0.2
+      '@smithy/hash-node': 4.0.2
+      '@smithy/invalid-dependency': 4.0.2
+      '@smithy/middleware-content-length': 4.0.2
+      '@smithy/middleware-endpoint': 4.1.0
+      '@smithy/middleware-retry': 4.1.0
+      '@smithy/middleware-serde': 4.0.3
+      '@smithy/middleware-stack': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/node-http-handler': 4.0.4
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/url-parser': 4.0.2
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.8
+      '@smithy/util-defaults-mode-node': 4.0.8
+      '@smithy/util-endpoints': 3.0.2
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-retry': 4.0.2
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/region-config-resolver@3.775.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/token-providers@3.797.0':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.797.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/types@3.775.0':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-endpoints@3.787.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-endpoints': 3.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-locate-window@3.723.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-user-agent-browser@3.775.0':
+    dependencies:
+      '@aws-sdk/types': 3.775.0
+      '@smithy/types': 4.2.0
+      bowser: 2.11.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-user-agent-node@3.796.0':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.796.0
+      '@aws-sdk/types': 3.775.0
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.26.8': {}
+
+  '@babel/core@7.17.8':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.17.7
+      '@babel/helper-compilation-targets': 7.27.0
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.17.8)
+      '@babel/helpers': 7.27.0
+      '@babel/parser': 7.18.9
+      '@babel/template': 7.27.0
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      convert-source-map: 1.9.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.17.7':
+    dependencies:
+      '@babel/types': 7.17.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
+
+  '@babel/generator@7.27.0':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.0':
+    dependencies:
+      '@babel/compat-data': 7.26.8
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-environment-visitor@7.24.7':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/helper-function-name@7.24.7':
+    dependencies:
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/helper-hoist-variables@7.24.7':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.17.8)':
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-split-export-declaration@7.24.7':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/helper-string-parser@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helpers@7.27.0':
+    dependencies:
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/parser@7.18.9':
+    dependencies:
+      '@babel/types': 7.17.0
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
+
+  '@babel/template@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
+  '@babel/traverse@7.17.3':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.17.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/parser': 7.18.9
+      '@babel/types': 7.17.0
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.23.2':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.17.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      to-fast-properties: 2.0.0
+
+  '@babel/types@7.27.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+
+  '@colors/colors@1.5.0':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@eslint-community/eslint-utils@4.6.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.1': {}
+
+  '@fastify/ajv-compiler@3.6.0':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      fast-uri: 2.4.0
+
+  '@fastify/error@3.4.1': {}
+
+  '@fastify/fast-json-stringify-compiler@4.3.0':
+    dependencies:
+      fast-json-stringify: 5.16.1
+
+  '@fastify/merge-json-schemas@0.1.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+
+  '@fastify/type-provider-typebox@3.6.0(@sinclair/typebox@0.31.28)':
+    dependencies:
+      '@sinclair/typebox': 0.31.28
+
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.8':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@mongodb-js/saslprep@1.2.2':
+    dependencies:
+      sparse-bitfield: 3.0.3
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
+
+  '@rollup/plugin-commonjs@26.0.3(rollup@4.40.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 10.4.5
+      is-reference: 1.2.1
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 4.40.0
+
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.40.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.10
+    optionalDependencies:
+      rollup: 4.40.0
+
+  '@rollup/plugin-typescript@11.1.6(rollup@4.40.0)(tslib@2.8.1)(typescript@5.9.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.0)
+      resolve: 1.22.10
+      typescript: 5.9.2
+    optionalDependencies:
+      rollup: 4.40.0
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.1.4(rollup@4.40.0)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.40.0
+
+  '@rollup/rollup-android-arm-eabi@4.40.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.40.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.40.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.40.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.40.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.40.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.40.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.40.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.40.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.40.0':
+    optional: true
+
+  '@samchon/openapi@4.7.1': {}
+
+  '@sinclair/typebox@0.31.28': {}
+
+  '@smithy/abort-controller@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/config-resolver@4.1.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/core@3.2.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.0.3
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-stream': 4.2.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/credential-provider-imds@4.0.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      '@smithy/url-parser': 4.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/fetch-http-handler@5.0.2':
+    dependencies:
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/querystring-builder': 4.0.2
+      '@smithy/types': 4.2.0
+      '@smithy/util-base64': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/hash-node@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/invalid-dependency@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-content-length@4.0.2':
+    dependencies:
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-endpoint@4.1.0':
+    dependencies:
+      '@smithy/core': 3.2.0
+      '@smithy/middleware-serde': 4.0.3
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      '@smithy/url-parser': 4.0.2
+      '@smithy/util-middleware': 4.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-retry@4.1.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/service-error-classification': 4.0.2
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-retry': 4.0.2
+      tslib: 2.8.1
+      uuid: 9.0.1
+    optional: true
+
+  '@smithy/middleware-serde@4.0.3':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-stack@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/node-config-provider@4.0.2':
+    dependencies:
+      '@smithy/property-provider': 4.0.2
+      '@smithy/shared-ini-file-loader': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/node-http-handler@4.0.4':
+    dependencies:
+      '@smithy/abort-controller': 4.0.2
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/querystring-builder': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/property-provider@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/protocol-http@5.1.0':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/querystring-builder@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      '@smithy/util-uri-escape': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/querystring-parser@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/service-error-classification@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+    optional: true
+
+  '@smithy/shared-ini-file-loader@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/signature-v4@5.1.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.0.0
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-middleware': 4.0.2
+      '@smithy/util-uri-escape': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/smithy-client@4.2.0':
+    dependencies:
+      '@smithy/core': 3.2.0
+      '@smithy/middleware-endpoint': 4.1.0
+      '@smithy/middleware-stack': 4.0.2
+      '@smithy/protocol-http': 5.1.0
+      '@smithy/types': 4.2.0
+      '@smithy/util-stream': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/types@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/url-parser@4.0.2':
+    dependencies:
+      '@smithy/querystring-parser': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-base64@4.0.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-body-length-browser@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-body-length-node@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@4.0.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-config-provider@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-defaults-mode-browser@4.0.8':
+    dependencies:
+      '@smithy/property-provider': 4.0.2
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      bowser: 2.11.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-defaults-mode-node@4.0.8':
+    dependencies:
+      '@smithy/config-resolver': 4.1.0
+      '@smithy/credential-provider-imds': 4.0.2
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/property-provider': 4.0.2
+      '@smithy/smithy-client': 4.2.0
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-endpoints@3.0.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-hex-encoding@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-middleware@4.0.2':
+    dependencies:
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-retry@4.0.2':
+    dependencies:
+      '@smithy/service-error-classification': 4.0.2
+      '@smithy/types': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-stream@4.2.0':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.0.2
+      '@smithy/node-http-handler': 4.0.4
+      '@smithy/types': 4.2.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-uri-escape@4.0.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@4.0.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.0.0
+      tslib: 2.8.1
+    optional: true
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@tootallnate/once@2.0.0': {}
+
+  '@trivago/prettier-plugin-sort-imports@3.4.0(prettier@2.8.8)':
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/generator': 7.17.7
+      '@babel/parser': 7.18.9
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      '@vue/compiler-sfc': 3.5.13
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)':
+    dependencies:
+      '@babel/generator': 7.17.7
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.17.0
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 3.5.3
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@typegoose/typegoose@10.6.0(mongoose@6.13.8)':
     dependencies:
       lodash: 4.17.21
       loglevel: 1.9.2
       mongoose: 6.13.8
       reflect-metadata: 0.1.14
-      semver: 7.7.2
+      semver: 7.7.1
       tslib: 2.8.1
-    dev: true
 
-  /@types/autocannon@7.12.7:
-    resolution: {integrity: sha512-Pd4nPf7wRpacULa6D/EC9x3CwzFQXwA0z5WFuik/fvJjW44V3WzBTM3jtt8nSBoflUNgswPiMCtgrr1bwnAcMg==}
+  '@types/autocannon@7.12.6':
     dependencies:
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/benchmark@2.1.5:
-    resolution: {integrity: sha512-cKio2eFB3v7qmKcvIHLUMw/dIx/8bhWPuzpzRT4unCPRTD8VdA9Zb0afxpcxOqR4PixRS7yT42FqGS8BYL8g1w==}
-    dev: true
+  '@types/benchmark@2.1.5': {}
 
-  /@types/body-parser@1.19.6:
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+  '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/cli@0.11.25:
-    resolution: {integrity: sha512-dO7U6Q+6f7IIDtPwFe3RGIC7QBKEq6zPmQ2UaNt6NskhrupafbrftJ+PzzfMnxCL+y1oGKMJb7vC6vvSGEIElg==}
+  '@types/cli@0.11.25':
     dependencies:
-      '@types/node': 20.19.9
-    dev: true
+      '@types/node': 20.17.30
 
-  /@types/connect@3.4.38:
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+  '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/d3-array@3.2.1:
-    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
-    dev: true
+  '@types/d3-array@3.2.1': {}
 
-  /@types/d3-axis@3.0.6:
-    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+  '@types/d3-axis@3.0.6':
     dependencies:
       '@types/d3-selection': 3.0.11
-    dev: true
 
-  /@types/d3-brush@3.0.6:
-    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+  '@types/d3-brush@3.0.6':
     dependencies:
       '@types/d3-selection': 3.0.11
-    dev: true
 
-  /@types/d3-chord@3.0.6:
-    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
-    dev: true
+  '@types/d3-chord@3.0.6': {}
 
-  /@types/d3-color@3.1.3:
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-    dev: true
+  '@types/d3-color@3.1.3': {}
 
-  /@types/d3-contour@3.0.6:
-    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+  '@types/d3-contour@3.0.6':
     dependencies:
       '@types/d3-array': 3.2.1
       '@types/geojson': 7946.0.16
-    dev: true
 
-  /@types/d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
-    dev: true
+  '@types/d3-delaunay@6.0.4': {}
 
-  /@types/d3-dispatch@3.0.7:
-    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
-    dev: true
+  '@types/d3-dispatch@3.0.6': {}
 
-  /@types/d3-drag@3.0.7:
-    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+  '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
-    dev: true
 
-  /@types/d3-dsv@3.0.7:
-    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
-    dev: true
+  '@types/d3-dsv@3.0.7': {}
 
-  /@types/d3-ease@3.0.2:
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-    dev: true
+  '@types/d3-ease@3.0.2': {}
 
-  /@types/d3-fetch@3.0.7:
-    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+  '@types/d3-fetch@3.0.7':
     dependencies:
       '@types/d3-dsv': 3.0.7
-    dev: true
 
-  /@types/d3-force@3.0.10:
-    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
-    dev: true
+  '@types/d3-force@3.0.10': {}
 
-  /@types/d3-format@3.0.4:
-    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
-    dev: true
+  '@types/d3-format@3.0.4': {}
 
-  /@types/d3-geo@3.1.0:
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+  '@types/d3-geo@3.1.0':
     dependencies:
       '@types/geojson': 7946.0.16
-    dev: true
 
-  /@types/d3-hierarchy@3.1.7:
-    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
-    dev: true
+  '@types/d3-hierarchy@3.1.7': {}
 
-  /@types/d3-interpolate@3.0.4:
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+  '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
-    dev: true
 
-  /@types/d3-path@3.1.1:
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-    dev: true
+  '@types/d3-path@3.1.1': {}
 
-  /@types/d3-polygon@3.0.2:
-    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
-    dev: true
+  '@types/d3-polygon@3.0.2': {}
 
-  /@types/d3-quadtree@3.0.6:
-    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
-    dev: true
+  '@types/d3-quadtree@3.0.6': {}
 
-  /@types/d3-random@3.0.3:
-    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
-    dev: true
+  '@types/d3-random@3.0.3': {}
 
-  /@types/d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
-    dev: true
+  '@types/d3-scale-chromatic@3.1.0': {}
 
-  /@types/d3-scale@4.0.9:
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+  '@types/d3-scale@4.0.9':
     dependencies:
       '@types/d3-time': 3.0.4
-    dev: true
 
-  /@types/d3-selection@3.0.11:
-    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
-    dev: true
+  '@types/d3-selection@3.0.11': {}
 
-  /@types/d3-shape@3.1.7:
-    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+  '@types/d3-shape@3.1.7':
     dependencies:
       '@types/d3-path': 3.1.1
-    dev: true
 
-  /@types/d3-time-format@4.0.3:
-    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
-    dev: true
+  '@types/d3-time-format@4.0.3': {}
 
-  /@types/d3-time@3.0.4:
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-    dev: true
+  '@types/d3-time@3.0.4': {}
 
-  /@types/d3-timer@3.0.2:
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
-    dev: true
+  '@types/d3-timer@3.0.2': {}
 
-  /@types/d3-transition@3.0.9:
-    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+  '@types/d3-transition@3.0.9':
     dependencies:
       '@types/d3-selection': 3.0.11
-    dev: true
 
-  /@types/d3-zoom@3.0.8:
-    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+  '@types/d3-zoom@3.0.8':
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
-    dev: true
 
-  /@types/d3@7.4.3:
-    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+  '@types/d3@7.4.3':
     dependencies:
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
@@ -2327,7 +4570,7 @@ packages:
       '@types/d3-color': 3.1.3
       '@types/d3-contour': 3.0.6
       '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.7
+      '@types/d3-dispatch': 3.0.6
       '@types/d3-drag': 3.0.7
       '@types/d3-dsv': 3.0.7
       '@types/d3-ease': 3.0.2
@@ -2350,307 +4593,183 @@ packages:
       '@types/d3-timer': 3.0.2
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
-    dev: true
 
-  /@types/estree@1.0.8:
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-    dev: true
+  '@types/estree@1.0.7': {}
 
-  /@types/express-serve-static-core@4.19.6:
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+  '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 18.19.121
-      '@types/qs': 6.14.0
+      '@types/node': 18.19.86
+      '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.5
-    dev: true
+      '@types/send': 0.17.4
 
-  /@types/express@4.17.23:
-    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
+  '@types/express@4.17.21':
     dependencies:
-      '@types/body-parser': 1.19.6
+      '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 4.19.6
-      '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.8
-    dev: true
+      '@types/qs': 6.9.18
+      '@types/serve-static': 1.15.7
 
-  /@types/geojson@7946.0.16:
-    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
-    dev: true
+  '@types/geojson@7946.0.16': {}
 
-  /@types/http-errors@2.0.5:
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
-    dev: true
+  '@types/http-errors@2.0.4': {}
 
-  /@types/inquirer@8.2.12:
-    resolution: {integrity: sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ==}
+  '@types/inquirer@8.2.10':
     dependencies:
       '@types/through': 0.0.33
       rxjs: 7.8.2
-    dev: true
 
-  /@types/mime@1.3.5:
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-    dev: true
+  '@types/mime@1.3.5': {}
 
-  /@types/node-fetch@2.6.13:
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+  '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 20.19.9
-      form-data: 4.0.4
-    dev: false
+      '@types/node': 20.17.30
+      form-data: 4.0.2
 
-  /@types/node@18.19.121:
-    resolution: {integrity: sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==}
+  '@types/node@18.19.86':
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.19.9:
-    resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
+  '@types/node@20.17.30':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
 
-  /@types/node@22.17.0:
-    resolution: {integrity: sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==}
-    dependencies:
-      undici-types: 6.21.0
-    dev: true
+  '@types/physical-cpu-count@2.0.2': {}
 
-  /@types/physical-cpu-count@2.0.2:
-    resolution: {integrity: sha512-dWrdOZd9fy8HGz77lN+yX3hBAsSDDSizGD5Ho/SNDUmm2hQlxmCR3rQbULOwV8+83RHiy8icF4D3urQSMy2Vaw==}
-    dev: true
+  '@types/qs@6.9.18': {}
 
-  /@types/qs@6.14.0:
-    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
-    dev: true
+  '@types/range-parser@1.2.7': {}
 
-  /@types/range-parser@1.2.7:
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-    dev: true
+  '@types/resolve@1.20.2': {}
 
-  /@types/resolve@1.20.2:
-    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
-    dev: true
-
-  /@types/send@0.17.5:
-    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+  '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/serve-static@1.15.8:
-    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
+  '@types/serve-static@1.15.7':
     dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 18.19.121
-      '@types/send': 0.17.5
-    dev: true
+      '@types/http-errors': 2.0.4
+      '@types/node': 18.19.86
+      '@types/send': 0.17.4
 
-  /@types/through@0.0.33:
-    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+  '@types/through@0.0.33':
     dependencies:
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/uuid@10.0.0:
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-    dev: true
+  '@types/uuid@10.0.0': {}
 
-  /@types/uuid@8.3.4:
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-    dev: true
+  '@types/uuid@8.3.4': {}
 
-  /@types/uuid@9.0.8:
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
-    dev: true
+  '@types/uuid@9.0.8': {}
 
-  /@types/validator@13.15.2:
-    resolution: {integrity: sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==}
-    dev: true
+  '@types/validator@13.15.0': {}
 
-  /@types/webidl-conversions@7.0.3:
-    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
-    dev: true
+  '@types/webidl-conversions@7.0.3': {}
 
-  /@types/websocket@1.0.10:
-    resolution: {integrity: sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==}
+  '@types/websocket@1.0.10':
     dependencies:
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@types/whatwg-url@8.2.2:
-    resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
+  '@types/whatwg-url@8.2.2':
     dependencies:
-      '@types/node': 22.17.0
+      '@types/node': 22.14.1
       '@types/webidl-conversions': 7.0.3
-    dev: true
 
-  /@types/ws@7.4.7:
-    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+  '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 18.19.121
-    dev: true
+      '@types/node': 18.19.86
 
-  /@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0)(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.39.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+  '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/type-utils': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.39.0
+      '@typescript-eslint/parser': 8.30.1(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.30.1
+      '@typescript-eslint/type-utils': 8.30.1(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.30.1(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.30.1
       eslint: 8.57.1
       graphemer: 1.4.0
-      ignore: 7.0.5
+      ignore: 5.3.2
       natural-compare: 1.4.0
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+  '@typescript-eslint/parser@8.30.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.1
+      '@typescript-eslint/scope-manager': 8.30.1
+      '@typescript-eslint/types': 8.30.1
+      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.30.1
+      debug: 4.4.0
       eslint: 8.57.1
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/project-service@8.39.0(typescript@5.9.2):
-    resolution: {integrity: sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.39.0
-      debug: 4.4.1
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@7.18.0:
-    resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-    dev: true
 
-  /@typescript-eslint/scope-manager@8.39.0:
-    resolution: {integrity: sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@typescript-eslint/scope-manager@8.30.1':
     dependencies:
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/visitor-keys': 8.39.0
-    dev: true
+      '@typescript-eslint/types': 8.30.1
+      '@typescript-eslint/visitor-keys': 8.30.1
 
-  /@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.2):
-    resolution: {integrity: sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+  '@typescript-eslint/type-utils@8.30.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      typescript: 5.9.2
-    dev: true
-
-  /@typescript-eslint/type-utils@8.39.0(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-    dependencies:
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
-      debug: 4.4.1
+      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.30.1(eslint@8.57.1)(typescript@5.9.2)
+      debug: 4.4.0
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/types@7.18.0:
-    resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    dev: true
+  '@typescript-eslint/types@7.18.0': {}
 
-  /@typescript-eslint/types@8.39.0:
-    resolution: {integrity: sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
+  '@typescript-eslint/types@8.30.1': {}
 
-  /@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.2):
-    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.1
       ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/typescript-estree@8.39.0(typescript@5.9.2):
-    resolution: {integrity: sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+  '@typescript-eslint/typescript-estree@8.30.1(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.1
+      '@typescript-eslint/types': 8.30.1
+      '@typescript-eslint/visitor-keys': 8.30.1
+      debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.2)
@@ -2658,263 +4777,160 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
-  /@typescript-eslint/utils@8.39.0(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+  '@typescript-eslint/utils@8.30.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.30.1
+      '@typescript-eslint/types': 8.30.1
+      '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.2)
       eslint: 8.57.1
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@typescript-eslint/visitor-keys@7.18.0:
-    resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
-    dev: true
 
-  /@typescript-eslint/visitor-keys@8.39.0:
-    resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@typescript-eslint/visitor-keys@8.30.1':
     dependencies:
-      '@typescript-eslint/types': 8.39.0
-      eslint-visitor-keys: 4.2.1
-    dev: true
+      '@typescript-eslint/types': 8.30.1
+      eslint-visitor-keys: 4.2.0
 
-  /@ungap/structured-clone@1.3.0:
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    dev: true
+  '@ungap/structured-clone@1.3.0': {}
 
-  /@vue/compiler-core@3.5.18:
-    resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
+  '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.27.0
+      '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
-    dev: true
 
-  /@vue/compiler-dom@3.5.18:
-    resolution: {integrity: sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==}
+  '@vue/compiler-dom@3.5.13':
     dependencies:
-      '@vue/compiler-core': 3.5.18
-      '@vue/shared': 3.5.18
-    dev: true
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
 
-  /@vue/compiler-sfc@3.5.18:
-    resolution: {integrity: sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==}
+  '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/compiler-core': 3.5.18
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.27.0
+      '@vue/compiler-core': 3.5.13
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.6
+      postcss: 8.5.3
       source-map-js: 1.2.1
-    dev: true
 
-  /@vue/compiler-ssr@3.5.18:
-    resolution: {integrity: sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==}
+  '@vue/compiler-ssr@3.5.13':
     dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/shared': 3.5.18
-    dev: true
+      '@vue/compiler-dom': 3.5.13
+      '@vue/shared': 3.5.13
 
-  /@vue/shared@3.5.18:
-    resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
-    dev: true
+  '@vue/shared@3.5.13': {}
 
-  /abab@2.0.6:
-    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    deprecated: Use your platform's native atob() and btoa() methods instead
-    dev: true
+  abab@2.0.6: {}
 
-  /abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
+  abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
-    dev: false
 
-  /abstract-logging@2.0.1:
-    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
-    dev: true
+  abstract-logging@2.0.1: {}
 
-  /accepts@1.3.8:
-    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
+  accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: true
 
-  /acorn-globals@7.0.1:
-    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+  acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.14.1
       acorn-walk: 8.3.4
-    dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.15.0):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
-      acorn: 8.15.0
-    dev: true
+      acorn: 8.14.1
 
-  /acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
+  acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
-    dev: true
+      acorn: 8.14.1
 
-  /acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
+  acorn@8.14.1: {}
 
-  /agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
+  agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
+  agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
-    dev: false
 
-  /ajv-formats@2.1.1(ajv@8.17.1):
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
       ajv: 8.17.1
-    dev: true
 
-  /ajv-formats@3.0.1(ajv@8.17.1):
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
       ajv: 8.17.1
-    dev: true
 
-  /ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
 
-  /ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    dev: true
 
-  /ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
+  ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
-    dev: false
 
-  /ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+  ansi-regex@5.0.1: {}
 
-  /ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
-    dev: true
+  ansi-regex@6.1.0: {}
 
-  /ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+  ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
-  /ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-    dev: true
+  ansi-styles@6.2.1: {}
 
-  /arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
-    dev: true
+  arg@4.1.3: {}
 
-  /argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
+  argparse@2.0.1: {}
 
-  /array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-    dev: true
+  array-flatten@1.1.1: {}
 
-  /array-timsort@1.0.3:
-    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
-    dev: false
+  array-timsort@1.0.3: {}
 
-  /array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-    dev: true
+  array-union@2.1.0: {}
 
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+  asynckit@0.4.0: {}
 
-  /atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
-    dev: true
+  atomic-sleep@1.0.0: {}
 
-  /autocannon@7.15.0:
-    resolution: {integrity: sha512-NaP2rQyA+tcubOJMFv2+oeW9jv2pq/t+LM6BL3cfJic0HEfscEcnWgAyU5YovE/oTHUzAgTliGdLPR+RQAWUbg==}
-    hasBin: true
+  autocannon@7.15.0:
     dependencies:
       chalk: 4.1.2
       char-spinner: 1.0.1
       cli-table3: 0.6.5
       color-support: 1.1.3
       cross-argv: 2.0.0
-      form-data: 4.0.4
+      form-data: 4.0.2
       has-async-hooks: 1.0.0
-      hdr-histogram-js: 3.0.1
+      hdr-histogram-js: 3.0.0
       hdr-histogram-percentiles-obj: 3.0.0
       http-parser-js: 0.5.10
       hyperid: 3.3.0
@@ -2927,42 +4943,31 @@ packages:
       progress: 2.0.3
       reinterval: 1.1.0
       retimer: 3.0.0
-      semver: 7.7.2
+      semver: 7.7.1
       subarg: 1.0.0
       timestring: 6.0.0
-    dev: true
 
-  /avvio@8.4.0:
-    resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
+  avvio@8.4.0:
     dependencies:
       '@fastify/error': 3.4.1
       fastq: 1.19.1
-    dev: true
 
-  /balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@1.0.2: {}
 
-  /base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+  base64-js@1.5.1: {}
 
-  /benchmark@2.1.4:
-    resolution: {integrity: sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==}
+  benchmark@2.1.4:
     dependencies:
       lodash: 4.17.21
       platform: 1.3.6
-    dev: true
 
-  /bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+  bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    dev: false
 
-  /body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+  body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -2978,390 +4983,234 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /bowser@2.11.0:
-    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
-    requiresBuild: true
-    dev: true
+  bowser@2.11.0:
     optional: true
 
-  /brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  /brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
-  /braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+  braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-    dev: true
 
-  /browserslist@4.25.1:
-    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
+  browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001733
-      electron-to-chromium: 1.5.199
+      caniuse-lite: 1.0.30001715
+      electron-to-chromium: 1.5.139
       node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.1)
-    dev: true
+      update-browserslist-db: 1.1.3(browserslist@4.24.4)
 
-  /bson@4.7.2:
-    resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
-    engines: {node: '>=6.9.0'}
+  bson@4.7.2:
     dependencies:
       buffer: 5.7.1
-    dev: true
 
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: false
+  buffer-from@1.1.2: {}
 
-  /buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+  buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  /builtins@2.0.1:
-    resolution: {integrity: sha512-XkkVe5QAb6guWPXTzpSrYpSlN3nqEmrrE2TkAr/tp7idSF6+MONh9WvKrAuR3HiKLvoSgmbs8l1U9IPmMrIoLw==}
+  builtins@2.0.1:
     dependencies:
       semver: 6.3.1
-    dev: true
 
-  /bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  bytes@3.1.2: {}
 
-  /call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+  call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  /call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
+  call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    dev: true
 
-  /callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-    dev: true
+  callsites@3.1.0: {}
 
-  /caniuse-lite@1.0.30001733:
-    resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
-    dev: true
+  caniuse-lite@1.0.30001715: {}
 
-  /chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+  chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  /char-spinner@1.0.1:
-    resolution: {integrity: sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==}
-    dev: true
+  char-spinner@1.0.1: {}
 
-  /chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-    dev: false
+  chardet@0.7.0: {}
 
-  /class-transformer@0.5.1:
-    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
-    dev: true
+  class-transformer@0.5.1: {}
 
-  /class-validator@0.14.2:
-    resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
+  class-validator@0.14.1:
     dependencies:
-      '@types/validator': 13.15.2
-      libphonenumber-js: 1.12.10
-      validator: 13.15.15
-    dev: true
+      '@types/validator': 13.15.0
+      libphonenumber-js: 1.12.7
+      validator: 13.15.0
 
-  /cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
+  cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
-    dev: false
 
-  /cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
-    dev: false
+  cli-spinners@2.9.2: {}
 
-  /cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
-    engines: {node: 10.* || >= 12.*}
+  cli-table3@0.6.5:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
-    dev: true
 
-  /cli-width@3.0.0:
-    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
-    engines: {node: '>= 10'}
-    dev: false
+  cli-width@3.0.0: {}
 
-  /cli@1.0.1:
-    resolution: {integrity: sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==}
-    engines: {node: '>=0.2.5'}
+  cli@1.0.1:
     dependencies:
       exit: 0.1.2
       glob: 7.2.3
-    dev: false
 
-  /clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
-    dev: false
+  clone@1.0.4: {}
 
-  /color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+  color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
-  /color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+  color-name@1.1.4: {}
 
-  /color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
-    dev: true
+  color-support@1.1.3: {}
 
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+  combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
-  /commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
-    dev: false
+  commander@10.0.1: {}
 
-  /commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: true
+  commander@2.20.3: {}
 
-  /comment-json@4.2.5:
-    resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
-    engines: {node: '>= 6'}
+  comment-json@4.2.5:
     dependencies:
       array-timsort: 1.0.3
       core-util-is: 1.0.3
       esprima: 4.0.1
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
-    dev: false
 
-  /commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-    dev: true
+  commondir@1.0.1: {}
 
-  /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+  concat-map@0.0.1: {}
 
-  /content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
+  content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
-  /content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  content-type@1.0.5: {}
 
-  /convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
+  convert-source-map@1.9.0: {}
 
-  /cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: true
+  cookie-signature@1.0.6: {}
 
-  /cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  cookie@0.7.1: {}
 
-  /cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  cookie@0.7.2: {}
 
-  /core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: false
+  core-util-is@1.0.3: {}
 
-  /create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: true
+  create-require@1.1.1: {}
 
-  /cross-argv@2.0.0:
-    resolution: {integrity: sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==}
-    dev: true
+  cross-argv@2.0.0: {}
 
-  /cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
-  /cssstyle@3.0.0:
-    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
-    engines: {node: '>=14'}
+  cssstyle@3.0.0:
     dependencies:
       rrweb-cssom: 0.6.0
-    dev: true
 
-  /d3-array@1.2.4:
-    resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
-    dev: true
+  d3-array@1.2.4: {}
 
-  /d3-axis@1.0.12:
-    resolution: {integrity: sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==}
-    dev: true
+  d3-axis@1.0.12: {}
 
-  /d3-brush@1.1.6:
-    resolution: {integrity: sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==}
+  d3-brush@1.1.6:
     dependencies:
       d3-dispatch: 1.0.6
       d3-drag: 1.2.5
       d3-interpolate: 1.4.0
       d3-selection: 1.4.2
       d3-transition: 1.3.2
-    dev: true
 
-  /d3-chord@1.0.6:
-    resolution: {integrity: sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==}
+  d3-chord@1.0.6:
     dependencies:
       d3-array: 1.2.4
       d3-path: 1.0.9
-    dev: true
 
-  /d3-collection@1.0.7:
-    resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
-    dev: true
+  d3-collection@1.0.7: {}
 
-  /d3-color@1.4.1:
-    resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
-    dev: true
+  d3-color@1.4.1: {}
 
-  /d3-contour@1.3.2:
-    resolution: {integrity: sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==}
+  d3-contour@1.3.2:
     dependencies:
       d3-array: 1.2.4
-    dev: true
 
-  /d3-dispatch@1.0.6:
-    resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
-    dev: true
+  d3-dispatch@1.0.6: {}
 
-  /d3-drag@1.2.5:
-    resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
+  d3-drag@1.2.5:
     dependencies:
       d3-dispatch: 1.0.6
       d3-selection: 1.4.2
-    dev: true
 
-  /d3-dsv@1.2.0:
-    resolution: {integrity: sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==}
-    hasBin: true
+  d3-dsv@1.2.0:
     dependencies:
       commander: 2.20.3
       iconv-lite: 0.4.24
       rw: 1.3.3
-    dev: true
 
-  /d3-ease@1.0.7:
-    resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
-    dev: true
+  d3-ease@1.0.7: {}
 
-  /d3-fetch@1.2.0:
-    resolution: {integrity: sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==}
+  d3-fetch@1.2.0:
     dependencies:
       d3-dsv: 1.2.0
-    dev: true
 
-  /d3-force@1.2.1:
-    resolution: {integrity: sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==}
+  d3-force@1.2.1:
     dependencies:
       d3-collection: 1.0.7
       d3-dispatch: 1.0.6
       d3-quadtree: 1.0.7
       d3-timer: 1.0.10
-    dev: true
 
-  /d3-format@1.4.5:
-    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
-    dev: true
+  d3-format@1.4.5: {}
 
-  /d3-geo@1.12.1:
-    resolution: {integrity: sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==}
+  d3-geo@1.12.1:
     dependencies:
       d3-array: 1.2.4
-    dev: true
 
-  /d3-hierarchy@1.1.9:
-    resolution: {integrity: sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==}
-    dev: true
+  d3-hierarchy@1.1.9: {}
 
-  /d3-interpolate@1.4.0:
-    resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
+  d3-interpolate@1.4.0:
     dependencies:
       d3-color: 1.4.1
-    dev: true
 
-  /d3-path@1.0.9:
-    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
-    dev: true
+  d3-path@1.0.9: {}
 
-  /d3-polygon@1.0.6:
-    resolution: {integrity: sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==}
-    dev: true
+  d3-polygon@1.0.6: {}
 
-  /d3-quadtree@1.0.7:
-    resolution: {integrity: sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==}
-    dev: true
+  d3-quadtree@1.0.7: {}
 
-  /d3-random@1.1.2:
-    resolution: {integrity: sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==}
-    dev: true
+  d3-random@1.1.2: {}
 
-  /d3-scale-chromatic@1.5.0:
-    resolution: {integrity: sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==}
+  d3-scale-chromatic@1.5.0:
     dependencies:
       d3-color: 1.4.1
       d3-interpolate: 1.4.0
-    dev: true
 
-  /d3-scale@2.2.2:
-    resolution: {integrity: sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==}
+  d3-scale@2.2.2:
     dependencies:
       d3-array: 1.2.4
       d3-collection: 1.0.7
@@ -3369,34 +5218,22 @@ packages:
       d3-interpolate: 1.4.0
       d3-time: 1.1.0
       d3-time-format: 2.3.0
-    dev: true
 
-  /d3-selection@1.4.2:
-    resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
-    dev: true
+  d3-selection@1.4.2: {}
 
-  /d3-shape@1.3.7:
-    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+  d3-shape@1.3.7:
     dependencies:
       d3-path: 1.0.9
-    dev: true
 
-  /d3-time-format@2.3.0:
-    resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
+  d3-time-format@2.3.0:
     dependencies:
       d3-time: 1.1.0
-    dev: true
 
-  /d3-time@1.1.0:
-    resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
-    dev: true
+  d3-time@1.1.0: {}
 
-  /d3-timer@1.0.10:
-    resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
-    dev: true
+  d3-timer@1.0.10: {}
 
-  /d3-transition@1.3.2:
-    resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
+  d3-transition@1.3.2:
     dependencies:
       d3-color: 1.4.1
       d3-dispatch: 1.0.6
@@ -3404,24 +5241,18 @@ packages:
       d3-interpolate: 1.4.0
       d3-selection: 1.4.2
       d3-timer: 1.0.10
-    dev: true
 
-  /d3-voronoi@1.1.4:
-    resolution: {integrity: sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==}
-    dev: true
+  d3-voronoi@1.1.4: {}
 
-  /d3-zoom@1.8.3:
-    resolution: {integrity: sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==}
+  d3-zoom@1.8.3:
     dependencies:
       d3-dispatch: 1.0.6
       d3-drag: 1.2.5
       d3-interpolate: 1.4.0
       d3-selection: 1.4.2
       d3-transition: 1.3.2
-    dev: true
 
-  /d3@5.16.0:
-    resolution: {integrity: sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==}
+  d3@5.16.0:
     dependencies:
       d3-array: 1.2.4
       d3-axis: 1.0.12
@@ -3454,217 +5285,111 @@ packages:
       d3-transition: 1.3.2
       d3-voronoi: 1.1.4
       d3-zoom: 1.8.3
-    dev: true
 
-  /data-urls@4.0.0:
-    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
-    engines: {node: '>=14'}
+  data-urls@4.0.0:
     dependencies:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-    dev: true
 
-  /debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    dev: true
 
-  /debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
-    dev: true
 
-  /decimal.js@10.6.0:
-    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
-    dev: true
+  decimal.js@10.5.0: {}
 
-  /deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-    dev: true
+  deep-is@0.1.4: {}
 
-  /deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  deepmerge@4.3.1: {}
 
-  /defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+  defaults@1.0.4:
     dependencies:
       clone: 1.0.4
-    dev: false
 
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
+  delayed-stream@1.0.0: {}
 
-  /depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  depd@2.0.0: {}
 
-  /destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dev: true
+  destroy@1.2.0: {}
 
-  /diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-    dev: true
+  diff@4.0.2: {}
 
-  /dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
+  dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-    dev: true
 
-  /doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
-    engines: {node: '>=6.0.0'}
+  doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
-    dev: true
 
-  /domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    deprecated: Use your platform's native DOMException instead
+  domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
-    dev: true
 
-  /drange@1.1.1:
-    resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
-    engines: {node: '>=4'}
-    dev: false
+  drange@1.1.1: {}
 
-  /dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+  dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
+  eastasianwidth@0.2.0: {}
 
-  /ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-    dev: true
+  ee-first@1.1.1: {}
 
-  /electron-to-chromium@1.5.199:
-    resolution: {integrity: sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==}
-    dev: true
+  electron-to-chromium@1.5.139: {}
 
-  /emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+  emoji-regex@8.0.0: {}
 
-  /emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
+  emoji-regex@9.2.2: {}
 
-  /encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  encodeurl@1.0.2: {}
 
-  /encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  encodeurl@2.0.0: {}
 
-  /entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-    dev: true
+  entities@4.5.0: {}
 
-  /entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-    dev: true
-
-  /error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+  error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
-  /es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+  es-define-property@1.0.1: {}
 
-  /es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+  es-errors@1.3.0: {}
 
-  /es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+  es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
-  /es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+  es-set-tostringtag@2.1.0:
     dependencies:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  /escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-    dev: true
+  escalade@3.2.0: {}
 
-  /escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-    dev: true
+  escape-html@1.0.3: {}
 
-  /escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-    dev: false
+  escape-string-regexp@1.0.5: {}
 
-  /escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-    dev: true
+  escape-string-regexp@4.0.0: {}
 
-  /escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
+  escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
       estraverse: 5.3.0
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
-    dev: true
 
-  /eslint-plugin-deprecation@3.0.0(eslint@8.57.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==}
-    peerDependencies:
-      eslint: ^8.0.0
-      typescript: ^4.2.4 || ^5.0.0
+  eslint-plugin-deprecation@3.0.0(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
@@ -3673,33 +5398,19 @@ packages:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
 
-  /eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
+  eslint-visitor-keys@3.4.3: {}
 
-  /eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
+  eslint-visitor-keys@4.2.0: {}
 
-  /eslint@8.57.1:
-    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
@@ -3710,7 +5421,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -3739,68 +5450,36 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /espree@9.6.1:
-    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  espree@9.6.1:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 3.4.3
-    dev: true
 
-  /esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
+  esprima@4.0.1: {}
 
-  /esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
-    engines: {node: '>=0.10'}
+  esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
-    dev: true
 
-  /esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+  esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
-    dev: true
 
-  /estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-    dev: true
+  estraverse@5.3.0: {}
 
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
+  estree-walker@2.0.2: {}
 
-  /esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  esutils@2.0.3: {}
 
-  /etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  etag@1.8.1: {}
 
-  /event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-    dev: false
+  event-target-shim@5.0.1: {}
 
-  /exit@0.1.2:
-    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
-    engines: {node: '>= 0.8.0'}
-    dev: false
+  exit@0.1.2: {}
 
-  /express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
-    engines: {node: '>= 0.10.0'}
+  express@4.21.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -3835,46 +5514,30 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
-    engines: {node: '>=4'}
+  external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    dev: false
 
-  /fast-content-type-parse@1.1.0:
-    resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
-    dev: true
+  fast-content-type-parse@1.1.0: {}
 
-  /fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
-    dev: true
+  fast-decode-uri-component@1.0.1: {}
 
-  /fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
+  fast-deep-equal@3.1.3: {}
 
-  /fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
+  fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
-    dev: true
 
-  /fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    dev: true
+  fast-json-stable-stringify@2.1.0: {}
 
-  /fast-json-stringify@5.16.1:
-    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+  fast-json-stringify@5.16.1:
     dependencies:
       '@fastify/merge-json-schemas': 0.1.1
       ajv: 8.17.1
@@ -3883,42 +5546,25 @@ packages:
       fast-uri: 2.4.0
       json-schema-ref-resolver: 1.0.1
       rfdc: 1.4.1
-    dev: true
 
-  /fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-    dev: true
+  fast-levenshtein@2.0.6: {}
 
-  /fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+  fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
-    dev: true
 
-  /fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-    dev: true
+  fast-redact@3.5.0: {}
 
-  /fast-uri@2.4.0:
-    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
-    dev: true
+  fast-uri@2.4.0: {}
 
-  /fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
-    dev: true
+  fast-uri@3.0.6: {}
 
-  /fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
-    hasBin: true
-    requiresBuild: true
+  fast-xml-parser@4.4.1:
     dependencies:
-      strnum: 2.1.1
-    dev: true
+      strnum: 1.1.2
     optional: true
 
-  /fastify@4.29.1:
-    resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
+  fastify@4.29.0:
     dependencies:
       '@fastify/ajv-compiler': 3.6.0
       '@fastify/error': 3.4.1
@@ -3929,56 +5575,35 @@ packages:
       fast-json-stringify: 5.16.1
       find-my-way: 8.2.2
       light-my-request: 5.14.0
-      pino: 9.8.0
+      pino: 9.6.0
       process-warning: 3.0.0
       proxy-addr: 2.0.7
       rfdc: 1.4.1
       secure-json-parse: 2.7.0
-      semver: 7.7.2
+      semver: 7.7.1
       toad-cache: 3.7.0
-    dev: true
 
-  /fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+  fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
-    dev: true
 
-  /fdir@6.4.6(picomatch@4.0.3):
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-    dependencies:
-      picomatch: 4.0.3
-    dev: true
+  fdir@6.4.4(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
-  /figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
+  figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
-    dev: false
 
-  /file-entry-cache@6.0.1:
-    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-    dev: true
 
-  /fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
-  /finalhandler@1.3.1:
-    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
-    engines: {node: '>= 0.8'}
+  finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
       encodeurl: 2.0.0
@@ -3989,103 +5614,61 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /find-my-way@8.2.2:
-    resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
-    engines: {node: '>=14'}
+  find-my-way@8.2.2:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 3.1.0
-    dev: true
 
-  /find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+  find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: true
 
-  /flat-cache@3.2.0:
-    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.3
       keyv: 4.5.4
       rimraf: 3.0.2
-    dev: true
 
-  /flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-    dev: true
+  flatted@3.3.3: {}
 
-  /foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
+  foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-    dev: true
 
-  /form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-    dev: false
+  form-data-encoder@1.7.2: {}
 
-  /form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
+  form-data@4.0.2:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
       mime-types: 2.1.35
 
-  /formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
+  formdata-node@4.4.1:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
-    dev: false
 
-  /forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  forwarded@0.2.0: {}
 
-  /fp-ts@2.16.10:
-    resolution: {integrity: sha512-vuROzbNVfCmUkZSUbnWSltR1sbheyQbTzug7LB/46fEa1c0EucLeBaCEUE0gF3ZGUGBt9lVUiziGOhhj6K1ORA==}
+  fp-ts@2.16.10: {}
 
-  /fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  fresh@0.5.2: {}
 
-  /fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+  fs.realpath@1.0.0: {}
 
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  fsevents@2.3.3:
     optional: true
 
-  /function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+  function-bind@1.1.2: {}
 
-  /gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
+  gensync@1.0.0-beta.2: {}
 
-  /get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+  get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -4098,30 +5681,20 @@ packages:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  /get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+  get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  /glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+  glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
-  /glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
-  /glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
+  glob@10.4.5:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
@@ -4129,11 +5702,8 @@ packages:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-    dev: true
 
-  /glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+  glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -4142,30 +5712,19 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  /global-prefix@4.0.0:
-    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
-    engines: {node: '>=16'}
+  global-prefix@4.0.0:
     dependencies:
       ini: 4.1.3
       kind-of: 6.0.3
       which: 4.0.0
-    dev: true
 
-  /globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-    dev: true
+  globals@11.12.0: {}
 
-  /globals@13.24.0:
-    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
-    engines: {node: '>=8'}
+  globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
-    dev: true
 
-  /globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
+  globby@11.1.0:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
@@ -4173,184 +5732,109 @@ packages:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
-  /gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+  gopd@1.2.0: {}
 
-  /graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
+  graceful-fs@4.2.11: {}
 
-  /graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-    dev: true
+  graphemer@1.4.0: {}
 
-  /has-async-hooks@1.0.0:
-    resolution: {integrity: sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==}
-    dev: true
+  has-async-hooks@1.0.0: {}
 
-  /has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+  has-flag@4.0.0: {}
 
-  /has-own-prop@2.0.0:
-    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
-    engines: {node: '>=8'}
-    dev: false
+  has-own-prop@2.0.0: {}
 
-  /has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+  has-symbols@1.1.0: {}
 
-  /has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+  has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
 
-  /hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+  hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
-  /hdr-histogram-js@3.0.1:
-    resolution: {integrity: sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==}
-    engines: {node: '>=14'}
+  hdr-histogram-js@3.0.0:
     dependencies:
       '@assemblyscript/loader': 0.19.23
       base64-js: 1.5.1
       pako: 1.0.11
-    dev: true
 
-  /hdr-histogram-percentiles-obj@3.0.0:
-    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
-    dev: true
+  hdr-histogram-percentiles-obj@3.0.0: {}
 
-  /hosted-git-info@2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
-    dev: true
+  hosted-git-info@2.8.9: {}
 
-  /html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
+  html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
-    dev: true
 
-  /http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
+  http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-    dev: true
 
-  /http-parser-js@0.5.10:
-    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
-    dev: true
+  http-parser-js@0.5.10: {}
 
-  /http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
+  http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
+  https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+  humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
-    dev: false
 
-  /hyperid@3.3.0:
-    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
+  hyperid@3.3.0:
     dependencies:
       buffer: 5.7.1
       uuid: 8.3.2
       uuid-parse: 1.1.0
-    dev: true
 
-  /iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
+  iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
 
-  /iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
-  /ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+  ieee754@1.2.1: {}
 
-  /ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-    dev: true
+  ignore@5.3.2: {}
 
-  /ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-    dev: true
-
-  /import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+  import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
-  /import2@1.0.3:
-    resolution: {integrity: sha512-X7KHNp1fovFaiah9Q+njdxXJKIV9/XippWGZwHL9ZdJYnQPBs+4wLd4PuCigbxz2IWNm5YvFycSjRA/1lgmdGw==}
-    dev: true
+  import2@1.0.3: {}
 
-  /imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-    dev: true
+  imurmurhash@0.1.4: {}
 
-  /inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+  inflight@1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+  inherits@2.0.4: {}
 
-  /ini@4.1.3:
-    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: true
+  ini@4.1.3: {}
 
-  /inquirer@8.2.6:
-    resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
-    engines: {node: '>=12.0.0'}
+  inquirer@8.2.6:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -4367,150 +5851,85 @@ packages:
       strip-ansi: 6.0.1
       through: 2.3.8
       wrap-ansi: 6.2.0
-    dev: false
 
-  /io-ts@2.2.22(fp-ts@2.16.10):
-    resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
-    peerDependencies:
-      fp-ts: ^2.5.0
+  io-ts@2.2.22(fp-ts@2.16.10):
     dependencies:
       fp-ts: 2.16.10
-    dev: true
 
-  /ip-address@9.0.5:
-    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
-    engines: {node: '>= 12'}
+  ip-address@9.0.5:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
-    dev: true
 
-  /ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-    dev: true
+  ipaddr.js@1.9.1: {}
 
-  /is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
+  is-arrayish@0.2.1: {}
 
-  /is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
+  is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
-    dev: true
 
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  is-extglob@2.1.1: {}
 
-  /is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+  is-fullwidth-code-point@3.0.0: {}
 
-  /is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+  is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
-  /is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
-    dev: false
+  is-interactive@1.0.0: {}
 
-  /is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: true
+  is-module@1.0.0: {}
 
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-    dev: true
+  is-number@7.0.0: {}
 
-  /is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-    dev: true
+  is-path-inside@3.0.3: {}
 
-  /is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-    dev: true
+  is-potential-custom-element-name@1.0.1: {}
 
-  /is-reference@1.2.1:
-    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+  is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
-    dev: true
+      '@types/estree': 1.0.7
 
-  /is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
-    dev: false
+  is-unicode-supported@0.1.0: {}
 
-  /isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
+  isexe@2.0.0: {}
 
-  /isexe@3.1.1:
-    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
-    engines: {node: '>=16'}
-    dev: true
+  isexe@3.1.1: {}
 
-  /jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+  jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
-  /javascript-natural-sort@0.7.1:
-    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
-    dev: true
+  javascript-natural-sort@0.7.1: {}
 
-  /js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
+  js-tokens@4.0.0: {}
 
-  /js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
+  js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
-    dev: true
 
-  /jsbn@1.1.0:
-    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
-    dev: true
+  jsbn@1.1.0: {}
 
-  /jsdom@21.1.2:
-    resolution: {integrity: sha512-sCpFmK2jv+1sjff4u7fzft+pUh2KSUbUrEHYHyfSIbGTIcmnjyp83qg6qLwdJ/I3LpTXx33ACxeRL7Lsyc6lGQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
+  jsdom@21.1.2:
     dependencies:
       abab: 2.0.6
-      acorn: 8.15.0
+      acorn: 8.14.1
       acorn-globals: 7.0.1
       cssstyle: 3.0.0
       data-urls: 4.0.0
-      decimal.js: 10.6.0
+      decimal.js: 10.5.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.4
+      form-data: 4.0.2
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.21
-      parse5: 7.3.0
+      nwsapi: 2.2.20
+      parse5: 7.2.1
       rrweb-cssom: 0.6.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -4520,274 +5939,155 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-      ws: 8.18.3
+      ws: 8.18.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: true
 
-  /jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
+  jsesc@2.5.2: {}
 
-  /jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
+  jsesc@3.1.0: {}
 
-  /json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: true
+  json-buffer@3.0.1: {}
 
-  /json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
-    dev: true
+  json-parse-better-errors@1.0.2: {}
 
-  /json-schema-ref-resolver@1.0.1:
-    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+  json-schema-ref-resolver@1.0.1:
     dependencies:
       fast-deep-equal: 3.1.3
-    dev: true
 
-  /json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
+  json-schema-traverse@0.4.1: {}
 
-  /json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: true
+  json-schema-traverse@1.0.0: {}
 
-  /json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-    dev: true
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
-  /json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
+  json5@2.2.3: {}
 
-  /kareem@2.5.1:
-    resolution: {integrity: sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==}
-    engines: {node: '>=12.0.0'}
-    dev: true
+  kareem@2.5.1: {}
 
-  /keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+  keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-    dev: true
 
-  /kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  kind-of@6.0.3: {}
 
-  /levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+  levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-    dev: true
 
-  /libphonenumber-js@1.12.10:
-    resolution: {integrity: sha512-E91vHJD61jekHHR/RF/E83T/CMoaLXT7cwYA75T4gim4FZjnM6hbJjVIGg7chqlSqRsSvQ3izGmOjHy1SQzcGQ==}
-    dev: true
+  libphonenumber-js@1.12.7: {}
 
-  /light-my-request@5.14.0:
-    resolution: {integrity: sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==}
+  light-my-request@5.14.0:
     dependencies:
       cookie: 0.7.2
       process-warning: 3.0.0
       set-cookie-parser: 2.7.1
-    dev: true
 
-  /load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
-    engines: {node: '>=4'}
+  load-json-file@4.0.0:
     dependencies:
       graceful-fs: 4.2.11
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
-    dev: true
 
-  /locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+  locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-    dev: true
 
-  /lodash.chunk@4.2.0:
-    resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
-    dev: true
+  lodash.chunk@4.2.0: {}
 
-  /lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-    dev: true
+  lodash.clonedeep@4.5.0: {}
 
-  /lodash.flatten@4.4.0:
-    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
-    dev: true
+  lodash.flatten@4.4.0: {}
 
-  /lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
+  lodash.merge@4.6.2: {}
 
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.21: {}
 
-  /log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
+  log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: false
 
-  /loglevel@1.9.2:
-    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
-    engines: {node: '>= 0.6.0'}
-    dev: true
+  loglevel@1.9.2: {}
 
-  /long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-    dev: false
+  long@5.3.2: {}
 
-  /lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: true
+  lru-cache@10.4.3: {}
 
-  /lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+  lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-    dev: true
 
-  /magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+  magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-    dev: true
+      '@jridgewell/sourcemap-codec': 1.5.0
 
-  /make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-    dev: true
+  make-error@1.3.6: {}
 
-  /manage-path@2.0.0:
-    resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
-    dev: true
+  manage-path@2.0.0: {}
 
-  /math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+  math-intrinsics@1.1.0: {}
 
-  /media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  media-typer@0.3.0: {}
 
-  /memory-pager@1.5.0:
-    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
-    requiresBuild: true
-    dev: true
+  memory-pager@1.5.0:
     optional: true
 
-  /merge-descriptors@1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-    dev: true
+  merge-descriptors@1.0.3: {}
 
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
+  merge2@1.4.1: {}
 
-  /methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  methods@1.1.2: {}
 
-  /micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+  micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-    dev: true
 
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
+  mime-db@1.52.0: {}
 
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+  mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
 
-  /mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: true
+  mime@1.6.0: {}
 
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: false
+  mimic-fn@2.1.0: {}
 
-  /minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.11
 
-  /minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.2
-    dev: true
+      brace-expansion: 2.0.1
 
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
+  minimist@1.2.8: {}
 
-  /minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
+  minipass@7.1.2: {}
 
-  /mongodb-connection-string-url@2.6.0:
-    resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
+  mongodb-connection-string-url@2.6.0:
     dependencies:
       '@types/whatwg-url': 8.2.2
       whatwg-url: 11.0.0
-    dev: true
 
-  /mongodb@4.17.2:
-    resolution: {integrity: sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==}
-    engines: {node: '>=12.9.0'}
+  mongodb@4.17.2:
     dependencies:
       bson: 4.7.2
       mongodb-connection-string-url: 2.6.0
-      socks: 2.8.6
+      socks: 2.8.4
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.863.0
-      '@mongodb-js/saslprep': 1.3.0
+      '@aws-sdk/credential-providers': 3.797.0
+      '@mongodb-js/saslprep': 1.2.2
     transitivePeerDependencies:
       - aws-crt
-    dev: true
 
-  /mongoose@6.13.8:
-    resolution: {integrity: sha512-JHKco/533CyVrqCbyQsnqMpLn8ZCiKrPDTd2mvo2W7ygIvhygWjX2wj+RPjn6upZZgw0jC6U51RD7kUsyK8NBg==}
-    engines: {node: '>=12.0.0'}
+  mongoose@6.13.8:
     dependencies:
       bson: 4.7.2
       kareem: 2.5.1
@@ -4799,143 +6099,78 @@ packages:
     transitivePeerDependencies:
       - aws-crt
       - supports-color
-    dev: true
 
-  /mpath@0.9.0:
-    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
-    engines: {node: '>=4.0.0'}
-    dev: true
+  mpath@0.9.0: {}
 
-  /mquery@4.0.3:
-    resolution: {integrity: sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==}
-    engines: {node: '>=12.0.0'}
+  mquery@4.0.3:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
+  ms@2.0.0: {}
 
-  /ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+  ms@2.1.3: {}
 
-  /mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-    dev: false
+  mute-stream@0.0.8: {}
 
-  /nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
+  nanoid@3.3.11: {}
 
-  /natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-    dev: true
+  natural-compare@1.4.0: {}
 
-  /negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  negotiator@0.6.3: {}
 
-  /node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-    dev: false
+  node-domexception@1.0.0: {}
 
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
+  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
-  /node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-    dev: true
+  node-releases@2.0.19: {}
 
-  /normalize-package-data@2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+  normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.10
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
-    dev: true
 
-  /nwsapi@2.2.21:
-    resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
-    dev: true
+  nwsapi@2.2.20: {}
 
-  /object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-    dev: true
+  object-inspect@1.13.4: {}
 
-  /on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
-    dev: true
+  on-exit-leak-free@2.1.2: {}
 
-  /on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
+  on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-    dev: true
 
-  /on-net-listen@1.1.2:
-    resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
-    engines: {node: '>=9.4.0 || ^8.9.4'}
-    dev: true
+  on-net-listen@1.1.2: {}
 
-  /once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+  once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+  onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-    dev: false
 
-  /openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
+  openai@4.95.1(ws@8.18.1)(zod@3.24.3):
     dependencies:
-      '@types/node': 18.19.121
-      '@types/node-fetch': 2.6.13
+      '@types/node': 18.19.86
+      '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.1
+      zod: 3.24.3
     transitivePeerDependencies:
       - encoding
-    dev: false
 
-  /optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+  optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
@@ -4943,11 +6178,8 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-    dev: true
 
-  /ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
+  ora@5.4.1:
     dependencies:
       bl: 4.1.0
       chalk: 4.1.2
@@ -4958,211 +6190,114 @@ packages:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-    dev: false
 
-  /os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-    dev: false
+  os-tmpdir@1.0.2: {}
 
-  /p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+  p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
-  /p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+  p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-    dev: true
 
-  /package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-    dev: true
+  package-json-from-dist@1.0.1: {}
 
-  /package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+  package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.10
-    dev: false
 
-  /pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-    dev: true
+  pako@1.0.11: {}
 
-  /parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+  parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-    dev: true
 
-  /parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
-    engines: {node: '>=4'}
+  parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
-    dev: true
 
-  /parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+  parse5@7.2.1:
     dependencies:
-      entities: 6.0.1
-    dev: true
+      entities: 4.5.0
 
-  /parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  parseurl@1.3.3: {}
 
-  /path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-    dev: true
+  path-exists@4.0.0: {}
 
-  /path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
+  path-is-absolute@1.0.1: {}
 
-  /path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-    dev: true
+  path-key@3.1.1: {}
 
-  /path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
+  path-parse@1.0.7: {}
 
-  /path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
+  path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-    dev: true
 
-  /path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-    dev: true
+  path-to-regexp@0.1.12: {}
 
-  /path-type@3.0.0:
-    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
-    engines: {node: '>=4'}
+  path-type@3.0.0:
     dependencies:
       pify: 3.0.0
-    dev: true
 
-  /path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-    dev: true
+  path-type@4.0.0: {}
 
-  /physical-cpu-count@2.0.0:
-    resolution: {integrity: sha512-rxJOljMuWtYlvREBmd6TZYanfcPhNUKtGDZBjBBS8WG1dpN2iwPsRJZgQqN/OtJuiQckdRFOfzogqJClTrsi7g==}
-    dev: true
+  physical-cpu-count@2.0.0: {}
 
-  /picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-    dev: true
+  picocolors@1.1.1: {}
 
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-    dev: true
+  picomatch@2.3.1: {}
 
-  /picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-    dev: true
+  picomatch@4.0.2: {}
 
-  /pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
-    engines: {node: '>=4'}
-    dev: true
+  pify@3.0.0: {}
 
-  /pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+  pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
-    dev: true
 
-  /pino-std-serializers@7.0.0:
-    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
-    dev: true
+  pino-std-serializers@7.0.0: {}
 
-  /pino@9.8.0:
-    resolution: {integrity: sha512-L5+rV1wL7vGAcxXP7sPpN5lrJ07Piruka6ArXr7EWBXxdVWjJshGVX8suFsiusJVcGKDGUFfbgbnKdg+VAC+0g==}
-    hasBin: true
+  pino@9.6.0:
     dependencies:
       atomic-sleep: 1.0.0
       fast-redact: 3.5.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.0.0
-      process-warning: 5.0.0
+      process-warning: 4.0.1
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
-    dev: true
 
-  /platform@1.3.6:
-    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
-    dev: true
+  platform@1.3.6: {}
 
-  /postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
+  postcss@8.5.3:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    dev: true
 
-  /prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
+  prelude-ls@1.2.1: {}
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: true
+  prettier@2.8.8: {}
 
-  /prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
+  prettier@3.5.3: {}
 
-  /pretty-bytes@5.6.0:
-    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
-    engines: {node: '>=6'}
-    dev: true
+  pretty-bytes@5.6.0: {}
 
-  /process-warning@3.0.0:
-    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
-    dev: true
+  process-warning@3.0.0: {}
 
-  /process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-    dev: true
+  process-warning@4.0.1: {}
 
-  /progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-    dev: true
+  progress@2.0.3: {}
 
-  /protobufjs@7.2.5:
-    resolution: {integrity: sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==}
-    engines: {node: '>=12.0.0'}
-    requiresBuild: true
+  protobufjs@7.2.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -5174,308 +6309,178 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.9
+      '@types/node': 20.17.30
       long: 5.3.2
-    dev: false
 
-  /proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
+  proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-    dev: true
 
-  /psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+  psl@1.15.0:
     dependencies:
       punycode: 2.3.1
-    dev: true
 
-  /punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-    dev: true
+  punycode@2.3.1: {}
 
-  /qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
+  qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
-    dev: true
 
-  /quansync@0.2.10:
-    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
-    dev: false
+  quansync@0.2.10: {}
 
-  /querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: true
+  querystringify@2.2.0: {}
 
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
+  queue-microtask@1.2.3: {}
 
-  /quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-    dev: true
+  quick-format-unescaped@4.0.4: {}
 
-  /randexp@0.5.3:
-    resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
-    engines: {node: '>=4'}
+  randexp@0.5.3:
     dependencies:
       drange: 1.1.1
       ret: 0.2.2
-    dev: false
 
-  /range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-    dev: true
+  range-parser@1.2.1: {}
 
-  /raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
-    engines: {node: '>= 0.8'}
+  raw-body@2.5.2:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
-  /read-pkg@3.0.0:
-    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
-    engines: {node: '>=4'}
+  read-pkg@3.0.0:
     dependencies:
       load-json-file: 4.0.0
       normalize-package-data: 2.5.0
       path-type: 3.0.0
-    dev: true
 
-  /readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
+  readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    dev: false
 
-  /real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
-    dev: true
+  real-require@0.2.0: {}
 
-  /reflect-metadata@0.1.14:
-    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
-    dev: true
+  reflect-metadata@0.1.14: {}
 
-  /reinterval@1.1.0:
-    resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
-    dev: true
+  reinterval@1.1.0: {}
 
-  /repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
-    dev: false
+  repeat-string@1.6.1: {}
 
-  /require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  require-from-string@2.0.2: {}
 
-  /requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: true
+  requires-port@1.0.0: {}
 
-  /resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-    dev: true
+  resolve-from@4.0.0: {}
 
-  /resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
+  resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
-  /restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
+  restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: false
 
-  /ret@0.2.2:
-    resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
-    engines: {node: '>=4'}
-    dev: false
+  ret@0.2.2: {}
 
-  /ret@0.4.3:
-    resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
-    engines: {node: '>=10'}
-    dev: true
+  ret@0.4.3: {}
 
-  /retimer@3.0.0:
-    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
-    dev: true
+  retimer@3.0.0: {}
 
-  /reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
+  reusify@1.1.0: {}
 
-  /rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-    dev: true
+  rfdc@1.4.1: {}
 
-  /rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
+  rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-    dev: true
 
-  /rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
+  rimraf@5.0.10:
     dependencies:
       glob: 10.4.5
-    dev: true
 
-  /rollup-plugin-auto-external@2.0.0(rollup@4.46.2):
-    resolution: {integrity: sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rollup: '>=0.45.2'
+  rollup-plugin-auto-external@2.0.0(rollup@4.40.0):
     dependencies:
       builtins: 2.0.1
       read-pkg: 3.0.0
-      rollup: 4.46.2
+      rollup: 4.40.0
       safe-resolve: 1.0.0
       semver: 5.7.2
-    dev: true
 
-  /rollup-plugin-node-externals@8.0.1(rollup@4.46.2):
-    resolution: {integrity: sha512-j6uve/BPEyHCmQuXpu5/LT5qXw69QLIi6YnFrs6F7tmGFXjkFDT0zqZMt0KaMuWSvkcxJFBklsKfYYoKKEPwyw==}
-    engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
-    peerDependencies:
-      rollup: ^4.0.0
+  rollup-plugin-node-externals@8.0.0(rollup@4.40.0):
     dependencies:
-      rollup: 4.46.2
-    dev: true
+      rollup: 4.40.0
 
-  /rollup@4.46.2:
-    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
+  rollup@4.40.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.46.2
-      '@rollup/rollup-android-arm64': 4.46.2
-      '@rollup/rollup-darwin-arm64': 4.46.2
-      '@rollup/rollup-darwin-x64': 4.46.2
-      '@rollup/rollup-freebsd-arm64': 4.46.2
-      '@rollup/rollup-freebsd-x64': 4.46.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
-      '@rollup/rollup-linux-arm64-gnu': 4.46.2
-      '@rollup/rollup-linux-arm64-musl': 4.46.2
-      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-musl': 4.46.2
-      '@rollup/rollup-linux-s390x-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-musl': 4.46.2
-      '@rollup/rollup-win32-arm64-msvc': 4.46.2
-      '@rollup/rollup-win32-ia32-msvc': 4.46.2
-      '@rollup/rollup-win32-x64-msvc': 4.46.2
+      '@rollup/rollup-android-arm-eabi': 4.40.0
+      '@rollup/rollup-android-arm64': 4.40.0
+      '@rollup/rollup-darwin-arm64': 4.40.0
+      '@rollup/rollup-darwin-x64': 4.40.0
+      '@rollup/rollup-freebsd-arm64': 4.40.0
+      '@rollup/rollup-freebsd-x64': 4.40.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.40.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.40.0
+      '@rollup/rollup-linux-arm64-gnu': 4.40.0
+      '@rollup/rollup-linux-arm64-musl': 4.40.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.40.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.40.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.40.0
+      '@rollup/rollup-linux-riscv64-musl': 4.40.0
+      '@rollup/rollup-linux-s390x-gnu': 4.40.0
+      '@rollup/rollup-linux-x64-gnu': 4.40.0
+      '@rollup/rollup-linux-x64-musl': 4.40.0
+      '@rollup/rollup-win32-arm64-msvc': 4.40.0
+      '@rollup/rollup-win32-ia32-msvc': 4.40.0
+      '@rollup/rollup-win32-x64-msvc': 4.40.0
       fsevents: 2.3.3
-    dev: true
 
-  /rrweb-cssom@0.6.0:
-    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
-    dev: true
+  rrweb-cssom@0.6.0: {}
 
-  /run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
-    dev: false
+  run-async@2.4.1: {}
 
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+  run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
-  /rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
-    dev: true
+  rw@1.3.3: {}
 
-  /rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+  rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
 
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+  safe-buffer@5.2.1: {}
 
-  /safe-regex2@3.1.0:
-    resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}
+  safe-regex2@3.1.0:
     dependencies:
       ret: 0.4.3
-    dev: true
 
-  /safe-resolve@1.0.0:
-    resolution: {integrity: sha512-aQpRvfxoi1y0UxKEU0tNO327kb0/LMo8Xrk64M2u172UqOOLCCM0khxN2OTClDiTqTJz5864GMD1X92j4YiHTg==}
-    dev: true
+  safe-resolve@1.0.0: {}
 
-  /safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-    dev: true
+  safe-stable-stringify@2.5.0: {}
 
-  /safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+  safer-buffer@2.1.2: {}
 
-  /saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
+  saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    dev: true
 
-  /secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-    dev: true
+  secure-json-parse@2.7.0: {}
 
-  /semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-    dev: true
+  semver@5.7.2: {}
 
-  /semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-    dev: true
+  semver@6.3.1: {}
 
-  /semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
+  semver@7.7.1: {}
 
-  /send@0.19.0:
-    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
-    engines: {node: '>= 0.8.0'}
+  send@0.19.0:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
@@ -5492,11 +6497,8 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /serve-static@1.16.2:
-    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
-    engines: {node: '>= 0.8.0'}
+  serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -5504,254 +6506,150 @@ packages:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
-    dev: true
+  set-cookie-parser@2.7.1: {}
 
-  /setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-    dev: true
+  setprototypeof@1.2.0: {}
 
-  /shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+  shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
-  /shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-    dev: true
+  shebang-regex@3.0.0: {}
 
-  /side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
+  side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
-  /side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
+  side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
-  /side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
+  side-channel-weakmap@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    dev: true
 
-  /side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
+  side-channel@1.1.0:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    dev: true
 
-  /sift@16.0.1:
-    resolution: {integrity: sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==}
-    dev: true
+  sift@16.0.1: {}
 
-  /signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: false
+  signal-exit@3.0.7: {}
 
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: true
+  signal-exit@4.1.0: {}
 
-  /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-    dev: true
+  slash@3.0.0: {}
 
-  /smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-    dev: true
+  smart-buffer@4.2.0: {}
 
-  /socks@2.8.6:
-    resolution: {integrity: sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+  socks@2.8.4:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
-    dev: true
 
-  /sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+  sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
-    dev: true
 
-  /source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  source-map-js@1.2.1: {}
 
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+  source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: false
 
-  /source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  source-map@0.5.7: {}
 
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
+  source-map@0.6.1: {}
 
-  /sparse-bitfield@3.0.3:
-    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
-    requiresBuild: true
+  sparse-bitfield@3.0.3:
     dependencies:
       memory-pager: 1.5.0
-    dev: true
     optional: true
 
-  /spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+  spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
-    dev: true
+      spdx-license-ids: 3.0.21
 
-  /spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-    dev: true
+  spdx-exceptions@2.5.0: {}
 
-  /spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+  spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
-    dev: true
+      spdx-license-ids: 3.0.21
 
-  /spdx-license-ids@3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
-    dev: true
+  spdx-license-ids@3.0.21: {}
 
-  /split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-    dev: true
+  split2@4.2.0: {}
 
-  /sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
-    dev: true
+  sprintf-js@1.1.3: {}
 
-  /statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  statuses@2.0.1: {}
 
-  /string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+  string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  /string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
+  string-width@5.1.2:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
-  /string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+  string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
 
-  /strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+  strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  /strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
+  strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-    dev: true
 
-  /strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-    dev: true
+  strip-bom@3.0.0: {}
 
-  /strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
-    dev: true
+  strip-json-comments@3.1.1: {}
 
-  /strnum@2.1.1:
-    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
-    requiresBuild: true
-    dev: true
+  strnum@1.1.2:
     optional: true
 
-  /subarg@1.0.0:
-    resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
+  subarg@1.0.0:
     dependencies:
       minimist: 1.2.8
-    dev: true
 
-  /supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+  supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-    dev: true
+  supports-preserve-symlinks-flag@1.0.0: {}
 
-  /suppress-warnings@1.0.2:
-    resolution: {integrity: sha512-zrKSiWJ7BNG14YfGd6BzgKN4wBPrjviMP3EYIGdQNDjDI8qbKcnxdbKL2C6ODAmonj63JTH+d7/l0MPqaqQLHg==}
+  suppress-warnings@1.0.2: {}
 
-  /symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: true
+  symbol-tree@3.2.4: {}
 
-  /text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-    dev: true
+  text-table@0.2.0: {}
 
-  /tgrid@0.10.3:
-    resolution: {integrity: sha512-EWIdHvc1BOX0p88P/lg8wXk1nnNmXCc6wf2mm7S/wxAWUXdAfk1klBBbM7FC+//tSlLHy6ITlmZHWxe+XmrNJg==}
+  tgrid@0.10.3:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 20.17.30
       '@types/websocket': 1.0.10
       '@types/ws': 7.4.7
       import2: 1.0.3
@@ -5760,131 +6658,70 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: true
 
-  /thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+  thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
-    dev: true
 
-  /through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-    dev: false
+  through@2.3.8: {}
 
-  /timestring@6.0.0:
-    resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
-    engines: {node: '>=8'}
-    dev: true
+  timestring@6.0.0: {}
 
-  /tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
+  tinyglobby@0.2.13:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
-      picomatch: 4.0.3
-    dev: true
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
 
-  /tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
-    dev: false
 
-  /to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-    dev: true
+  to-fast-properties@2.0.0: {}
 
-  /to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+  to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-    dev: true
 
-  /toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
-    dev: true
+  toad-cache@3.7.0: {}
 
-  /toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-    dev: true
+  toidentifier@1.0.1: {}
 
-  /tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
+  tough-cookie@4.1.4:
     dependencies:
       psl: 1.15.0
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
-    dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
+  tr46@0.0.3: {}
 
-  /tr46@3.0.0:
-    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
-    engines: {node: '>=12'}
+  tr46@3.0.0:
     dependencies:
       punycode: 2.3.1
-    dev: true
 
-  /tr46@4.1.1:
-    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
-    engines: {node: '>=14'}
+  tr46@4.1.1:
     dependencies:
       punycode: 2.3.1
-    dev: true
 
-  /ts-api-utils@1.4.3(typescript@5.9.2):
-    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      typescript: '>=4.2.0'
+  ts-api-utils@1.4.3(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
-    dev: true
 
-  /ts-api-utils@2.1.0(typescript@5.9.2):
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
+  ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
-    dev: true
 
-  /ts-expose-internals@5.6.3:
-    resolution: {integrity: sha512-reb+7TXGaC0odGjywnLocM4f2i8mBhSEjc3gnKqdM21wDy8FcGGVjKbtMNjn17hka34CrwvqNREs0R7CGIeH3w==}
-    dev: true
+  ts-expose-internals@5.6.3: {}
 
-  /ts-node@10.9.2(@types/node@18.19.121)(typescript@5.9.2):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
+  ts-node@10.9.2(@types/node@18.19.86)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.121
-      acorn: 8.15.0
+      '@types/node': 18.19.86
+      acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -5893,29 +6730,16 @@ packages:
       typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
 
-  /ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.2):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
+  ts-node@10.9.2(@types/node@20.17.30)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.9
-      acorn: 8.15.0
+      '@types/node': 20.17.30
+      acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -5924,302 +6748,158 @@ packages:
       typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
 
-  /ts-patch@3.3.0:
-    resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
-    hasBin: true
+  ts-patch@3.3.0:
     dependencies:
       chalk: 4.1.2
       global-prefix: 4.0.0
       minimist: 1.2.8
       resolve: 1.22.10
-      semver: 7.7.2
+      semver: 7.7.1
       strip-ansi: 6.0.1
-    dev: true
 
-  /tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+  tslib@2.8.1: {}
 
-  /tstl@3.0.0:
-    resolution: {integrity: sha512-pR83y6/tbJx6jeGRqGJXk2t/eCUynaHEE6zsOLB0Zga8ej61LXtPfoeiROdhezpoCT15+1QMbqKB1Um5kasSKg==}
+  tstl@3.0.0: {}
 
-  /type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+  type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-    dev: true
 
-  /type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
-    dev: true
+  type-fest@0.20.2: {}
 
-  /type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
-    dev: false
+  type-fest@0.21.3: {}
 
-  /type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
+  type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-    dev: true
 
-  /typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
+  typescript@5.9.2: {}
 
-  /undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@5.26.5: {}
 
-  /undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@6.19.8: {}
 
-  /universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-    dev: true
+  undici-types@6.21.0: {}
 
-  /unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  universalify@0.2.0: {}
 
-  /update-browserslist-db@1.1.3(browserslist@4.25.1):
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
+  unpipe@1.0.0: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:
-      browserslist: 4.25.1
+      browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
-    dev: true
 
-  /uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+  uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-    dev: true
 
-  /url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+  url-parse@1.5.10:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-    dev: true
 
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: false
+  util-deprecate@1.0.2: {}
 
-  /utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
-    dev: true
+  utils-merge@1.0.1: {}
 
-  /uuid-parse@1.1.0:
-    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
-    dev: true
+  uuid-parse@1.1.0: {}
 
-  /uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-    dev: true
+  uuid@8.3.2: {}
 
-  /uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    hasBin: true
+  uuid@9.0.1: {}
 
-  /v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-    dev: true
+  v8-compile-cache-lib@3.0.1: {}
 
-  /validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+  validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-    dev: true
 
-  /validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
-    engines: {node: '>= 0.10'}
-    dev: true
+  validator@13.15.0: {}
 
-  /vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
-    dev: true
+  vary@1.1.2: {}
 
-  /w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
+  w3c-xmlserializer@4.0.0:
     dependencies:
       xml-name-validator: 4.0.0
-    dev: true
 
-  /wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+  wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-    dev: false
 
-  /web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-    dev: false
+  web-streams-polyfill@4.0.0-beta.3: {}
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
+  webidl-conversions@3.0.1: {}
 
-  /webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-    dev: true
+  webidl-conversions@7.0.0: {}
 
-  /whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
-    engines: {node: '>=12'}
+  whatwg-encoding@2.0.0:
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
 
-  /whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
-    dev: true
+  whatwg-mimetype@3.0.0: {}
 
-  /whatwg-url@11.0.0:
-    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
-    engines: {node: '>=12'}
+  whatwg-url@11.0.0:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
-    dev: true
 
-  /whatwg-url@12.0.1:
-    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
-    engines: {node: '>=14'}
+  whatwg-url@12.0.1:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
-    dev: true
 
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+  whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
-  /which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
+  which@2.0.2:
     dependencies:
       isexe: 2.0.0
-    dev: true
 
-  /which@4.0.0:
-    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
-    engines: {node: ^16.13.0 || >=18.0.0}
-    hasBin: true
+  which@4.0.0:
     dependencies:
       isexe: 3.1.1
-    dev: true
 
-  /word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
+  word-wrap@1.2.5: {}
 
-  /wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
+  wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: false
 
-  /wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+  wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
-  /wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
+  wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
-  /wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+  wrappy@1.0.2: {}
 
-  /ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
+  ws@7.5.10: {}
 
-  /ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
+  ws@8.18.1: {}
 
-  /xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
-    dev: true
+  xml-name-validator@4.0.0: {}
 
-  /xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: true
+  xmlchars@2.2.0: {}
 
-  /yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-    dev: true
+  yallist@3.1.1: {}
 
-  /yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-    dev: true
+  yn@3.1.1: {}
 
-  /yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
-    dev: true
+  yocto-queue@0.1.0: {}
 
-  /zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-    dev: true
+  zod@3.24.3: {}

--- a/src/transformers/ImportTransformer.ts
+++ b/src/transformers/ImportTransformer.ts
@@ -38,10 +38,10 @@ export namespace ImportTransformer {
         }),
       props.context,
     );
-    
+
     // Second pass: remove unused typia imports
     transformedFile = removeUnusedTypiaImports(transformedFile);
-    
+
     return transformedFile;
   };
 
@@ -91,91 +91,96 @@ const get_directory_path = (file: string): string => {
  */
 const removeUnusedTypiaImports = (file: ts.SourceFile): ts.SourceFile => {
   // Find typia imports and collect all identifiers
-  const typiaImports = new Map<string, { statement: ts.ImportDeclaration; isDefault: boolean }>();
-  
-  for (const statement of file.statements) {
-    if (ts.isImportDeclaration(statement) && 
-        ts.isStringLiteral(statement.moduleSpecifier) &&
-        statement.moduleSpecifier.text === "typia" &&
-        statement.importClause) {
-      
-      // Track default import (import typia from 'typia')
-      if (statement.importClause.name) {
-        const name = statement.importClause.name.text;
-        typiaImports.set(name, { statement, isDefault: true });
-      }
-      
-      // Track named imports (import { tags } from 'typia') - keep these
-      if (statement.importClause.namedBindings && 
-          ts.isNamedImports(statement.importClause.namedBindings)) {
-        for (const element of statement.importClause.namedBindings.elements) {
-          const name = element.name.text;
-          typiaImports.set(name, { statement, isDefault: false });
-        }
-      }
-    }
+  interface ImportMetadata {
+    declaration: ts.ImportDeclaration;
+    default: boolean;
   }
-  
-  if (typiaImports.size === 0) {
-    return file; // No typia imports to check
+  const imports: Map<string, ImportMetadata> = new Map();
+  for (const stmt of file.statements) {
+    if (
+      ts.isImportDeclaration(stmt) === false ||
+      ts.isStringLiteral(stmt.moduleSpecifier) === false ||
+      stmt.moduleSpecifier.text !== "typia" ||
+      stmt.importClause === undefined
+    )
+      continue;
+
+    // Track default import (import typia from 'typia')
+    if (stmt.importClause.name)
+      imports.set(stmt.importClause.name.text, {
+        declaration: stmt,
+        default: true,
+      });
+
+    // Track named imports (import { tags } from 'typia') - keep these
+    if (
+      stmt.importClause.namedBindings &&
+      ts.isNamedImports(stmt.importClause.namedBindings)
+    )
+      for (const element of stmt.importClause.namedBindings.elements)
+        imports.set(element.name.text, {
+          declaration: stmt,
+          default: false,
+        });
   }
-  
+  if (imports.size === 0) return file; // No typia imports to check
+
   // Find usage of typia identifiers that are NOT transformable calls
   const nonTransformableUsage = new Set<string>();
-  
   const checkUsage = (node: ts.Node) => {
-    if (ts.isIdentifier(node) && typiaImports.has(node.text)) {
-      const identifier = node.text;
-      
+    if (ts.isIdentifier(node) && imports.has(node.text)) {
+      const identifier: string = node.text;
       // Check if this identifier is being used as part of a property access
-      if (ts.isPropertyAccessExpression(node.parent) && node.parent.expression === node) {
+      if (
+        node.parent &&
+        ts.isPropertyAccessExpression(node.parent) &&
+        node.parent.expression === node
+      ) {
         // This is typia.something - check if it's a transformable call pattern
-        if (!isLikelyTransformableCall(node.parent)) {
+        if (!isLikelyTransformableCall(node.parent))
           nonTransformableUsage.add(identifier);
-        }
-      } else {
+      } else
         // Direct usage of the typia identifier (not as property access)
         // This is definitely non-transformable usage
         nonTransformableUsage.add(identifier);
-      }
     }
-    
     ts.forEachChild(node, checkUsage);
   };
-  
+
   // Check all statements except import declarations
-  for (const statement of file.statements) {
-    if (!ts.isImportDeclaration(statement) || 
-        !ts.isStringLiteral(statement.moduleSpecifier) ||
-        statement.moduleSpecifier.text !== "typia") {
-      checkUsage(statement);
-    }
-  }
-  
+  for (const stmt of file.statements)
+    if (
+      !ts.isImportDeclaration(stmt) ||
+      !ts.isStringLiteral(stmt.moduleSpecifier) ||
+      stmt.moduleSpecifier.text !== "typia"
+    )
+      checkUsage(stmt);
+
   // Update import statements
-  const newStatements: ts.Statement[] = [];
-  
-  for (const statement of file.statements) {
-    if (ts.isImportDeclaration(statement) && 
-        ts.isStringLiteral(statement.moduleSpecifier) &&
-        statement.moduleSpecifier.text === "typia" &&
-        statement.importClause) {
-      
-      const newImportClause = filterTypiaImportClause(statement.importClause, nonTransformableUsage);
-      if (newImportClause) {
-        newStatements.push(ts.factory.createImportDeclaration(
-          statement.modifiers,
-          newImportClause,
-          statement.moduleSpecifier,
-          statement.assertClause
-        ));
+  const newStatements: ts.Statement[] = file.statements
+    .map((stmt) => {
+      if (
+        ts.isImportDeclaration(stmt) &&
+        ts.isStringLiteral(stmt.moduleSpecifier) &&
+        stmt.moduleSpecifier.text === "typia" &&
+        stmt.importClause
+      ) {
+        const newImportClause = filterTypiaImportClause(
+          stmt.importClause,
+          nonTransformableUsage,
+        );
+        if (newImportClause)
+          return ts.factory.createImportDeclaration(
+            stmt.modifiers,
+            newImportClause,
+            stmt.moduleSpecifier,
+            stmt.attributes,
+          );
+        return null; // Skip adding the import if all imports are unused
       }
-      // Skip adding the import if all imports are unused
-    } else {
-      newStatements.push(statement);
-    }
-  }
-  
+      return stmt;
+    })
+    .filter((stmt) => stmt !== null);
   return ts.factory.updateSourceFile(
     file,
     newStatements,
@@ -183,7 +188,7 @@ const removeUnusedTypiaImports = (file: ts.SourceFile): ts.SourceFile => {
     file.referencedFiles,
     file.typeReferenceDirectives,
     file.hasNoDefaultLib,
-    file.libReferenceDirectives
+    file.libReferenceDirectives,
   );
 };
 
@@ -191,24 +196,28 @@ const removeUnusedTypiaImports = (file: ts.SourceFile): ts.SourceFile => {
  * Check if a property access expression looks like a transformable typia call
  * This uses heuristics to detect patterns like typia.xxx(), typia.namespace.xxx()
  */
-const isLikelyTransformableCall = (node: ts.PropertyAccessExpression): boolean => {
+const isLikelyTransformableCall = (
+  node: ts.PropertyAccessExpression,
+): boolean => {
   // Check if this is eventually part of a call expression
   let current: ts.Node = node;
-  
+
   // Walk up the chain to find if this leads to a call expression
   // Handle patterns like: typia.xxx(), typia.namespace.xxx()
   while (ts.isPropertyAccessExpression(current)) {
     current = current.parent;
   }
-  
+
   // If the final result is a call expression, this is likely transformable
-  if (ts.isCallExpression(current) && 
-      (current.expression === node || 
-       (ts.isPropertyAccessExpression(current.expression) && 
-        isTypiaPropertyChain(current.expression)))) {
+  if (
+    ts.isCallExpression(current) &&
+    (current.expression === node ||
+      (ts.isPropertyAccessExpression(current.expression) &&
+        isTypiaPropertyChain(current.expression)))
+  ) {
     return true;
   }
-  
+
   return false;
 };
 
@@ -217,32 +226,33 @@ const isLikelyTransformableCall = (node: ts.PropertyAccessExpression): boolean =
  */
 const isTypiaPropertyChain = (node: ts.PropertyAccessExpression): boolean => {
   let current: ts.Expression = node;
-  
+
   while (ts.isPropertyAccessExpression(current)) {
     current = current.expression;
   }
-  
-  return ts.isIdentifier(current) && current.text === 'typia';
+
+  return ts.isIdentifier(current) && current.text === "typia";
 };
 
 /**
  * Filter import clause to remove unused default imports
  */
 const filterTypiaImportClause = (
-  importClause: ts.ImportClause, 
-  usedImports: Set<string>
+  importClause: ts.ImportClause,
+  usedImports: Set<string>,
 ): ts.ImportClause | undefined => {
-  const hasDefaultImport = importClause.name && usedImports.has(importClause.name.text);
+  const hasDefaultImport =
+    importClause.name && usedImports.has(importClause.name.text);
   const namedBindings = importClause.namedBindings; // Always keep named bindings like { tags }
-  
+
   // Return undefined if no imports are used
   if (!hasDefaultImport && !namedBindings) {
     return undefined;
   }
-  
+
   return ts.factory.createImportClause(
     importClause.isTypeOnly,
     hasDefaultImport ? importClause.name : undefined,
-    namedBindings
+    namedBindings,
   );
 };

--- a/test/generate/output/generate_http.ts
+++ b/test/generate/output/generate_http.ts
@@ -1,10 +1,347 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__httpQueryParseURLSearchParams from "typia/lib/internal/_httpQueryParseURLSearchParams.js";
+import * as __typia_transform__httpQueryReadBigint from "typia/lib/internal/_httpQueryReadBigint.js";
+import * as __typia_transform__httpQueryReadNumber from "typia/lib/internal/_httpQueryReadNumber.js";
+import * as __typia_transform__httpQueryReadString from "typia/lib/internal/_httpQueryReadString.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ISomething {
-    id: string & tags.Format<"uuid">;
-    beta: number[];
-    gamma: bigint;
+  id: string & tags.Format<"uuid">;
+  beta: number[];
+  gamma: bigint;
 }
-export const query = typia.http.createQuery<ISomething>();
-export const isQuery = typia.http.createIsQuery<ISomething>();
-export const assertQuery = typia.http.createAssertQuery<ISomething>();
-export const validateQuery = typia.http.createValidateQuery<ISomething>();
+export const query = (() => {
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+})();
+export const isQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> | null => {
+    const value = __decode(input);
+    if (!__is(value)) return null;
+    return value;
+  };
+})();
+export const assertQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.http.createAssertQuery",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.beta) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        },
+        _errorFactory,
+      )) &&
+      input.beta.every(
+        (elem: any, _index2: number) =>
+          ("number" === typeof elem && Number.isFinite(elem)) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.http.createAssertQuery",
+              path: _path + ".beta[" + _index2 + "]",
+              expected: "number",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        },
+        _errorFactory,
+      )) &&
+    ("bigint" === typeof input.gamma ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.http.createAssertQuery",
+          path: _path + ".gamma",
+          expected: "bigint",
+          value: input.gamma,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ISomething => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.http.createAssertQuery",
+              path: _path + "",
+              expected: "ISomething",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.http.createAssertQuery",
+            path: _path + "",
+            expected: "ISomething",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").Resolved<ISomething> =>
+    __assert(__decode(input), errorFactory);
+})();
+export const validateQuery = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    Array.isArray(input.beta) &&
+    input.beta.every(
+      (elem: any) => "number" === typeof elem && Number.isFinite(elem),
+    ) &&
+    "bigint" === typeof input.gamma;
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ((Array.isArray(input.beta) ||
+        _report(_exceptionable, {
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        })) &&
+        input.beta
+          .map(
+            (elem: any, _index2: number) =>
+              ("number" === typeof elem && Number.isFinite(elem)) ||
+              _report(_exceptionable, {
+                path: _path + ".beta[" + _index2 + "]",
+                expected: "number",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".beta",
+          expected: "Array<number>",
+          value: input.beta,
+        }),
+      "bigint" === typeof input.gamma ||
+        _report(_exceptionable, {
+          path: _path + ".gamma",
+          expected: "bigint",
+          value: input.gamma,
+        }),
+    ].every((flag: boolean) => flag);
+  const __is = (input: any): input is ISomething =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ISomething> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ISomething",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ISomething",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __decode = (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").Resolved<ISomething> => {
+    input =
+      __typia_transform__httpQueryParseURLSearchParams._httpQueryParseURLSearchParams(
+        input,
+      ) as import("typia").IReadableURLSearchParams;
+    const output = {
+      id: __typia_transform__httpQueryReadString._httpQueryReadString(
+        input.get("id"),
+      ),
+      beta: input
+        .getAll("beta")
+        .map((elem: any) =>
+          __typia_transform__httpQueryReadNumber._httpQueryReadNumber(elem),
+        ),
+      gamma: __typia_transform__httpQueryReadBigint._httpQueryReadBigint(
+        input.get("gamma"),
+      ),
+    };
+    return output as any;
+  };
+  return (
+    input: string | import("typia").IReadableURLSearchParams,
+  ): import("typia").IValidation<import("typia").Resolved<ISomething>> =>
+    __validate(__decode(input));
+})();

--- a/test/generate/output/generate_index.ts
+++ b/test/generate/output/generate_index.ts
@@ -1,21 +1,1797 @@
 import { tags } from "typia";
+import * as __typia_transform__accessExpressionAsString from "typia/lib/internal/_accessExpressionAsString.js";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__createStandardSchema from "typia/lib/internal/_createStandardSchema.js";
+import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__randomArray from "typia/lib/internal/_randomArray.js";
+import * as __typia_transform__randomFormatDatetime from "typia/lib/internal/_randomFormatDatetime.js";
+import * as __typia_transform__randomFormatEmail from "typia/lib/internal/_randomFormatEmail.js";
+import * as __typia_transform__randomFormatUuid from "typia/lib/internal/_randomFormatUuid.js";
+import * as __typia_transform__randomInteger from "typia/lib/internal/_randomInteger.js";
+import * as __typia_transform__randomPattern from "typia/lib/internal/_randomPattern.js";
+import * as __typia_transform__randomPick from "typia/lib/internal/_randomPick.js";
+import * as __typia_transform__randomString from "typia/lib/internal/_randomString.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ICitizen {
-    id: string & tags.Format<"uuid">;
-    name: string & tags.Pattern<"^[A-Z][a-z]+$">;
-    email: string & tags.Format<"email">;
-    age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
-    motto: string;
-    birthdate: Date;
-    died_at: null | Date;
-    parent: ICitizen | null;
-    children: ICitizen[];
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
 }
-export const is = typia.createIs<ICitizen>();
-export const assert = typia.createAssert<ICitizen>();
-export const assertGuard = typia.createAssertGuard<ICitizen>();
-export const validate = typia.createValidate<ICitizen>();
-export const equals = typia.createEquals<ICitizen>();
-export const assertEquals = typia.createAssertEquals<ICitizen>();
-export const assertGuardEquals = typia.createAssertGuardEquals<ICitizen>();
-export const validateEquals = typia.createValidateEquals<ICitizen>();
-export const random = typia.createRandom<ICitizen>();
+export const is = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  return (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+})();
+export const assert = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssert",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssert",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssert",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssert",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+})();
+export const assertGuard = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuard",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+  };
+})();
+export const validate = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  return __typia_transform__createStandardSchema._createStandardSchema(
+    (input: any): import("typia").IValidation<ICitizen> => {
+      if (false === __is(input)) {
+        errors = [];
+        _report = (__typia_transform__validateReport._validateReport as any)(
+          errors,
+        );
+        ((input: any, _path: string, _exceptionable: boolean = true) =>
+          ((("object" === typeof input && null !== input) ||
+            _report(true, {
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            })) &&
+            _vo0(input, _path + "", true)) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          }))(input, "$input", true);
+        const success = 0 === errors.length;
+        return success
+          ? {
+              success,
+              data: input,
+            }
+          : ({
+              success,
+              errors,
+              data: input,
+            } as any);
+      }
+      return {
+        success: true,
+        data: input,
+      } as any;
+    },
+  );
+})();
+export const equals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  return (input: any, _exceptionable: boolean = true): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+})();
+export const assertEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+})();
+export const assertGuardEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuardEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+  };
+})();
+export const validateEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+      9 === Object.keys(input).length ||
+        false === _exceptionable ||
+        Object.keys(input)
+          .map((key: any) => {
+            if (
+              [
+                "id",
+                "name",
+                "email",
+                "age",
+                "motto",
+                "birthdate",
+                "died_at",
+                "parent",
+                "children",
+              ].some((prop: any) => key === prop)
+            )
+              return true;
+            const value = input[key];
+            if (undefined === value) return true;
+            return _report(_exceptionable, {
+              path:
+                _path +
+                __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                  key,
+                ),
+              expected: "undefined",
+              value: value,
+              description: [
+                `The property \`${key}\` is not defined in the object type.`,
+                "",
+                "Please remove the property next time.",
+              ].join("\n"),
+            });
+          })
+          .every((flag: boolean) => flag),
+    ].every((flag: boolean) => flag);
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let errors: any;
+  let _report: any;
+  return __typia_transform__createStandardSchema._createStandardSchema(
+    (input: any): import("typia").IValidation<ICitizen> => {
+      if (false === __is(input)) {
+        errors = [];
+        _report = (__typia_transform__validateReport._validateReport as any)(
+          errors,
+        );
+        ((input: any, _path: string, _exceptionable: boolean = true) =>
+          ((("object" === typeof input && null !== input) ||
+            _report(true, {
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            })) &&
+            _vo0(input, _path + "", true)) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          }))(input, "$input", true);
+        const success = 0 === errors.length;
+        return success
+          ? {
+              success,
+              data: input,
+            }
+          : ({
+              success,
+              errors,
+              data: input,
+            } as any);
+      }
+      return {
+        success: true,
+        data: input,
+      } as any;
+    },
+  );
+})();
+export const random = (() => {
+  const _ro0 = (_recursive: boolean = true, _depth: number = 0): any => ({
+    id: (
+      _generator?.uuid ?? __typia_transform__randomFormatUuid._randomFormatUuid
+    )(),
+    name: (
+      _generator?.pattern ?? __typia_transform__randomPattern._randomPattern
+    )(new RegExp("^[A-Z][a-z]+$")),
+    email: (
+      _generator?.email ??
+      __typia_transform__randomFormatEmail._randomFormatEmail
+    )(),
+    age: (
+      _generator?.integer ?? __typia_transform__randomInteger._randomInteger
+    )({
+      type: "integer",
+      minimum: 0,
+      exclusiveMaximum: 100,
+    }),
+    motto: (
+      _generator?.string ?? __typia_transform__randomString._randomString
+    )({
+      type: "string",
+    }),
+    birthdate: new Date(
+      (
+        _generator?.datetime ??
+        __typia_transform__randomFormatDatetime._randomFormatDatetime
+      )(),
+    ),
+    died_at: __typia_transform__randomPick._randomPick([
+      () => null,
+      () =>
+        new Date(
+          (
+            _generator?.datetime ??
+            __typia_transform__randomFormatDatetime._randomFormatDatetime
+          )(),
+        ),
+    ])(),
+    parent: __typia_transform__randomPick._randomPick([
+      () => null,
+      () => _ro0(true, _recursive ? 1 + _depth : _depth),
+    ])(),
+    children:
+      5 >= _depth
+        ? (_generator?.array ?? __typia_transform__randomArray._randomArray)({
+            type: "array",
+            element: () => _ro0(true, _recursive ? 1 + _depth : _depth),
+          })
+        : [],
+  });
+  let _generator: Partial<import("typia").IRandomGenerator> | undefined;
+  return (
+    generator?: Partial<import("typia").IRandomGenerator>,
+  ): import("typia").Resolved<ICitizen> => {
+    _generator = generator;
+    return _ro0();
+  };
+})();

--- a/test/generate/output/generate_json.ts
+++ b/test/generate/output/generate_json.ts
@@ -1,22 +1,1125 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__jsonStringifyNumber from "typia/lib/internal/_jsonStringifyNumber.js";
+import * as __typia_transform__jsonStringifyString from "typia/lib/internal/_jsonStringifyString.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ICitizen {
-    id: string & tags.Format<"uuid">;
-    name: string & tags.Pattern<"^[A-Z][a-z]+$">;
-    email: string & tags.Format<"email">;
-    age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
-    motto: string;
-    birthdate: Date;
-    died_at: null | Date;
-    parent: ICitizen | null;
-    children: ICitizen[];
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
 }
-export const collection = typia.json.schemas<[
-    ICitizen
-]>();
-export const createStringify = typia.json.createStringify<ICitizen>();
-export const createIsStringify = typia.json.createIsStringify<ICitizen>();
-export const createAssertStringify = typia.json.createAssertStringify<ICitizen>();
-export const createValidateStringify = typia.json.createValidateStringify<ICitizen>();
-export const createIsParse = typia.json.createIsParse<ICitizen>();
-export const createAssertParse = typia.json.createAssertParse<ICitizen>();
-export const createValidateParse = typia.json.createValidateParse<ICitizen>();
+export const collection = {
+  version: "3.1",
+  components: {
+    schemas: {
+      ICitizen: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+          name: {
+            type: "string",
+            pattern: "^[A-Z][a-z]+$",
+          },
+          email: {
+            type: "string",
+            format: "email",
+          },
+          age: {
+            type: "integer",
+            minimum: 0,
+            exclusiveMaximum: 100,
+          },
+          motto: {
+            type: "string",
+          },
+          birthdate: {
+            type: "string",
+            format: "date-time",
+          },
+          died_at: {
+            oneOf: [
+              {
+                type: "null",
+              },
+              {
+                type: "string",
+                format: "date-time",
+              },
+            ],
+          },
+          parent: {
+            oneOf: [
+              {
+                type: "null",
+              },
+              {
+                $ref: "#/components/schemas/ICitizen",
+              },
+            ],
+          },
+          children: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/ICitizen",
+            },
+          },
+        },
+        required: [
+          "id",
+          "name",
+          "email",
+          "age",
+          "motto",
+          "birthdate",
+          "died_at",
+          "parent",
+          "children",
+        ],
+      },
+    },
+  },
+  schemas: [
+    {
+      $ref: "#/components/schemas/ICitizen",
+    },
+  ],
+} as import("typia").IJsonSchemaCollection<"3.1">;
+export const createStringify = (() => {
+  const _so0 = (input: any): any =>
+    `{"id":${__typia_transform__jsonStringifyString._jsonStringifyString(input.id)},"name":${__typia_transform__jsonStringifyString._jsonStringifyString(input.name)},"email":${__typia_transform__jsonStringifyString._jsonStringifyString(input.email)},"age":${__typia_transform__jsonStringifyNumber._jsonStringifyNumber(input.age)},"motto":${__typia_transform__jsonStringifyString._jsonStringifyString(input.motto)},"birthdate":${__typia_transform__jsonStringifyString._jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform__jsonStringifyString._jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? _so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => _so0(elem)).join(",")}]`}}`;
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  return (input: ICitizen): string => _so0(input);
+})();
+export const createIsStringify = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _so0 = (input: any): any =>
+    `{"id":${__typia_transform__jsonStringifyString._jsonStringifyString(input.id)},"name":${__typia_transform__jsonStringifyString._jsonStringifyString(input.name)},"email":${__typia_transform__jsonStringifyString._jsonStringifyString(input.email)},"age":${__typia_transform__jsonStringifyNumber._jsonStringifyNumber(input.age)},"motto":${__typia_transform__jsonStringifyString._jsonStringifyString(input.motto)},"birthdate":${__typia_transform__jsonStringifyString._jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform__jsonStringifyString._jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? _so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => _so0(elem)).join(",")}]`}}`;
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __stringify = (input: ICitizen): string => _so0(input);
+  return (input: any): string | null =>
+    __is(input) ? __stringify(input) : null;
+})();
+export const createAssertStringify = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.json.createAssertStringify",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.json.createAssertStringify",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertStringify",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _so0 = (input: any): any =>
+    `{"id":${__typia_transform__jsonStringifyString._jsonStringifyString(input.id)},"name":${__typia_transform__jsonStringifyString._jsonStringifyString(input.name)},"email":${__typia_transform__jsonStringifyString._jsonStringifyString(input.email)},"age":${__typia_transform__jsonStringifyNumber._jsonStringifyNumber(input.age)},"motto":${__typia_transform__jsonStringifyString._jsonStringifyString(input.motto)},"birthdate":${__typia_transform__jsonStringifyString._jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform__jsonStringifyString._jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? _so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => _so0(elem)).join(",")}]`}}`;
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.json.createAssertStringify",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.json.createAssertStringify",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __stringify = (input: ICitizen): string => _so0(input);
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): string => {
+    __assert(input, errorFactory);
+    return __stringify(input);
+  };
+})();
+export const createValidateStringify = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _so0 = (input: any): any =>
+    `{"id":${__typia_transform__jsonStringifyString._jsonStringifyString(input.id)},"name":${__typia_transform__jsonStringifyString._jsonStringifyString(input.name)},"email":${__typia_transform__jsonStringifyString._jsonStringifyString(input.email)},"age":${__typia_transform__jsonStringifyNumber._jsonStringifyNumber(input.age)},"motto":${__typia_transform__jsonStringifyString._jsonStringifyString(input.motto)},"birthdate":${__typia_transform__jsonStringifyString._jsonStringifyString(input.birthdate.toJSON())},"died_at":${null !== input.died_at ? __typia_transform__jsonStringifyString._jsonStringifyString(input.died_at.toJSON()) : "null"},"parent":${null !== input.parent ? _so0(input.parent) : "null"},"children":${`[${input.children.map((elem: any) => _so0(elem)).join(",")}]`}}`;
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __stringify = (input: ICitizen): string => _so0(input);
+  return (input: any): import("typia").IValidation<string> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __stringify(input);
+    return result;
+  };
+})();
+export const createIsParse = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  return (input: string): import("typia").Primitive<ICitizen> | null => {
+    input = JSON.parse(input);
+    return __is(input) ? (input as any) : null;
+  };
+})();
+export const createAssertParse = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.json.createAssertParse",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.json.createAssertParse",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.json.createAssertParse",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.json.createAssertParse",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.json.createAssertParse",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  return (
+    input: string,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").Primitive<ICitizen> =>
+    __assert(JSON.parse(input), errorFactory) as any;
+})();
+export const createValidateParse = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  return (
+    input: string,
+  ): import("typia").IValidation<import("typia").Primitive<ICitizen>> =>
+    __validate(JSON.parse(input)) as any;
+})();

--- a/test/generate/output/generate_llm.ts
+++ b/test/generate/output/generate_llm.ts
@@ -1,0 +1,6338 @@
+import { ILlmApplication, LlamaTypeChecker } from "@samchon/openapi";
+import { tags } from "typia";
+import * as __typia_transform__isFormatDateTime from "typia/lib/internal/_isFormatDateTime.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__llmApplicationFinalize from "typia/lib/internal/_llmApplicationFinalize.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
+export const schema = ((props: {
+  $defs?:
+    | Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>
+    | undefined;
+}) => {
+  if (undefined !== props?.$defs)
+    Object.assign(props.$defs, {
+      ICompany: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
+          },
+          serial: {
+            type: "number",
+          },
+          name: {
+            type: "string",
+          },
+          established_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+          departments: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+        },
+        required: ["id", "serial", "name", "established_at", "departments"],
+      },
+      IDepartment: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
+          },
+          code: {
+            type: "string",
+          },
+          sales: {
+            type: "number",
+          },
+          created_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+          children: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+          employees: {
+            type: "array",
+            items: {
+              $ref: "#/$defs/IEmployee",
+            },
+          },
+        },
+        required: [
+          "id",
+          "code",
+          "sales",
+          "created_at",
+          "children",
+          "employees",
+        ],
+      },
+      IEmployee: {
+        type: "object",
+        properties: {
+          id: {
+            description: "@format uuid",
+            type: "string",
+          },
+          name: {
+            type: "string",
+          },
+          age: {
+            type: "number",
+          },
+          grade: {
+            type: "number",
+          },
+          employed_at: {
+            description: "@format date-time",
+            type: "string",
+          },
+        },
+        required: ["id", "name", "age", "grade", "employed_at"],
+      },
+    } as Record<string, import("@samchon/openapi").ILlmSchema<"chatgpt">>);
+  return {
+    $ref: "#/$defs/ICompany",
+  } as import("@samchon/openapi").ILlmSchema<"chatgpt">;
+})({});
+export const parameters = {
+  type: "object",
+  properties: {
+    company: {
+      $ref: "#/$defs/ICompany",
+    },
+    department: {
+      $ref: "#/$defs/IDepartment",
+    },
+    employee: {
+      $ref: "#/$defs/IEmployee",
+    },
+  },
+  required: ["company", "department", "employee"],
+  additionalProperties: false,
+  $defs: {
+    ICompany: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          format: "uuid",
+        },
+        serial: {
+          type: "number",
+        },
+        name: {
+          type: "string",
+        },
+        established_at: {
+          type: "string",
+          format: "date-time",
+        },
+        departments: {
+          type: "array",
+          items: {
+            $ref: "#/$defs/IDepartment",
+          },
+        },
+      },
+      required: ["id", "serial", "name", "established_at", "departments"],
+    },
+    IDepartment: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          format: "uuid",
+        },
+        code: {
+          type: "string",
+        },
+        sales: {
+          type: "number",
+        },
+        created_at: {
+          type: "string",
+          format: "date-time",
+        },
+        children: {
+          type: "array",
+          items: {
+            $ref: "#/$defs/IDepartment",
+          },
+        },
+        employees: {
+          type: "array",
+          items: {
+            $ref: "#/$defs/IEmployee",
+          },
+        },
+      },
+      required: ["id", "code", "sales", "created_at", "children", "employees"],
+    },
+    IEmployee: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          format: "uuid",
+        },
+        name: {
+          type: "string",
+        },
+        age: {
+          type: "number",
+        },
+        grade: {
+          type: "number",
+        },
+        employed_at: {
+          type: "string",
+          format: "date-time",
+        },
+      },
+      required: ["id", "name", "age", "grade", "employed_at"],
+    },
+  },
+} as import("@samchon/openapi").ILlmSchema.IParameters<"claude">;
+export const application = (() => {
+  const application = {
+    model: "llama",
+    options: {
+      reference: true,
+      separate: null,
+    },
+    functions: [
+      {
+        name: "establishCompany",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+          },
+          required: ["company"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/ICompany",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["establishCompany"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["establishCompany"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "createDepartment",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+          required: ["company", "department"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IDepartment",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["createDepartment"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["createDepartment"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "hire",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+            employee: {
+              $ref: "#/$defs/IEmployee",
+            },
+          },
+          required: ["company", "department", "employee"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IEmployee",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department) &&
+            "object" === typeof input.employee &&
+            null !== input.employee &&
+            _io3(input.employee);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+              ((("object" === typeof input.employee &&
+                null !== input.employee) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                })) &&
+                _vo3(
+                  input.employee,
+                  _path + ".employee",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["hire"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["hire"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "erase",
+        parameters: {
+          type: "object",
+          properties: {
+            entity: {
+              oneOf: [
+                {
+                  $ref: "#/$defs/ICompany",
+                },
+                {
+                  $ref: "#/$defs/IDepartment",
+                },
+                {
+                  $ref: "#/$defs/IEmployee",
+                },
+              ],
+            },
+          },
+          required: ["entity"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          type: "string",
+          format: "uuid",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.entity &&
+            null !== input.entity &&
+            _iu0(input.entity);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _iu0 = (input: any): any =>
+            (() => {
+              if (undefined !== input.serial) return _io1(input);
+              else if (undefined !== input.code) return _io2(input);
+              else if (undefined !== input.age) return _io3(input);
+              else return false;
+            })();
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.entity && null !== input.entity) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                })) &&
+                _vu0(
+                  input.entity,
+                  _path + ".entity",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vu0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): any =>
+            (() => {
+              if (undefined !== input.serial)
+                return _vo1(input, _path, true && _exceptionable);
+              else if (undefined !== input.code)
+                return _vo2(input, _path, true && _exceptionable);
+              else if (undefined !== input.age)
+                return _vo3(input, _path, true && _exceptionable);
+              else
+                return _report(_exceptionable, {
+                  path: _path,
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input,
+                });
+            })();
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["erase"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["erase"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+    ],
+  } as import("@samchon/openapi").ILlmApplication<"llama">;
+  __typia_transform__llmApplicationFinalize._llmApplicationFinalize(
+    application,
+    {
+      ...({
+        separate: (schema) =>
+          LlamaTypeChecker.isString(schema) && schema.format === "date-time",
+      } satisfies Partial<
+        Pick<
+          import("@samchon/openapi").ILlmApplication.IOptions<"llama">,
+          "separate" | "validate"
+        >
+      >),
+      equals: false,
+    },
+  );
+  return application;
+})();
+(() => {
+  const application = {
+    model: "llama",
+    options: {
+      reference: true,
+      separate: null,
+    },
+    functions: [
+      {
+        name: "establishCompany",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+          },
+          required: ["company"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/ICompany",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["establishCompany"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["establishCompany"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "createDepartment",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+          required: ["company", "department"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IDepartment",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["createDepartment"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["createDepartment"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "hire",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+            employee: {
+              $ref: "#/$defs/IEmployee",
+            },
+          },
+          required: ["company", "department", "employee"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IEmployee",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department) &&
+            "object" === typeof input.employee &&
+            null !== input.employee &&
+            _io3(input.employee);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+              ((("object" === typeof input.employee &&
+                null !== input.employee) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                })) &&
+                _vo3(
+                  input.employee,
+                  _path + ".employee",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["hire"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["hire"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "erase",
+        parameters: {
+          type: "object",
+          properties: {
+            entity: {
+              oneOf: [
+                {
+                  $ref: "#/$defs/ICompany",
+                },
+                {
+                  $ref: "#/$defs/IDepartment",
+                },
+                {
+                  $ref: "#/$defs/IEmployee",
+                },
+              ],
+            },
+          },
+          required: ["entity"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          type: "string",
+          format: "uuid",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.entity &&
+            null !== input.entity &&
+            _iu0(input.entity);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _iu0 = (input: any): any =>
+            (() => {
+              if (undefined !== input.serial) return _io1(input);
+              else if (undefined !== input.code) return _io2(input);
+              else if (undefined !== input.age) return _io3(input);
+              else return false;
+            })();
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.entity && null !== input.entity) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                })) &&
+                _vu0(
+                  input.entity,
+                  _path + ".entity",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vu0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): any =>
+            (() => {
+              if (undefined !== input.serial)
+                return _vo1(input, _path, true && _exceptionable);
+              else if (undefined !== input.code)
+                return _vo2(input, _path, true && _exceptionable);
+              else if (undefined !== input.age)
+                return _vo3(input, _path, true && _exceptionable);
+              else
+                return _report(_exceptionable, {
+                  path: _path,
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input,
+                });
+            })();
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["erase"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["erase"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+    ],
+  } as import("@samchon/openapi").ILlmApplication<"llama">;
+  __typia_transform__llmApplicationFinalize._llmApplicationFinalize(
+    application,
+    {
+      ...({
+        separate: (schema) =>
+          LlamaTypeChecker.isString(schema) && schema.format === "date-time",
+      } satisfies Partial<
+        Pick<ILlmApplication.IOptions<"llama">, "separate">
+      > satisfies Partial<
+        Pick<
+          import("@samchon/openapi").ILlmApplication.IOptions<"llama">,
+          "separate" | "validate"
+        >
+      >),
+      equals: false,
+    },
+  );
+  return application;
+})();
+export const controller = ((): import("@samchon/openapi").ILlmController<
+  "deepseek",
+  IApplication
+> => {
+  const application = {
+    model: "deepseek",
+    options: {
+      reference: true,
+      separate: null,
+    },
+    functions: [
+      {
+        name: "establishCompany",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+          },
+          required: ["company"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/ICompany",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["establishCompany"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["establishCompany"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "createDepartment",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+          },
+          required: ["company", "department"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IDepartment",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["createDepartment"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["createDepartment"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "hire",
+        parameters: {
+          type: "object",
+          properties: {
+            company: {
+              $ref: "#/$defs/ICompany",
+            },
+            department: {
+              $ref: "#/$defs/IDepartment",
+            },
+            employee: {
+              $ref: "#/$defs/IEmployee",
+            },
+          },
+          required: ["company", "department", "employee"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          $ref: "#/$defs/IEmployee",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.company &&
+            null !== input.company &&
+            _io1(input.company) &&
+            "object" === typeof input.department &&
+            null !== input.department &&
+            _io2(input.department) &&
+            "object" === typeof input.employee &&
+            null !== input.employee &&
+            _io3(input.employee);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.company && null !== input.company) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                })) &&
+                _vo1(
+                  input.company,
+                  _path + ".company",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".company",
+                  expected: "ICompany",
+                  value: input.company,
+                }),
+              ((("object" === typeof input.department &&
+                null !== input.department) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                })) &&
+                _vo2(
+                  input.department,
+                  _path + ".department",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".department",
+                  expected: "IDepartment",
+                  value: input.department,
+                }),
+              ((("object" === typeof input.employee &&
+                null !== input.employee) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                })) &&
+                _vo3(
+                  input.employee,
+                  _path + ".employee",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".employee",
+                  expected: "IEmployee",
+                  value: input.employee,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["hire"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["hire"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+      {
+        name: "erase",
+        parameters: {
+          type: "object",
+          properties: {
+            entity: {
+              oneOf: [
+                {
+                  $ref: "#/$defs/ICompany",
+                },
+                {
+                  $ref: "#/$defs/IDepartment",
+                },
+                {
+                  $ref: "#/$defs/IEmployee",
+                },
+              ],
+            },
+          },
+          required: ["entity"],
+          additionalProperties: false,
+          $defs: {
+            ICompany: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                serial: {
+                  type: "number",
+                },
+                name: {
+                  type: "string",
+                },
+                established_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                departments: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "serial",
+                "name",
+                "established_at",
+                "departments",
+              ],
+            },
+            IDepartment: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                code: {
+                  type: "string",
+                },
+                sales: {
+                  type: "number",
+                },
+                created_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+                children: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IDepartment",
+                  },
+                },
+                employees: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/IEmployee",
+                  },
+                },
+              },
+              required: [
+                "id",
+                "code",
+                "sales",
+                "created_at",
+                "children",
+                "employees",
+              ],
+            },
+            IEmployee: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  format: "uuid",
+                },
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "number",
+                },
+                grade: {
+                  type: "number",
+                },
+                employed_at: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+              required: ["id", "name", "age", "grade", "employed_at"],
+            },
+          },
+        },
+        output: {
+          type: "string",
+          format: "uuid",
+        },
+        validate: (() => {
+          const _io0 = (input: any): boolean =>
+            "object" === typeof input.entity &&
+            null !== input.entity &&
+            _iu0(input.entity);
+          const _io1 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "number" === typeof input.serial &&
+            Number.isFinite(input.serial) &&
+            "string" === typeof input.name &&
+            "string" === typeof input.established_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.established_at,
+            ) &&
+            Array.isArray(input.departments) &&
+            input.departments.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            );
+          const _io2 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.code &&
+            "number" === typeof input.sales &&
+            Number.isFinite(input.sales) &&
+            "string" === typeof input.created_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.created_at,
+            ) &&
+            Array.isArray(input.children) &&
+            input.children.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io2(elem),
+            ) &&
+            Array.isArray(input.employees) &&
+            input.employees.every(
+              (elem: any) =>
+                "object" === typeof elem && null !== elem && _io3(elem),
+            );
+          const _io3 = (input: any): boolean =>
+            "string" === typeof input.id &&
+            __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+            "string" === typeof input.name &&
+            "number" === typeof input.age &&
+            Number.isFinite(input.age) &&
+            "number" === typeof input.grade &&
+            Number.isFinite(input.grade) &&
+            "string" === typeof input.employed_at &&
+            __typia_transform__isFormatDateTime._isFormatDateTime(
+              input.employed_at,
+            );
+          const _iu0 = (input: any): any =>
+            (() => {
+              if (undefined !== input.serial) return _io1(input);
+              else if (undefined !== input.code) return _io2(input);
+              else if (undefined !== input.age) return _io3(input);
+              else return false;
+            })();
+          const _vo0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ((("object" === typeof input.entity && null !== input.entity) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                })) &&
+                _vu0(
+                  input.entity,
+                  _path + ".entity",
+                  true && _exceptionable,
+                )) ||
+                _report(_exceptionable, {
+                  path: _path + ".entity",
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input.entity,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo1 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              ("number" === typeof input.serial &&
+                Number.isFinite(input.serial)) ||
+                _report(_exceptionable, {
+                  path: _path + ".serial",
+                  expected: "number",
+                  value: input.serial,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("string" === typeof input.established_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.established_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".established_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.established_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".established_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.established_at,
+                }),
+              ((Array.isArray(input.departments) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                })) &&
+                input.departments
+                  .map(
+                    (elem: any, _index4: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".departments[" + _index4 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".departments[" + _index4 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".departments[" + _index4 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".departments",
+                  expected: "Array<IDepartment>",
+                  value: input.departments,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo2 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.code ||
+                _report(_exceptionable, {
+                  path: _path + ".code",
+                  expected: "string",
+                  value: input.code,
+                }),
+              ("number" === typeof input.sales &&
+                Number.isFinite(input.sales)) ||
+                _report(_exceptionable, {
+                  path: _path + ".sales",
+                  expected: "number",
+                  value: input.sales,
+                }),
+              ("string" === typeof input.created_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.created_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".created_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.created_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".created_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.created_at,
+                }),
+              ((Array.isArray(input.children) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                })) &&
+                input.children
+                  .map(
+                    (elem: any, _index5: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".children[" + _index5 + "]",
+                          expected: "IDepartment",
+                          value: elem,
+                        })) &&
+                        _vo2(
+                          elem,
+                          _path + ".children[" + _index5 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".children[" + _index5 + "]",
+                        expected: "IDepartment",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".children",
+                  expected: "Array<IDepartment>",
+                  value: input.children,
+                }),
+              ((Array.isArray(input.employees) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                })) &&
+                input.employees
+                  .map(
+                    (elem: any, _index6: number) =>
+                      ((("object" === typeof elem && null !== elem) ||
+                        _report(_exceptionable, {
+                          path: _path + ".employees[" + _index6 + "]",
+                          expected: "IEmployee",
+                          value: elem,
+                        })) &&
+                        _vo3(
+                          elem,
+                          _path + ".employees[" + _index6 + "]",
+                          true && _exceptionable,
+                        )) ||
+                      _report(_exceptionable, {
+                        path: _path + ".employees[" + _index6 + "]",
+                        expected: "IEmployee",
+                        value: elem,
+                      }),
+                  )
+                  .every((flag: boolean) => flag)) ||
+                _report(_exceptionable, {
+                  path: _path + ".employees",
+                  expected: "Array<IEmployee>",
+                  value: input.employees,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vo3 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): boolean =>
+            [
+              ("string" === typeof input.id &&
+                (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+                  _report(_exceptionable, {
+                    path: _path + ".id",
+                    expected: 'string & Format<"uuid">',
+                    value: input.id,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".id",
+                  expected: '(string & Format<"uuid">)',
+                  value: input.id,
+                }),
+              "string" === typeof input.name ||
+                _report(_exceptionable, {
+                  path: _path + ".name",
+                  expected: "string",
+                  value: input.name,
+                }),
+              ("number" === typeof input.age && Number.isFinite(input.age)) ||
+                _report(_exceptionable, {
+                  path: _path + ".age",
+                  expected: "number",
+                  value: input.age,
+                }),
+              ("number" === typeof input.grade &&
+                Number.isFinite(input.grade)) ||
+                _report(_exceptionable, {
+                  path: _path + ".grade",
+                  expected: "number",
+                  value: input.grade,
+                }),
+              ("string" === typeof input.employed_at &&
+                (__typia_transform__isFormatDateTime._isFormatDateTime(
+                  input.employed_at,
+                ) ||
+                  _report(_exceptionable, {
+                    path: _path + ".employed_at",
+                    expected: 'string & Format<"date-time">',
+                    value: input.employed_at,
+                  }))) ||
+                _report(_exceptionable, {
+                  path: _path + ".employed_at",
+                  expected: '(string & Format<"date-time">)',
+                  value: input.employed_at,
+                }),
+            ].every((flag: boolean) => flag);
+          const _vu0 = (
+            input: any,
+            _path: string,
+            _exceptionable: boolean = true,
+          ): any =>
+            (() => {
+              if (undefined !== input.serial)
+                return _vo1(input, _path, true && _exceptionable);
+              else if (undefined !== input.code)
+                return _vo2(input, _path, true && _exceptionable);
+              else if (undefined !== input.age)
+                return _vo3(input, _path, true && _exceptionable);
+              else
+                return _report(_exceptionable, {
+                  path: _path,
+                  expected: "(ICompany | IDepartment | IEmployee)",
+                  value: input,
+                });
+            })();
+          const __is = (
+            input: any,
+          ): input is Parameters<IApplication["erase"]>[0] =>
+            "object" === typeof input && null !== input && _io0(input);
+          let errors: any;
+          let _report: any;
+          return (
+            input: any,
+          ): import("typia").IValidation<
+            Parameters<IApplication["erase"]>[0]
+          > => {
+            if (false === __is(input)) {
+              errors = [];
+              _report = (
+                __typia_transform__validateReport._validateReport as any
+              )(errors);
+              ((input: any, _path: string, _exceptionable: boolean = true) =>
+                ((("object" === typeof input && null !== input) ||
+                  _report(true, {
+                    path: _path + "",
+                    expected: "__type",
+                    value: input,
+                  })) &&
+                  _vo0(input, _path + "", true)) ||
+                _report(true, {
+                  path: _path + "",
+                  expected: "__type",
+                  value: input,
+                }))(input, "$input", true);
+              const success = 0 === errors.length;
+              return success
+                ? {
+                    success,
+                    data: input,
+                  }
+                : ({
+                    success,
+                    errors,
+                    data: input,
+                  } as any);
+            }
+            return {
+              success: true,
+              data: input,
+            } as any;
+          };
+        })(),
+      },
+    ],
+  } as import("@samchon/openapi").ILlmApplication<"deepseek">;
+  return {
+    protocol: "class",
+    name: "company",
+    execute: {
+      establishCompany: (props: { company: ICompany }) => props.company,
+      createDepartment: (props: {
+        company: ICompany;
+        department: IDepartment;
+      }) => props.department,
+      hire: async (props: {
+        company: ICompany;
+        department: IDepartment;
+        employee: IEmployee;
+      }) => props.employee,
+      erase: async (props: { entity: ICompany | IDepartment | IEmployee }) =>
+        props.entity.id,
+    },
+    application,
+  };
+})();
+export interface IApplication {
+  establishCompany(props: { company: ICompany }): ICompany;
+  createDepartment(props: {
+    company: ICompany;
+    department: IDepartment;
+  }): IDepartment;
+  hire(props: {
+    company: ICompany;
+    department: IDepartment;
+    employee: IEmployee;
+  }): Promise<IEmployee>;
+  erase(props: {
+    entity: ICompany | IDepartment | IEmployee;
+  }): Promise<string & tags.Format<"uuid">>;
+}
+export interface ICompany {
+  id: string & tags.Format<"uuid">;
+  serial: number;
+  name: string;
+  established_at: string & tags.Format<"date-time">;
+  departments: IDepartment[];
+}
+export interface IDepartment {
+  id: string & tags.Format<"uuid">;
+  code: string;
+  sales: number;
+  created_at: string & tags.Format<"date-time">;
+  children: IDepartment[];
+  employees: IEmployee[];
+}
+export interface IEmployee {
+  id: string & tags.Format<"uuid">;
+  name: string;
+  age: number;
+  grade: number;
+  employed_at: string & tags.Format<"date-time">;
+}

--- a/test/generate/output/generate_misc.ts
+++ b/test/generate/output/generate_misc.ts
@@ -1,21 +1,1227 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ICitizen {
-    id: string & tags.Format<"uuid">;
-    name: string & tags.Pattern<"^[A-Z][a-z]+$">;
-    email: string & tags.Format<"email">;
-    age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
-    motto: string;
-    birthdate: Date;
-    died_at: null | Date;
-    parent: ICitizen | null;
-    children: ICitizen[];
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
 }
-export const createClone = typia.misc.createClone<ICitizen>();
-export const createAssertClone = typia.misc.createAssertClone<ICitizen>();
-export const createIsClone = typia.misc.createIsClone<ICitizen>();
-export const createValidateClone = typia.misc.createValidateClone<ICitizen>();
-export const createPrune = typia.misc.createPrune<ICitizen>();
-export const createAssertPrune = typia.misc.createAssertPrune<ICitizen>();
-export const createIsPrune = typia.misc.createIsPrune<ICitizen>();
-export const createValidatePrune = typia.misc.createValidatePrune<ICitizen>();
-export const literals = typia.misc.literals<false | 1 | "two">();
+export const createClone = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  return (input: ICitizen): import("typia").Resolved<ICitizen> =>
+    _co0(input) as any;
+})();
+export const createAssertClone = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.misc.createAssertClone",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.misc.createAssertClone",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertClone",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.misc.createAssertClone",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.misc.createAssertClone",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").Resolved<ICitizen> =>
+    __clone(__assert(input, errorFactory));
+})();
+export const createIsClone = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
+    _co0(input) as any;
+  return (input: any): import("typia").Resolved<ICitizen> | null => {
+    if (!__is(input)) return null;
+    return __clone(input);
+  };
+})();
+export const createValidateClone = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __clone = (input: ICitizen): import("typia").Resolved<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+  ): import("typia").IValidation<import("typia").Resolved<ICitizen>> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __clone(input);
+    return result;
+  };
+})();
+export const createPrune = (() => {
+  const _pp0 = (input: any) =>
+    input.forEach((elem: any) => {
+      if ("object" === typeof elem && null !== elem) _po0(elem);
+    });
+  const _po0 = (input: any): any => {
+    if ("object" === typeof input.parent && null !== input.parent)
+      _po0(input.parent);
+    if (Array.isArray(input.children)) _pp0(input.children);
+    for (const key of Object.keys(input)) {
+      if (
+        "id" === key ||
+        "name" === key ||
+        "email" === key ||
+        "age" === key ||
+        "motto" === key ||
+        "birthdate" === key ||
+        "died_at" === key ||
+        "parent" === key ||
+        "children" === key
+      )
+        continue;
+      delete input[key];
+    }
+  };
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  return (input: ICitizen): void => {
+    if ("object" === typeof input && null !== input) _po0(input);
+  };
+})();
+export const createAssertPrune = (() => {
+  const _pp0 = (input: any) =>
+    input.forEach((elem: any) => {
+      if ("object" === typeof elem && null !== elem) _po0(elem);
+    });
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.misc.createAssertPrune",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.misc.createAssertPrune",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.misc.createAssertPrune",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _po0 = (input: any): any => {
+    if ("object" === typeof input.parent && null !== input.parent)
+      _po0(input.parent);
+    if (Array.isArray(input.children)) _pp0(input.children);
+    for (const key of Object.keys(input)) {
+      if (
+        "id" === key ||
+        "name" === key ||
+        "email" === key ||
+        "age" === key ||
+        "motto" === key ||
+        "birthdate" === key ||
+        "died_at" === key ||
+        "parent" === key ||
+        "children" === key
+      )
+        continue;
+      delete input[key];
+    }
+  };
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.misc.createAssertPrune",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.misc.createAssertPrune",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __prune = (input: ICitizen): void => {
+    if ("object" === typeof input && null !== input) _po0(input);
+  };
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    input = __assert(input, errorFactory);
+    __prune(input);
+    return input;
+  };
+})();
+export const createIsPrune = (() => {
+  const _pp0 = (input: any) =>
+    input.forEach((elem: any) => {
+      if ("object" === typeof elem && null !== elem) _po0(elem);
+    });
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _po0 = (input: any): any => {
+    if ("object" === typeof input.parent && null !== input.parent)
+      _po0(input.parent);
+    if (Array.isArray(input.children)) _pp0(input.children);
+    for (const key of Object.keys(input)) {
+      if (
+        "id" === key ||
+        "name" === key ||
+        "email" === key ||
+        "age" === key ||
+        "motto" === key ||
+        "birthdate" === key ||
+        "died_at" === key ||
+        "parent" === key ||
+        "children" === key
+      )
+        continue;
+      delete input[key];
+    }
+  };
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __prune = (input: ICitizen): void => {
+    if ("object" === typeof input && null !== input) _po0(input);
+  };
+  return (input: any): input is ICitizen => {
+    if (false == __is(input)) return false;
+    __prune(input);
+    return true;
+  };
+})();
+export const createValidatePrune = (() => {
+  const _pp0 = (input: any) =>
+    input.forEach((elem: any) => {
+      if ("object" === typeof elem && null !== elem) _po0(elem);
+    });
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _po0 = (input: any): any => {
+    if ("object" === typeof input.parent && null !== input.parent)
+      _po0(input.parent);
+    if (Array.isArray(input.children)) _pp0(input.children);
+    for (const key of Object.keys(input)) {
+      if (
+        "id" === key ||
+        "name" === key ||
+        "email" === key ||
+        "age" === key ||
+        "motto" === key ||
+        "birthdate" === key ||
+        "died_at" === key ||
+        "parent" === key ||
+        "children" === key
+      )
+        continue;
+      delete input[key];
+    }
+  };
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __prune = (input: ICitizen): void => {
+    if ("object" === typeof input && null !== input) _po0(input);
+  };
+  return (input: any): import("typia").IValidation<ICitizen> => {
+    const result = __validate(input);
+    if (result.success) __prune(input);
+    return result;
+  };
+})();
+export const literals = [false, 1, "two"] as const;

--- a/test/generate/output/generate_notations.ts
+++ b/test/generate/output/generate_notations.ts
@@ -1,24 +1,1686 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ICitizen {
-    id: string & tags.Format<"uuid">;
-    name: string & tags.Pattern<"^[A-Z][a-z]+$">;
-    email: string & tags.Format<"email">;
-    age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
-    motto: string;
-    birthdate: Date;
-    died_at: null | Date;
-    parent: ICitizen | null;
-    children: ICitizen[];
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
 }
-export const createCamel = typia.notations.createCamel<ICitizen>();
-export const createAssertCamel = typia.notations.createAssertCamel<ICitizen>();
-export const createIsCamel = typia.notations.createIsCamel<ICitizen>();
-export const createValidateCamel = typia.notations.createValidateCamel<ICitizen>();
-export const createPascal = typia.notations.createPascal<ICitizen>();
-export const createAssertPascal = typia.notations.createAssertPascal<ICitizen>();
-export const createIsPascal = typia.notations.createIsPascal<ICitizen>();
-export const createValidatePascal = typia.notations.createValidatePascal<ICitizen>();
-export const createSnake = typia.notations.createSnake<ICitizen>();
-export const createAssertSnake = typia.notations.createAssertSnake<ICitizen>();
-export const createIsSnake = typia.notations.createIsSnake<ICitizen>();
-export const createValidateSnake = typia.notations.createValidateSnake<ICitizen>();
+export const createCamel = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    diedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  return (input: ICitizen): import("typia").CamelCase<ICitizen> =>
+    _co0(input) as any;
+})();
+export const createAssertCamel = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.notations.createAssertCamel",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.notations.createAssertCamel",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertCamel",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    diedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.notations.createAssertCamel",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.notations.createAssertCamel",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __notation = (input: ICitizen): import("typia").CamelCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").CamelCase<ICitizen> =>
+    __notation(__assert(input, errorFactory));
+})();
+export const createIsCamel = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    diedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __notation = (input: ICitizen): import("typia").CamelCase<ICitizen> =>
+    _co0(input) as any;
+  return (input: any): import("typia").CamelCase<ICitizen> | null => {
+    if (!__is(input)) return null;
+    return __notation(input);
+  };
+})();
+export const createValidateCamel = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    diedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __notation = (input: ICitizen): import("typia").CamelCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+  ): import("typia").IValidation<import("typia").CamelCase<ICitizen>> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __notation(input);
+    return result as any;
+  };
+})();
+export const createPascal = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _co0 = (input: any): any => ({
+    Id: input.id,
+    Name: input.name,
+    Email: input.email,
+    Age: input.age,
+    Motto: input.motto,
+    Birthdate: new Date(input.birthdate) as any,
+    DiedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    Parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    Children: _cp0(input.children) as any,
+  });
+  return (input: ICitizen): import("typia").PascalCase<ICitizen> =>
+    _co0(input) as any;
+})();
+export const createAssertPascal = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.notations.createAssertPascal",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.notations.createAssertPascal",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertPascal",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _co0 = (input: any): any => ({
+    Id: input.id,
+    Name: input.name,
+    Email: input.email,
+    Age: input.age,
+    Motto: input.motto,
+    Birthdate: new Date(input.birthdate) as any,
+    DiedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    Parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    Children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.notations.createAssertPascal",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.notations.createAssertPascal",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __notation = (input: ICitizen): import("typia").PascalCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").PascalCase<ICitizen> =>
+    __notation(__assert(input, errorFactory));
+})();
+export const createIsPascal = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _co0 = (input: any): any => ({
+    Id: input.id,
+    Name: input.name,
+    Email: input.email,
+    Age: input.age,
+    Motto: input.motto,
+    Birthdate: new Date(input.birthdate) as any,
+    DiedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    Parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    Children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __notation = (input: ICitizen): import("typia").PascalCase<ICitizen> =>
+    _co0(input) as any;
+  return (input: any): import("typia").PascalCase<ICitizen> | null => {
+    if (!__is(input)) return null;
+    return __notation(input);
+  };
+})();
+export const createValidatePascal = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _co0 = (input: any): any => ({
+    Id: input.id,
+    Name: input.name,
+    Email: input.email,
+    Age: input.age,
+    Motto: input.motto,
+    Birthdate: new Date(input.birthdate) as any,
+    DiedAt: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    Parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    Children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __notation = (input: ICitizen): import("typia").PascalCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+  ): import("typia").IValidation<import("typia").PascalCase<ICitizen>> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __notation(input);
+    return result as any;
+  };
+})();
+export const createSnake = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  return (input: ICitizen): import("typia").SnakeCase<ICitizen> =>
+    _co0(input) as any;
+})();
+export const createAssertSnake = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.notations.createAssertSnake",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.notations.createAssertSnake",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.notations.createAssertSnake",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.notations.createAssertSnake",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.notations.createAssertSnake",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __notation = (input: ICitizen): import("typia").SnakeCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").SnakeCase<ICitizen> =>
+    __notation(__assert(input, errorFactory));
+})();
+export const createIsSnake = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __notation = (input: ICitizen): import("typia").SnakeCase<ICitizen> =>
+    _co0(input) as any;
+  return (input: any): import("typia").SnakeCase<ICitizen> | null => {
+    if (!__is(input)) return null;
+    return __notation(input);
+  };
+})();
+export const createValidateSnake = (() => {
+  const _cp0 = (input: any) => input.map((elem: any) => _co0(elem) as any);
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const _co0 = (input: any): any => ({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    age: input.age,
+    motto: input.motto,
+    birthdate: new Date(input.birthdate) as any,
+    died_at: input.died_at ? new Date(input.died_at) : (input.died_at as any),
+    parent: input.parent ? _co0(input.parent) : (input.parent as any),
+    children: _cp0(input.children) as any,
+  });
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<ICitizen> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "ICitizen",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __notation = (input: ICitizen): import("typia").SnakeCase<ICitizen> =>
+    _co0(input) as any;
+  return (
+    input: any,
+  ): import("typia").IValidation<import("typia").SnakeCase<ICitizen>> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __notation(input);
+    return result as any;
+  };
+})();

--- a/test/generate/output/generate_plain.ts
+++ b/test/generate/output/generate_plain.ts
@@ -1,21 +1,1797 @@
 import { tags } from "typia";
+import * as __typia_transform__accessExpressionAsString from "typia/lib/internal/_accessExpressionAsString.js";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__createStandardSchema from "typia/lib/internal/_createStandardSchema.js";
+import * as __typia_transform__isFormatEmail from "typia/lib/internal/_isFormatEmail.js";
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__randomArray from "typia/lib/internal/_randomArray.js";
+import * as __typia_transform__randomFormatDatetime from "typia/lib/internal/_randomFormatDatetime.js";
+import * as __typia_transform__randomFormatEmail from "typia/lib/internal/_randomFormatEmail.js";
+import * as __typia_transform__randomFormatUuid from "typia/lib/internal/_randomFormatUuid.js";
+import * as __typia_transform__randomInteger from "typia/lib/internal/_randomInteger.js";
+import * as __typia_transform__randomPattern from "typia/lib/internal/_randomPattern.js";
+import * as __typia_transform__randomPick from "typia/lib/internal/_randomPick.js";
+import * as __typia_transform__randomString from "typia/lib/internal/_randomString.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface ICitizen {
-    id: string & tags.Format<"uuid">;
-    name: string & tags.Pattern<"^[A-Z][a-z]+$">;
-    email: string & tags.Format<"email">;
-    age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
-    motto: string;
-    birthdate: Date;
-    died_at: null | Date;
-    parent: ICitizen | null;
-    children: ICitizen[];
+  id: string & tags.Format<"uuid">;
+  name: string & tags.Pattern<"^[A-Z][a-z]+$">;
+  email: string & tags.Format<"email">;
+  age: number & tags.Type<"uint32"> & tags.ExclusiveMaximum<100>;
+  motto: string;
+  birthdate: Date;
+  died_at: null | Date;
+  parent: ICitizen | null;
+  children: ICitizen[];
 }
-export const createIs = typia.createIs<ICitizen>();
-export const createEquals = typia.createEquals<ICitizen>();
-export const createAssert = typia.createAssert<ICitizen>();
-export const createAssertEquals = typia.createAssertEquals<ICitizen>();
-export const createAssertGuard = typia.createAssertGuard<ICitizen>();
-export const createAssertGuardEquals = typia.createAssertGuardEquals<ICitizen>();
-export const createValidate = typia.createValidate<ICitizen>();
-export const createValidateEquals = typia.createValidateEquals<ICitizen>();
-export const createRandom = typia.createRandom<ICitizen>();
+export const createIs = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  return (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+})();
+export const createEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  return (input: any, _exceptionable: boolean = true): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+})();
+export const createAssert = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssert",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssert",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssert",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssert",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssert",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssert",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+})();
+export const createAssertEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+})();
+export const createAssertGuard = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuard",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuard",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      ));
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuard",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuard",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+  };
+})();
+export const createAssertGuardEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.id &&
+      (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.name &&
+      (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (("string" === typeof input.email &&
+      (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.age &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          },
+          _errorFactory,
+        )) &&
+      (input.age < 100 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        },
+        _errorFactory,
+      )) &&
+    ("string" === typeof input.motto ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        },
+        _errorFactory,
+      )) &&
+    (input.birthdate instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.died_at ||
+      input.died_at instanceof Date ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.parent ||
+      ((("object" === typeof input.parent && null !== input.parent) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          },
+          _errorFactory,
+        )) &&
+        _ao0(input.parent, _path + ".parent", true && _exceptionable)) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        },
+        _errorFactory,
+      )) &&
+    (((Array.isArray(input.children) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+      input.children.every(
+        (elem: any, _index2: number) =>
+          ((("object" === typeof elem && null !== elem) ||
+            __typia_transform__assertGuard._assertGuard(
+              _exceptionable,
+              {
+                method: "typia.createAssertGuardEquals",
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              },
+              _errorFactory,
+            )) &&
+            _ao0(
+              elem,
+              _path + ".children[" + _index2 + "]",
+              true && _exceptionable,
+            )) ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + ".children[" + _index2 + "]",
+              expected: "ICitizen",
+              value: elem,
+            },
+            _errorFactory,
+          ),
+      )) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.createAssertGuardEquals",
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        },
+        _errorFactory,
+      )) &&
+    (9 === Object.keys(input).length ||
+      false === _exceptionable ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.createAssertGuardEquals",
+            path:
+              _path +
+              __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                key,
+              ),
+            expected: "undefined",
+            value: value,
+          },
+          _errorFactory,
+        );
+      }));
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let _errorFactory: any;
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): asserts input is ICitizen => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.createAssertGuardEquals",
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.createAssertGuardEquals",
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+  };
+})();
+export const createValidate = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any) => "object" === typeof elem && null !== elem && _io0(elem),
+    );
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+    ].every((flag: boolean) => flag);
+  const __is = (input: any): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  return __typia_transform__createStandardSchema._createStandardSchema(
+    (input: any): import("typia").IValidation<ICitizen> => {
+      if (false === __is(input)) {
+        errors = [];
+        _report = (__typia_transform__validateReport._validateReport as any)(
+          errors,
+        );
+        ((input: any, _path: string, _exceptionable: boolean = true) =>
+          ((("object" === typeof input && null !== input) ||
+            _report(true, {
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            })) &&
+            _vo0(input, _path + "", true)) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          }))(input, "$input", true);
+        const success = 0 === errors.length;
+        return success
+          ? {
+              success,
+              data: input,
+            }
+          : ({
+              success,
+              errors,
+              data: input,
+            } as any);
+      }
+      return {
+        success: true,
+        data: input,
+      } as any;
+    },
+  );
+})();
+export const createValidateEquals = (() => {
+  const _io0 = (input: any, _exceptionable: boolean = true): boolean =>
+    "string" === typeof input.id &&
+    __typia_transform__isFormatUuid._isFormatUuid(input.id) &&
+    "string" === typeof input.name &&
+    RegExp("^[A-Z][a-z]+$").test(input.name) &&
+    "string" === typeof input.email &&
+    __typia_transform__isFormatEmail._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.age) &&
+    input.age < 100 &&
+    "string" === typeof input.motto &&
+    input.birthdate instanceof Date &&
+    (null === input.died_at || input.died_at instanceof Date) &&
+    (null === input.parent ||
+      ("object" === typeof input.parent &&
+        null !== input.parent &&
+        _io0(input.parent, true && _exceptionable))) &&
+    Array.isArray(input.children) &&
+    input.children.every(
+      (elem: any, _index1: number) =>
+        "object" === typeof elem &&
+        null !== elem &&
+        _io0(elem, true && _exceptionable),
+    ) &&
+    (9 === Object.keys(input).length ||
+      Object.keys(input).every((key: any) => {
+        if (
+          [
+            "id",
+            "name",
+            "email",
+            "age",
+            "motto",
+            "birthdate",
+            "died_at",
+            "parent",
+            "children",
+          ].some((prop: any) => key === prop)
+        )
+          return true;
+        const value = input[key];
+        if (undefined === value) return true;
+        return false;
+      }));
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.id &&
+        (__typia_transform__isFormatUuid._isFormatUuid(input.id) ||
+          _report(_exceptionable, {
+            path: _path + ".id",
+            expected: 'string & Format<"uuid">',
+            value: input.id,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".id",
+          expected: '(string & Format<"uuid">)',
+          value: input.id,
+        }),
+      ("string" === typeof input.name &&
+        (RegExp("^[A-Z][a-z]+$").test(input.name) ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: 'string & Pattern<"^[A-Z][a-z]+$">',
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: '(string & Pattern<"^[A-Z][a-z]+$">)',
+          value: input.name,
+        }),
+      ("string" === typeof input.email &&
+        (__typia_transform__isFormatEmail._isFormatEmail(input.email) ||
+          _report(_exceptionable, {
+            path: _path + ".email",
+            expected: 'string & Format<"email">',
+            value: input.email,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".email",
+          expected: '(string & Format<"email">)',
+          value: input.email,
+        }),
+      ("number" === typeof input.age &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.age) ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: 'number & Type<"uint32">',
+            value: input.age,
+          })) &&
+        (input.age < 100 ||
+          _report(_exceptionable, {
+            path: _path + ".age",
+            expected: "number & ExclusiveMaximum<100>",
+            value: input.age,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".age",
+          expected: '(number & Type<"uint32"> & ExclusiveMaximum<100>)',
+          value: input.age,
+        }),
+      "string" === typeof input.motto ||
+        _report(_exceptionable, {
+          path: _path + ".motto",
+          expected: "string",
+          value: input.motto,
+        }),
+      input.birthdate instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".birthdate",
+          expected: "Date",
+          value: input.birthdate,
+        }),
+      null === input.died_at ||
+        input.died_at instanceof Date ||
+        _report(_exceptionable, {
+          path: _path + ".died_at",
+          expected: "(Date | null)",
+          value: input.died_at,
+        }),
+      null === input.parent ||
+        ((("object" === typeof input.parent && null !== input.parent) ||
+          _report(_exceptionable, {
+            path: _path + ".parent",
+            expected: "(ICitizen | null)",
+            value: input.parent,
+          })) &&
+          _vo0(input.parent, _path + ".parent", true && _exceptionable)) ||
+        _report(_exceptionable, {
+          path: _path + ".parent",
+          expected: "(ICitizen | null)",
+          value: input.parent,
+        }),
+      ((Array.isArray(input.children) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        })) &&
+        input.children
+          .map(
+            (elem: any, _index2: number) =>
+              ((("object" === typeof elem && null !== elem) ||
+                _report(_exceptionable, {
+                  path: _path + ".children[" + _index2 + "]",
+                  expected: "ICitizen",
+                  value: elem,
+                })) &&
+                _vo0(
+                  elem,
+                  _path + ".children[" + _index2 + "]",
+                  true && _exceptionable,
+                )) ||
+              _report(_exceptionable, {
+                path: _path + ".children[" + _index2 + "]",
+                expected: "ICitizen",
+                value: elem,
+              }),
+          )
+          .every((flag: boolean) => flag)) ||
+        _report(_exceptionable, {
+          path: _path + ".children",
+          expected: "Array<ICitizen>",
+          value: input.children,
+        }),
+      9 === Object.keys(input).length ||
+        false === _exceptionable ||
+        Object.keys(input)
+          .map((key: any) => {
+            if (
+              [
+                "id",
+                "name",
+                "email",
+                "age",
+                "motto",
+                "birthdate",
+                "died_at",
+                "parent",
+                "children",
+              ].some((prop: any) => key === prop)
+            )
+              return true;
+            const value = input[key];
+            if (undefined === value) return true;
+            return _report(_exceptionable, {
+              path:
+                _path +
+                __typia_transform__accessExpressionAsString._accessExpressionAsString(
+                  key,
+                ),
+              expected: "undefined",
+              value: value,
+              description: [
+                `The property \`${key}\` is not defined in the object type.`,
+                "",
+                "Please remove the property next time.",
+              ].join("\n"),
+            });
+          })
+          .every((flag: boolean) => flag),
+    ].every((flag: boolean) => flag);
+  const __is = (
+    input: any,
+    _exceptionable: boolean = true,
+  ): input is ICitizen =>
+    "object" === typeof input && null !== input && _io0(input, true);
+  let errors: any;
+  let _report: any;
+  return __typia_transform__createStandardSchema._createStandardSchema(
+    (input: any): import("typia").IValidation<ICitizen> => {
+      if (false === __is(input)) {
+        errors = [];
+        _report = (__typia_transform__validateReport._validateReport as any)(
+          errors,
+        );
+        ((input: any, _path: string, _exceptionable: boolean = true) =>
+          ((("object" === typeof input && null !== input) ||
+            _report(true, {
+              path: _path + "",
+              expected: "ICitizen",
+              value: input,
+            })) &&
+            _vo0(input, _path + "", true)) ||
+          _report(true, {
+            path: _path + "",
+            expected: "ICitizen",
+            value: input,
+          }))(input, "$input", true);
+        const success = 0 === errors.length;
+        return success
+          ? {
+              success,
+              data: input,
+            }
+          : ({
+              success,
+              errors,
+              data: input,
+            } as any);
+      }
+      return {
+        success: true,
+        data: input,
+      } as any;
+    },
+  );
+})();
+export const createRandom = (() => {
+  const _ro0 = (_recursive: boolean = true, _depth: number = 0): any => ({
+    id: (
+      _generator?.uuid ?? __typia_transform__randomFormatUuid._randomFormatUuid
+    )(),
+    name: (
+      _generator?.pattern ?? __typia_transform__randomPattern._randomPattern
+    )(new RegExp("^[A-Z][a-z]+$")),
+    email: (
+      _generator?.email ??
+      __typia_transform__randomFormatEmail._randomFormatEmail
+    )(),
+    age: (
+      _generator?.integer ?? __typia_transform__randomInteger._randomInteger
+    )({
+      type: "integer",
+      minimum: 0,
+      exclusiveMaximum: 100,
+    }),
+    motto: (
+      _generator?.string ?? __typia_transform__randomString._randomString
+    )({
+      type: "string",
+    }),
+    birthdate: new Date(
+      (
+        _generator?.datetime ??
+        __typia_transform__randomFormatDatetime._randomFormatDatetime
+      )(),
+    ),
+    died_at: __typia_transform__randomPick._randomPick([
+      () => null,
+      () =>
+        new Date(
+          (
+            _generator?.datetime ??
+            __typia_transform__randomFormatDatetime._randomFormatDatetime
+          )(),
+        ),
+    ])(),
+    parent: __typia_transform__randomPick._randomPick([
+      () => null,
+      () => _ro0(true, _recursive ? 1 + _depth : _depth),
+    ])(),
+    children:
+      5 >= _depth
+        ? (_generator?.array ?? __typia_transform__randomArray._randomArray)({
+            type: "array",
+            element: () => _ro0(true, _recursive ? 1 + _depth : _depth),
+          })
+        : [],
+  });
+  let _generator: Partial<import("typia").IRandomGenerator> | undefined;
+  return (
+    generator?: Partial<import("typia").IRandomGenerator>,
+  ): import("typia").Resolved<ICitizen> => {
+    _generator = generator;
+    return _ro0();
+  };
+})();

--- a/test/generate/output/generate_protobuf.ts
+++ b/test/generate/output/generate_protobuf.ts
@@ -1,15 +1,898 @@
-import typia, { tags } from "typia";
+import { tags } from "typia";
+import * as __typia_transform__ProtobufReader from "typia/lib/internal/_ProtobufReader.js";
+import * as __typia_transform__ProtobufSizer from "typia/lib/internal/_ProtobufSizer.js";
+import * as __typia_transform__ProtobufWriter from "typia/lib/internal/_ProtobufWriter.js";
+import * as __typia_transform__assertGuard from "typia/lib/internal/_assertGuard.js";
+import * as __typia_transform__isTypeUint32 from "typia/lib/internal/_isTypeUint32.js";
+import * as __typia_transform__validateReport from "typia/lib/internal/_validateReport.js";
+
 interface IFile {
-    name: string & tags.MaxLength<8>;
-    extension: null | (string & tags.MinLength<1> & tags.MaxLength<3>);
-    size: number & tags.Type<"uint32">;
-    data: Uint8Array;
+  name: string & tags.MaxLength<8>;
+  extension: null | (string & tags.MinLength<1> & tags.MaxLength<3>);
+  size: number & tags.Type<"uint32">;
+  data: Uint8Array;
 }
-export const createEncode = typia.protobuf.createEncode<IFile>();
-export const createAssertEncode = typia.protobuf.createAssertEncode<IFile>();
-export const createIsEncode = typia.protobuf.createIsEncode<IFile>();
-export const createValidateEncode = typia.protobuf.createValidateEncode<IFile>();
-export const createDecode = typia.protobuf.createDecode<IFile>();
-export const createAssertDecode = typia.protobuf.createAssertDecode<IFile>();
-export const createIsDecode = typia.protobuf.createIsDecode<IFile>();
-export const createValidateDecode = typia.protobuf.createValidateDecode<IFile>();
+export const createEncode = (() => {
+  const encoder = <
+    Writer extends
+      import("typia/lib/internal/_IProtobufWriter.js")._IProtobufWriter,
+  >(
+    writer: Writer,
+    input: any,
+  ): Writer => {
+    const _peo0 = (input: any): any => {
+      // property "name": (string & MaxLength<8>);
+      writer.uint32(10);
+      writer.string(input.name);
+      // property "extension": ((string & MinLength<1> & MaxLength<3>) | null);
+      if (null !== input.extension) {
+        writer.uint32(18);
+        writer.string(input.extension);
+      }
+      // property "size": (number & Type<"uint32">);
+      writer.uint32(24);
+      writer.uint32(input.size);
+      // property "data": Uint8Array;
+      writer.uint32(34);
+      writer.bytes(input.data);
+    };
+    _peo0(input);
+    return writer;
+  };
+  return (input: IFile): Uint8Array => {
+    const sizer = encoder(
+      new __typia_transform__ProtobufSizer._ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform__ProtobufWriter._ProtobufWriter(sizer),
+      input,
+    );
+    return writer.buffer();
+  };
+})();
+export const createAssertEncode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.name &&
+      (input.name.length <= 8 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.protobuf.createAssertEncode",
+            path: _path + ".name",
+            expected: "string & MaxLength<8>",
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertEncode",
+          path: _path + ".name",
+          expected: "(string & MaxLength<8>)",
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        (1 <= input.extension.length ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.protobuf.createAssertEncode",
+              path: _path + ".extension",
+              expected: "string & MinLength<1>",
+              value: input.extension,
+            },
+            _errorFactory,
+          )) &&
+        (input.extension.length <= 3 ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.protobuf.createAssertEncode",
+              path: _path + ".extension",
+              expected: "string & MaxLength<3>",
+              value: input.extension,
+            },
+            _errorFactory,
+          ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertEncode",
+          path: _path + ".extension",
+          expected: "((string & MinLength<1> & MaxLength<3>) | null)",
+          value: input.extension,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.size &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.protobuf.createAssertEncode",
+            path: _path + ".size",
+            expected: 'number & Type<"uint32">',
+            value: input.size,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertEncode",
+          path: _path + ".size",
+          expected: '(number & Type<"uint32">)',
+          value: input.size,
+        },
+        _errorFactory,
+      )) &&
+    (input.data instanceof Uint8Array ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertEncode",
+          path: _path + ".data",
+          expected: "Uint8Array",
+          value: input.data,
+        },
+        _errorFactory,
+      ));
+  const encoder = <
+    Writer extends
+      import("typia/lib/internal/_IProtobufWriter.js")._IProtobufWriter,
+  >(
+    writer: Writer,
+    input: any,
+  ): Writer => {
+    const _peo0 = (input: any): any => {
+      // property "name": (string & MaxLength<8>);
+      writer.uint32(10);
+      writer.string(input.name);
+      // property "extension": ((string & MinLength<1> & MaxLength<3>) | null);
+      if (null !== input.extension) {
+        writer.uint32(18);
+        writer.string(input.extension);
+      }
+      // property "size": (number & Type<"uint32">);
+      writer.uint32(24);
+      writer.uint32(input.size);
+      // property "data": Uint8Array;
+      writer.uint32(34);
+      writer.bytes(input.data);
+    };
+    const _io0 = (input: any): boolean =>
+      "string" === typeof input.name &&
+      input.name.length <= 8 &&
+      (null === input.extension ||
+        ("string" === typeof input.extension &&
+          1 <= input.extension.length &&
+          input.extension.length <= 3)) &&
+      "number" === typeof input.size &&
+      __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+      input.data instanceof Uint8Array;
+    _peo0(input);
+    return writer;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): IFile => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.protobuf.createAssertEncode",
+              path: _path + "",
+              expected: "IFile",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.protobuf.createAssertEncode",
+            path: _path + "",
+            expected: "IFile",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __encode = (input: IFile): Uint8Array => {
+    const sizer = encoder(
+      new __typia_transform__ProtobufSizer._ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform__ProtobufWriter._ProtobufWriter(sizer),
+      input,
+    );
+    return writer.buffer();
+  };
+  return (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): Uint8Array => __encode(__assert(input, errorFactory));
+})();
+export const createIsEncode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const encoder = <
+    Writer extends
+      import("typia/lib/internal/_IProtobufWriter.js")._IProtobufWriter,
+  >(
+    writer: Writer,
+    input: any,
+  ): Writer => {
+    const _peo0 = (input: any): any => {
+      // property "name": (string & MaxLength<8>);
+      writer.uint32(10);
+      writer.string(input.name);
+      // property "extension": ((string & MinLength<1> & MaxLength<3>) | null);
+      if (null !== input.extension) {
+        writer.uint32(18);
+        writer.string(input.extension);
+      }
+      // property "size": (number & Type<"uint32">);
+      writer.uint32(24);
+      writer.uint32(input.size);
+      // property "data": Uint8Array;
+      writer.uint32(34);
+      writer.bytes(input.data);
+    };
+    const _io0 = (input: any): boolean =>
+      "string" === typeof input.name &&
+      input.name.length <= 8 &&
+      (null === input.extension ||
+        ("string" === typeof input.extension &&
+          1 <= input.extension.length &&
+          input.extension.length <= 3)) &&
+      "number" === typeof input.size &&
+      __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+      input.data instanceof Uint8Array;
+    _peo0(input);
+    return writer;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __encode = (input: IFile): Uint8Array => {
+    const sizer = encoder(
+      new __typia_transform__ProtobufSizer._ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform__ProtobufWriter._ProtobufWriter(sizer),
+      input,
+    );
+    return writer.buffer();
+  };
+  return (input: any): Uint8Array | null =>
+    __is(input) ? __encode(input) : null;
+})();
+export const createValidateEncode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.name &&
+        (input.name.length <= 8 ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: "string & MaxLength<8>",
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: "(string & MaxLength<8>)",
+          value: input.name,
+        }),
+      null === input.extension ||
+        ("string" === typeof input.extension &&
+          (1 <= input.extension.length ||
+            _report(_exceptionable, {
+              path: _path + ".extension",
+              expected: "string & MinLength<1>",
+              value: input.extension,
+            })) &&
+          (input.extension.length <= 3 ||
+            _report(_exceptionable, {
+              path: _path + ".extension",
+              expected: "string & MaxLength<3>",
+              value: input.extension,
+            }))) ||
+        _report(_exceptionable, {
+          path: _path + ".extension",
+          expected: "((string & MinLength<1> & MaxLength<3>) | null)",
+          value: input.extension,
+        }),
+      ("number" === typeof input.size &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
+          _report(_exceptionable, {
+            path: _path + ".size",
+            expected: 'number & Type<"uint32">',
+            value: input.size,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".size",
+          expected: '(number & Type<"uint32">)',
+          value: input.size,
+        }),
+      input.data instanceof Uint8Array ||
+        _report(_exceptionable, {
+          path: _path + ".data",
+          expected: "Uint8Array",
+          value: input.data,
+        }),
+    ].every((flag: boolean) => flag);
+  const encoder = <
+    Writer extends
+      import("typia/lib/internal/_IProtobufWriter.js")._IProtobufWriter,
+  >(
+    writer: Writer,
+    input: any,
+  ): Writer => {
+    const _peo0 = (input: any): any => {
+      // property "name": (string & MaxLength<8>);
+      writer.uint32(10);
+      writer.string(input.name);
+      // property "extension": ((string & MinLength<1> & MaxLength<3>) | null);
+      if (null !== input.extension) {
+        writer.uint32(18);
+        writer.string(input.extension);
+      }
+      // property "size": (number & Type<"uint32">);
+      writer.uint32(24);
+      writer.uint32(input.size);
+      // property "data": Uint8Array;
+      writer.uint32(34);
+      writer.bytes(input.data);
+    };
+    const _io0 = (input: any): boolean =>
+      "string" === typeof input.name &&
+      input.name.length <= 8 &&
+      (null === input.extension ||
+        ("string" === typeof input.extension &&
+          1 <= input.extension.length &&
+          input.extension.length <= 3)) &&
+      "number" === typeof input.size &&
+      __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+      input.data instanceof Uint8Array;
+    _peo0(input);
+    return writer;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<IFile> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "IFile",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "IFile",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __encode = (input: IFile): Uint8Array => {
+    const sizer = encoder(
+      new __typia_transform__ProtobufSizer._ProtobufSizer(),
+      input,
+    );
+    const writer = encoder(
+      new __typia_transform__ProtobufWriter._ProtobufWriter(sizer),
+      input,
+    );
+    return writer.buffer();
+  };
+  return (input: any): import("typia").IValidation<Uint8Array> => {
+    const result = __validate(input) as any;
+    if (result.success) result.data = __encode(input);
+    return result;
+  };
+})();
+export const createDecode = (() => {
+  const _pdo0 = (reader: any, length: number = -1): any => {
+    length = length < 0 ? reader.size() : reader.index() + length;
+    const output = {
+      name: "" as any,
+      extension: null as any,
+      size: undefined as any,
+      data: new Uint8Array([]) as any,
+    } as any;
+    while (reader.index() < length) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          // string;
+          output.name = reader.string();
+          break;
+        case 2:
+          // string;
+          output.extension = reader.string();
+          break;
+        case 3:
+          // uint32;
+          output.size = reader.uint32();
+          break;
+        case 4:
+          // bytes;
+          output.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return output;
+  };
+  return (input: Uint8Array): import("typia").Resolved<IFile> => {
+    const reader = new __typia_transform__ProtobufReader._ProtobufReader(input);
+    return _pdo0(reader);
+  };
+})();
+export const createAssertDecode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const _ao0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    (("string" === typeof input.name &&
+      (input.name.length <= 8 ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.protobuf.createAssertDecode",
+            path: _path + ".name",
+            expected: "string & MaxLength<8>",
+            value: input.name,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertDecode",
+          path: _path + ".name",
+          expected: "(string & MaxLength<8>)",
+          value: input.name,
+        },
+        _errorFactory,
+      )) &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        (1 <= input.extension.length ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.protobuf.createAssertDecode",
+              path: _path + ".extension",
+              expected: "string & MinLength<1>",
+              value: input.extension,
+            },
+            _errorFactory,
+          )) &&
+        (input.extension.length <= 3 ||
+          __typia_transform__assertGuard._assertGuard(
+            _exceptionable,
+            {
+              method: "typia.protobuf.createAssertDecode",
+              path: _path + ".extension",
+              expected: "string & MaxLength<3>",
+              value: input.extension,
+            },
+            _errorFactory,
+          ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertDecode",
+          path: _path + ".extension",
+          expected: "((string & MinLength<1> & MaxLength<3>) | null)",
+          value: input.extension,
+        },
+        _errorFactory,
+      )) &&
+    (("number" === typeof input.size &&
+      (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
+        __typia_transform__assertGuard._assertGuard(
+          _exceptionable,
+          {
+            method: "typia.protobuf.createAssertDecode",
+            path: _path + ".size",
+            expected: 'number & Type<"uint32">',
+            value: input.size,
+          },
+          _errorFactory,
+        ))) ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertDecode",
+          path: _path + ".size",
+          expected: '(number & Type<"uint32">)',
+          value: input.size,
+        },
+        _errorFactory,
+      )) &&
+    (input.data instanceof Uint8Array ||
+      __typia_transform__assertGuard._assertGuard(
+        _exceptionable,
+        {
+          method: "typia.protobuf.createAssertDecode",
+          path: _path + ".data",
+          expected: "Uint8Array",
+          value: input.data,
+        },
+        _errorFactory,
+      ));
+  const _pdo0 = (reader: any, length: number = -1): any => {
+    length = length < 0 ? reader.size() : reader.index() + length;
+    const output = {
+      name: "" as any,
+      extension: null as any,
+      size: undefined as any,
+      data: new Uint8Array([]) as any,
+    } as any;
+    while (reader.index() < length) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          // string;
+          output.name = reader.string();
+          break;
+        case 2:
+          // string;
+          output.extension = reader.string();
+          break;
+        case 3:
+          // uint32;
+          output.size = reader.uint32();
+          break;
+        case 4:
+          // bytes;
+          output.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return output;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  let _errorFactory: any;
+  const __assert = (
+    input: any,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): IFile => {
+    if (false === __is(input)) {
+      _errorFactory = errorFactory;
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          __typia_transform__assertGuard._assertGuard(
+            true,
+            {
+              method: "typia.protobuf.createAssertDecode",
+              path: _path + "",
+              expected: "IFile",
+              value: input,
+            },
+            _errorFactory,
+          )) &&
+          _ao0(input, _path + "", true)) ||
+        __typia_transform__assertGuard._assertGuard(
+          true,
+          {
+            method: "typia.protobuf.createAssertDecode",
+            path: _path + "",
+            expected: "IFile",
+            value: input,
+          },
+          _errorFactory,
+        ))(input, "$input", true);
+    }
+    return input;
+  };
+  const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
+    const reader = new __typia_transform__ProtobufReader._ProtobufReader(input);
+    return _pdo0(reader);
+  };
+  return (
+    input: Uint8Array,
+    errorFactory?: (p: import("typia").TypeGuardError.IProps) => Error,
+  ): import("typia").Resolved<IFile> => __assert(__decode(input), errorFactory);
+})();
+export const createIsDecode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const _pdo0 = (reader: any, length: number = -1): any => {
+    length = length < 0 ? reader.size() : reader.index() + length;
+    const output = {
+      name: "" as any,
+      extension: null as any,
+      size: undefined as any,
+      data: new Uint8Array([]) as any,
+    } as any;
+    while (reader.index() < length) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          // string;
+          output.name = reader.string();
+          break;
+        case 2:
+          // string;
+          output.extension = reader.string();
+          break;
+        case 3:
+          // uint32;
+          output.size = reader.uint32();
+          break;
+        case 4:
+          // bytes;
+          output.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return output;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
+    const reader = new __typia_transform__ProtobufReader._ProtobufReader(input);
+    return _pdo0(reader);
+  };
+  return (input: Uint8Array): import("typia").Resolved<IFile> | null => {
+    const value = __decode(input);
+    if (!__is(value)) return null;
+    return value;
+  };
+})();
+export const createValidateDecode = (() => {
+  const _io0 = (input: any): boolean =>
+    "string" === typeof input.name &&
+    input.name.length <= 8 &&
+    (null === input.extension ||
+      ("string" === typeof input.extension &&
+        1 <= input.extension.length &&
+        input.extension.length <= 3)) &&
+    "number" === typeof input.size &&
+    __typia_transform__isTypeUint32._isTypeUint32(input.size) &&
+    input.data instanceof Uint8Array;
+  const _vo0 = (
+    input: any,
+    _path: string,
+    _exceptionable: boolean = true,
+  ): boolean =>
+    [
+      ("string" === typeof input.name &&
+        (input.name.length <= 8 ||
+          _report(_exceptionable, {
+            path: _path + ".name",
+            expected: "string & MaxLength<8>",
+            value: input.name,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".name",
+          expected: "(string & MaxLength<8>)",
+          value: input.name,
+        }),
+      null === input.extension ||
+        ("string" === typeof input.extension &&
+          (1 <= input.extension.length ||
+            _report(_exceptionable, {
+              path: _path + ".extension",
+              expected: "string & MinLength<1>",
+              value: input.extension,
+            })) &&
+          (input.extension.length <= 3 ||
+            _report(_exceptionable, {
+              path: _path + ".extension",
+              expected: "string & MaxLength<3>",
+              value: input.extension,
+            }))) ||
+        _report(_exceptionable, {
+          path: _path + ".extension",
+          expected: "((string & MinLength<1> & MaxLength<3>) | null)",
+          value: input.extension,
+        }),
+      ("number" === typeof input.size &&
+        (__typia_transform__isTypeUint32._isTypeUint32(input.size) ||
+          _report(_exceptionable, {
+            path: _path + ".size",
+            expected: 'number & Type<"uint32">',
+            value: input.size,
+          }))) ||
+        _report(_exceptionable, {
+          path: _path + ".size",
+          expected: '(number & Type<"uint32">)',
+          value: input.size,
+        }),
+      input.data instanceof Uint8Array ||
+        _report(_exceptionable, {
+          path: _path + ".data",
+          expected: "Uint8Array",
+          value: input.data,
+        }),
+    ].every((flag: boolean) => flag);
+  const _pdo0 = (reader: any, length: number = -1): any => {
+    length = length < 0 ? reader.size() : reader.index() + length;
+    const output = {
+      name: "" as any,
+      extension: null as any,
+      size: undefined as any,
+      data: new Uint8Array([]) as any,
+    } as any;
+    while (reader.index() < length) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          // string;
+          output.name = reader.string();
+          break;
+        case 2:
+          // string;
+          output.extension = reader.string();
+          break;
+        case 3:
+          // uint32;
+          output.size = reader.uint32();
+          break;
+        case 4:
+          // bytes;
+          output.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return output;
+  };
+  const __is = (input: any): input is IFile =>
+    "object" === typeof input && null !== input && _io0(input);
+  let errors: any;
+  let _report: any;
+  const __validate = (input: any): import("typia").IValidation<IFile> => {
+    if (false === __is(input)) {
+      errors = [];
+      _report = (__typia_transform__validateReport._validateReport as any)(
+        errors,
+      );
+      ((input: any, _path: string, _exceptionable: boolean = true) =>
+        ((("object" === typeof input && null !== input) ||
+          _report(true, {
+            path: _path + "",
+            expected: "IFile",
+            value: input,
+          })) &&
+          _vo0(input, _path + "", true)) ||
+        _report(true, {
+          path: _path + "",
+          expected: "IFile",
+          value: input,
+        }))(input, "$input", true);
+      const success = 0 === errors.length;
+      return success
+        ? {
+            success,
+            data: input,
+          }
+        : ({
+            success,
+            errors,
+            data: input,
+          } as any);
+    }
+    return {
+      success: true,
+      data: input,
+    } as any;
+  };
+  const __decode = (input: Uint8Array): import("typia").Resolved<IFile> => {
+    const reader = new __typia_transform__ProtobufReader._ProtobufReader(input);
+    return _pdo0(reader);
+  };
+  return (
+    input: Uint8Array,
+  ): import("typia").IValidation<import("typia").Resolved<IFile>> =>
+    __validate(__decode(input));
+})();

--- a/test/generate/output/generate_use.ts
+++ b/test/generate/output/generate_use.ts
@@ -1,4 +1,11 @@
 "use strict";
-'use server';
+"use server";
+
 import { tags } from "typia";
-typia.createIs<string & tags.Format<"uuid">>();
+import * as __typia_transform__isFormatUuid from "typia/lib/internal/_isFormatUuid.js";
+
+(() => {
+  return (input: any): input is string & tags.Format<"uuid"> =>
+    "string" === typeof input &&
+    __typia_transform__isFormatUuid._isFormatUuid(input);
+})();


### PR DESCRIPTION
This pull request introduces a patch update to the `typia` package, focusing on improving how unused imports are removed and updating generated output to use internal helpers directly. The most significant changes are a refactor of the `removeUnusedTypiaImports` function for better clarity and maintainability, and updates to generated test files to avoid default imports and use explicit internal helpers.

### Import transformer improvements

- Refactored the `removeUnusedTypiaImports` function in `ImportTransformer.ts` to use clearer variable names, a dedicated `ImportMetadata` interface, and more concise logic for collecting and updating imports. This should make the code easier to follow and maintain.
- Improved the logic for detecting transformable calls and property chains, and made minor formatting and style adjustments for consistency. [[1]](diffhunk://#diff-837877fe1d4f0ca65784db0ea2dff668d8d6f6377174c87fd4bb563609c0726bL205-R217) [[2]](diffhunk://#diff-837877fe1d4f0ca65784db0ea2dff668d8d6f6377174c87fd4bb563609c0726bL225-R245) [[3]](diffhunk://#diff-837877fe1d4f0ca65784db0ea2dff668d8d6f6377174c87fd4bb563609c0726bL246-R256)

### Generated output updates

- Updated `test/generate/output/generate_http.ts` to remove the default `typia` import and instead import only the required named exports and internal helpers. The generated functions now use these helpers directly for parsing, validation, and assertion, resulting in more explicit and modular code.
- Updated `test/generate/output/generate_use.ts` to remove the default `typia` import, import only the necessary named export, and use the internal `_isFormatUuid` helper directly.

### Version bump

- Bumped the package version from `9.7.0` to `9.7.1` in `package.json` to reflect these improvements and fixes.