### PR TITLE
Close #1700: accept file arguments in typia generate CLI

### DIFF
--- a/src/executable/TypiaGenerateWizard.ts
+++ b/src/executable/TypiaGenerateWizard.ts
@@ -24,6 +24,7 @@ export namespace TypiaGenerateWizard {
     action,
   ) => {
     // PREPARE ASSETS
+    command.argument("[files...]", "input .ts files (alternative to --input)");
     command.option("--input [path]", "input directory");
     command.option("--output [directory]", "output directory");
     command.option("--project [project]", "tsconfig.json file location");
@@ -68,7 +69,11 @@ export namespace TypiaGenerateWizard {
     };
 
     return action(async (options) => {
-      options.input ??= await input("input")("input directory");
+      // If files are provided, input directory is not required
+      const hasFiles = options.files && options.files.length > 0;
+      if (!hasFiles) {
+        options.input ??= await input("input")("input directory");
+      }
       options.output ??= await input("output")("output directory");
       options.project ??= await configure();
       return options as IArguments;
@@ -79,5 +84,6 @@ export namespace TypiaGenerateWizard {
     input: string;
     output: string;
     project: string;
+    files?: string[];
   }
 }

--- a/src/executable/setup/ArgumentParser.ts
+++ b/src/executable/setup/ArgumentParser.ts
@@ -23,8 +23,15 @@ export namespace ArgumentParser {
     // TAKE OPTIONS
     const action = (closure: (options: Partial<T>) => Promise<T>) =>
       new Promise<T>((resolve, reject) => {
-        commander.program.action(async (options) => {
+        commander.program.action(async (...args: unknown[]) => {
           try {
+            // Commander passes: (positionalArgs..., options, command)
+            // Use program.opts() for reliable option extraction
+            const options = commander.program.opts() as Partial<T>;
+            // If there are positional arguments (files), attach them to options
+            if (args.length > 0 && Array.isArray(args[0])) {
+              (options as Partial<T> & { files?: string[] }).files = args[0];
+            }
             resolve(await closure(options));
           } catch (exp) {
             reject(exp);


### PR DESCRIPTION
## Summary

Add support for file arguments as an alternative to `--input` directory in `typia generate` CLI.

```bash
# New: file arguments
typia generate src/**/*.typia.ts --output src/generated --project tsconfig.json

# Existing: directory mode (unchanged)
typia generate --input src/templates --output src/generated --project tsconfig.json
```

## Changes

- `ArgumentParser.ts`: Use `program.opts()` for reliable option extraction, capture positional file arguments
- `TypiaGenerateWizard.ts`: Add `[files...]` argument definition, skip `--input` prompt when files provided
- `TypiaProgrammer.ts`: Handle file list mode - use files directly instead of `gather()`, output to `--output` with basename

## CLI Interface

```
Usage: typia generate [options] [files...]

Arguments:
  files                 input .ts files (alternative to --input)

Options:
  --input [path]        input directory
  --output [directory]  output directory
  --project [project]   tsconfig.json file location
```

## Testing

- [x] CLI help shows new `[files...]` argument
- [x] Options before files: `typia generate --output dir file.ts` works
- [x] Files before options: `typia generate file.ts --output dir` works
- [x] Transformation produces correct output

Closes #1700