### PR TITLE
Include "format" of integer types

### DIFF
--- a/src/tags/Type.ts
+++ b/src/tags/Type.ts
@@ -53,10 +53,12 @@ export type Type<
   exclusive: true;
   schema: Value extends "uint32" | "uint64"
     ? {
+        format: Value;
         type: "integer";
         minimum: 0;
       }
     : {
+        format: Value;
         type: Value extends "int32" | "uint32" | "int64" | "uint64"
           ? "integer"
           : "number";


### PR DESCRIPTION
Somewhat related to #1676, although this doesn't add new types.

Includes the actual integer type as a `format` in the generated schema; this is valid per [Formats Registry](https://spec.openapis.org/registry/format/).