### PR TITLE
Change numeric option to finite in JsonAssertStringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/programmers/json/JsonAssertStringifyProgrammer.ts
+++ b/src/programmers/json/JsonAssertStringifyProgrammer.ts
@@ -27,7 +27,7 @@ export namespace JsonAssertStringifyProgrammer {
         options: {
           ...props.context.options,
           functional: false,
-          numeric: true,
+          finite: true,
         },
       },
       config: {

--- a/src/programmers/json/JsonIsStringifyProgrammer.ts
+++ b/src/programmers/json/JsonIsStringifyProgrammer.ts
@@ -26,7 +26,7 @@ export namespace JsonIsStringifyProgrammer {
         options: {
           ...props.context.options,
           functional: false,
-          numeric: true,
+          finite: true,
         },
       },
       config: {

--- a/src/programmers/json/JsonValidateStringifyProgrammer.ts
+++ b/src/programmers/json/JsonValidateStringifyProgrammer.ts
@@ -28,7 +28,7 @@ export namespace JsonValidateStringifyProgrammer {
           options: {
             ...props.context.options,
             functional: false,
-            numeric: true,
+            finite: true,
           },
         },
         config: {

--- a/src/programmers/protobuf/ProtobufAssertEncodeProgrammer.ts
+++ b/src/programmers/protobuf/ProtobufAssertEncodeProgrammer.ts
@@ -28,7 +28,7 @@ export namespace ProtobufAssertEncodeProgrammer {
         options: {
           ...props.context.options,
           functional: false,
-          numeric: true,
+          finite: true,
         },
       },
       config: {

--- a/src/programmers/protobuf/ProtobufIsEncodeProgrammer.ts
+++ b/src/programmers/protobuf/ProtobufIsEncodeProgrammer.ts
@@ -27,7 +27,7 @@ export namespace ProtobufIsEncodeProgrammer {
         options: {
           ...props.context.options,
           functional: false,
-          numeric: true,
+          finite: true,
         },
       },
       config: {

--- a/src/programmers/protobuf/ProtobufValidateEncodeProgrammer.ts
+++ b/src/programmers/protobuf/ProtobufValidateEncodeProgrammer.ts
@@ -27,7 +27,7 @@ export namespace ProtobufValidateEncodeProgrammer {
         options: {
           ...props.context.options,
           functional: false,
-          numeric: true,
+          finite: true,
         },
       },
       config: {


### PR DESCRIPTION
Fix #1673

-------------------------

This pull request updates the package version and changes the validation logic in multiple programmer modules to require numeric values to be finite, rather than just numeric. This ensures stricter data validation across both JSON and Protobuf encoding/validation routines.

**Validation logic improvements:**

* Changed the validation option from `numeric: true` to `finite: true` in the following programmer modules, ensuring only finite numbers are accepted:
  - `JsonAssertStringifyProgrammer` (`src/programmers/json/JsonAssertStringifyProgrammer.ts`)
  - `JsonIsStringifyProgrammer` (`src/programmers/json/JsonIsStringifyProgrammer.ts`)
  - `JsonValidateStringifyProgrammer` (`src/programmers/json/JsonValidateStringifyProgrammer.ts`)
  - `ProtobufAssertEncodeProgrammer` (`src/programmers/protobuf/ProtobufAssertEncodeProgrammer.ts`)
  - `ProtobufIsEncodeProgrammer` (`src/programmers/protobuf/ProtobufIsEncodeProgrammer.ts`)
  - `ProtobufValidateEncodeProgrammer` (`src/programmers/protobuf/ProtobufValidateEncodeProgrammer.ts`)

**Version update:**

* Bumped the package version from `10.0.0` to `10.0.1` in `package.json` to reflect these changes.