### PR TITLE
Fix TS compiler error by invalid LLM function calling case.

### DIFF
--- a/src/transformers/features/llm/LlmSchemaTransformer.ts
+++ b/src/transformers/features/llm/LlmSchemaTransformer.ts
@@ -164,7 +164,9 @@ export namespace LlmSchemaTransformer {
         ),
       ),
       undefined,
-      [props.expression.arguments[0]!],
+      props.expression.arguments?.[0] !== undefined
+        ? [props.expression.arguments[0]!]
+        : [],
     );
   };
 }

--- a/test-error/src/llm/llm.schema.argument.ts
+++ b/test-error/src/llm/llm.schema.argument.ts
@@ -1,0 +1,36 @@
+import typia from "typia";
+
+typia.llm.schema<
+  {
+    dynamic: Record<string, string>;
+  },
+  "chatgpt"
+>();
+
+typia.llm.schema<
+  {
+    dynamic: Record<string, string>;
+  },
+  "claude"
+>();
+
+typia.llm.schema<
+  {
+    dynamic: Record<string, string>;
+  },
+  "gemini"
+>();
+
+typia.llm.schema<
+  {
+    dynamic: Record<string, string>;
+  },
+  "3.1"
+>();
+
+typia.llm.schema<
+  {
+    dynamic: Record<string, string>;
+  },
+  "3.0"
+>({});


### PR DESCRIPTION
This pull request introduces a minor bug fix in the `LlmSchemaTransformer` and adds a new test file to verify LLM schema argument handling for several models. The main focus is on improving the handling of optional arguments and expanding test coverage for different LLM providers.

Bug fix and code robustness:

* Updated the argument handling in `LlmSchemaTransformer.ts` to safely handle cases where `props.expression.arguments` may be `undefined`, preventing potential runtime errors.

Testing improvements:

* Added a new test file `llm.schema.argument.ts` that exercises the `typia.llm.schema` function with a dynamic record type for several LLM providers, including "chatgpt", "claude", "gemini", "3.1", and "3.0".