### PR TITLE
Fix #1661: no argument required in random boolean.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "typia",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/programmers/RandomProgrammer.ts
+++ b/src/programmers/RandomProgrammer.ts
@@ -532,7 +532,12 @@ export namespace RandomProgrammer {
               internal: "randomInteger",
               arguments: [LiteralFactory.write(schema)],
             };
-        }
+        } else if (props.atomic.type === "boolean")
+          return {
+            method: props.atomic.type,
+            internal: "randomBoolean",
+            arguments: [],
+          };
         return {
           method: props.atomic.type,
           internal: `random${StringUtil.capitalize(props.atomic.type)}`,

--- a/test/src/debug/randomBoolean.ts
+++ b/test/src/debug/randomBoolean.ts
@@ -1,0 +1,3 @@
+import typia from "typia";
+
+console.log(typia.createRandom<boolean>().toString());

--- a/test/src/features/issues/test_issue_1661_random_boolean.ts
+++ b/test/src/features/issues/test_issue_1661_random_boolean.ts
@@ -1,0 +1,8 @@
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_1661_random_boolean = (): void => {
+  const fn: string = typia.createRandom<boolean>().toString();
+  TestValidator.predicate("no argument")(() => fn.includes("_randomBoolean()"));
+};

--- a/test/src/features/issues/test_issue_1661_random_boolean.ts
+++ b/test/src/features/issues/test_issue_1661_random_boolean.ts
@@ -4,5 +4,7 @@ import { TestValidator } from "../../helpers/TestValidator";
 
 export const test_issue_1661_random_boolean = (): void => {
   const fn: string = typia.createRandom<boolean>().toString();
-  TestValidator.predicate("no argument")(() => fn.includes("_randomBoolean()"));
+  TestValidator.predicate("no argument")(() =>
+    fn.includes("_randomBoolean)()"),
+  );
 };


### PR DESCRIPTION
This pull request addresses an issue with random boolean generation by adding support for generating random boolean values and includes a corresponding test. It also bumps the package version to reflect these changes.

**Random boolean support:**

* Added logic in `RandomProgrammer.ts` to handle the `"boolean"` atomic type, ensuring that random boolean values are generated using the new `randomBoolean` internal method.

**Testing:**

* Introduced a new test file `test_issue_1661_random_boolean.ts` to validate that the random boolean generator is correctly invoked.

**Version update:**

* Incremented the package version from `9.7.1` to `9.7.2` in `package.json` to reflect the new feature and bug fix.