### PR TITLE
Use npm's trusted publisher instead

### DIFF
--- a/deploy/internal/DeployRunner.ts
+++ b/deploy/internal/DeployRunner.ts
@@ -69,10 +69,7 @@ export namespace DeployRunner {
         "utf8",
       );
       if (tag !== "test")
-        cp.execSync(
-          `npm publish --tag ${tag}${tag === "latest" ? " --provenance" : ""}`,
-          { stdio: "inherit" },
-        );
+        cp.execSync(`npm publish --tag ${tag}`, { stdio: "inherit" });
       return version;
     } catch (error) {
       throw error;

--- a/package.json
+++ b/package.json
@@ -118,5 +118,6 @@
     "claude",
     "gemini",
     "llama"
-  ]
+  ],
+  "packageManager": "pnpm@10.6.4"
 }


### PR DESCRIPTION
This pull request introduces a couple of small but important updates related to deployment and package management. The main changes are a simplification of the npm publish command in the deployment script and the specification of the package manager in `package.json`.

Deployment process update:
* The `npm publish` command in `DeployRunner.ts` no longer includes the `--provenance` flag for the `latest` tag, streamlining the deployment process.

Package management update:
* The `package.json` now explicitly specifies `pnpm@10.6.4` as the package manager, which helps ensure consistent dependency management across environments.