### PR TITLE
Support `@ignore` tag (due to `prettier-plugin-jsdoc`).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/programmers/internal/json_schema_object.ts
+++ b/src/programmers/internal/json_schema_object.ts
@@ -67,7 +67,10 @@ const create_object_schema = (props: {
       continue;
     else if (
       property.jsDocTags.find(
-        (tag) => tag.name === "hidden" || tag.name === "ignore",
+        (tag) =>
+          tag.name === "hidden" ||
+          tag.name === "ignore" ||
+          tag.name === "internal",
       )
     )
       continue; // THE HIDDEN/IGNORE TAG

--- a/src/programmers/internal/json_schema_object.ts
+++ b/src/programmers/internal/json_schema_object.ts
@@ -65,7 +65,12 @@ const create_object_schema = (props: {
       property.value.size() === 0
     )
       continue;
-    else if (property.jsDocTags.find((tag) => tag.name === "hidden")) continue; // THE HIDDEN TAG
+    else if (
+      property.jsDocTags.find(
+        (tag) => tag.name === "hidden" || tag.name === "ignore",
+      )
+    )
+      continue; // THE HIDDEN/IGNORE TAG
 
     const value: OpenApi.IJsonSchema | null = json_schema_station({
       blockNever: true,

--- a/src/programmers/internal/json_schema_object.ts
+++ b/src/programmers/internal/json_schema_object.ts
@@ -73,7 +73,7 @@ const create_object_schema = (props: {
           tag.name === "internal",
       )
     )
-      continue; // THE HIDDEN/IGNORE TAG
+      continue; // THE HIDDEN/IGNORE/INTERNAL TAGS
 
     const value: OpenApi.IJsonSchema | null = json_schema_station({
       blockNever: true,

--- a/src/programmers/json/JsonApplicationProgrammer.ts
+++ b/src/programmers/json/JsonApplicationProgrammer.ts
@@ -90,7 +90,10 @@ export namespace JsonApplicationProgrammer {
       .filter(
         (p) =>
           p.jsDocTags.find(
-            (tag) => tag.name === "hidden" || tag.name === "internal",
+            (tag) =>
+              tag.name === "hidden" ||
+              tag.name === "internal" ||
+              tag.name === "ignore",
           ) === undefined &&
           (props.filter === undefined || props.filter(p) === true),
       )

--- a/src/programmers/json/JsonApplicationProgrammer.ts
+++ b/src/programmers/json/JsonApplicationProgrammer.ts
@@ -92,8 +92,8 @@ export namespace JsonApplicationProgrammer {
           p.jsDocTags.find(
             (tag) =>
               tag.name === "hidden" ||
-              tag.name === "internal" ||
-              tag.name === "ignore",
+              tag.name === "ignore" ||
+              tag.name === "internal",
           ) === undefined &&
           (props.filter === undefined || props.filter(p) === true),
       )

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -178,7 +178,10 @@ export namespace LlmApplicationProgrammer {
           .filter(
             (p) =>
               p.jsDocTags.find(
-                (tag) => tag.name === "hidden" || tag.name === "internal",
+                (tag) =>
+                  tag.name === "hidden" ||
+                  tag.name === "internal" ||
+                  tag.name === "ignore",
               ) === undefined,
           )
           .map((p) => [

--- a/src/programmers/llm/LlmApplicationProgrammer.ts
+++ b/src/programmers/llm/LlmApplicationProgrammer.ts
@@ -180,8 +180,8 @@ export namespace LlmApplicationProgrammer {
               p.jsDocTags.find(
                 (tag) =>
                   tag.name === "hidden" ||
-                  tag.name === "internal" ||
-                  tag.name === "ignore",
+                  tag.name === "ignore" ||
+                  tag.name === "internal",
               ) === undefined,
           )
           .map((p) => [


### PR DESCRIPTION
As `prettier-plugin-jsdoc` automatically changes `@hidden` tag to `@ignore` by its origin rule, `typia` needs to support the `@ignore` tag.

--------------------

This pull request introduces a minor version update and expands the handling of JSDoc tags to allow for more flexible exclusion of properties in schema and application programmers. The main focus is to ensure that properties tagged with `@ignore` (in addition to `@hidden` and `@internal`) are consistently excluded from generated schemas and outputs.

Expanded exclusion of properties by JSDoc tag:

* Updated `src/programmers/internal/json_schema_object.ts` to also skip properties tagged with `@ignore` (in addition to `@hidden` and `@internal`) when generating object schemas.
* Modified `src/programmers/json/JsonApplicationProgrammer.ts` and `src/programmers/llm/LlmApplicationProgrammer.ts` to ensure properties with the `@ignore` tag are excluded alongside `@hidden` and `@internal` in their respective filtering logic. [[1]](diffhunk://#diff-ca1896bae72643cb8fb4543024585ec2552c307dc4d353527616dc997a997f75L93-R96) [[2]](diffhunk://#diff-1f6de160b0cb4f9102c8aaef68468a40f6c185dd3b8c2c8c217e3ae55d4fc920L181-R184)

Version update:

* Bumped the package version in `package.json` from `11.0.2` to `11.0.3` to reflect these changes.