### PR TITLE
Close #1690: support `IJsonSchema.readOnly`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install
       - name: Publish to npm
         run: pnpm run package:latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}
       - name: Root
         run: pnpm run package:tgz
       - name: Website Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: release
 on:
   release:
     types: [created]
+permissions:
+  id-token: write
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://typia.io",
   "dependencies": {
-    "@samchon/openapi": "^5.0.1",
+    "@samchon/openapi": "^5.1.0",
     "@standard-schema/spec": "^1.0.0",
     "commander": "^10.0.0",
     "comment-json": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@samchon/openapi':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.1.0
+        version: 5.1.0
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -865,8 +865,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@5.0.1':
-    resolution: {integrity: sha512-u5UYYBLDeCOFKaTm2hE4tRuxR1reNy/PrEZSQyBPUC+/O+IRa6jSHkiXMgtPVSxJK1s9fyhuJhfw+z5OT3myoQ==}
+  '@samchon/openapi@5.1.0':
+    resolution: {integrity: sha512-PudEhIB/YO+NJPv712+6U7H5qVGJ314QfOnabRxLWoR/A3Hw/wHuHq1Yeb1sdi1Xlx3dUWvGTKXuzE2qEfWR0w==}
 
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
@@ -4246,7 +4246,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.0':
     optional: true
 
-  '@samchon/openapi@5.0.1': {}
+  '@samchon/openapi@5.1.0': {}
 
   '@sinclair/typebox@0.31.28': {}
 

--- a/src/factories/internal/metadata/emplace_metadata_object.ts
+++ b/src/factories/internal/metadata/emplace_metadata_object.ts
@@ -63,14 +63,16 @@ export const emplace_metadata_object = (
     ).filter(props.filter ?? (() => true));
 
     // CHECK MUTABILITY
-    const mutability: "readonly" | null | undefined = props.node
-      ? ts.canHaveModifiers(props.node) &&
-        ts
-          .getModifiers(props.node)
-          ?.some((modifier) => modifier.kind === ts.SyntaxKind.ReadonlyKeyword)
+    const mutability: "readonly" | null | undefined =
+      props.node &&
+      ts.canHaveModifiers(props.node) &&
+      ts
+        .getModifiers(props.node)
+        ?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ReadonlyKeyword,
+        ) === true
         ? "readonly"
-        : null
-      : null;
+        : null;
 
     // THE PROPERTY
     const property: MetadataProperty = MetadataProperty.create({

--- a/src/programmers/internal/json_schema_object.ts
+++ b/src/programmers/internal/json_schema_object.ts
@@ -76,6 +76,7 @@ const create_object_schema = (props: {
           undefined,
         title: json_schema_title(property),
         description: json_schema_description(property),
+        readOnly: property.mutability === "readonly" ? true : undefined,
       },
       metadata: property.value,
     });

--- a/src/schemas/metadata/IMetadataProperty.ts
+++ b/src/schemas/metadata/IMetadataProperty.ts
@@ -6,4 +6,5 @@ export interface IMetadataProperty {
   value: IMetadata;
   description: string | null;
   jsDocTags: IJsDocTagInfo[];
+  mutability?: "readonly" | null | undefined;
 }

--- a/src/schemas/metadata/MetadataProperty.ts
+++ b/src/schemas/metadata/MetadataProperty.ts
@@ -11,6 +11,7 @@ export class MetadataProperty {
   public readonly value: Metadata;
   public readonly description: string | null;
   public readonly jsDocTags: IJsDocTagInfo[];
+  public readonly mutability?: "readonly" | null | undefined;
 
   public of_protobuf_?: IProtobufProperty;
 
@@ -23,6 +24,7 @@ export class MetadataProperty {
     this.value = props.value;
     this.description = props.description;
     this.jsDocTags = props.jsDocTags;
+    this.mutability = props.mutability;
   }
 
   /** @internal */
@@ -39,6 +41,7 @@ export class MetadataProperty {
       value: Metadata.from(property.value, dict),
       description: property.description,
       jsDocTags: property.jsDocTags.slice(),
+      mutability: property.mutability,
     });
   }
 
@@ -48,6 +51,7 @@ export class MetadataProperty {
       value: this.value.toJSON(),
       description: this.description,
       jsDocTags: this.jsDocTags,
+      mutability: this.mutability,
     };
   }
 }

--- a/test/schemas/json.schema/v3_0/ClassGetter.json
+++ b/test/schemas/json.schema/v3_0/ClassGetter.json
@@ -6,14 +6,17 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_0/ClassMethod.json
+++ b/test/schemas/json.schema/v3_0/ClassMethod.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_0/ClassPropertyAssignment.json
+++ b/test/schemas/json.schema/v3_0/ClassPropertyAssignment.json
@@ -6,22 +6,26 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
             "type": "string",
             "enum": [
               "assignment"
-            ]
+            ],
+            "readOnly": true
           },
           "editable": {
             "type": "boolean",
             "enum": [
               false
-            ]
+            ],
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/json.schema/v3_0/ObjectDescription.json
+++ b/test/schemas/json.schema/v3_0/ObjectDescription.json
@@ -12,7 +12,8 @@
           },
           "deprecated": {
             "type": "boolean",
-            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+            "deprecated": true
           },
           "title": {
             "type": "string",

--- a/test/schemas/json.schema/v3_0/ToJsonDouble.json
+++ b/test/schemas/json.schema/v3_0/ToJsonDouble.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_0/UltimateUnion.json
+++ b/test/schemas/json.schema/v3_0/UltimateUnion.json
@@ -69,12 +69,6 @@
       "OpenApi.IJsonSchema": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-          },
-          {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-          },
-          {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
           },
           {
@@ -82,6 +76,12 @@
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -106,134 +106,6 @@
           }
         ],
         "description": "Type schema information.\n\n`OpenApi.IJsonSchema` is a type schema info for OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but is refined to remove ambiguous and duplicated expressions\nof OpenAPI v3.1 for convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property:\n  {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to\n  {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to\n  {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to\n  {@link OpenApi.IJsonSchema.IReference}"
-      },
-      "OpenApi.IJsonSchema.IString": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "string",
-            "description": "Default value of the string type."
-          },
-          "format": {
-            "type": "string",
-            "description": "Format restriction."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "Pattern restriction."
-          },
-          "contentMediaType": {
-            "type": "string",
-            "description": "Content media type restriction."
-          },
-          "minLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Minimum length restriction."
-          },
-          "maxLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Maximum length restriction."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "string"
-            ],
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "String type info."
-      },
-      "Recordstringany": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {}
-      },
-      "OpenApi.IJsonSchema.INumber": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "number",
-            "description": "Default value of the number type."
-          },
-          "minimum": {
-            "type": "number",
-            "description": "Minimum value restriction."
-          },
-          "maximum": {
-            "type": "number",
-            "description": "Maximum value restriction."
-          },
-          "exclusiveMinimum": {
-            "type": "number",
-            "description": "Exclusive minimum value restriction."
-          },
-          "exclusiveMaximum": {
-            "type": "number",
-            "description": "Exclusive maximum value restriction."
-          },
-          "multipleOf": {
-            "type": "number",
-            "exclusiveMinimum": 0,
-            "description": "Multiple of value restriction."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "number"
-            ],
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "Number (double) type info."
       },
       "OpenApi.IJsonSchema.IConstant": {
         "type": "object",
@@ -270,12 +142,27 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "const"
         ],
         "description": "Constant value type."
+      },
+      "Recordstringany": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {}
       },
       "OpenApi.IJsonSchema.IBoolean": {
         "type": "object",
@@ -309,6 +196,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -369,12 +264,157 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "type"
         ],
         "description": "Integer type info."
+      },
+      "OpenApi.IJsonSchema.INumber": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "number",
+            "description": "Default value of the number type."
+          },
+          "minimum": {
+            "type": "number",
+            "description": "Minimum value restriction."
+          },
+          "maximum": {
+            "type": "number",
+            "description": "Maximum value restriction."
+          },
+          "exclusiveMinimum": {
+            "type": "number",
+            "description": "Exclusive minimum value restriction."
+          },
+          "exclusiveMaximum": {
+            "type": "number",
+            "description": "Exclusive maximum value restriction."
+          },
+          "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Multiple of value restriction."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "number"
+            ],
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "Number (double) type info."
+      },
+      "OpenApi.IJsonSchema.IString": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string",
+            "description": "Default value of the string type."
+          },
+          "format": {
+            "type": "string",
+            "description": "Format restriction."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Pattern restriction."
+          },
+          "contentMediaType": {
+            "type": "string",
+            "description": "Content media type restriction."
+          },
+          "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Minimum length restriction."
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum length restriction."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string"
+            ],
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "String type info."
       },
       "OpenApi.IJsonSchema.IArray": {
         "type": "object",
@@ -422,6 +462,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -453,19 +501,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -523,6 +571,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -544,19 +600,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -614,6 +670,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -646,6 +710,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -661,19 +733,19 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-                },
-                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
                 },
                 {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+                },
+                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -719,6 +791,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -750,6 +830,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [],
@@ -787,6 +875,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_1/ClassGetter.json
+++ b/test/schemas/json.schema/v3_1/ClassGetter.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "oneOf": [
@@ -19,7 +21,8 @@
               {
                 "type": "boolean"
               }
-            ]
+            ],
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_1/ClassMethod.json
+++ b/test/schemas/json.schema/v3_1/ClassMethod.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_1/ClassPropertyAssignment.json
+++ b/test/schemas/json.schema/v3_1/ClassPropertyAssignment.json
@@ -6,16 +6,20 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
-            "const": "assignment"
+            "const": "assignment",
+            "readOnly": true
           },
           "editable": {
-            "const": false
+            "const": false,
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/json.schema/v3_1/ToJsonDouble.json
+++ b/test/schemas/json.schema/v3_1/ToJsonDouble.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schema/v3_1/UltimateUnion.json
+++ b/test/schemas/json.schema/v3_1/UltimateUnion.json
@@ -66,12 +66,6 @@
       "OpenApi.IJsonSchema": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-          },
-          {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-          },
-          {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
           },
           {
@@ -79,6 +73,12 @@
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -103,128 +103,6 @@
           }
         ],
         "description": "Type schema information.\n\n`OpenApi.IJsonSchema` is a type schema info for OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but is refined to remove ambiguous and duplicated expressions\nof OpenAPI v3.1 for convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property:\n  {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to\n  {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to\n  {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to\n  {@link OpenApi.IJsonSchema.IReference}"
-      },
-      "OpenApi.IJsonSchema.IString": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "string",
-            "description": "Default value of the string type."
-          },
-          "format": {
-            "type": "string",
-            "description": "Format restriction."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "Pattern restriction."
-          },
-          "contentMediaType": {
-            "type": "string",
-            "description": "Content media type restriction."
-          },
-          "minLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Minimum length restriction."
-          },
-          "maxLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Maximum length restriction."
-          },
-          "type": {
-            "const": "string",
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "String type info."
-      },
-      "Recordstringany": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {}
-      },
-      "OpenApi.IJsonSchema.INumber": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "number",
-            "description": "Default value of the number type."
-          },
-          "minimum": {
-            "type": "number",
-            "description": "Minimum value restriction."
-          },
-          "maximum": {
-            "type": "number",
-            "description": "Maximum value restriction."
-          },
-          "exclusiveMinimum": {
-            "type": "number",
-            "description": "Exclusive minimum value restriction."
-          },
-          "exclusiveMaximum": {
-            "type": "number",
-            "description": "Exclusive maximum value restriction."
-          },
-          "multipleOf": {
-            "type": "number",
-            "exclusiveMinimum": 0,
-            "description": "Multiple of value restriction."
-          },
-          "type": {
-            "const": "number",
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "Number (double) type info."
       },
       "OpenApi.IJsonSchema.IConstant": {
         "type": "object",
@@ -261,12 +139,27 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "const"
         ],
         "description": "Constant value type."
+      },
+      "Recordstringany": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {}
       },
       "OpenApi.IJsonSchema.IBoolean": {
         "type": "object",
@@ -297,6 +190,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -354,12 +255,151 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "type"
         ],
         "description": "Integer type info."
+      },
+      "OpenApi.IJsonSchema.INumber": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "number",
+            "description": "Default value of the number type."
+          },
+          "minimum": {
+            "type": "number",
+            "description": "Minimum value restriction."
+          },
+          "maximum": {
+            "type": "number",
+            "description": "Maximum value restriction."
+          },
+          "exclusiveMinimum": {
+            "type": "number",
+            "description": "Exclusive minimum value restriction."
+          },
+          "exclusiveMaximum": {
+            "type": "number",
+            "description": "Exclusive maximum value restriction."
+          },
+          "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Multiple of value restriction."
+          },
+          "type": {
+            "const": "number",
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "Number (double) type info."
+      },
+      "OpenApi.IJsonSchema.IString": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string",
+            "description": "Default value of the string type."
+          },
+          "format": {
+            "type": "string",
+            "description": "Format restriction."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Pattern restriction."
+          },
+          "contentMediaType": {
+            "type": "string",
+            "description": "Content media type restriction."
+          },
+          "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Minimum length restriction."
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum length restriction."
+          },
+          "type": {
+            "const": "string",
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "String type info."
       },
       "OpenApi.IJsonSchema.IArray": {
         "type": "object",
@@ -404,6 +444,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -432,19 +480,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -502,6 +550,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -523,19 +579,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -590,6 +646,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -622,6 +686,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -637,19 +709,19 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-                },
-                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
                 },
                 {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+                },
+                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -695,6 +767,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -726,6 +806,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [],
@@ -760,6 +848,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_0/ClassGetter.json
+++ b/test/schemas/json.schemas/v3_0/ClassGetter.json
@@ -6,14 +6,17 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_0/ClassMethod.json
+++ b/test/schemas/json.schemas/v3_0/ClassMethod.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_0/ClassPropertyAssignment.json
+++ b/test/schemas/json.schemas/v3_0/ClassPropertyAssignment.json
@@ -6,22 +6,26 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
             "type": "string",
             "enum": [
               "assignment"
-            ]
+            ],
+            "readOnly": true
           },
           "editable": {
             "type": "boolean",
             "enum": [
               false
-            ]
+            ],
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/json.schemas/v3_0/ObjectDescription.json
+++ b/test/schemas/json.schemas/v3_0/ObjectDescription.json
@@ -12,7 +12,8 @@
           },
           "deprecated": {
             "type": "boolean",
-            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+            "deprecated": true
           },
           "title": {
             "type": "string",

--- a/test/schemas/json.schemas/v3_0/ToJsonDouble.json
+++ b/test/schemas/json.schemas/v3_0/ToJsonDouble.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_0/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_0/UltimateUnion.json
@@ -69,12 +69,6 @@
       "OpenApi.IJsonSchema": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-          },
-          {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-          },
-          {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
           },
           {
@@ -82,6 +76,12 @@
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -106,134 +106,6 @@
           }
         ],
         "description": "Type schema information.\n\n`OpenApi.IJsonSchema` is a type schema info for OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but is refined to remove ambiguous and duplicated expressions\nof OpenAPI v3.1 for convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property:\n  {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to\n  {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to\n  {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to\n  {@link OpenApi.IJsonSchema.IReference}"
-      },
-      "OpenApi.IJsonSchema.IString": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "string",
-            "description": "Default value of the string type."
-          },
-          "format": {
-            "type": "string",
-            "description": "Format restriction."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "Pattern restriction."
-          },
-          "contentMediaType": {
-            "type": "string",
-            "description": "Content media type restriction."
-          },
-          "minLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Minimum length restriction."
-          },
-          "maxLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Maximum length restriction."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "string"
-            ],
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "String type info."
-      },
-      "Recordstringany": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {}
-      },
-      "OpenApi.IJsonSchema.INumber": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "number",
-            "description": "Default value of the number type."
-          },
-          "minimum": {
-            "type": "number",
-            "description": "Minimum value restriction."
-          },
-          "maximum": {
-            "type": "number",
-            "description": "Maximum value restriction."
-          },
-          "exclusiveMinimum": {
-            "type": "number",
-            "description": "Exclusive minimum value restriction."
-          },
-          "exclusiveMaximum": {
-            "type": "number",
-            "description": "Exclusive maximum value restriction."
-          },
-          "multipleOf": {
-            "type": "number",
-            "exclusiveMinimum": 0,
-            "description": "Multiple of value restriction."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "number"
-            ],
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "Number (double) type info."
       },
       "OpenApi.IJsonSchema.IConstant": {
         "type": "object",
@@ -270,12 +142,27 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "const"
         ],
         "description": "Constant value type."
+      },
+      "Recordstringany": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {}
       },
       "OpenApi.IJsonSchema.IBoolean": {
         "type": "object",
@@ -309,6 +196,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -369,12 +264,157 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "type"
         ],
         "description": "Integer type info."
+      },
+      "OpenApi.IJsonSchema.INumber": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "number",
+            "description": "Default value of the number type."
+          },
+          "minimum": {
+            "type": "number",
+            "description": "Minimum value restriction."
+          },
+          "maximum": {
+            "type": "number",
+            "description": "Maximum value restriction."
+          },
+          "exclusiveMinimum": {
+            "type": "number",
+            "description": "Exclusive minimum value restriction."
+          },
+          "exclusiveMaximum": {
+            "type": "number",
+            "description": "Exclusive maximum value restriction."
+          },
+          "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Multiple of value restriction."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "number"
+            ],
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "Number (double) type info."
+      },
+      "OpenApi.IJsonSchema.IString": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string",
+            "description": "Default value of the string type."
+          },
+          "format": {
+            "type": "string",
+            "description": "Format restriction."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Pattern restriction."
+          },
+          "contentMediaType": {
+            "type": "string",
+            "description": "Content media type restriction."
+          },
+          "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Minimum length restriction."
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum length restriction."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string"
+            ],
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "String type info."
       },
       "OpenApi.IJsonSchema.IArray": {
         "type": "object",
@@ -422,6 +462,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -453,19 +501,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -523,6 +571,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -544,19 +600,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -614,6 +670,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -646,6 +710,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -661,19 +733,19 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-                },
-                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
                 },
                 {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+                },
+                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -719,6 +791,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -750,6 +830,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [],
@@ -787,6 +875,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_1/ClassGetter.json
+++ b/test/schemas/json.schemas/v3_1/ClassGetter.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "oneOf": [
@@ -19,7 +21,8 @@
               {
                 "type": "boolean"
               }
-            ]
+            ],
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_1/ClassMethod.json
+++ b/test/schemas/json.schemas/v3_1/ClassMethod.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_1/ClassPropertyAssignment.json
+++ b/test/schemas/json.schemas/v3_1/ClassPropertyAssignment.json
@@ -6,16 +6,20 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
-            "const": "assignment"
+            "const": "assignment",
+            "readOnly": true
           },
           "editable": {
-            "const": false
+            "const": false,
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/json.schemas/v3_1/ToJsonDouble.json
+++ b/test/schemas/json.schemas/v3_1/ToJsonDouble.json
@@ -6,10 +6,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/json.schemas/v3_1/UltimateUnion.json
+++ b/test/schemas/json.schemas/v3_1/UltimateUnion.json
@@ -66,12 +66,6 @@
       "OpenApi.IJsonSchema": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-          },
-          {
-            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-          },
-          {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
           },
           {
@@ -79,6 +73,12 @@
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+          },
+          {
+            "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
           },
           {
             "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -103,128 +103,6 @@
           }
         ],
         "description": "Type schema information.\n\n`OpenApi.IJsonSchema` is a type schema info for OpenAPI.\n\n`OpenApi.IJsonSchema` basically follows the JSON schema definition of\nOpenAPI v3.1, but is refined to remove ambiguous and duplicated expressions\nof OpenAPI v3.1 for convenience and clarity.\n\n- Decompose mixed type: {@link OpenApiV3_1.IJsonSchema.IMixed}\n- Resolve nullable property:\n  {@link OpenApiV3_1.IJsonSchema.__ISignificant.nullable}\n- Array type utilizes only single {@link OpenAPI.IJsonSchema.IArray.items}\n- Tuple type utilizes only {@link OpenApi.IJsonSchema.ITuple.prefixItems}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAllOf} to\n  {@link OpenApi.IJsonSchema.IObject}\n- Merge {@link OpenApiV3_1.IJsonSchema.IAnyOf} to\n  {@link OpenApi.IJsonSchema.IOneOf}\n- Merge {@link OpenApiV3_1.IJsonSchema.IRecursiveReference} to\n  {@link OpenApi.IJsonSchema.IReference}"
-      },
-      "OpenApi.IJsonSchema.IString": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "string",
-            "description": "Default value of the string type."
-          },
-          "format": {
-            "type": "string",
-            "description": "Format restriction."
-          },
-          "pattern": {
-            "type": "string",
-            "description": "Pattern restriction."
-          },
-          "contentMediaType": {
-            "type": "string",
-            "description": "Content media type restriction."
-          },
-          "minLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Minimum length restriction."
-          },
-          "maxLength": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Maximum length restriction."
-          },
-          "type": {
-            "const": "string",
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "String type info."
-      },
-      "Recordstringany": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "description": "Construct a type with a set of properties K of type T",
-        "additionalProperties": {}
-      },
-      "OpenApi.IJsonSchema.INumber": {
-        "type": "object",
-        "properties": {
-          "default": {
-            "type": "number",
-            "description": "Default value of the number type."
-          },
-          "minimum": {
-            "type": "number",
-            "description": "Minimum value restriction."
-          },
-          "maximum": {
-            "type": "number",
-            "description": "Maximum value restriction."
-          },
-          "exclusiveMinimum": {
-            "type": "number",
-            "description": "Exclusive minimum value restriction."
-          },
-          "exclusiveMaximum": {
-            "type": "number",
-            "description": "Exclusive maximum value restriction."
-          },
-          "multipleOf": {
-            "type": "number",
-            "exclusiveMinimum": 0,
-            "description": "Multiple of value restriction."
-          },
-          "type": {
-            "const": "number",
-            "description": "Discriminator value of the type."
-          },
-          "title": {
-            "type": "string",
-            "description": "Title of the schema."
-          },
-          "description": {
-            "type": "string",
-            "description": "Detailed description of the schema."
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Whether the type is deprecated or not."
-          },
-          "example": {
-            "description": "Example value."
-          },
-          "examples": {
-            "$ref": "#/components/schemas/Recordstringany",
-            "description": "List of example values as key-value pairs."
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "description": "Number (double) type info."
       },
       "OpenApi.IJsonSchema.IConstant": {
         "type": "object",
@@ -261,12 +139,27 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "const"
         ],
         "description": "Constant value type."
+      },
+      "Recordstringany": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "description": "Construct a type with a set of properties K of type T",
+        "additionalProperties": {}
       },
       "OpenApi.IJsonSchema.IBoolean": {
         "type": "object",
@@ -297,6 +190,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -354,12 +255,151 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
           "type"
         ],
         "description": "Integer type info."
+      },
+      "OpenApi.IJsonSchema.INumber": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "number",
+            "description": "Default value of the number type."
+          },
+          "minimum": {
+            "type": "number",
+            "description": "Minimum value restriction."
+          },
+          "maximum": {
+            "type": "number",
+            "description": "Maximum value restriction."
+          },
+          "exclusiveMinimum": {
+            "type": "number",
+            "description": "Exclusive minimum value restriction."
+          },
+          "exclusiveMaximum": {
+            "type": "number",
+            "description": "Exclusive maximum value restriction."
+          },
+          "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Multiple of value restriction."
+          },
+          "type": {
+            "const": "number",
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "Number (double) type info."
+      },
+      "OpenApi.IJsonSchema.IString": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string",
+            "description": "Default value of the string type."
+          },
+          "format": {
+            "type": "string",
+            "description": "Format restriction."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Pattern restriction."
+          },
+          "contentMediaType": {
+            "type": "string",
+            "description": "Content media type restriction."
+          },
+          "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Minimum length restriction."
+          },
+          "maxLength": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum length restriction."
+          },
+          "type": {
+            "const": "string",
+            "description": "Discriminator value of the type."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the schema."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the schema."
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether the type is deprecated or not."
+          },
+          "example": {
+            "description": "Example value."
+          },
+          "examples": {
+            "$ref": "#/components/schemas/Recordstringany",
+            "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "description": "String type info."
       },
       "OpenApi.IJsonSchema.IArray": {
         "type": "object",
@@ -404,6 +444,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -432,19 +480,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -502,6 +550,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -523,19 +579,19 @@
                 "type": "boolean"
               },
               {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-              },
-              {
-                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-              },
-              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
               },
               {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+              },
+              {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+              },
+              {
+                "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
               },
               {
                 "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -590,6 +646,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -622,6 +686,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -637,19 +709,19 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
-                },
-                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IConstant"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IBoolean"
                 },
                 {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.INumber"
+                },
+                {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IInteger"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenApi.IJsonSchema.IString"
                 },
                 {
                   "$ref": "#/components/schemas/OpenApi.IJsonSchema.IArray"
@@ -695,6 +767,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [
@@ -726,6 +806,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [],
@@ -760,6 +848,14 @@
           "examples": {
             "$ref": "#/components/schemas/Recordstringany",
             "description": "List of example values as key-value pairs."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Whether the property is read-only."
+          },
+          "writeOnly": {
+            "type": "boolean",
+            "description": "Whether the property is write-only."
           }
         },
         "required": [

--- a/test/schemas/llm.application/3.0/ClassGetter.json
+++ b/test/schemas/llm.application/3.0/ClassGetter.json
@@ -15,14 +15,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -49,14 +52,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -71,14 +77,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -100,14 +109,17 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "readOnly": true
           }
         },
         "required": [
@@ -128,14 +140,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -150,14 +165,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -172,14 +190,17 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "dead": {
                 "type": "boolean",
-                "nullable": true
+                "nullable": true,
+                "readOnly": true
               }
             },
             "required": [
@@ -201,14 +222,17 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.application/3.0/ClassMethod.json
+++ b/test/schemas/llm.application/3.0/ClassMethod.json
@@ -15,10 +15,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -44,10 +46,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -61,10 +65,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -85,10 +91,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [
@@ -108,10 +116,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -125,10 +135,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -142,10 +154,12 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "age": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               }
             },
             "required": [
@@ -166,10 +180,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.application/3.0/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/3.0/ClassPropertyAssignment.json
@@ -15,22 +15,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -62,22 +66,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -97,22 +105,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -139,22 +151,26 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
             "type": "string",
             "enum": [
               "assignment"
-            ]
+            ],
+            "readOnly": true
           },
           "editable": {
             "type": "boolean",
             "enum": [
               false
-            ]
+            ],
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"
@@ -180,22 +196,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -215,22 +235,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -250,22 +274,26 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "note": {
                 "type": "string",
                 "enum": [
                   "assignment"
-                ]
+                ],
+                "readOnly": true
               },
               "editable": {
                 "type": "boolean",
                 "enum": [
                   false
-                ]
+                ],
+                "readOnly": true
               },
               "incremental": {
                 "type": "boolean"
@@ -292,22 +320,26 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
             "type": "string",
             "enum": [
               "assignment"
-            ]
+            ],
+            "readOnly": true
           },
           "editable": {
             "type": "boolean",
             "enum": [
               false
-            ]
+            ],
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/llm.application/3.0/ObjectDescription.json
+++ b/test/schemas/llm.application/3.0/ObjectDescription.json
@@ -21,7 +21,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -73,7 +74,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -113,7 +115,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -159,7 +162,8 @@
           },
           "deprecated": {
             "type": "boolean",
-            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+            "deprecated": true
           },
           "title": {
             "type": "string",
@@ -205,7 +209,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -244,7 +249,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -283,7 +289,8 @@
               },
               "deprecated": {
                 "type": "boolean",
-                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+                "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+                "deprecated": true
               },
               "title": {
                 "type": "string",
@@ -329,7 +336,8 @@
           },
           "deprecated": {
             "type": "boolean",
-            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+            "deprecated": true
           },
           "title": {
             "type": "string",

--- a/test/schemas/llm.application/3.0/ToJsonDouble.json
+++ b/test/schemas/llm.application/3.0/ToJsonDouble.json
@@ -15,10 +15,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -44,10 +46,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -61,10 +65,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -85,10 +91,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [
@@ -108,10 +116,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -125,10 +135,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -142,10 +154,12 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "type": "number",
+                "readOnly": true
               },
               "flag": {
-                "type": "boolean"
+                "type": "boolean",
+                "readOnly": true
               }
             },
             "required": [
@@ -166,10 +180,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.application/3.1/ClassGetter.json
+++ b/test/schemas/llm.application/3.1/ClassGetter.json
@@ -24,12 +24,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"
@@ -78,12 +81,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"
@@ -152,12 +158,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"

--- a/test/schemas/llm.application/3.1/ClassMethod.json
+++ b/test/schemas/llm.application/3.1/ClassMethod.json
@@ -24,9 +24,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -67,9 +69,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -130,9 +134,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },

--- a/test/schemas/llm.application/3.1/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/3.1/ClassPropertyAssignment.json
@@ -24,15 +24,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {
@@ -85,15 +89,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {
@@ -178,15 +186,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {

--- a/test/schemas/llm.application/3.1/ObjectDescription.json
+++ b/test/schemas/llm.application/3.1/ObjectDescription.json
@@ -32,8 +32,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -100,8 +100,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -188,8 +188,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",

--- a/test/schemas/llm.application/3.1/ObjectJsonTag.json
+++ b/test/schemas/llm.application/3.1/ObjectJsonTag.json
@@ -24,8 +24,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -81,8 +81,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -158,8 +158,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",

--- a/test/schemas/llm.application/3.1/ToJsonDouble.json
+++ b/test/schemas/llm.application/3.1/ToJsonDouble.json
@@ -24,9 +24,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -67,9 +69,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -130,9 +134,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },

--- a/test/schemas/llm.application/chatgpt/ClassGetter.json
+++ b/test/schemas/llm.application/chatgpt/ClassGetter.json
@@ -24,12 +24,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"
@@ -78,12 +81,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"
@@ -152,12 +158,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"

--- a/test/schemas/llm.application/chatgpt/ClassMethod.json
+++ b/test/schemas/llm.application/chatgpt/ClassMethod.json
@@ -24,9 +24,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -67,9 +69,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -130,9 +134,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },

--- a/test/schemas/llm.application/chatgpt/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/chatgpt/ClassPropertyAssignment.json
@@ -24,18 +24,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false
@@ -91,18 +95,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false
@@ -190,18 +198,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false

--- a/test/schemas/llm.application/chatgpt/ObjectDescription.json
+++ b/test/schemas/llm.application/chatgpt/ObjectDescription.json
@@ -31,8 +31,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -98,8 +98,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -185,8 +185,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",

--- a/test/schemas/llm.application/chatgpt/ObjectJsonTag.json
+++ b/test/schemas/llm.application/chatgpt/ObjectJsonTag.json
@@ -24,8 +24,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -81,8 +81,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -158,8 +158,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",

--- a/test/schemas/llm.application/chatgpt/ToJsonDouble.json
+++ b/test/schemas/llm.application/chatgpt/ToJsonDouble.json
@@ -24,9 +24,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -67,9 +69,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -130,9 +134,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },

--- a/test/schemas/llm.application/claude/ClassGetter.json
+++ b/test/schemas/llm.application/claude/ClassGetter.json
@@ -23,12 +23,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"
@@ -77,12 +80,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"
@@ -151,12 +157,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "oneOf": [
                   {
                     "type": "null"

--- a/test/schemas/llm.application/claude/ClassMethod.json
+++ b/test/schemas/llm.application/claude/ClassMethod.json
@@ -23,9 +23,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -66,9 +68,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -129,9 +133,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },

--- a/test/schemas/llm.application/claude/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/claude/ClassPropertyAssignment.json
@@ -23,15 +23,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {
@@ -84,15 +88,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {
@@ -177,15 +185,19 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "const": "assignment"
               },
               "editable": {
+                "readOnly": true,
                 "const": false
               },
               "incremental": {

--- a/test/schemas/llm.application/claude/ObjectDescription.json
+++ b/test/schemas/llm.application/claude/ObjectDescription.json
@@ -31,8 +31,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -99,8 +99,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -187,8 +187,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",

--- a/test/schemas/llm.application/claude/ObjectJsonTag.json
+++ b/test/schemas/llm.application/claude/ObjectJsonTag.json
@@ -23,8 +23,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -80,8 +80,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -157,8 +157,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",

--- a/test/schemas/llm.application/claude/ToJsonDouble.json
+++ b/test/schemas/llm.application/claude/ToJsonDouble.json
@@ -23,9 +23,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -66,9 +68,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -129,9 +133,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },

--- a/test/schemas/llm.application/gemini/ClassGetter.json
+++ b/test/schemas/llm.application/gemini/ClassGetter.json
@@ -23,12 +23,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"
@@ -77,12 +80,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"
@@ -151,12 +157,15 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "string"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "dead": {
+                "readOnly": true,
                 "anyOf": [
                   {
                     "type": "null"

--- a/test/schemas/llm.application/gemini/ClassMethod.json
+++ b/test/schemas/llm.application/gemini/ClassMethod.json
@@ -23,9 +23,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -66,9 +68,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },
@@ -129,9 +133,11 @@
             "type": "object",
             "properties": {
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "age": {
+                "readOnly": true,
                 "type": "number"
               }
             },

--- a/test/schemas/llm.application/gemini/ClassPropertyAssignment.json
+++ b/test/schemas/llm.application/gemini/ClassPropertyAssignment.json
@@ -23,18 +23,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false
@@ -90,18 +94,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false
@@ -189,18 +197,22 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "name": {
+                "readOnly": true,
                 "type": "string"
               },
               "note": {
+                "readOnly": true,
                 "type": "string",
                 "enum": [
                   "assignment"
                 ]
               },
               "editable": {
+                "readOnly": true,
                 "type": "boolean",
                 "enum": [
                   false

--- a/test/schemas/llm.application/gemini/ObjectDescription.json
+++ b/test/schemas/llm.application/gemini/ObjectDescription.json
@@ -31,8 +31,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -99,8 +99,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",
@@ -187,8 +187,8 @@
               },
               "deprecated": {
                 "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-                "type": "boolean",
-                "deprecated": true
+                "deprecated": true,
+                "type": "boolean"
               },
               "title": {
                 "title": "This is the title",

--- a/test/schemas/llm.application/gemini/ObjectJsonTag.json
+++ b/test/schemas/llm.application/gemini/ObjectJsonTag.json
@@ -23,8 +23,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -80,8 +80,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",
@@ -157,8 +157,8 @@
             "type": "object",
             "properties": {
               "vulnerable": {
-                "type": "string",
-                "deprecated": true
+                "deprecated": true,
+                "type": "string"
               },
               "description": {
                 "description": "Descripted property.",

--- a/test/schemas/llm.application/gemini/ToJsonDouble.json
+++ b/test/schemas/llm.application/gemini/ToJsonDouble.json
@@ -23,9 +23,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -66,9 +68,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },
@@ -129,9 +133,11 @@
             "type": "object",
             "properties": {
               "id": {
+                "readOnly": true,
                 "type": "number"
               },
               "flag": {
+                "readOnly": true,
                 "type": "boolean"
               }
             },

--- a/test/schemas/llm.parameters/3.0/ClassGetter.json
+++ b/test/schemas/llm.parameters/3.0/ClassGetter.json
@@ -5,14 +5,17 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "dead": {
           "type": "boolean",
-          "nullable": true
+          "nullable": true,
+          "readOnly": true
         }
       },
       "required": [
@@ -27,14 +30,17 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "dead": {
           "type": "boolean",
-          "nullable": true
+          "nullable": true,
+          "readOnly": true
         }
       },
       "required": [
@@ -49,14 +55,17 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "dead": {
           "type": "boolean",
-          "nullable": true
+          "nullable": true,
+          "readOnly": true
         }
       },
       "required": [
@@ -71,14 +80,17 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "dead": {
           "type": "boolean",
-          "nullable": true
+          "nullable": true,
+          "readOnly": true
         }
       },
       "required": [
@@ -95,14 +107,17 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "dead": {
             "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.parameters/3.0/ClassMethod.json
+++ b/test/schemas/llm.parameters/3.0/ClassMethod.json
@@ -5,10 +5,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "age": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         }
       },
       "required": [
@@ -22,10 +24,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "age": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         }
       },
       "required": [
@@ -39,10 +43,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "age": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         }
       },
       "required": [
@@ -56,10 +62,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "age": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         }
       },
       "required": [
@@ -75,10 +83,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "age": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.parameters/3.0/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/3.0/ClassPropertyAssignment.json
@@ -5,22 +5,26 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "note": {
           "type": "string",
           "enum": [
             "assignment"
-          ]
+          ],
+          "readOnly": true
         },
         "editable": {
           "type": "boolean",
           "enum": [
             false
-          ]
+          ],
+          "readOnly": true
         },
         "incremental": {
           "type": "boolean"
@@ -40,22 +44,26 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "note": {
           "type": "string",
           "enum": [
             "assignment"
-          ]
+          ],
+          "readOnly": true
         },
         "editable": {
           "type": "boolean",
           "enum": [
             false
-          ]
+          ],
+          "readOnly": true
         },
         "incremental": {
           "type": "boolean"
@@ -75,22 +83,26 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "note": {
           "type": "string",
           "enum": [
             "assignment"
-          ]
+          ],
+          "readOnly": true
         },
         "editable": {
           "type": "boolean",
           "enum": [
             false
-          ]
+          ],
+          "readOnly": true
         },
         "incremental": {
           "type": "boolean"
@@ -110,22 +122,26 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "note": {
           "type": "string",
           "enum": [
             "assignment"
-          ]
+          ],
+          "readOnly": true
         },
         "editable": {
           "type": "boolean",
           "enum": [
             false
-          ]
+          ],
+          "readOnly": true
         },
         "incremental": {
           "type": "boolean"
@@ -147,22 +163,26 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "note": {
             "type": "string",
             "enum": [
               "assignment"
-            ]
+            ],
+            "readOnly": true
           },
           "editable": {
             "type": "boolean",
             "enum": [
               false
-            ]
+            ],
+            "readOnly": true
           },
           "incremental": {
             "type": "boolean"

--- a/test/schemas/llm.parameters/3.0/ObjectDescription.json
+++ b/test/schemas/llm.parameters/3.0/ObjectDescription.json
@@ -11,7 +11,8 @@
         },
         "deprecated": {
           "type": "boolean",
-          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+          "deprecated": true
         },
         "title": {
           "type": "string",
@@ -51,7 +52,8 @@
         },
         "deprecated": {
           "type": "boolean",
-          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+          "deprecated": true
         },
         "title": {
           "type": "string",
@@ -90,7 +92,8 @@
         },
         "deprecated": {
           "type": "boolean",
-          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+          "deprecated": true
         },
         "title": {
           "type": "string",
@@ -130,7 +133,8 @@
         },
         "deprecated": {
           "type": "boolean",
-          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+          "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+          "deprecated": true
         },
         "title": {
           "type": "string",
@@ -171,7 +175,8 @@
           },
           "deprecated": {
             "type": "boolean",
-            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+            "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+            "deprecated": true
           },
           "title": {
             "type": "string",

--- a/test/schemas/llm.parameters/3.0/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/3.0/ToJsonDouble.json
@@ -5,10 +5,12 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "flag": {
-          "type": "boolean"
+          "type": "boolean",
+          "readOnly": true
         }
       },
       "required": [
@@ -22,10 +24,12 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "flag": {
-          "type": "boolean"
+          "type": "boolean",
+          "readOnly": true
         }
       },
       "required": [
@@ -39,10 +43,12 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "flag": {
-          "type": "boolean"
+          "type": "boolean",
+          "readOnly": true
         }
       },
       "required": [
@@ -56,10 +62,12 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": "number",
+          "readOnly": true
         },
         "flag": {
-          "type": "boolean"
+          "type": "boolean",
+          "readOnly": true
         }
       },
       "required": [
@@ -75,10 +83,12 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           },
           "flag": {
-            "type": "boolean"
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "required": [

--- a/test/schemas/llm.parameters/3.1/ClassGetter.json
+++ b/test/schemas/llm.parameters/3.1/ClassGetter.json
@@ -45,12 +45,15 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "dead": {
+          "readOnly": true,
           "oneOf": [
             {
               "type": "null"

--- a/test/schemas/llm.parameters/3.1/ClassMethod.json
+++ b/test/schemas/llm.parameters/3.1/ClassMethod.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "age": {
+          "readOnly": true,
           "type": "number"
         }
       },

--- a/test/schemas/llm.parameters/3.1/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/3.1/ClassPropertyAssignment.json
@@ -57,15 +57,19 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "note": {
+          "readOnly": true,
           "const": "assignment"
         },
         "editable": {
+          "readOnly": true,
           "const": false
         },
         "incremental": {

--- a/test/schemas/llm.parameters/3.1/ObjectDescription.json
+++ b/test/schemas/llm.parameters/3.1/ObjectDescription.json
@@ -53,8 +53,8 @@
         },
         "deprecated": {
           "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-          "type": "boolean",
-          "deprecated": true
+          "deprecated": true,
+          "type": "boolean"
         },
         "title": {
           "title": "This is the title",

--- a/test/schemas/llm.parameters/3.1/ObjectJsonTag.json
+++ b/test/schemas/llm.parameters/3.1/ObjectJsonTag.json
@@ -45,8 +45,8 @@
       "type": "object",
       "properties": {
         "vulnerable": {
-          "type": "string",
-          "deprecated": true
+          "deprecated": true,
+          "type": "string"
         },
         "description": {
           "description": "Descripted property.",

--- a/test/schemas/llm.parameters/3.1/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/3.1/ToJsonDouble.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "flag": {
+          "readOnly": true,
           "type": "boolean"
         }
       },

--- a/test/schemas/llm.parameters/chatgpt/ClassGetter.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassGetter.json
@@ -45,12 +45,15 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "dead": {
+          "readOnly": true,
           "anyOf": [
             {
               "type": "null"

--- a/test/schemas/llm.parameters/chatgpt/ClassMethod.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassMethod.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "age": {
+          "readOnly": true,
           "type": "number"
         }
       },

--- a/test/schemas/llm.parameters/chatgpt/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/chatgpt/ClassPropertyAssignment.json
@@ -57,18 +57,22 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "note": {
+          "readOnly": true,
           "type": "string",
           "enum": [
             "assignment"
           ]
         },
         "editable": {
+          "readOnly": true,
           "type": "boolean",
           "enum": [
             false

--- a/test/schemas/llm.parameters/chatgpt/ObjectDescription.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectDescription.json
@@ -52,8 +52,8 @@
         },
         "deprecated": {
           "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-          "type": "boolean",
-          "deprecated": true
+          "deprecated": true,
+          "type": "boolean"
         },
         "title": {
           "title": "This is the title",

--- a/test/schemas/llm.parameters/chatgpt/ObjectJsonTag.json
+++ b/test/schemas/llm.parameters/chatgpt/ObjectJsonTag.json
@@ -45,8 +45,8 @@
       "type": "object",
       "properties": {
         "vulnerable": {
-          "type": "string",
-          "deprecated": true
+          "deprecated": true,
+          "type": "string"
         },
         "description": {
           "description": "Descripted property.",

--- a/test/schemas/llm.parameters/chatgpt/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/chatgpt/ToJsonDouble.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "flag": {
+          "readOnly": true,
           "type": "boolean"
         }
       },

--- a/test/schemas/llm.parameters/claude/ClassGetter.json
+++ b/test/schemas/llm.parameters/claude/ClassGetter.json
@@ -45,12 +45,15 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "dead": {
+          "readOnly": true,
           "oneOf": [
             {
               "type": "null"

--- a/test/schemas/llm.parameters/claude/ClassMethod.json
+++ b/test/schemas/llm.parameters/claude/ClassMethod.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "age": {
+          "readOnly": true,
           "type": "number"
         }
       },

--- a/test/schemas/llm.parameters/claude/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/claude/ClassPropertyAssignment.json
@@ -57,15 +57,19 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "note": {
+          "readOnly": true,
           "const": "assignment"
         },
         "editable": {
+          "readOnly": true,
           "const": false
         },
         "incremental": {

--- a/test/schemas/llm.parameters/claude/ObjectDescription.json
+++ b/test/schemas/llm.parameters/claude/ObjectDescription.json
@@ -53,8 +53,8 @@
         },
         "deprecated": {
           "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-          "type": "boolean",
-          "deprecated": true
+          "deprecated": true,
+          "type": "boolean"
         },
         "title": {
           "title": "This is the title",

--- a/test/schemas/llm.parameters/claude/ObjectJsonTag.json
+++ b/test/schemas/llm.parameters/claude/ObjectJsonTag.json
@@ -45,8 +45,8 @@
       "type": "object",
       "properties": {
         "vulnerable": {
-          "type": "string",
-          "deprecated": true
+          "deprecated": true,
+          "type": "string"
         },
         "description": {
           "description": "Descripted property.",

--- a/test/schemas/llm.parameters/claude/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/claude/ToJsonDouble.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "flag": {
+          "readOnly": true,
           "type": "boolean"
         }
       },

--- a/test/schemas/llm.parameters/gemini/ClassGetter.json
+++ b/test/schemas/llm.parameters/gemini/ClassGetter.json
@@ -45,12 +45,15 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "dead": {
+          "readOnly": true,
           "anyOf": [
             {
               "type": "null"

--- a/test/schemas/llm.parameters/gemini/ClassMethod.json
+++ b/test/schemas/llm.parameters/gemini/ClassMethod.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "age": {
+          "readOnly": true,
           "type": "number"
         }
       },

--- a/test/schemas/llm.parameters/gemini/ClassPropertyAssignment.json
+++ b/test/schemas/llm.parameters/gemini/ClassPropertyAssignment.json
@@ -57,18 +57,22 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "name": {
+          "readOnly": true,
           "type": "string"
         },
         "note": {
+          "readOnly": true,
           "type": "string",
           "enum": [
             "assignment"
           ]
         },
         "editable": {
+          "readOnly": true,
           "type": "boolean",
           "enum": [
             false

--- a/test/schemas/llm.parameters/gemini/ObjectDescription.json
+++ b/test/schemas/llm.parameters/gemini/ObjectDescription.json
@@ -53,8 +53,8 @@
         },
         "deprecated": {
           "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
-          "type": "boolean",
-          "deprecated": true
+          "deprecated": true,
+          "type": "boolean"
         },
         "title": {
           "title": "This is the title",

--- a/test/schemas/llm.parameters/gemini/ObjectJsonTag.json
+++ b/test/schemas/llm.parameters/gemini/ObjectJsonTag.json
@@ -45,8 +45,8 @@
       "type": "object",
       "properties": {
         "vulnerable": {
-          "type": "string",
-          "deprecated": true
+          "deprecated": true,
+          "type": "string"
         },
         "description": {
           "description": "Descripted property.",

--- a/test/schemas/llm.parameters/gemini/ToJsonDouble.json
+++ b/test/schemas/llm.parameters/gemini/ToJsonDouble.json
@@ -45,9 +45,11 @@
       "type": "object",
       "properties": {
         "id": {
+          "readOnly": true,
           "type": "number"
         },
         "flag": {
+          "readOnly": true,
           "type": "boolean"
         }
       },

--- a/test/schemas/llm.schema/3.0/ClassGetter.json
+++ b/test/schemas/llm.schema/3.0/ClassGetter.json
@@ -2,14 +2,17 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "readOnly": true
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "readOnly": true
     },
     "dead": {
       "type": "boolean",
-      "nullable": true
+      "nullable": true,
+      "readOnly": true
     }
   },
   "required": [

--- a/test/schemas/llm.schema/3.0/ClassMethod.json
+++ b/test/schemas/llm.schema/3.0/ClassMethod.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "readOnly": true
     },
     "age": {
-      "type": "number"
+      "type": "number",
+      "readOnly": true
     }
   },
   "required": [

--- a/test/schemas/llm.schema/3.0/ClassPropertyAssignment.json
+++ b/test/schemas/llm.schema/3.0/ClassPropertyAssignment.json
@@ -2,22 +2,26 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "number"
+      "type": "number",
+      "readOnly": true
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "readOnly": true
     },
     "note": {
       "type": "string",
       "enum": [
         "assignment"
-      ]
+      ],
+      "readOnly": true
     },
     "editable": {
       "type": "boolean",
       "enum": [
         false
-      ]
+      ],
+      "readOnly": true
     },
     "incremental": {
       "type": "boolean"

--- a/test/schemas/llm.schema/3.0/ObjectDescription.json
+++ b/test/schemas/llm.schema/3.0/ObjectDescription.json
@@ -8,7 +8,8 @@
     },
     "deprecated": {
       "type": "boolean",
-      "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema."
+      "description": "Deprecated property.\n\nIf `@deprecated` comment tag being utilized, the property will be marked as\ndeprecated in the JSON schema.",
+      "deprecated": true
     },
     "title": {
       "type": "string",

--- a/test/schemas/llm.schema/3.0/ToJsonDouble.json
+++ b/test/schemas/llm.schema/3.0/ToJsonDouble.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "number"
+      "type": "number",
+      "readOnly": true
     },
     "flag": {
-      "type": "boolean"
+      "type": "boolean",
+      "readOnly": true
     }
   },
   "required": [

--- a/test/schemas/reflect/metadata/ArrayAny.json
+++ b/test/schemas/reflect/metadata/ArrayAny.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -427,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -541,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayHierarchical.json
+++ b/test/schemas/reflect/metadata/ArrayHierarchical.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -563,7 +571,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -620,7 +629,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -677,7 +687,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -734,7 +745,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -802,7 +814,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -859,7 +872,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -916,7 +930,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -973,7 +988,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1030,7 +1046,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayHierarchicalPointer.json
+++ b/test/schemas/reflect/metadata/ArrayHierarchicalPointer.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -449,7 +455,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -574,7 +582,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -631,7 +640,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -688,7 +698,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -745,7 +756,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -802,7 +814,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -870,7 +883,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -927,7 +941,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -984,7 +999,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1041,7 +1057,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1098,7 +1115,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRecursive.json
+++ b/test/schemas/reflect/metadata/ArrayRecursive.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicit.json
+++ b/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicit.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -318,7 +322,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -386,7 +391,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -443,7 +449,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -500,7 +507,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -557,7 +565,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -614,7 +623,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -671,7 +681,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -728,7 +739,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -790,7 +802,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -852,7 +865,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -920,7 +934,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -977,7 +992,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1034,7 +1050,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1091,7 +1108,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1148,7 +1166,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1210,7 +1229,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1272,7 +1292,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1340,7 +1361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1397,7 +1419,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1454,7 +1477,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1511,7 +1535,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1568,7 +1593,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1630,7 +1656,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1692,7 +1719,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1760,7 +1788,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1817,7 +1846,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1874,7 +1904,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1947,7 +1978,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2009,7 +2041,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2071,7 +2104,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicitPointer.json
+++ b/test/schemas/reflect/metadata/ArrayRecursiveUnionExplicitPointer.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -169,7 +170,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -237,7 +239,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -294,7 +297,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -351,7 +355,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -408,7 +413,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -470,7 +476,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -538,7 +545,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -595,7 +603,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -652,7 +661,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -709,7 +719,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -766,7 +777,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -823,7 +835,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -880,7 +893,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -942,7 +956,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1004,7 +1019,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1072,7 +1088,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1129,7 +1146,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1186,7 +1204,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1243,7 +1262,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1300,7 +1320,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1362,7 +1383,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1424,7 +1446,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1492,7 +1515,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1549,7 +1573,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1606,7 +1631,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1663,7 +1689,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1720,7 +1747,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1782,7 +1810,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1844,7 +1873,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1912,7 +1942,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1969,7 +2000,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2026,7 +2058,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2083,7 +2116,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2145,7 +2179,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2207,7 +2242,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRecursiveUnionImplicit.json
+++ b/test/schemas/reflect/metadata/ArrayRecursiveUnionImplicit.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -333,7 +337,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -390,7 +395,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -447,7 +453,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -504,7 +511,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -561,7 +569,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -629,7 +638,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -686,7 +696,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -743,7 +754,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -800,7 +812,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -857,7 +870,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -914,7 +928,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -971,7 +986,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1039,7 +1055,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1096,7 +1113,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1153,7 +1171,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1210,7 +1229,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1267,7 +1287,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1335,7 +1356,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1392,7 +1414,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1449,7 +1472,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1506,7 +1530,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1563,7 +1588,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1631,7 +1657,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1688,7 +1715,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1745,7 +1773,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1822,7 +1851,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRepeatedUnion.json
+++ b/test/schemas/reflect/metadata/ArrayRepeatedUnion.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -159,7 +160,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -216,7 +218,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -273,7 +276,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -341,7 +345,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -398,7 +403,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -455,7 +461,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArrayRepeatedUnionWithTuple.json
+++ b/test/schemas/reflect/metadata/ArrayRepeatedUnionWithTuple.json
@@ -111,7 +111,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -168,7 +169,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -225,7 +227,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -282,7 +285,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -350,7 +354,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -407,7 +412,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -464,7 +470,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArraySimple.json
+++ b/test/schemas/reflect/metadata/ArraySimple.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobuf.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -427,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -541,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -598,7 +607,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufNullable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -427,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -541,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -598,7 +607,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ArraySimpleProtobufOptional.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -427,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -541,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -598,7 +607,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ClassClosure.json
+++ b/test/schemas/reflect/metadata/ClassClosure.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -147,7 +148,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -228,7 +230,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ClassGetter.json
+++ b/test/schemas/reflect/metadata/ClassGetter.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ClassMethod.json
+++ b/test/schemas/reflect/metadata/ClassMethod.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -223,7 +225,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ClassNonPublic.json
+++ b/test/schemas/reflect/metadata/ClassNonPublic.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -223,7 +225,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ClassPropertyAssignment.json
+++ b/test/schemas/reflect/metadata/ClassPropertyAssignment.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -204,7 +206,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -266,7 +269,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -323,7 +327,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagArray.json
+++ b/test/schemas/reflect/metadata/CommentTagArray.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -188,7 +189,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -269,7 +271,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +373,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -471,7 +475,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -546,7 +551,8 @@
               {
                 "name": "uniqueItems"
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagArrayUnion.json
+++ b/test/schemas/reflect/metadata/CommentTagArrayUnion.json
@@ -120,7 +120,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -201,7 +202,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -282,7 +284,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -383,7 +386,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagAtomicUnion.json
+++ b/test/schemas/reflect/metadata/CommentTagAtomicUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -227,7 +228,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagBigInt.json
+++ b/test/schemas/reflect/metadata/CommentTagBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -198,7 +199,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -285,7 +287,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -372,7 +375,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -456,7 +460,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagDefault.json
+++ b/test/schemas/reflect/metadata/CommentTagDefault.json
@@ -95,7 +95,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -162,7 +163,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -229,7 +231,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -296,7 +299,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -389,7 +393,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -464,7 +469,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -539,7 +545,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -614,7 +621,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -730,7 +738,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -869,7 +878,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagFormat.json
+++ b/test/schemas/reflect/metadata/CommentTagFormat.json
@@ -109,7 +109,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -190,7 +191,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -271,7 +273,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -352,7 +355,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -433,7 +437,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -514,7 +519,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -595,7 +601,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -676,7 +683,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -757,7 +765,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -838,7 +847,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -919,7 +929,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1000,7 +1011,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1081,7 +1093,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1162,7 +1175,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1243,7 +1257,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1324,7 +1339,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1405,7 +1421,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1486,7 +1503,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1567,7 +1585,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1648,7 +1667,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1729,7 +1749,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1810,7 +1831,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagInfinite.json
+++ b/test/schemas/reflect/metadata/CommentTagInfinite.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -192,7 +193,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -276,7 +278,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -360,7 +363,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -441,7 +445,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -522,7 +527,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagLength.json
+++ b/test/schemas/reflect/metadata/CommentTagLength.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -188,7 +189,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -269,7 +271,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -350,7 +353,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -451,7 +455,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -552,7 +557,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagNaN.json
+++ b/test/schemas/reflect/metadata/CommentTagNaN.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -192,7 +193,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -276,7 +278,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -360,7 +363,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -441,7 +445,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -522,7 +527,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagObjectUnion.json
+++ b/test/schemas/reflect/metadata/CommentTagObjectUnion.json
@@ -112,7 +112,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -224,7 +225,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagPattern.json
+++ b/test/schemas/reflect/metadata/CommentTagPattern.json
@@ -111,7 +111,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -194,7 +195,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -277,7 +279,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -360,7 +363,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagRange.json
+++ b/test/schemas/reflect/metadata/CommentTagRange.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -200,7 +201,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -304,7 +306,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -408,7 +411,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -512,7 +516,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -639,7 +644,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -766,7 +772,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -893,7 +900,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1020,7 +1028,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1147,7 +1156,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagRangeBigInt.json
+++ b/test/schemas/reflect/metadata/CommentTagRangeBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -183,7 +184,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -270,7 +272,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -357,7 +360,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -444,7 +448,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -557,7 +562,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -670,7 +676,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -783,7 +790,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -896,7 +904,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -1009,7 +1018,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagType.json
+++ b/test/schemas/reflect/metadata/CommentTagType.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -177,7 +178,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -259,7 +261,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -340,7 +343,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -422,7 +426,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -503,7 +508,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -585,7 +591,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -663,7 +670,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/CommentTagTypeBigInt.json
+++ b/test/schemas/reflect/metadata/CommentTagTypeBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -166,7 +167,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ConstantAtomicAbsorbed.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicAbsorbed.json
@@ -98,7 +98,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -168,7 +169,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ConstantAtomicTagged.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicTagged.json
@@ -112,7 +112,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -208,7 +209,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ConstantAtomicUnion.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicUnion.json
@@ -90,7 +90,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ConstantAtomicWrapper.json
+++ b/test/schemas/reflect/metadata/ConstantAtomicWrapper.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -221,7 +223,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicArray.json
+++ b/test/schemas/reflect/metadata/DynamicArray.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -148,7 +149,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicComposite.json
+++ b/test/schemas/reflect/metadata/DynamicComposite.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -194,7 +196,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -300,7 +303,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -406,7 +410,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -520,7 +525,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -679,7 +685,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicConstant.json
+++ b/test/schemas/reflect/metadata/DynamicConstant.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicEnumeration.json
+++ b/test/schemas/reflect/metadata/DynamicEnumeration.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -495,7 +502,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -552,7 +560,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -609,7 +618,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -666,7 +676,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicJsonValue.json
+++ b/test/schemas/reflect/metadata/DynamicJsonValue.json
@@ -116,7 +116,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicNever.json
+++ b/test/schemas/reflect/metadata/DynamicNever.json
@@ -75,7 +75,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicSimple.json
+++ b/test/schemas/reflect/metadata/DynamicSimple.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -148,7 +149,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicTag.json
+++ b/test/schemas/reflect/metadata/DynamicTag.json
@@ -126,7 +126,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -212,7 +213,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicTemplate.json
+++ b/test/schemas/reflect/metadata/DynamicTemplate.json
@@ -134,7 +134,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -240,7 +241,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -346,7 +348,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -505,7 +508,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicTree.json
+++ b/test/schemas/reflect/metadata/DynamicTree.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -262,7 +265,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with a set of properties K of type T",

--- a/test/schemas/reflect/metadata/DynamicUndefined.json
+++ b/test/schemas/reflect/metadata/DynamicUndefined.json
@@ -75,7 +75,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/DynamicUnion.json
+++ b/test/schemas/reflect/metadata/DynamicUnion.json
@@ -80,7 +80,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -186,7 +187,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -292,7 +294,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -451,7 +454,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/FunctionalObjectUnion.json
+++ b/test/schemas/reflect/metadata/FunctionalObjectUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -253,7 +255,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -321,7 +324,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -378,7 +382,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -459,7 +464,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -527,7 +533,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -608,7 +615,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -676,7 +684,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -757,7 +766,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -838,7 +848,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/FunctionalProperty.json
+++ b/test/schemas/reflect/metadata/FunctionalProperty.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -196,7 +197,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/FunctionalPropertyUnion.json
+++ b/test/schemas/reflect/metadata/FunctionalPropertyUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -200,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/InstanceUnion.json
+++ b/test/schemas/reflect/metadata/InstanceUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -563,7 +571,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -625,7 +634,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -693,7 +703,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -750,7 +761,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -812,7 +824,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -880,7 +893,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -937,7 +951,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1005,7 +1020,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1062,7 +1078,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1119,7 +1136,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1181,7 +1199,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1249,7 +1268,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1306,7 +1326,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1363,7 +1384,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1420,7 +1442,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1482,7 +1505,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1550,7 +1574,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1612,7 +1637,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1680,7 +1706,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1737,7 +1764,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1799,7 +1827,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1867,7 +1896,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1935,7 +1965,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1992,7 +2023,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2054,7 +2086,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapAlias.json
+++ b/test/schemas/reflect/metadata/MapAlias.json
@@ -132,7 +132,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -236,7 +237,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -340,7 +342,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -444,7 +447,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -548,7 +552,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -616,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -673,7 +679,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -730,7 +737,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapSimple.json
+++ b/test/schemas/reflect/metadata/MapSimple.json
@@ -132,7 +132,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -236,7 +237,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -340,7 +342,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -444,7 +447,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -548,7 +552,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -616,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -673,7 +679,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -730,7 +737,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapSimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobuf.json
@@ -132,7 +132,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +251,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -354,7 +356,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -458,7 +461,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -576,7 +580,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -680,7 +685,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -784,7 +790,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapSimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobufNullable.json
@@ -132,7 +132,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +251,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -354,7 +356,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -458,7 +461,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -576,7 +580,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -680,7 +685,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -784,7 +790,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapSimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/MapSimpleProtobufOptional.json
@@ -132,7 +132,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +251,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -354,7 +356,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -458,7 +461,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -576,7 +580,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -680,7 +685,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -784,7 +790,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/MapUnion.json
+++ b/test/schemas/reflect/metadata/MapUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/NativeSimple.json
+++ b/test/schemas/reflect/metadata/NativeSimple.json
@@ -129,7 +129,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -186,7 +187,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -243,7 +245,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -300,7 +303,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -357,7 +361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -414,7 +419,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -471,7 +477,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -528,7 +535,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -585,7 +593,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -642,7 +651,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -699,7 +709,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -756,7 +767,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -813,7 +825,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -870,7 +883,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -927,7 +941,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/NativeUnion.json
+++ b/test/schemas/reflect/metadata/NativeUnion.json
@@ -129,7 +129,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -202,7 +203,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -271,7 +273,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -332,7 +335,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -393,7 +397,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectAlias.json
+++ b/test/schemas/reflect/metadata/ObjectAlias.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -278,7 +281,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -335,7 +339,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -392,7 +397,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectClosure.json
+++ b/test/schemas/reflect/metadata/ObjectClosure.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -166,7 +167,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectDate.json
+++ b/test/schemas/reflect/metadata/ObjectDate.json
@@ -129,7 +129,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -203,7 +204,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -277,7 +279,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -351,7 +354,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -425,7 +429,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectDescription.json
+++ b/test/schemas/reflect/metadata/ObjectDescription.json
@@ -112,7 +112,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -173,7 +174,8 @@
               {
                 "name": "deprecated"
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -240,7 +242,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -297,7 +300,8 @@
               "maps": []
             },
             "description": "Description property.\n\nIf you write first line and the first line ends with \".\" character, it\nwould be considered as the title. By the way, description does not\nexclusive the title, so that full content be written.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -354,7 +358,8 @@
               "maps": []
             },
             "description": "New line before dot character\n\nIf dot character (\".\") being used before the first new line, it would not\nbe considered as title in the JSON schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "An interface designed to test JSON schema's object description.",

--- a/test/schemas/reflect/metadata/ObjectDynamic.json
+++ b/test/schemas/reflect/metadata/ObjectDynamic.json
@@ -88,7 +88,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectGeneric.json
+++ b/test/schemas/reflect/metadata/ObjectGeneric.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -392,7 +397,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -449,7 +455,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -574,7 +582,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -631,7 +640,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -699,7 +709,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -756,7 +767,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -813,7 +825,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -881,7 +894,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -938,7 +952,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectGenericAlias.json
+++ b/test/schemas/reflect/metadata/ObjectGenericAlias.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectGenericArray.json
+++ b/test/schemas/reflect/metadata/ObjectGenericArray.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -449,7 +455,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectGenericUnion.json
+++ b/test/schemas/reflect/metadata/ObjectGenericUnion.json
@@ -89,7 +89,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -157,7 +158,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -214,7 +216,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -271,7 +274,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -328,7 +332,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -385,7 +390,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -442,7 +448,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -510,7 +517,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -567,7 +575,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -624,7 +633,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -681,7 +691,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -749,7 +760,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -806,7 +818,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -863,7 +876,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -920,7 +934,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -977,7 +992,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1045,7 +1061,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1102,7 +1119,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1159,7 +1177,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1227,7 +1246,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1284,7 +1304,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1341,7 +1362,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1398,7 +1420,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1455,7 +1478,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1512,7 +1536,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1580,7 +1605,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1637,7 +1663,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1694,7 +1721,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1751,7 +1779,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1808,7 +1837,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1865,7 +1895,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHierarchical.json
+++ b/test/schemas/reflect/metadata/ObjectHierarchical.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -427,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -552,7 +560,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -609,7 +618,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -666,7 +676,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -723,7 +734,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -780,7 +792,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -837,7 +850,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -894,7 +908,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -962,7 +977,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1019,7 +1035,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1087,7 +1104,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1144,7 +1162,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1201,7 +1220,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1258,7 +1278,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1315,7 +1336,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1372,7 +1394,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1440,7 +1463,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1497,7 +1521,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1554,7 +1579,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1623,7 +1649,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1680,7 +1707,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1737,7 +1765,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1794,7 +1823,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1851,7 +1881,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpArray.json
+++ b/test/schemas/reflect/metadata/ObjectHttpArray.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpAtomic.json
+++ b/test/schemas/reflect/metadata/ObjectHttpAtomic.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpCommentTag.json
+++ b/test/schemas/reflect/metadata/ObjectHttpCommentTag.json
@@ -109,7 +109,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -190,7 +191,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -271,7 +273,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -372,7 +375,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpConstant.json
+++ b/test/schemas/reflect/metadata/ObjectHttpConstant.json
@@ -90,7 +90,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -156,7 +157,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -222,7 +224,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -292,7 +295,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -403,7 +407,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpFormData.json
+++ b/test/schemas/reflect/metadata/ObjectHttpFormData.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -159,7 +160,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -216,7 +218,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -273,7 +276,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -330,7 +334,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -387,7 +392,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -444,7 +450,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpNullable.json
+++ b/test/schemas/reflect/metadata/ObjectHttpNullable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -216,7 +218,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -273,7 +276,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -335,7 +339,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -405,7 +410,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -475,7 +481,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -545,7 +552,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -602,7 +610,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
+++ b/test/schemas/reflect/metadata/ObjectHttpTypeTag.json
@@ -99,7 +99,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -171,7 +172,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -245,7 +247,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -327,7 +330,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -409,7 +413,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectHttpUndefindable.json
+++ b/test/schemas/reflect/metadata/ObjectHttpUndefindable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -318,7 +322,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -388,7 +393,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -458,7 +464,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -528,7 +535,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectInternal.json
+++ b/test/schemas/reflect/metadata/ObjectInternal.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectIntersection.json
+++ b/test/schemas/reflect/metadata/ObjectIntersection.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectJsonTag.json
+++ b/test/schemas/reflect/metadata/ObjectJsonTag.json
@@ -89,7 +89,8 @@
               {
                 "name": "deprecated"
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -146,7 +147,8 @@
               "maps": []
             },
             "description": "Descripted property.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -213,7 +215,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -296,7 +299,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectLiteralProperty.json
+++ b/test/schemas/reflect/metadata/ObjectLiteralProperty.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectLiteralType.json
+++ b/test/schemas/reflect/metadata/ObjectLiteralType.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectNullable.json
+++ b/test/schemas/reflect/metadata/ObjectNullable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -328,7 +332,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -401,7 +406,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -458,7 +464,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -532,7 +539,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -589,7 +597,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectOptional.json
+++ b/test/schemas/reflect/metadata/ObjectOptional.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectPartial.json
+++ b/test/schemas/reflect/metadata/ObjectPartial.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Make all properties in T optional",
@@ -382,7 +387,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -439,7 +445,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -496,7 +503,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -553,7 +561,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -610,7 +619,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectPartialAndRequired.json
+++ b/test/schemas/reflect/metadata/ObjectPartialAndRequired.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectPrimitive.json
+++ b/test/schemas/reflect/metadata/ObjectPrimitive.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -155,7 +156,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -212,7 +214,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -269,7 +272,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -326,7 +330,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -383,7 +388,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -440,7 +446,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -508,7 +515,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -565,7 +573,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -622,7 +631,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -679,7 +689,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -736,7 +747,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectPropertyNullable.json
+++ b/test/schemas/reflect/metadata/ObjectPropertyNullable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -221,7 +223,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -289,7 +292,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -357,7 +361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -414,7 +419,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -471,7 +477,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -528,7 +535,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -585,7 +593,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectRecursive.json
+++ b/test/schemas/reflect/metadata/ObjectRecursive.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -370,7 +375,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -439,7 +445,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -496,7 +503,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectRequired.json
+++ b/test/schemas/reflect/metadata/ObjectRequired.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -313,7 +317,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Make all properties in T required",
@@ -382,7 +387,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -439,7 +445,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -496,7 +503,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -553,7 +561,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -610,7 +619,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSequenceProtobuf.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": "Reference of the value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Pointer referencing value.",
@@ -214,7 +215,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -284,7 +286,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -354,7 +357,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -471,7 +475,8 @@
               ]
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -559,7 +564,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -633,7 +639,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -690,7 +697,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -775,7 +783,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -832,7 +841,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -889,7 +899,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectSimple.json
+++ b/test/schemas/reflect/metadata/ObjectSimple.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +259,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobuf.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -156,7 +157,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -228,7 +230,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -285,7 +288,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -357,7 +361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -428,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -499,7 +505,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -556,7 +563,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -613,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufNullable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -156,7 +157,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -228,7 +230,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -285,7 +288,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -357,7 +361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -428,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -499,7 +505,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -556,7 +563,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -613,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
+++ b/test/schemas/reflect/metadata/ObjectSimpleProtobufOptional.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -156,7 +157,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -228,7 +230,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -285,7 +288,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -357,7 +361,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -428,7 +433,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -499,7 +505,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -556,7 +563,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -613,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectTuple.json
+++ b/test/schemas/reflect/metadata/ObjectTuple.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUndefined.json
+++ b/test/schemas/reflect/metadata/ObjectUndefined.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -146,7 +147,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -203,7 +205,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -260,7 +263,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -312,7 +316,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -364,7 +369,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -416,7 +422,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -484,7 +491,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -541,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionComposite.json
+++ b/test/schemas/reflect/metadata/ObjectUnionComposite.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -210,7 +212,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -335,7 +339,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -392,7 +397,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -449,7 +455,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -517,7 +524,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -574,7 +582,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -631,7 +640,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -688,7 +698,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -756,7 +767,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -824,7 +836,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -881,7 +894,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -949,7 +963,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1006,7 +1021,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1074,7 +1090,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1131,7 +1148,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionCompositePointer.json
+++ b/test/schemas/reflect/metadata/ObjectUnionCompositePointer.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -181,7 +182,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -249,7 +251,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -306,7 +309,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -374,7 +378,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -431,7 +436,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -499,7 +505,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -556,7 +563,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -613,7 +621,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -681,7 +690,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -738,7 +748,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -795,7 +806,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -852,7 +864,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -920,7 +933,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -988,7 +1002,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1045,7 +1060,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1113,7 +1129,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1170,7 +1187,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1238,7 +1256,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1295,7 +1314,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionDouble.json
+++ b/test/schemas/reflect/metadata/ObjectUnionDouble.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -146,7 +147,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -214,7 +216,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -282,7 +285,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -350,7 +354,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -418,7 +423,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -486,7 +492,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -554,7 +561,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -615,7 +623,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -683,7 +692,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -751,7 +761,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -819,7 +830,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -887,7 +899,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -955,7 +968,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionExplicit.json
+++ b/test/schemas/reflect/metadata/ObjectUnionExplicit.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -204,7 +206,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -272,7 +275,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -329,7 +333,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -391,7 +396,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -459,7 +465,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -516,7 +523,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -584,7 +592,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -641,7 +650,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -698,7 +708,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -760,7 +771,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -828,7 +840,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -885,7 +898,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -942,7 +956,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -999,7 +1014,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1061,7 +1077,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1129,7 +1146,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1191,7 +1209,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1259,7 +1278,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1316,7 +1336,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1378,7 +1399,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1446,7 +1468,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1514,7 +1537,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1571,7 +1595,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1633,7 +1658,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionExplicitPointer.json
+++ b/test/schemas/reflect/metadata/ObjectUnionExplicitPointer.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -177,7 +178,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -245,7 +247,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -302,7 +305,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -364,7 +368,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -432,7 +437,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -489,7 +495,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -551,7 +558,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -619,7 +627,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -676,7 +685,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -744,7 +754,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -801,7 +812,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -858,7 +870,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -920,7 +933,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -988,7 +1002,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1045,7 +1060,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1102,7 +1118,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1159,7 +1176,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1221,7 +1239,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1289,7 +1308,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1351,7 +1371,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1419,7 +1440,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1476,7 +1498,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1538,7 +1561,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1606,7 +1630,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1674,7 +1699,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1731,7 +1757,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1793,7 +1820,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionImplicit.json
+++ b/test/schemas/reflect/metadata/ObjectUnionImplicit.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -267,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +328,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -381,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -438,7 +444,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -506,7 +513,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -563,7 +571,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -620,7 +629,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -677,7 +687,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -734,7 +745,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -791,7 +803,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -859,7 +872,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -916,7 +930,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -973,7 +988,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1030,7 +1046,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1087,7 +1104,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1144,7 +1162,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1201,7 +1220,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1269,7 +1289,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1326,7 +1347,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1394,7 +1416,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1451,7 +1474,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1508,7 +1532,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -1576,7 +1601,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1633,7 +1659,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1690,7 +1717,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ObjectUnionNonPredictable.json
+++ b/test/schemas/reflect/metadata/ObjectUnionNonPredictable.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -153,7 +154,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -229,7 +231,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -297,7 +300,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -365,7 +369,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -433,7 +438,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -501,7 +507,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -569,7 +576,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -637,7 +645,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/SetAlias.json
+++ b/test/schemas/reflect/metadata/SetAlias.json
@@ -108,7 +108,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -188,7 +189,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -268,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -348,7 +351,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -428,7 +432,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -496,7 +501,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -553,7 +559,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -610,7 +617,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/SetSimple.json
+++ b/test/schemas/reflect/metadata/SetSimple.json
@@ -108,7 +108,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -188,7 +189,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -268,7 +270,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -348,7 +351,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -428,7 +432,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -496,7 +501,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -553,7 +559,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -610,7 +617,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/SetUnion.json
+++ b/test/schemas/reflect/metadata/SetUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TemplateAtomic.json
+++ b/test/schemas/reflect/metadata/TemplateAtomic.json
@@ -139,7 +139,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +251,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -390,7 +392,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -530,7 +533,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -670,7 +674,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -736,7 +741,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -977,7 +983,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1165,7 +1172,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TemplateConstant.json
+++ b/test/schemas/reflect/metadata/TemplateConstant.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -166,7 +167,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -236,7 +238,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -330,7 +333,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TemplateUnion.json
+++ b/test/schemas/reflect/metadata/TemplateUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -265,7 +266,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -434,7 +436,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -588,7 +591,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -756,7 +760,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -824,7 +829,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonArray.json
+++ b/test/schemas/reflect/metadata/ToJsonArray.json
@@ -109,7 +109,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -201,7 +202,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -293,7 +295,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -385,7 +388,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -453,7 +457,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonAtomicSimple.json
+++ b/test/schemas/reflect/metadata/ToJsonAtomicSimple.json
@@ -109,7 +109,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -201,7 +202,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -293,7 +295,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonAtomicUnion.json
+++ b/test/schemas/reflect/metadata/ToJsonAtomicUnion.json
@@ -117,7 +117,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonDouble.json
+++ b/test/schemas/reflect/metadata/ToJsonDouble.json
@@ -197,7 +197,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -265,7 +266,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           },
           {
             "key": {
@@ -322,7 +324,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": "readonly"
           }
         ],
         "jsDocTags": [],
@@ -390,7 +393,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -447,7 +451,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonNull.json
+++ b/test/schemas/reflect/metadata/ToJsonNull.json
@@ -143,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonTuple.json
+++ b/test/schemas/reflect/metadata/ToJsonTuple.json
@@ -109,7 +109,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -201,7 +202,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -293,7 +295,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -385,7 +388,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -453,7 +457,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -510,7 +515,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/ToJsonUnion.json
+++ b/test/schemas/reflect/metadata/ToJsonUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -142,7 +143,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -199,7 +201,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -291,7 +294,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -383,7 +387,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -475,7 +480,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -543,7 +549,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -600,7 +607,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -657,7 +665,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TupleRestObject.json
+++ b/test/schemas/reflect/metadata/TupleRestObject.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagArray.json
+++ b/test/schemas/reflect/metadata/TypeTagArray.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -178,7 +179,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -249,7 +251,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -331,7 +334,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -413,7 +417,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +489,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagArrayUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagArrayUnion.json
@@ -110,7 +110,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -181,7 +182,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -252,7 +254,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -334,7 +337,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagAtomicUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagAtomicUnion.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -199,7 +200,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagBigInt.json
+++ b/test/schemas/reflect/metadata/TypeTagBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -179,7 +180,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -256,7 +258,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -333,7 +336,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -407,7 +411,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagCustom.json
+++ b/test/schemas/reflect/metadata/TypeTagCustom.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -173,7 +174,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -244,7 +246,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -315,7 +318,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagDefault.json
+++ b/test/schemas/reflect/metadata/TypeTagDefault.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -155,7 +156,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -225,7 +227,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -295,7 +298,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -386,7 +390,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -451,7 +456,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -529,7 +535,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -607,7 +614,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -740,7 +748,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagFormat.json
+++ b/test/schemas/reflect/metadata/TypeTagFormat.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -176,7 +177,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +252,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +327,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -398,7 +402,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -472,7 +477,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -546,7 +552,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -620,7 +627,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -694,7 +702,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -768,7 +777,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -842,7 +852,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -916,7 +927,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -990,7 +1002,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1064,7 +1077,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1138,7 +1152,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1212,7 +1227,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1286,7 +1302,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1360,7 +1377,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1434,7 +1452,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1508,7 +1527,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1582,7 +1602,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -1656,7 +1677,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagInfinite.json
+++ b/test/schemas/reflect/metadata/TypeTagInfinite.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -173,7 +174,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -247,7 +249,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -321,7 +324,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -392,7 +396,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -463,7 +468,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagLength.json
+++ b/test/schemas/reflect/metadata/TypeTagLength.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -178,7 +179,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -249,7 +251,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -320,7 +323,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -402,7 +406,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -484,7 +489,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagMatrix.json
+++ b/test/schemas/reflect/metadata/TypeTagMatrix.json
@@ -110,7 +110,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagNaN.json
+++ b/test/schemas/reflect/metadata/TypeTagNaN.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -173,7 +174,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -247,7 +249,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -321,7 +324,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -392,7 +396,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -463,7 +468,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagObjectUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagObjectUnion.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -195,7 +196,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagPattern.json
+++ b/test/schemas/reflect/metadata/TypeTagPattern.json
@@ -102,7 +102,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -176,7 +177,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +252,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -324,7 +327,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagRange.json
+++ b/test/schemas/reflect/metadata/TypeTagRange.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -181,7 +182,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -266,7 +268,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -351,7 +354,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -436,7 +440,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -535,7 +540,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -634,7 +640,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -733,7 +740,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -832,7 +840,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -931,7 +940,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagRangeBigInt.json
+++ b/test/schemas/reflect/metadata/TypeTagRangeBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -173,7 +174,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -250,7 +252,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -327,7 +330,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -404,7 +408,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -498,7 +503,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -592,7 +598,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -686,7 +693,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -780,7 +788,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -874,7 +883,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagTuple.json
+++ b/test/schemas/reflect/metadata/TypeTagTuple.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagType.json
+++ b/test/schemas/reflect/metadata/TypeTagType.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -167,7 +168,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -239,7 +241,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -310,7 +313,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -382,7 +386,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -453,7 +458,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -525,7 +531,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -596,7 +603,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeBigInt.json
@@ -85,7 +85,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -157,7 +158,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/TypeTagTypeUnion.json
+++ b/test/schemas/reflect/metadata/TypeTagTypeUnion.json
@@ -113,7 +113,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -197,7 +198,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -282,7 +284,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -366,7 +369,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -450,7 +454,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -535,7 +540,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -619,7 +625,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -703,7 +710,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -787,7 +795,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -925,7 +934,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],

--- a/test/schemas/reflect/metadata/UltimateUnion.json
+++ b/test/schemas/reflect/metadata/UltimateUnion.json
@@ -90,7 +90,8 @@
               "maps": []
             },
             "description": "OpenAPI specification version identifier.\n\nAlways set to \"3.1\" to indicate this collection uses OpenAPI v3.1 schema\nformat with enhanced JSON Schema compatibility.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -147,7 +148,8 @@
               "maps": []
             },
             "description": "Reusable schema components for OpenAPI v3.1.\n\nContains reusable schema definitions and other components following the\nOpenAPI v3.1 specification. This structure is similar to v3.0 but\nsupports enhanced JSON Schema features and improved type definitions.\n\nComponents include:\n\n- Schemas: Named type definitions with enhanced JSON Schema support\n- SecuritySchemes: Authentication and authorization schemes\n\nThe emended OpenAPI v3.1 format used here removes ambiguous expressions\nand standardizes certain patterns for better tooling compatibility.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -204,7 +206,8 @@
               "maps": []
             },
             "description": "Array of generated JSON schemas with v3.1 enhancements.\n\nContains JSON schema definitions that take advantage of OpenAPI v3.1's\nenhanced capabilities. These schemas can express more complex TypeScript\ntypes accurately, including:\n\n- Tuple types using prefixItems\n- Union types with proper null handling\n- Complex nested object structures\n- Pattern-based property definitions\n\nEach schema corresponds to one of the input TypeScript types and may\nreference components defined in the {@link components} property.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -261,7 +264,8 @@
               "maps": []
             },
             "description": "Type metadata for compile-time type tracking.\n\nThis optional property stores the original TypeScript types that were\nused to generate the JSON schemas. It provides compile-time type safety\nand enables better development experience without affecting runtime\nbehavior.\n\nBenefits include:\n\n- Strong typing connection to original TypeScript definitions\n- Enhanced IDE support and autocompletion\n- Compile-time validation of schema usage\n- Type-safe integration with validation libraries",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "JSON Schema collection formatted for OpenAPI v3.1 specification.\n\nThis interface represents a collection of JSON schemas that comply with\nOpenAPI v3.1 standards, which provide enhanced JSON Schema compatibility\nand support for modern JSON Schema features. OpenAPI v3.1 is based on JSON\nSchema Draft 2020-12 and offers significant improvements over v3.0.\n\nKey advantages of v3.1:\n\n- Full tuple type support with prefixItems\n- Pattern properties support for dynamic object keys\n- Proper null type handling via union types\n- Enhanced JSON Schema Draft 2020-12 compatibility\n- Better const, enum, and validation support",
@@ -348,7 +352,8 @@
               "maps": []
             },
             "description": "An object to hold reusable DTO schemas.\n\nIn other words, a collection of named JSON schemas.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -405,7 +410,8 @@
               "maps": []
             },
             "description": "An object to hold reusable security schemes.\n\nIn other words, a collection of named security schemes.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Reusable components in OpenAPI.\n\nA storage of reusable components in OpenAPI document.\n\nIn other words, it is a storage of named DTO schemas and security schemes.",
@@ -459,14 +465,6 @@
               "tuples": [],
               "objects": [
                 {
-                  "name": "OpenApi.IJsonSchema.IString",
-                  "tags": []
-                },
-                {
-                  "name": "OpenApi.IJsonSchema.INumber",
-                  "tags": []
-                },
-                {
                   "name": "OpenApi.IJsonSchema.IConstant",
                   "tags": []
                 },
@@ -475,7 +473,15 @@
                   "tags": []
                 },
                 {
+                  "name": "OpenApi.IJsonSchema.INumber",
+                  "tags": []
+                },
+                {
                   "name": "OpenApi.IJsonSchema.IInteger",
+                  "tags": []
+                },
+                {
+                  "name": "OpenApi.IJsonSchema.IString",
                   "tags": []
                 },
                 {
@@ -513,1541 +519,14 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with a set of properties K of type T",
         "jsDocTags": [],
         "index": 2,
         "recursive": true,
-        "nullables": [
-          false
-        ]
-      },
-      {
-        "name": "OpenApi.IJsonSchema.IString",
-        "properties": [
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "default",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Default value of the string type.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "format",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Format restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "pattern",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Pattern restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "contentMediaType",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Content media type restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "minLength",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": [
-                    [
-                      {
-                        "target": "number",
-                        "name": "Type<\"uint64\">",
-                        "kind": "type",
-                        "value": "uint64",
-                        "validate": "Math.floor($input) === $input && 0 <= $input && $input <= 18446744073709551615",
-                        "exclusive": true,
-                        "schema": {
-                          "type": "integer",
-                          "minimum": 0
-                        }
-                      }
-                    ]
-                  ]
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Minimum length restriction.",
-            "jsDocTags": [
-              {
-                "name": "type",
-                "text": [
-                  {
-                    "text": "uint64",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "maxLength",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": [
-                    [
-                      {
-                        "target": "number",
-                        "name": "Type<\"uint64\">",
-                        "kind": "type",
-                        "value": "uint64",
-                        "validate": "Math.floor($input) === $input && 0 <= $input && $input <= 18446744073709551615",
-                        "exclusive": true,
-                        "schema": {
-                          "type": "integer",
-                          "minimum": 0
-                        }
-                      }
-                    ]
-                  ]
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Maximum length restriction.",
-            "jsDocTags": [
-              {
-                "name": "type",
-                "text": [
-                  {
-                    "text": "uint64",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "type",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "string",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Discriminator value of the type.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "title",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Title of the schema.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "description",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Detailed description of the schema.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "deprecated",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "boolean",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "example",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": true,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Example value.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "examples",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [
-                {
-                  "name": "Record<string, any>",
-                  "tags": []
-                }
-              ],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
-          }
-        ],
-        "description": "String type info.",
-        "jsDocTags": [],
-        "index": 3,
-        "recursive": false,
-        "nullables": [
-          false
-        ]
-      },
-      {
-        "name": "Record<string, any>",
-        "properties": [
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": true,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": null,
-            "jsDocTags": []
-          }
-        ],
-        "description": "Construct a type with a set of properties K of type T",
-        "jsDocTags": [],
-        "index": 4,
-        "recursive": false,
-        "nullables": [
-          false
-        ]
-      },
-      {
-        "name": "OpenApi.IJsonSchema.INumber",
-        "properties": [
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "default",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Default value of the number type.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "minimum",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Minimum value restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "maximum",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Maximum value restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "exclusiveMinimum",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Exclusive minimum value restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "exclusiveMaximum",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Exclusive maximum value restriction.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "multipleOf",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "number",
-                  "tags": [
-                    [
-                      {
-                        "target": "number",
-                        "name": "ExclusiveMinimum<0>",
-                        "kind": "exclusiveMinimum",
-                        "value": 0,
-                        "validate": "0 < $input",
-                        "exclusive": [
-                          "minimum",
-                          "exclusiveMinimum"
-                        ],
-                        "schema": {
-                          "exclusiveMinimum": 0
-                        }
-                      }
-                    ]
-                  ]
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Multiple of value restriction.",
-            "jsDocTags": [
-              {
-                "name": "exclusiveMinimum",
-                "text": [
-                  {
-                    "text": "0",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "type",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "number",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Discriminator value of the type.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "title",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Title of the schema.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "description",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "string",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Detailed description of the schema.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "deprecated",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [
-                {
-                  "type": "boolean",
-                  "tags": []
-                }
-              ],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "example",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": true,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "Example value.",
-            "jsDocTags": []
-          },
-          {
-            "key": {
-              "any": false,
-              "required": true,
-              "optional": false,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [
-                {
-                  "type": "string",
-                  "values": [
-                    {
-                      "value": "examples",
-                      "tags": []
-                    }
-                  ]
-                }
-              ],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "value": {
-              "any": false,
-              "required": true,
-              "optional": true,
-              "nullable": false,
-              "functions": [],
-              "atomics": [],
-              "constants": [],
-              "templates": [],
-              "escaped": null,
-              "rest": null,
-              "arrays": [],
-              "tuples": [],
-              "objects": [
-                {
-                  "name": "Record<string, any>",
-                  "tags": []
-                }
-              ],
-              "aliases": [],
-              "natives": [],
-              "sets": [],
-              "maps": []
-            },
-            "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
-          }
-        ],
-        "description": "Number (double) type info.",
-        "jsDocTags": [],
-        "index": 5,
-        "recursive": false,
         "nullables": [
           false
         ]
@@ -2118,7 +597,8 @@
               "maps": []
             },
             "description": "The constant value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2175,7 +655,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2232,7 +713,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2289,7 +771,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2341,7 +824,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2398,12 +882,189 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Constant value type.",
         "jsDocTags": [],
-        "index": 6,
+        "index": 3,
+        "recursive": false,
+        "nullables": [
+          false
+        ]
+      },
+      {
+        "name": "Record<string, any>",
+        "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": true,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": null,
+            "jsDocTags": [],
+            "mutability": null
+          }
+        ],
+        "description": "Construct a type with a set of properties K of type T",
+        "jsDocTags": [],
+        "index": 4,
         "recursive": false,
         "nullables": [
           false
@@ -2467,7 +1128,8 @@
               "maps": []
             },
             "description": "The default value of the boolean type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2529,7 +1191,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2586,7 +1249,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2643,7 +1307,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2700,7 +1365,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2752,7 +1418,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -2809,12 +1476,129 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Boolean type info.",
         "jsDocTags": [],
-        "index": 7,
+        "index": 5,
         "recursive": false,
         "nullables": [
           false
@@ -2902,7 +1686,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -2983,7 +1768,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -3064,7 +1850,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -3121,7 +1908,8 @@
               "maps": []
             },
             "description": "Exclusive minimum value restriction.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3178,7 +1966,8 @@
               "maps": []
             },
             "description": "Exclusive maximum value restriction.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3283,7 +2072,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -3345,7 +2135,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3402,7 +2193,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3459,7 +2251,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3516,7 +2309,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3568,7 +2362,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3625,10 +2420,1852 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Integer type info.",
+        "jsDocTags": [],
+        "index": 6,
+        "recursive": false,
+        "nullables": [
+          false
+        ]
+      },
+      {
+        "name": "OpenApi.IJsonSchema.INumber",
+        "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "default",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Default value of the number type.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "minimum",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Minimum value restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "maximum",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Maximum value restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "exclusiveMinimum",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Exclusive minimum value restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "exclusiveMaximum",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Exclusive maximum value restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "multipleOf",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": [
+                    [
+                      {
+                        "target": "number",
+                        "name": "ExclusiveMinimum<0>",
+                        "kind": "exclusiveMinimum",
+                        "value": 0,
+                        "validate": "0 < $input",
+                        "exclusive": [
+                          "minimum",
+                          "exclusiveMinimum"
+                        ],
+                        "schema": {
+                          "exclusiveMinimum": 0
+                        }
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Multiple of value restriction.",
+            "jsDocTags": [
+              {
+                "name": "exclusiveMinimum",
+                "text": [
+                  {
+                    "text": "0",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "type",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "number",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Discriminator value of the type.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "title",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Title of the schema.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "description",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Detailed description of the schema.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "deprecated",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the type is deprecated or not.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "example",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": true,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Example value.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "examples",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [
+                {
+                  "name": "Record<string, any>",
+                  "tags": []
+                }
+              ],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "List of example values as key-value pairs.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
+          }
+        ],
+        "description": "Number (double) type info.",
+        "jsDocTags": [],
+        "index": 7,
+        "recursive": false,
+        "nullables": [
+          false
+        ]
+      },
+      {
+        "name": "OpenApi.IJsonSchema.IString",
+        "properties": [
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "default",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Default value of the string type.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "format",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Format restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "pattern",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Pattern restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "contentMediaType",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Content media type restriction.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "minLength",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": [
+                    [
+                      {
+                        "target": "number",
+                        "name": "Type<\"uint64\">",
+                        "kind": "type",
+                        "value": "uint64",
+                        "validate": "Math.floor($input) === $input && 0 <= $input && $input <= 18446744073709551615",
+                        "exclusive": true,
+                        "schema": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Minimum length restriction.",
+            "jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint64",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "maxLength",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "number",
+                  "tags": [
+                    [
+                      {
+                        "target": "number",
+                        "name": "Type<\"uint64\">",
+                        "kind": "type",
+                        "value": "uint64",
+                        "validate": "Math.floor($input) === $input && 0 <= $input && $input <= 18446744073709551615",
+                        "exclusive": true,
+                        "schema": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Maximum length restriction.",
+            "jsDocTags": [
+              {
+                "name": "type",
+                "text": [
+                  {
+                    "text": "uint64",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "type",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "string",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Discriminator value of the type.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "title",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Title of the schema.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "description",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "string",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Detailed description of the schema.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "deprecated",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the type is deprecated or not.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "example",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": true,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Example value.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "examples",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [
+                {
+                  "name": "Record<string, any>",
+                  "tags": []
+                }
+              ],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "List of example values as key-value pairs.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
+          }
+        ],
+        "description": "String type info.",
         "jsDocTags": [],
         "index": 8,
         "recursive": false,
@@ -3684,14 +4321,6 @@
               "tuples": [],
               "objects": [
                 {
-                  "name": "OpenApi.IJsonSchema.IString",
-                  "tags": []
-                },
-                {
-                  "name": "OpenApi.IJsonSchema.INumber",
-                  "tags": []
-                },
-                {
                   "name": "OpenApi.IJsonSchema.IConstant",
                   "tags": []
                 },
@@ -3700,7 +4329,15 @@
                   "tags": []
                 },
                 {
+                  "name": "OpenApi.IJsonSchema.INumber",
+                  "tags": []
+                },
+                {
                   "name": "OpenApi.IJsonSchema.IInteger",
+                  "tags": []
+                },
+                {
+                  "name": "OpenApi.IJsonSchema.IString",
                   "tags": []
                 },
                 {
@@ -3738,7 +4375,8 @@
               "maps": []
             },
             "description": "Items type info.\n\nThe `items` means the type of the array elements. In other words, it is\nthe type schema info of the `T` in the TypeScript array type\n`Array<T>`.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3795,7 +4433,8 @@
               "maps": []
             },
             "description": "Unique items restriction.\n\nIf this property value is `true`, target array must have unique items.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -3877,7 +4516,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -3959,7 +4599,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -4021,7 +4662,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4078,7 +4720,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4135,7 +4778,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4192,7 +4836,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4244,7 +4889,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4301,7 +4947,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Array type info.",
@@ -4375,7 +5138,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.\n\nNote that, the tuple type cannot be distinguished with {@link IArray}\ntype just by this `discriminator` property.\n\nTo check whether the type is tuple or array, you have to check the\nexistence of {@link IArray.items} or {@link ITuple.prefixItems}\nproperties.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4432,7 +5196,8 @@
               "maps": []
             },
             "description": "Prefix items.\n\nThe `prefixItems` means the type schema info of the prefix items in the\ntuple type. In the TypeScript, it is expressed as `[T1, T2]`.\n\nIf you want to express `[T1, T2, ...TO[]]` type, you can configure the\n`...TO[]` through the {@link additionalItems} property.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4484,14 +5249,6 @@
               "tuples": [],
               "objects": [
                 {
-                  "name": "OpenApi.IJsonSchema.IString",
-                  "tags": []
-                },
-                {
-                  "name": "OpenApi.IJsonSchema.INumber",
-                  "tags": []
-                },
-                {
                   "name": "OpenApi.IJsonSchema.IConstant",
                   "tags": []
                 },
@@ -4500,7 +5257,15 @@
                   "tags": []
                 },
                 {
+                  "name": "OpenApi.IJsonSchema.INumber",
+                  "tags": []
+                },
+                {
                   "name": "OpenApi.IJsonSchema.IInteger",
+                  "tags": []
+                },
+                {
+                  "name": "OpenApi.IJsonSchema.IString",
                   "tags": []
                 },
                 {
@@ -4538,7 +5303,8 @@
               "maps": []
             },
             "description": "Additional items.\n\nThe `additionalItems` means the type schema info of the additional\nitems after the {@link prefixItems}. In the TypeScript, if there's a\ntype `[T1, T2, ...TO[]]`, the `...TO[]` is represented by the\n`additionalItems`.\n\nBy the way, if you configure the `additionalItems` as `true`, it means\nthe additional items are not restricted. They can be any type, so that\nit is equivalent to the TypeScript type `[T1, T2, ...any[]]`.\n\nOtherwise configure the `additionalItems` as the {@link IJsonSchema}, it\nmeans the additional items must follow the type schema info. Therefore,\nit is equivalent to the TypeScript type `[T1, T2, ...TO[]]`.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4595,7 +5361,8 @@
               "maps": []
             },
             "description": "Unique items restriction.\n\nIf this property value is `true`, target tuple must have unique items.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4677,7 +5444,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -4759,7 +5527,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "mutability": null
           },
           {
             "key": {
@@ -4816,7 +5585,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4873,7 +5643,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4930,7 +5701,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -4982,7 +5754,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5039,7 +5812,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Tuple type info.",
@@ -5108,7 +5998,8 @@
               "maps": []
             },
             "description": "Properties of the object.\n\nThe `properties` means a list of key-value pairs of the object's\nregular properties. The key is the name of the regular property, and\nthe value is the type schema info.\n\nIf you need additional properties that is represented by dynamic key,\nyou can use the {@link additionalProperties} instead.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5160,14 +6051,6 @@
               "tuples": [],
               "objects": [
                 {
-                  "name": "OpenApi.IJsonSchema.IString",
-                  "tags": []
-                },
-                {
-                  "name": "OpenApi.IJsonSchema.INumber",
-                  "tags": []
-                },
-                {
                   "name": "OpenApi.IJsonSchema.IConstant",
                   "tags": []
                 },
@@ -5176,7 +6059,15 @@
                   "tags": []
                 },
                 {
+                  "name": "OpenApi.IJsonSchema.INumber",
+                  "tags": []
+                },
+                {
                   "name": "OpenApi.IJsonSchema.IInteger",
+                  "tags": []
+                },
+                {
+                  "name": "OpenApi.IJsonSchema.IString",
                   "tags": []
                 },
                 {
@@ -5214,7 +6105,8 @@
               "maps": []
             },
             "description": "Additional properties' info.\n\nThe `additionalProperties` means the type schema info of the additional\nproperties that are not listed in the {@link properties}.\n\nIf the value is `true`, it means that the additional properties are not\nrestricted. They can be any type. Otherwise, if the value is\n{@link IJsonSchema} type, it means that the additional properties must\nfollow the type schema info.\n\n- `true`: `Record<string, any>`\n- `IJsonSchema`: `Record<string, T>`",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5271,7 +6163,8 @@
               "maps": []
             },
             "description": "List of key values of the required properties.\n\nThe `required` means a list of the key values of the required\n{@link properties}. If some property key is not listed in the `required`\nlist, it means that property is optional. Otherwise some property key\nexists in the `required` list, it means that the property must be\nfilled.\n\nBelow is an example of the {@link properties} and `required`.\n\n```typescript\ninterface SomeObject {\n  id: string;\n  email: string;\n  name?: string;\n}\n```\n\nAs you can see, `id` and `email` {@link properties} are {@link required},\nso that they are listed in the `required` list.\n\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": { \"type\": \"string\" },\n    \"email\": { \"type\": \"string\" },\n    \"name\": { \"type\": \"string\" }\n  },\n  \"required\": [\"id\", \"email\"]\n}\n```",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5333,7 +6226,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5390,7 +6284,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5447,7 +6342,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5504,7 +6400,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5556,7 +6453,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5613,7 +6511,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Object type info.",
@@ -5682,7 +6697,8 @@
               "maps": []
             },
             "description": "Reference to the named schema.\n\nThe `ref` is a reference to the named schema. Format of the `$ref` is\nfollowing the JSON Pointer specification. In the OpenAPI, the `$ref`\nstarts with `#/components/schemas/` which means the type is stored in\nthe {@link OpenApi.IComponents.schemas} object.\n\n- `#/components/schemas/SomeObject`\n- `#/components/schemas/AnotherObject`",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5739,7 +6755,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5796,7 +6813,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5853,7 +6871,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5905,7 +6924,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -5962,7 +6982,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Reference type directing named schema.",
@@ -6019,7 +7156,7 @@
               "rest": null,
               "arrays": [
                 {
-                  "name": "Array<IString | INumber | IConstant | IBoolean | IInteger | IArray | ITuple | IObject | IReference<string> | INull | IUnknown>",
+                  "name": "Array<IConstant | IBoolean | IInteger | INumber | IString | IArray | ITuple | IObject | IReference<string> | INull | IUnknown>",
                   "tags": []
                 }
               ],
@@ -6031,7 +7168,8 @@
               "maps": []
             },
             "description": "List of the union types.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6088,7 +7226,8 @@
               "maps": []
             },
             "description": "Discriminator info of the union type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6145,7 +7284,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6202,7 +7342,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6259,7 +7400,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6311,7 +7453,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6368,7 +7511,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Union type.\n\n`IOneOf` represents an union type of the TypeScript (`A | B | C`).\n\nFor reference, even though your Swagger (or OpenAPI) document has defined\n`anyOf` instead of the `oneOf`, {@link OpenApi} forcibly converts it to\n`oneOf` type.",
@@ -6432,7 +7692,8 @@
               "maps": []
             },
             "description": "Default value of the `null` type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6494,7 +7755,8 @@
               "maps": []
             },
             "description": "Discriminator value of the type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6551,7 +7813,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6608,7 +7871,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6665,7 +7929,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6717,7 +7982,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6774,7 +8040,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Null type.",
@@ -6838,7 +8221,8 @@
               "maps": []
             },
             "description": "Default value of the `any` type.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6890,7 +8274,8 @@
               "maps": []
             },
             "description": "Type is never be defined.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -6947,7 +8332,8 @@
               "maps": []
             },
             "description": "Title of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7004,7 +8390,8 @@
               "maps": []
             },
             "description": "Detailed description of the schema.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7061,7 +8448,8 @@
               "maps": []
             },
             "description": "Whether the type is deprecated or not.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7113,7 +8501,8 @@
               "maps": []
             },
             "description": "Example value.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7170,7 +8559,124 @@
               "maps": []
             },
             "description": "List of example values as key-value pairs.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "readOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is read-only.",
+            "jsDocTags": [],
+            "mutability": null
+          },
+          {
+            "key": {
+              "any": false,
+              "required": true,
+              "optional": false,
+              "nullable": false,
+              "functions": [],
+              "atomics": [],
+              "constants": [
+                {
+                  "type": "string",
+                  "values": [
+                    {
+                      "value": "writeOnly",
+                      "tags": []
+                    }
+                  ]
+                }
+              ],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "value": {
+              "any": false,
+              "required": true,
+              "optional": true,
+              "nullable": false,
+              "functions": [],
+              "atomics": [
+                {
+                  "type": "boolean",
+                  "tags": []
+                }
+              ],
+              "constants": [],
+              "templates": [],
+              "escaped": null,
+              "rest": null,
+              "arrays": [],
+              "tuples": [],
+              "objects": [],
+              "aliases": [],
+              "natives": [],
+              "sets": [],
+              "maps": []
+            },
+            "description": "Whether the property is write-only.",
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Unknown, the `any` type.",
@@ -7239,7 +8745,8 @@
               "maps": []
             },
             "description": "Property name for the discriminator.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7296,7 +8803,8 @@
               "maps": []
             },
             "description": "Mapping of the discriminator value to the schema name.\n\nThis property is valid only for {@link IReference} typed\n{@link IOneOf.oneof} elements. Therefore, `key` of `mapping` is the\ndiscriminator value, and `value` of `mapping` is the schema name like\n`#/components/schemas/SomeObject`.",
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Discriminator info of the union type.",
@@ -7360,7 +8868,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with a set of properties K of type T",
@@ -7440,7 +8949,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with a set of properties K of type T",
@@ -7514,7 +9024,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7584,7 +9095,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7641,7 +9153,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7698,7 +9211,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Normal API key type.",
@@ -7772,7 +9286,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7834,7 +9349,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -7891,7 +9407,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "HTTP basic authentication type.",
@@ -7965,7 +9482,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8027,7 +9545,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8084,7 +9603,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8141,7 +9661,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "HTTP bearer authentication type.",
@@ -8215,7 +9736,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8272,7 +9794,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8329,7 +9852,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "OAuth2 authentication type.",
@@ -8398,7 +9922,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8455,7 +9980,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8512,7 +10038,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8569,7 +10096,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -8637,7 +10165,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8694,7 +10223,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8751,7 +10281,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8808,7 +10339,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -8876,7 +10408,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8933,7 +10466,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -8990,7 +10524,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with the properties of T except for those in type K.",
@@ -9059,7 +10594,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -9116,7 +10652,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -9173,7 +10710,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "description": "Construct a type with the properties of T except for those in type K.",
@@ -9247,7 +10785,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -9304,7 +10843,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           },
           {
             "key": {
@@ -9361,7 +10901,8 @@
               "maps": []
             },
             "description": null,
-            "jsDocTags": []
+            "jsDocTags": [],
+            "mutability": null
           }
         ],
         "jsDocTags": [],
@@ -9423,14 +10964,6 @@
           "tuples": [],
           "objects": [
             {
-              "name": "OpenApi.IJsonSchema.IString",
-              "tags": []
-            },
-            {
-              "name": "OpenApi.IJsonSchema.INumber",
-              "tags": []
-            },
-            {
               "name": "OpenApi.IJsonSchema.IConstant",
               "tags": []
             },
@@ -9439,7 +10972,15 @@
               "tags": []
             },
             {
+              "name": "OpenApi.IJsonSchema.INumber",
+              "tags": []
+            },
+            {
               "name": "OpenApi.IJsonSchema.IInteger",
+              "tags": []
+            },
+            {
+              "name": "OpenApi.IJsonSchema.IString",
               "tags": []
             },
             {
@@ -9483,7 +11024,7 @@
         "index": null
       },
       {
-        "name": "Array<IString | INumber | IConstant | IBoolean | IInteger | IArray | ITuple | IObject | IReference<string> | INull | IUnknown>",
+        "name": "Array<IConstant | IBoolean | IInteger | INumber | IString | IArray | ITuple | IObject | IReference<string> | INull | IUnknown>",
         "value": {
           "any": false,
           "required": true,
@@ -9499,14 +11040,6 @@
           "tuples": [],
           "objects": [
             {
-              "name": "OpenApi.IJsonSchema.IString",
-              "tags": []
-            },
-            {
-              "name": "OpenApi.IJsonSchema.INumber",
-              "tags": []
-            },
-            {
               "name": "OpenApi.IJsonSchema.IConstant",
               "tags": []
             },
@@ -9515,7 +11048,15 @@
               "tags": []
             },
             {
+              "name": "OpenApi.IJsonSchema.INumber",
+              "tags": []
+            },
+            {
               "name": "OpenApi.IJsonSchema.IInteger",
+              "tags": []
+            },
+            {
+              "name": "OpenApi.IJsonSchema.IString",
               "tags": []
             },
             {

--- a/test/src/debug/readonly.ts
+++ b/test/src/debug/readonly.ts
@@ -1,0 +1,7 @@
+import typia from "typia";
+
+console.log(
+  typia.json.schema<{
+    readonly id: string;
+  }>().schema,
+);

--- a/test/src/features/issues/test_issue_readonly.ts
+++ b/test/src/features/issues/test_issue_readonly.ts
@@ -1,0 +1,17 @@
+import { OpenApi, OpenApiTypeChecker } from "@samchon/openapi";
+import typia from "typia";
+
+import { TestValidator } from "../../helpers/TestValidator";
+
+export const test_issue_readonly = () => {
+  const schema: OpenApi.IJsonSchema = typia.json.schema<{
+    readonly id: string;
+    readonly values: number[];
+    readonly nullable: boolean | null;
+  }>().schema;
+  if (OpenApiTypeChecker.isObject(schema) === false)
+    throw new Error("must be object type");
+  TestValidator.predicate("all readonly")(() =>
+    Object.values(schema.properties ?? {}).every((p) => !!p.readOnly),
+  );
+};


### PR DESCRIPTION
This pull request introduces support for tracking and exposing the `readonly` mutability of object properties in the metadata and JSON Schema output. This enables schemas generated by Typia to accurately reflect TypeScript's `readonly` modifier, improving type fidelity for consumers. Additionally, the pull request updates dependencies and CI workflows.

### Feature: Readonly property support

* Added a `mutability` field (specifically supporting `"readonly"`) to the `MetadataProperty` class, its interface, and serialization logic to track if a property is declared as `readonly` in TypeScript. (`src/schemas/metadata/IMetadataProperty.ts`, `src/schemas/metadata/MetadataProperty.ts`) [[1]](diffhunk://#diff-d122199875b139f3c869795b6ae3240c022031f0f1243a677657edf14fa8eff0R9) [[2]](diffhunk://#diff-a5ad4953ec490c2439604bd1d083d4f5fb605edc8669e65e1ba448611e9ae2f1R14) [[3]](diffhunk://#diff-a5ad4953ec490c2439604bd1d083d4f5fb605edc8669e65e1ba448611e9ae2f1R27) [[4]](diffhunk://#diff-a5ad4953ec490c2439604bd1d083d4f5fb605edc8669e65e1ba448611e9ae2f1R44) [[5]](diffhunk://#diff-a5ad4953ec490c2439604bd1d083d4f5fb605edc8669e65e1ba448611e9ae2f1R54)
* Updated the metadata object factory to extract and store the `readonly` status from TypeScript declarations when constructing metadata properties. (`src/factories/internal/metadata/emplace_metadata_object.ts`) [[1]](diffhunk://#diff-9c9ae7bf4163021570485acb821f0407a5094152c7e7c096db41d4c7fd32c8e4R54) [[2]](diffhunk://#diff-9c9ae7bf4163021570485acb821f0407a5094152c7e7c096db41d4c7fd32c8e4R65-R81) [[3]](diffhunk://#diff-9c9ae7bf4163021570485acb821f0407a5094152c7e7c096db41d4c7fd32c8e4R133) [[4]](diffhunk://#diff-9c9ae7bf4163021570485acb821f0407a5094152c7e7c096db41d4c7fd32c8e4R196)
* Modified the JSON Schema object generator to set the `readOnly` property in the schema when the source property is marked as `readonly`. (`src/programmers/internal/json_schema_object.ts`)

### Testing

* Added new tests to validate that schemas generated for objects with `readonly` properties correctly set the `readOnly` flag in the output. (`test/src/debug/readonly.ts`, `test/src/features/issues/test_issue_readonly.ts`) [[1]](diffhunk://#diff-4f031a1c7890d90b58b3f3ec7d2be1d2d855d812b511d6eea9751c445327d462R1-R7) [[2]](diffhunk://#diff-282c3d83d457c97196c7cbb5ee61a58a53b80b679b4c1dbce17a7a91369d3f6bR1-R17)

### Dependency and workflow updates

* Upgraded `@samchon/openapi` dependency from `5.0.1` to `5.1.0` in `package.json` and updated lockfile references. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL868-R869) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4249-R4249)
* Updated GitHub Actions workflow to use newer versions of `actions/setup-node` (v6) and `pnpm/action-setup` (v4) for improved CI reliability. (`.github/workflows/release.yml`)