### PR TITLE
Add meta description tag

### DIFF
--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -65,6 +65,7 @@ export default async function RootLayout(props) {
         //   saturation: { dark: 100, light: 100 },
         // }}
       >
+        <meta name="description" content={description} />
         {/* ICONS */}
         <link rel="manifest" href="/favicon/site.webmanifest" />
         <link


### PR DESCRIPTION
Google does not seem to recognize the description from OG nor twitter tags, the random description it grabs from the site's contents is really misleading.

<img width="665" height="131" alt="Screenshot 2025-09-22 at 10 50 15" src="https://github.com/user-attachments/assets/e37d6a61-2e70-4d39-9028-0f031f77514e" />
