### PR TITLE
feat(benchmark): benchmark module also be monorepo.

### DIFF
--- a/internals/benchmark/package.json
+++ b/internals/benchmark/package.json
@@ -38,6 +38,7 @@
     "@types/express": "^4.17.14",
     "@types/node": "catalog:utils",
     "@types/physical-cpu-count": "^2.0.0",
+    "@types/ts-expose-internals": "catalog:typescript",
     "@types/uuid": "catalog:utils",
     "ajv": "^8.12.0",
     "autocannon": "^7.10.0",
@@ -66,6 +67,7 @@
     "zod": "^3.19.1"
   },
   "dependencies": {
+    "@typia/interface": "workspace:^",
     "fp-ts": "^2.16.9",
     "randexp": "^0.5.3",
     "source-map-support": "^0.5.21",

--- a/internals/benchmark/src/internal/AjvFactory.ts
+++ b/internals/benchmark/src/internal/AjvFactory.ts
@@ -1,4 +1,4 @@
-import { OpenApiV3 } from "@samchon/openapi";
+import { OpenApiV3 } from "@typia/interface";
 import Ajv, { Options } from "ajv";
 import { IJsonSchemaCollection } from "typia";
 

--- a/internals/benchmark/src/internal/HorizontalBarChart.ts
+++ b/internals/benchmark/src/internal/HorizontalBarChart.ts
@@ -1,5 +1,4 @@
 import * as d3 from "d3";
-import { ArrayUtil } from "@nestia/e2e";
 
 import { BenchmarkStream } from "./BenhmarkStream";
 

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursive } from "../../../structures/class-validator/ClassValidatorArrayRecursive";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionImplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionImplicit";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectHierarchical } from "../../../structures/class-validator/ClassValidatorObjectHierarchical";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectRecursive } from "../../../structures/class-validator/ClassValidatorObjectRecursive";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectSimple } from "../../../structures/class-validator/ClassValidatorObjectSimple";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionExplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/class-validator/benchmark-assert-error-class-validator-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionImplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionImplicit";
+
 import { createAssertErrorClassValidatorBenchmarkProgram } from "./createAssertErrorClassValidatorBenchmarkProgram";
 
 createAssertErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursive } from "../../../structures/io-ts/IoTsArrayRecursive";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsArrayRecursive);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionExplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionExplicit";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionImplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionImplicit";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectHierarchical } from "../../../structures/io-ts/IoTsObjectHierarchical";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsObjectHierarchical);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectRecursive } from "../../../structures/io-ts/IoTsObjectRecursive";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsObjectRecursive);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectSimple } from "../../../structures/io-ts/IoTsObjectSimple";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsObjectSimple);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionExplicit } from "../../../structures/io-ts/IoTsObjectUnionExplicit";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionImplicit } from "../../../structures/io-ts/IoTsObjectUnionImplicit";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert-error/io-ts/benchmark-assert-error-io-ts-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { IoTsUltimateUnion } from "../../../structures/io-ts/IoTsUltimateUnion";
+
 import { createAssertErrorIoTsBenchmarkProgram } from "./createAssertErrorIoTsBenchmarkProgram";
 
 createAssertErrorIoTsBenchmarkProgram(IoTsUltimateUnion);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxArrayRecursive);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxObjectHierarchical);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxObjectRecursive);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxObjectSimple);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert-error/typebox/benchmark-assert-error-typebox-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { __TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
+
 import { createAssertErrorTypeboxBenchmarkProgram } from "./createAssertErrorTypeboxBenchmarkProgram";
 
 createAssertErrorTypeboxBenchmarkProgram(__TypeboxUltimateUnion);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursive } from "../../../structures/zod/ZodArrayRecursive";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodArrayRecursive);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionExplicit } from "../../../structures/zod/ZodArrayRecursiveUnionExplicit";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionImplicit } from "../../../structures/zod/ZodArrayRecursiveUnionImplicit";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ZodObjectHierarchical } from "../../../structures/zod/ZodObjectHierarchical";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodObjectHierarchical);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodObjectRecursive } from "../../../structures/zod/ZodObjectRecursive";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodObjectRecursive);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ZodObjectSimple } from "../../../structures/zod/ZodObjectSimple";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodObjectSimple);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionExplicit } from "../../../structures/zod/ZodObjectUnionExplicit";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionImplicit } from "../../../structures/zod/ZodObjectUnionImplicit";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert-error/zod/benchmark-assert-error-zod-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { ZodUltimateUnion } from "../../../structures/zod/ZodUltimateUnion";
+
 import { createAssertErrorZodBenchmarkProgram } from "./createAssertErrorZodBenchmarkProgram";
 
 createAssertErrorZodBenchmarkProgram(ZodUltimateUnion);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursive } from "../../../structures/class-validator/ClassValidatorArrayRecursive";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionImplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionImplicit";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectHierarchical } from "../../../structures/class-validator/ClassValidatorObjectHierarchical";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectRecursive } from "../../../structures/class-validator/ClassValidatorObjectRecursive";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectSimple } from "../../../structures/class-validator/ClassValidatorObjectSimple";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionExplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/class-validator/benchmark-assert-class-validator-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionImplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionImplicit";
+
 import { createAssertClassValidatorBenchmarkProgram } from "./createAssertClassValidatorBenchmarkProgram";
 
 createAssertClassValidatorBenchmarkProgram(ClassValidatorObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursive } from "../../../structures/io-ts/IoTsArrayRecursive";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsArrayRecursive);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionExplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionExplicit";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionImplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionImplicit";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectHierarchical } from "../../../structures/io-ts/IoTsObjectHierarchical";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsObjectHierarchical);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectRecursive } from "../../../structures/io-ts/IoTsObjectRecursive";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsObjectRecursive);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectSimple } from "../../../structures/io-ts/IoTsObjectSimple";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsObjectSimple);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionExplicit } from "../../../structures/io-ts/IoTsObjectUnionExplicit";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionImplicit } from "../../../structures/io-ts/IoTsObjectUnionImplicit";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert/io-ts/benchmark-assert-io-ts-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { IoTsUltimateUnion } from "../../../structures/io-ts/IoTsUltimateUnion";
+
 import { createAssertIoTsBenchmarkProgram } from "./createAssertIoTsBenchmarkProgram";
 
 createAssertIoTsBenchmarkProgram(IoTsUltimateUnion);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxArrayRecursive);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxObjectHierarchical);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxObjectRecursive);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxObjectSimple);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert/typebox/benchmark-assert-typebox-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
+
 import { createAssertTypeboxBenchmarkProgram } from "./createAssertTypeboxBenchmarkProgram";
 
 createAssertTypeboxBenchmarkProgram(TypeboxUltimateUnion);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursive } from "../../../structures/zod/ZodArrayRecursive";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodArrayRecursive);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionExplicit } from "../../../structures/zod/ZodArrayRecursiveUnionExplicit";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionImplicit } from "../../../structures/zod/ZodArrayRecursiveUnionImplicit";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ZodObjectHierarchical } from "../../../structures/zod/ZodObjectHierarchical";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodObjectHierarchical);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodObjectRecursive } from "../../../structures/zod/ZodObjectRecursive";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodObjectRecursive);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ZodObjectSimple } from "../../../structures/zod/ZodObjectSimple";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodObjectSimple);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionExplicit } from "../../../structures/zod/ZodObjectUnionExplicit";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodObjectUnionExplicit);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionImplicit } from "../../../structures/zod/ZodObjectUnionImplicit";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodObjectUnionImplicit);

--- a/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/assert/zod/benchmark-assert-zod-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { ZodUltimateUnion } from "../../../structures/zod/ZodUltimateUnion";
+
 import { createAssertZodBenchmarkProgram } from "./createAssertZodBenchmarkProgram";
 
 createAssertZodBenchmarkProgram(ZodUltimateUnion);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursive } from "../../../structures/class-validator/ClassValidatorArrayRecursive";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionImplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionImplicit";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectHierarchical } from "../../../structures/class-validator/ClassValidatorObjectHierarchical";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectRecursive } from "../../../structures/class-validator/ClassValidatorObjectRecursive";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectSimple } from "../../../structures/class-validator/ClassValidatorObjectSimple";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionExplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/class-validator/benchmark-is-class-validator-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionImplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionImplicit";
+
 import { createIsClassValidatorBenchmarkProgram } from "./createIsClassValidatorBenchmarkProgram";
 
 createIsClassValidatorBenchmarkProgram(ClassValidatorObjectUnionImplicit);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursive } from "../../../structures/io-ts/IoTsArrayRecursive";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsArrayRecursive);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionExplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionExplicit";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionImplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionImplicit";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectHierarchical } from "../../../structures/io-ts/IoTsObjectHierarchical";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsObjectHierarchical);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectRecursive } from "../../../structures/io-ts/IoTsObjectRecursive";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsObjectRecursive);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectSimple } from "../../../structures/io-ts/IoTsObjectSimple";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsObjectSimple);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionExplicit } from "../../../structures/io-ts/IoTsObjectUnionExplicit";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsObjectUnionExplicit);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionImplicit } from "../../../structures/io-ts/IoTsObjectUnionImplicit";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsObjectUnionImplicit);

--- a/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/is/io-ts/benchmark-is-io-ts-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { IoTsUltimateUnion } from "../../../structures/io-ts/IoTsUltimateUnion";
+
 import { createIsIoTsBenchmarkProgram } from "./createIsIoTsBenchmarkProgram";
 
 createIsIoTsBenchmarkProgram(IoTsUltimateUnion);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursive);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectHierarchical);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectRecursive);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectSimple);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectUnionExplicit);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxObjectUnionImplicit);

--- a/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/is/typebox/benchmark-is-typebox-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
+
 import { createIsTypeboxBenchmarkProgram } from "./createIsTypeboxBenchmarkProgram";
 
 createIsTypeboxBenchmarkProgram(TypeboxUltimateUnion);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursive } from "../../../structures/zod/ZodArrayRecursive";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodArrayRecursive);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionExplicit } from "../../../structures/zod/ZodArrayRecursiveUnionExplicit";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionImplicit } from "../../../structures/zod/ZodArrayRecursiveUnionImplicit";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ZodObjectHierarchical } from "../../../structures/zod/ZodObjectHierarchical";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodObjectHierarchical);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodObjectRecursive } from "../../../structures/zod/ZodObjectRecursive";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodObjectRecursive);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ZodObjectSimple } from "../../../structures/zod/ZodObjectSimple";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodObjectSimple);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionExplicit } from "../../../structures/zod/ZodObjectUnionExplicit";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodObjectUnionExplicit);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionImplicit } from "../../../structures/zod/ZodObjectUnionImplicit";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodObjectUnionImplicit);

--- a/internals/benchmark/src/programs/is/zod/benchmark-is-zod-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/is/zod/benchmark-is-zod-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { ZodUltimateUnion } from "../../../structures/zod/ZodUltimateUnion";
+
 import { createIsZodBenchmarkProgram } from "./createIsZodBenchmarkProgram";
 
 createIsZodBenchmarkProgram(ZodUltimateUnion);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ArraySimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectSimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/express-class-transformer/benchmark-server-assert-express-class-transformer-ObjectUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createExpressServerAssertBenchmarkProgram } from "../createExpressServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ArraySimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectSimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-assert/internal/fastify-class-transformer/benchmark-server-assert-fastify-class-transformer-ObjectUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createFastifyCustomServerAssertBenchmarkProgram } from "../createFastifyCustomServerAssertBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ArraySimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectSimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/express-class-transformer/benchmark-server-performance-express-class-transformer-ObjectUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createExpressServerPerformanceBenchmarkProgram } from "../createExpressServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ArraySimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectHierarchical.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectRecursive.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectSimple.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-performance/internal/fastify-class-transformer/benchmark-server-performance-fastify-class-transformer-ObjectUnionExplicit.ts
@@ -1,9 +1,9 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createFastifyCustomServerPerformanceBenchmarkProgram } from "../createFastifyCustomServerPerformanceBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayHierarchical.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayRecursive.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ArraySimple.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectHierarchical.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectRecursive.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectSimple.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/express-class-transformer/benchmark-server-stringify-express-class-transformer-ObjectUnionExplicit.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createExpressServerStringifyBenchmarkProgram } from "../createExpressServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayHierarchical.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayHierarchical.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayHierarchical } from "../../../../structures/pure/ArrayHierarchical";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayHierarchical } from "../../../../structures/class-validator/ClassValidatorArrayHierarchical";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayHierarchical);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayRecursive.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursive } from "../../../../structures/pure/ArrayRecursive";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursive } from "../../../../structures/class-validator/ClassValidatorArrayRecursive";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArrayRecursiveUnionExplicit.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArrayRecursiveUnionExplicit } from "../../../../structures/pure/ArrayRecursiveUnionExplicit";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArraySimple.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ArraySimple.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
-import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
-import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ArraySimple } from "../../../../structures/pure/ArraySimple";
+import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
+import { ClassValidatorArraySimple } from "../../../../structures/class-validator/ClassValidatorArraySimple";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorArraySimple);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectHierarchical.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectHierarchical } from "../../../../structures/class-validator/ClassValidatorObjectHierarchical";
-import { ObjectHierarchical } from "../../../../structures/pure/ObjectHierarchical";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectRecursive.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectRecursive } from "../../../../structures/class-validator/ClassValidatorObjectRecursive";
-import { ObjectRecursive } from "../../../../structures/pure/ObjectRecursive";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectSimple.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectSimple } from "../../../../structures/class-validator/ClassValidatorObjectSimple";
-import { ObjectSimple } from "../../../../structures/pure/ObjectSimple";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/server-stringify/internal/fastify-class-transformer/benchmark-server-stringify-fastify-class-transformer-ObjectUnionExplicit.ts
@@ -1,8 +1,8 @@
 import { instanceToPlain, plainToInstance } from "class-transformer";
 
+import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { ClassValidatorCollection } from "../../../../structures/class-validator/ClassValidatorCollection";
 import { ClassValidatorObjectUnionExplicit } from "../../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
-import { ObjectUnionExplicit } from "../../../../structures/pure/ObjectUnionExplicit";
 import { createFastifyCustomServerStringifyBenchmarkProgram } from "../createFastifyCustomServerStringifyBenchmarkProgram";
 
 const schema = ClassValidatorCollection(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursive } from "../../../structures/class-validator/ClassValidatorArrayRecursive";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionImplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionImplicit";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectHierarchical } from "../../../structures/class-validator/ClassValidatorObjectHierarchical";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectRecursive } from "../../../structures/class-validator/ClassValidatorObjectRecursive";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectSimple } from "../../../structures/class-validator/ClassValidatorObjectSimple";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionExplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/class-validator/benchmark-validate-error-class-validator-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionImplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionImplicit";
+
 import { createValidateErrorClassValidatorBenchmarkProgram } from "./createValidateErrorClassValidatorBenchmarkProgram";
 
 createValidateErrorClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursive } from "../../../structures/io-ts/IoTsArrayRecursive";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsArrayRecursive);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionExplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionExplicit";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionImplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionImplicit";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectHierarchical } from "../../../structures/io-ts/IoTsObjectHierarchical";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsObjectHierarchical);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectRecursive } from "../../../structures/io-ts/IoTsObjectRecursive";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsObjectRecursive);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectSimple } from "../../../structures/io-ts/IoTsObjectSimple";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsObjectSimple);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionExplicit } from "../../../structures/io-ts/IoTsObjectUnionExplicit";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionImplicit } from "../../../structures/io-ts/IoTsObjectUnionImplicit";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate-error/io-ts/benchmark-validate-error-io-ts-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { IoTsUltimateUnion } from "../../../structures/io-ts/IoTsUltimateUnion";
+
 import { createValidateErrorIoTsBenchmarkProgram } from "./createValidateErrorIoTsBenchmarkProgram";
 
 createValidateErrorIoTsBenchmarkProgram(IoTsUltimateUnion);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxArrayRecursive);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxObjectHierarchical);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxObjectRecursive);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxObjectSimple);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { __TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate-error/typebox/benchmark-validate-error-typebox-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { __TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
+
 import { createValidateErrorTypeboxBenchmarkProgram } from "./createValidateErrorTypeboxBenchmarkProgram";
 
 createValidateErrorTypeboxBenchmarkProgram(__TypeboxUltimateUnion);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursive } from "../../../structures/zod/ZodArrayRecursive";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodArrayRecursive);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionExplicit } from "../../../structures/zod/ZodArrayRecursiveUnionExplicit";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionImplicit } from "../../../structures/zod/ZodArrayRecursiveUnionImplicit";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ZodObjectHierarchical } from "../../../structures/zod/ZodObjectHierarchical";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodObjectHierarchical);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodObjectRecursive } from "../../../structures/zod/ZodObjectRecursive";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodObjectRecursive);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ZodObjectSimple } from "../../../structures/zod/ZodObjectSimple";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodObjectSimple);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionExplicit } from "../../../structures/zod/ZodObjectUnionExplicit";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionImplicit } from "../../../structures/zod/ZodObjectUnionImplicit";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate-error/zod/benchmark-validate-error-zod-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { ZodUltimateUnion } from "../../../structures/zod/ZodUltimateUnion";
+
 import { createValidateErrorZodBenchmarkProgram } from "./createValidateErrorZodBenchmarkProgram";
 
 createValidateErrorZodBenchmarkProgram(ZodUltimateUnion);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursive } from "../../../structures/class-validator/ClassValidatorArrayRecursive";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorArrayRecursive);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionExplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionExplicit";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorArrayRecursiveUnionImplicit } from "../../../structures/class-validator/ClassValidatorArrayRecursiveUnionImplicit";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectHierarchical } from "../../../structures/class-validator/ClassValidatorObjectHierarchical";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorObjectHierarchical);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectRecursive } from "../../../structures/class-validator/ClassValidatorObjectRecursive";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorObjectRecursive);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectSimple } from "../../../structures/class-validator/ClassValidatorObjectSimple";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorObjectSimple);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionExplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionExplicit";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/class-validator/benchmark-validate-class-validator-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ClassValidatorObjectUnionImplicit } from "../../../structures/class-validator/ClassValidatorObjectUnionImplicit";
+
 import { createValidateClassValidatorBenchmarkProgram } from "./createValidateClassValidatorBenchmarkProgram";
 
 createValidateClassValidatorBenchmarkProgram(ClassValidatorObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursive } from "../../../structures/io-ts/IoTsArrayRecursive";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsArrayRecursive);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionExplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionExplicit";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsArrayRecursiveUnionImplicit } from "../../../structures/io-ts/IoTsArrayRecursiveUnionImplicit";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectHierarchical } from "../../../structures/io-ts/IoTsObjectHierarchical";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsObjectHierarchical);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectRecursive } from "../../../structures/io-ts/IoTsObjectRecursive";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsObjectRecursive);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectSimple } from "../../../structures/io-ts/IoTsObjectSimple";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsObjectSimple);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionExplicit } from "../../../structures/io-ts/IoTsObjectUnionExplicit";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { IoTsObjectUnionImplicit } from "../../../structures/io-ts/IoTsObjectUnionImplicit";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate/io-ts/benchmark-validate-io-ts-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { IoTsUltimateUnion } from "../../../structures/io-ts/IoTsUltimateUnion";
+
 import { createValidateIoTsBenchmarkProgram } from "./createValidateIoTsBenchmarkProgram";
 
 createValidateIoTsBenchmarkProgram(IoTsUltimateUnion);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursive } from "../../../structures/typebox/TypeboxArrayRecursive";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxArrayRecursive);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionExplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionExplicit";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxArrayRecursiveUnionImplicit } from "../../../structures/typebox/TypeboxArrayRecursiveUnionImplicit";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectHierarchical } from "../../../structures/typebox/TypeboxObjectHierarchical";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxObjectHierarchical);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectRecursive } from "../../../structures/typebox/TypeboxObjectRecursive";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxObjectRecursive);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectSimple } from "../../../structures/typebox/TypeboxObjectSimple";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxObjectSimple);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionExplicit } from "../../../structures/typebox/TypeboxObjectUnionExplicit";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { TypeboxObjectUnionImplicit } from "../../../structures/typebox/TypeboxObjectUnionImplicit";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate/typebox/benchmark-validate-typebox-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { TypeboxUltimateUnion } from "../../../structures/typebox/TypeboxUltimateUnion";
+
 import { createValidateTypeboxBenchmarkProgram } from "./createValidateTypeboxBenchmarkProgram";
 
 createValidateTypeboxBenchmarkProgram(TypeboxUltimateUnion);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursive.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursive } from "../../../structures/zod/ZodArrayRecursive";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodArrayRecursive);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursiveUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursiveUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionExplicit } from "../../../structures/zod/ZodArrayRecursiveUnionExplicit";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodArrayRecursiveUnionExplicit);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursiveUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ArrayRecursiveUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodArrayRecursiveUnionImplicit } from "../../../structures/zod/ZodArrayRecursiveUnionImplicit";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodArrayRecursiveUnionImplicit);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectHierarchical.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectHierarchical.ts
@@ -1,4 +1,5 @@
 import { ZodObjectHierarchical } from "../../../structures/zod/ZodObjectHierarchical";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodObjectHierarchical);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectRecursive.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectRecursive.ts
@@ -1,4 +1,5 @@
 import { ZodObjectRecursive } from "../../../structures/zod/ZodObjectRecursive";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodObjectRecursive);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectSimple.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectSimple.ts
@@ -1,4 +1,5 @@
 import { ZodObjectSimple } from "../../../structures/zod/ZodObjectSimple";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodObjectSimple);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectUnionExplicit.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectUnionExplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionExplicit } from "../../../structures/zod/ZodObjectUnionExplicit";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodObjectUnionExplicit);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectUnionImplicit.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-ObjectUnionImplicit.ts
@@ -1,4 +1,5 @@
 import { ZodObjectUnionImplicit } from "../../../structures/zod/ZodObjectUnionImplicit";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodObjectUnionImplicit);

--- a/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-UltimateUnion.ts
+++ b/internals/benchmark/src/programs/validate/zod/benchmark-validate-zod-UltimateUnion.ts
@@ -1,4 +1,5 @@
 import { ZodUltimateUnion } from "../../../structures/zod/ZodUltimateUnion";
+
 import { createValidateZodBenchmarkProgram } from "./createValidateZodBenchmarkProgram";
 
 createValidateZodBenchmarkProgram(ZodUltimateUnion);

--- a/internals/benchmark/tsconfig.json
+++ b/internals/benchmark/tsconfig.json
@@ -101,7 +101,7 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
     "plugins": [
-      { "transform": "typia/lib/transform" },
+      { "transform": "typia/src/transform.ts" },
     ]
   },
   "include": ["./src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
 
   internals/benchmark:
     dependencies:
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../../packages/interface
       fp-ts:
         specifier: ^2.16.9
         version: 2.16.11
@@ -134,6 +137,9 @@ importers:
       '@types/physical-cpu-count':
         specifier: ^2.0.0
         version: 2.0.2
+      '@types/ts-expose-internals':
+        specifier: catalog:typescript
+        version: ts-expose-internals@5.6.3
       '@types/uuid':
         specifier: catalog:utils
         version: 11.0.0


### PR DESCRIPTION
This pull request updates dependencies and refines internal imports in the benchmark package, mainly for improved type support and code consistency. It also makes minor formatting changes to several benchmark program files.

Dependency and import updates:

* Switched the import of `OpenApiV3` in `AjvFactory.ts` from `@samchon/openapi` to `@typia/interface` to standardize type imports.
* Added `@typia/interface` as a dependency and `@types/ts-expose-internals` as a devDependency in `package.json` for better type coverage and internal API exposure. [[1]](diffhunk://#diff-03702f3ebdfd885c21b361621128c28d0a830874908baa1671d12ce9aad7ea7eR41) [[2]](diffhunk://#diff-03702f3ebdfd885c21b361621128c28d0a830874908baa1671d12ce9aad7ea7eR70)

Code cleanup and formatting:

* Removed an unused import (`ArrayUtil` from `@nestia/e2e`) in `HorizontalBarChart.ts` for code cleanliness.
* Added blank lines between imports and code in multiple `benchmark-assert-error-*` program files for improved readability and consistency. [[1]](diffhunk://#diff-1ae586d6b0f32349ed4b7f8500103cd558fe975eb5b219eef2f7b0b0df671e1cR2) [[2]](diffhunk://#diff-2989fbd1318e18cb65a2c42f57392f3276079df25d6dcbb4a62793ceb667958eR2) [[3]](diffhunk://#diff-cb9ae9353481b6cce465dea6d07dd1f63f4a658ccb7fe601fb1225019e05309eR2) [[4]](diffhunk://#diff-dc8a67b2a22af050da6da0a8522b23e6ea9bb829848734c8a11024325d347ae7R2) [[5]](diffhunk://#diff-01a930fa7f2d3fbbf1f8cd52856b050568c7a5612bafac8717e20625411ad4c1R2) [[6]](diffhunk://#diff-1e2c9d2ae7ad8bd445e6eccebdaa6f96bddcf893f83b48a1b3e001ac54892b17R2) [[7]](diffhunk://#diff-14710e249af1a7719343bf0135f2e20139b18ddbda69ffaba3027fcf6781802cR2) [[8]](diffhunk://#diff-89c73f0aff42385de5c553aa348b0528ded4dbb5896845492199c8eba3547e4bR2) [[9]](diffhunk://#diff-3f80746b21f5cf9911a93c257f4b2706c582cc57f9abce0d63b39d559122432cR2) [[10]](diffhunk://#diff-7970bf16c57c6cc39414556bffb323f53e26f31dba087379639fcec3f2a2b298R2) [[11]](diffhunk://#diff-25f365304d6e81ababa63ae03129920296912e53f695ff6439c2d3828fc1e64aR2) [[12]](diffhunk://#diff-63a1d0e58048bf330f33f4be3863c20dc5b62903e53112e18cd393d080bcd150R2) [[13]](diffhunk://#diff-c09c0cc3d2ae9522986a96ccf5ed9b6479dc222e5598ac728111e0562a2ffc72R2) [[14]](diffhunk://#diff-42acb0e7593b9ac342bd774ff354c24985c2573bc8574560f0220939f5da3b55R2) [[15]](diffhunk://#diff-6c9d1a67f25b0ddd4c8bcb63045c0ae6bef0ef758879df42370fb7826c55ddffR2) [[16]](diffhunk://#diff-55049ca4d84a1b60a383b7c360e654f23b4c7fbadc8cf89ac99722efd007f337R2) [[17]](diffhunk://#diff-102b4cf35a2e6d6ad1220b32c825387c7b2ddb37da49a34b0b4c5045f4bf7523R2)