### PR TITLE
Suppoer transform options in playground website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -58,7 +58,7 @@
     "rimraf": "^5.0.0",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.1",
-    "typedoc": "^0.28.8",
+    "typedoc": "^0.28.9",
     "typescript": "~5.9.2",
     "write-file-webpack-plugin": "^4.5.1"
   }

--- a/website/src/compiler/ICompilerService.ts
+++ b/website/src/compiler/ICompilerService.ts
@@ -1,10 +1,17 @@
+import { ITransformOptions } from "typia/lib/transformers/ITransformOptions";
+
 export interface ICompilerService {
-  compile(source: string): Promise<ICompilerService.IOutput>;
-  transform(source: string): Promise<ICompilerService.IOutput>;
-  bundle(source: string): Promise<ICompilerService.IOutput>;
+  compile(props: ICompilerService.IProps): Promise<ICompilerService.IResult>;
+  transform(props: ICompilerService.IProps): Promise<ICompilerService.IResult>;
+  bundle(props: ICompilerService.IProps): Promise<ICompilerService.IResult>;
 }
 export namespace ICompilerService {
-  export type IOutput = ISuccess | IFailure | IError;
+  export interface IProps {
+    source: string;
+    options?: ITransformOptions;
+  }
+  export type IResult = ISuccess | IFailure | IError;
+
   export interface ISuccess extends IBase<"success", string> {}
   export interface IFailure extends IBase<"failure", string> {
     diagnostics: object[];

--- a/website/src/components/playground/OptionsModal.tsx
+++ b/website/src/components/playground/OptionsModal.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Switch,
+  Typography,
+  Box,
+} from "@mui/material";
+import { ITransformOptions } from "typia/lib/transformers/ITransformOptions";
+
+interface OptionsModalProps {
+  open: boolean;
+  options: ITransformOptions;
+  onClose: () => void;
+  onSave: (options: ITransformOptions) => void;
+}
+
+const OptionsModal: React.FC<OptionsModalProps> = ({
+  open,
+  options,
+  onClose,
+  onSave,
+}) => {
+  const [localOptions, setLocalOptions] = React.useState<ITransformOptions>(options);
+
+  React.useEffect(() => {
+    setLocalOptions(options);
+  }, [options]);
+
+  const handleChange = (key: keyof ITransformOptions) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setLocalOptions({
+      ...localOptions,
+      [key]: event.target.checked,
+    });
+  };
+
+  const handleSave = () => {
+    onSave(localOptions);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Transform Options</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={localOptions.finite ?? false}
+                onChange={handleChange("finite")}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body1">Finite</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Validate finite numbers using Number.isFinite()
+                </Typography>
+              </Box>
+            }
+          />
+          
+          <FormControlLabel
+            control={
+              <Switch
+                checked={localOptions.numeric ?? false}
+                onChange={handleChange("numeric")}
+                disabled={localOptions.finite}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body1">Numeric</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Validate numeric values using Number.isNaN() (ignored when finite is true)
+                </Typography>
+              </Box>
+            }
+          />
+          
+          <FormControlLabel
+            control={
+              <Switch
+                checked={localOptions.functional ?? false}
+                onChange={handleChange("functional")}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body1">Functional</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Validate functional types (becomes false when marshaling/parsing)
+                </Typography>
+              </Box>
+            }
+          />
+          
+          <FormControlLabel
+            control={
+              <Switch
+                checked={localOptions.undefined ?? true}
+                onChange={handleChange("undefined")}
+              />
+            }
+            label={
+              <Box>
+                <Typography variant="body1">Undefined</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Allow undefined values in superfluous properties (only affects equals function)
+                </Typography>
+              </Box>
+            }
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" color="primary">
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default OptionsModal;

--- a/website/src/components/playground/ResultViewer.tsx
+++ b/website/src/components/playground/ResultViewer.tsx
@@ -1,6 +1,6 @@
 import Editor from "@monaco-editor/react";
 
-const OutputViewer = (props: OutputViewer.IProps) => (
+const ResultViewer = (props: ResultViewer.IProps) => (
   <Editor
     width={props.width}
     height={props.height}
@@ -26,7 +26,7 @@ const OutputViewer = (props: OutputViewer.IProps) => (
     value={props.value}
   />
 );
-namespace OutputViewer {
+namespace ResultViewer {
   export interface IProps {
     language: "typescript" | "javascript" | "json";
     value: string;
@@ -34,4 +34,4 @@ namespace OutputViewer {
     height: string;
   }
 }
-export default OutputViewer;
+export default ResultViewer;

--- a/website/src/movies/PlaygroundMovie.tsx
+++ b/website/src/movies/PlaygroundMovie.tsx
@@ -9,7 +9,7 @@ import prettierEsTreePlugin from "prettier/plugins/estree";
 import prettierTsPlugin from "prettier/plugins/typescript";
 import { format } from "prettier/standalone";
 import React, { useEffect, useState } from "react";
-import { Button, IconButton, Tooltip } from "@mui/material";
+import { Button, Tooltip } from "@mui/material";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { version } from "../../../package.json";


### PR DESCRIPTION
This pull request introduces support for customizable TypeScript transform options in the playground UI, allowing users to adjust transformation settings through a new modal dialog. It also refactors the compiler service interface and related code to handle these options throughout the compile/transform/bundle flow. Additionally, it renames the output viewer component for clarity and updates dependencies.

**Support for customizable transform options in the playground:**

* Added a new `OptionsModal` component (`OptionsModal.tsx`) that lets users adjust TypeScript transform options (finite, numeric, functional, undefined) via a UI dialog. This modal is integrated into the playground and can be opened with a settings button. [[1]](diffhunk://#diff-433d76a7d655bc456fb840f20c4e84496935d5f35dd9a49a83f9736c34b430deR1-R133) [[2]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eR224-R256) [[3]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eR313-R318)
* Updated the playground state and logic to store and propagate `ITransformOptions`, ensuring that compile and transform actions use the selected options. [[1]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL12-R46) [[2]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL49-R123)

**Refactoring of compiler service interface and usage:**

* Refactored `ICompilerService` to accept a `props` object containing both `source` and optional `options`, and renamed output types from `IOutput` to `IResult` for clarity. All calls to the compiler service now use this new interface. [[1]](diffhunk://#diff-084eae91f580639db4e4c91b2c9494c77bcf3c860b763e503104fe81cd2d6c5dR1-R14) [[2]](diffhunk://#diff-50552d4c5f71557f60f96c9d76a54d33d9ad5c1891edb9d138c5ba94a70891acR13-R33) [[3]](diffhunk://#diff-50552d4c5f71557f60f96c9d76a54d33d9ad5c1891edb9d138c5ba94a70891acL55-R69) [[4]](diffhunk://#diff-50552d4c5f71557f60f96c9d76a54d33d9ad5c1891edb9d138c5ba94a70891acL78-R93) [[5]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL49-R123) [[6]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL96-R146)

**Component renaming and code clarity:**

* Renamed the `OutputViewer` component to `ResultViewer` for improved clarity and updated all references accordingly. [[1]](diffhunk://#diff-e9f3ca9d5049ea9d7c37c3fb569b5c8ceeebabe44455ed3440aff7cdc689e19cL3-R3) [[2]](diffhunk://#diff-e9f3ca9d5049ea9d7c37c3fb569b5c8ceeebabe44455ed3440aff7cdc689e19cL29-R37) [[3]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL12-R46) [[4]](diffhunk://#diff-45e28d6d6f4c4f15af22fde56d8d5c9a0f00fe71f0586a0020289ba123d1562eL209-R287)

**Dependency updates:**

* Bumped the `typedoc` dependency from `0.28.8` to `0.28.9` in `package.json`.