### PR TITLE
JSON schema supports `@x-plugin null` comment.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/programmers/internal/json_schema_jsDocTags.ts
+++ b/src/programmers/internal/json_schema_jsDocTags.ts
@@ -18,10 +18,10 @@ export const json_schema_jsDocTags = <Schema extends OpenApi.IJsonSchema>(
   return schema;
 };
 
-const cast = (value: string): string | number | boolean => {
+const cast = (value: string): string | number | boolean | null => {
   if (value === "true") return true;
   if (value === "false") return false;
   const num: number = Number(value);
   if (Number.isNaN(num) === false) return num;
-  return value;
+  return value === "null" ? null : value;
 };

--- a/src/programmers/internal/json_schema_jsDocTags.ts
+++ b/src/programmers/internal/json_schema_jsDocTags.ts
@@ -11,7 +11,7 @@ export const json_schema_jsDocTags = <Schema extends OpenApi.IJsonSchema>(
 
     const value: string | undefined = tag.text
       ?.filter((s) => s.kind === "text")
-      .map((s) => s.text.split("\r\n").join("\n"))[0];
+      .map((s) => s.text.trim().split("\r\n").join("\n"))[0];
     if (value === undefined) continue;
     else (schema as any)[tag.name] = cast(value);
   }

--- a/test/src/features/issues/test_pr_1714_json_schema_plugin_by_jsDocTags.ts
+++ b/test/src/features/issues/test_pr_1714_json_schema_plugin_by_jsDocTags.ts
@@ -15,6 +15,9 @@ export const test_pr_1714_json_schema_plugin_by_jsDocTags = (): void => {
   TestValidator.equals("x-autobe-database-schema")(
     (something as any)?.["x-autobe-database-schema"],
   )("somethings");
+  TestValidator.equals("x-null-value")(
+    (something.properties?.id as any)?.["x-null-value"],
+  )(null);
   TestValidator.equals("x-custom-tag")(
     (something.properties?.id as any)?.["x-custom-tag"],
   )(3);
@@ -36,6 +39,7 @@ interface ISomething {
    * Primary Key.
    *
    * @x-autobe-database-schema-member id
+   * @x-null-value null
    * @x-custom-tag 3
    * @x-valid true
    * @regular This is a regular tag and should be ignored.


### PR DESCRIPTION
This pull request updates the handling of jsDoc tags in the JSON schema plugin to support proper casting of the string `"null"` to the JavaScript `null` value. It also adds corresponding tests to ensure this behavior is correctly validated.

**Enhancements to jsDoc tag value casting:**

* Updated the `cast` function in `src/programmers/internal/json_schema_jsDocTags.ts` to convert the string `"null"` to the JavaScript `null` value, in addition to existing conversions for booleans and numbers.

**Testing improvements:**

* Added a test in `test/src/features/issues/test_pr_1714_json_schema_plugin_by_jsDocTags.ts` to verify that the new `@x-null-value null` jsDoc tag is correctly cast to `null` in the generated schema.
* Modified the `ISomething` interface in the same test file to include the `@x-null-value null` jsDoc tag for the `id` property.

**Version update:**

* Bumped the package version in `package.json` from `11.0.1` to `11.0.2` to reflect these changes.