### PR TITLE
fix website, no toc on the index page

### DIFF
--- a/website/src/content/_meta.ts
+++ b/website/src/content/_meta.ts
@@ -5,6 +5,9 @@ export default {
     title: "Introduction",
     type: "page",
     display: "hidden",
+    theme: {
+      toc: false,
+    },
   },
   docs: {
     title: "📖 Guide Documents",

--- a/website/src/movies/HomeStrengthMovie.tsx
+++ b/website/src/movies/HomeStrengthMovie.tsx
@@ -62,7 +62,7 @@ const sections: HomeStrengthSectionMovie.Props[] = [
     href: "/docs/json/stringify",
   },
   {
-    title: "LLM Function Calling App",
+    title: "LLM Function Calling",
     subTitle: (
       <HomeCodeBlock
         namespace="llm"
@@ -74,7 +74,7 @@ const sections: HomeStrengthSectionMovie.Props[] = [
     ),
     description: (
       <React.Fragment>
-        <p>LLM Function Calling Application Composer</p>
+        <p>LLM Function Calling Schema Composer</p>
         <br />
         <p>
           Creates LLM function call schemas from a native TypeScript class or


### PR DESCRIPTION
This pull request introduces minor improvements to the website's introduction page and updates some wording in the home movie section for clarity. The most notable changes are:

Content display and theming:

* Disabled the table of contents (`toc`) for the introduction page by adding a `theme` property with `toc: false` in `_meta.ts`.

Copy and terminology updates:

* Updated the title from "LLM Function Calling App" to "LLM Function Calling" in the `HomeStrengthMovie` sections array.
* Changed the description from "LLM Function Calling Application Composer" to "LLM Function Calling Schema Composer" for improved accuracy.