### PR TITLE
fix(utils): correct schema assignment and adjustment.

### DIFF
--- a/packages/utils/src/converters/internal/OpenApiConstraintShifter.ts
+++ b/packages/utils/src/converters/internal/OpenApiConstraintShifter.ts
@@ -53,7 +53,7 @@ export namespace OpenApiConstraintShifter {
     | "multipleOf"
     | "default"
   > => {
-    Object.assign(OpenApiExclusiveEmender.emend(schema));
+    Object.assign(schema, OpenApiExclusiveEmender.emend(schema));
 
     const tags: string[] = [];
     if (schema.minimum !== undefined) {

--- a/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
+++ b/packages/utils/src/converters/internal/SwaggerV2Downgrader.ts
@@ -293,10 +293,10 @@ export namespace SwaggerV2Downgrader {
             matched.enum ??= [];
             matched.enum.push(value);
           } else union.push({ type: typeof value as "number", enum: [value] });
-          if (OpenApiTypeChecker.isConstant(schema)) insert(schema.const);
-          else if (OpenApiTypeChecker.isOneOf(schema))
-            schema.oneOf.forEach(insert);
         };
+        if (OpenApiTypeChecker.isConstant(schema)) insert(schema.const);
+        else if (OpenApiTypeChecker.isOneOf(schema))
+          schema.oneOf.forEach(insert);
       };
 
       visit(input);


### PR DESCRIPTION
This pull request addresses minor issues in the internal OpenAPI/Swagger converter utilities, focusing on bug fixes and small improvements to schema handling.

Bug fixes and improvements in OpenAPI/Swagger converters:

* Fixed a bug in `OpenApiConstraintShifter` by ensuring that the result of `OpenApiExclusiveEmender.emend(schema)` is merged into the original `schema` object, not the other way around.
* Corrected the logic in `SwaggerV2Downgrader` by properly closing a function block and ensuring the `insert` function is defined before use, which improves the handling of constant and `oneOf` schemas.