### PR TITLE
Fix #1689: `createXPrune()`'s fixed parameter type.

### DIFF
--- a/src/misc.ts
+++ b/src/misc.ts
@@ -507,7 +507,7 @@ export function createPrune(): never;
 export function createPrune<T extends object>(): (input: T) => void;
 
 /** @internal */
-export function createPrune<T extends object>(): (input: T) => void {
+export function createPrune(): never {
   NoTransformConfigurationError("misc.createPrune");
 }
 
@@ -534,10 +534,10 @@ export function createAssertPrune(
  */
 export function createAssertPrune<T extends object>(
   errorFactory?: undefined | ((props: TypeGuardError.IProps) => Error),
-): (input: T) => T;
+): (input: unknown) => T;
 
 /** @internal */
-export function createAssertPrune<T extends object>(): (input: T) => T {
+export function createAssertPrune(): never {
   NoTransformConfigurationError("misc.createAssertPrune");
 }
 
@@ -558,10 +558,12 @@ export function createIsPrune(): never;
  * @template T Type of the input value
  * @returns A reusable `isPrune` function
  */
-export function createIsPrune<T extends object>(): (input: T) => input is T;
+export function createIsPrune<T extends object>(): (
+  input: unknown,
+) => input is T;
 
 /** @internal */
-export function createIsPrune<T extends object>(): (input: T) => input is T {
+export function createIsPrune(): never {
   NoTransformConfigurationError("misc.createIsPrune");
 }
 
@@ -583,12 +585,10 @@ export function createValidatePrune(): never;
  * @returns A reusable `validatePrune` function
  */
 export function createValidatePrune<T extends object>(): (
-  input: T,
+  input: unknown,
 ) => IValidation<T>;
 
 /** @internal */
-export function createValidatePrune<T extends object>(): (
-  input: T,
-) => IValidation<T> {
+export function createValidatePrune(): never {
   NoTransformConfigurationError("misc.createValidatePrune");
 }


### PR DESCRIPTION
This pull request refactors several factory functions in `src/misc.ts` related to pruning operations. The main changes involve updating function signatures to accept `unknown` input types for better type safety and replacing implementations with error-throwing stubs to indicate that transformation configurations are not available.

### API signature updates

* Updated the input parameter type for `createAssertPrune`, `createIsPrune`, and `createValidatePrune` to accept `unknown` instead of a specific object type, improving type safety and flexibility. [[1]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL537-R540) [[2]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL561-R566) [[3]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL586-R592)

### Implementation changes

* Replaced the internal implementations of `createPrune`, `createAssertPrune`, `createIsPrune`, and `createValidatePrune` with stubs that throw a `NoTransformConfigurationError`, signaling that these functions are not available without a transformation configuration. [[1]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL510-R510) [[2]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL537-R540) [[3]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL561-R566) [[4]](diffhunk://#diff-e4e51b0b4b7ebb2d6fee833c037af555eff55cb24e5d0642a467e47bb4773fbeL586-R592)