### PR TITLE
feat(mcp): convert TypeScript classes to MCP tools.

### DIFF
--- a/packages/interface/src/http/IHttpLlmController.ts
+++ b/packages/interface/src/http/IHttpLlmController.ts
@@ -1,0 +1,96 @@
+import { IHttpConnection } from "./IHttpConnection";
+import { IHttpLlmApplication } from "./IHttpLlmApplication";
+import { IHttpLlmFunction } from "./IHttpLlmFunction";
+import { IHttpResponse } from "./IHttpResponse";
+
+/**
+ * Controller of HTTP LLM function calling.
+ *
+ * `IHttpLlmController` is a controller for registering OpenAPI operations as
+ * LLM function calling tools. It contains {@link IHttpLlmApplication} with
+ * {@link IHttpLlmFunction function calling schemas}, {@link name identifier},
+ * and {@link connection} to the API server.
+ *
+ * You can create this controller with {@link HttpLlm.controller} function,
+ * and register it to MCP server with {@link registerMcpControllers}:
+ *
+ * ```typescript
+ * import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+ * import { HttpLlm } from "@typia/utils";
+ * import { registerMcpControllers } from "@typia/mcp";
+ *
+ * const server = new McpServer({ name: "my-server", version: "1.0.0" });
+ * registerMcpControllers({
+ *   server,
+ *   controllers: [
+ *     HttpLlm.controller({
+ *       name: "shopping",
+ *       document: await fetch(
+ *         "https://shopping-be.wrtn.io/editor/swagger.json",
+ *       ).then((r) => r.json()),
+ *       connection: {
+ *         host: "https://shopping-be.wrtn.io",
+ *         headers: {
+ *           Authorization: "Bearer ********",
+ *         },
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * For TypeScript class-based controller, use {@link ILlmController} instead.
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface IHttpLlmController {
+  /** Protocol discriminator. */
+  protocol: "http";
+
+  /** Identifier name of the controller. */
+  name: string;
+
+  /** Application schema of function calling. */
+  application: IHttpLlmApplication;
+
+  /**
+   * Connection to the server.
+   *
+   * Connection to the API server including the URL and headers.
+   */
+  connection: IHttpConnection;
+
+  /**
+   * Executor of the API function.
+   *
+   * Default executor is {@link HttpLlm.execute} function, and you can override
+   * it with your own function.
+   *
+   * @param props Properties of the API function call
+   * @returns HTTP response of the API function call
+   */
+  execute?:
+    | undefined
+    | ((props: {
+        /** Connection to the server. */
+        connection: IHttpConnection;
+
+        /** Application schema. */
+        application: IHttpLlmApplication;
+
+        /** Function schema. */
+        function: IHttpLlmFunction;
+
+        /**
+         * Arguments of the function calling.
+         *
+         * It is an object of key-value pairs of the API function's parameters.
+         * The property keys are composed by below rules:
+         *
+         * - Parameter names
+         * - Query parameter as an object type if exists
+         * - Body parameter if exists
+         */
+        arguments: object;
+      }) => Promise<IHttpResponse>);
+}

--- a/packages/interface/src/http/index.ts
+++ b/packages/interface/src/http/index.ts
@@ -1,4 +1,5 @@
 export * from "./IHttpConnection";
+export * from "./IHttpLlmController";
 export * from "./IHttpLlmApplication";
 export * from "./IHttpLlmFunction";
 export * from "./IHttpMigrateApplication";

--- a/packages/interface/src/schema/ILlmController.ts
+++ b/packages/interface/src/schema/ILlmController.ts
@@ -1,14 +1,43 @@
 import { ILlmApplication } from "./ILlmApplication";
 
 /**
- * Controller of LLM function calling.
+ * Controller of TypeScript class-based LLM function calling.
  *
- * `ILlmController` wraps an {@link ILlmApplication} with identifier and
- * executor. Contains the controller {@link name}, function calling schemas in
- * {@link application}, and the class instance in {@link execute}.
+ * `ILlmController` is a controller for registering TypeScript class methods as
+ * LLM function calling tools. It contains {@link ILlmApplication} with
+ * {@link ILlmFunction function calling schemas}, {@link name identifier}, and
+ * {@link execute class instance} for method execution.
  *
- * For HTTP protocol, use `IHttpLlmController`. For MCP, use
- * `IMcpLlmController`.
+ * You can create this controller with `typia.llm.controller<Class>()` function,
+ * and register it to MCP server with {@link registerMcpControllers}:
+ *
+ * ```typescript
+ * import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+ * import typia from "typia";
+ * import { registerMcpControllers } from "@typia/mcp";
+ *
+ * class Calculator {
+ *   add(input: { a: number; b: number }): number {
+ *     return input.a + input.b;
+ *   }
+ *   subtract(input: { a: number; b: number }): number {
+ *     return input.a - input.b;
+ *   }
+ * }
+ *
+ * const server = new McpServer({ name: "my-server", version: "1.0.0" });
+ * registerMcpControllers({
+ *   server,
+ *   controllers: [
+ *     typia.llm.controller<Calculator>(
+ *       "calculator",
+ *       new Calculator(),
+ *     ),
+ *   ],
+ * });
+ * ```
+ *
+ * For OpenAPI/HTTP-based controller, use {@link IHttpLlmController} instead.
  *
  * @author Jeongho Nam - https://github.com/samchon
  * @template Class Class type of the function executor

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@typia/mcp",
+  "version": "11.0.1",
+  "description": "MCP (Model Context Protocol) integration for typia",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "rimraf lib && tsc",
+    "dev": "rimraf lib && tsc --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "dependencies": {
+    "@typia/interface": "workspace:^",
+    "@typia/utils": "workspace:^"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "rimraf": "catalog:utils",
+    "typescript": "catalog:typescript"
+  },
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "package.json",
+    "lib",
+    "src"
+  ],
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "typia",
+    "llm",
+    "llm-function-calling",
+    "ai",
+    "claude",
+    "openai",
+    "chatgpt",
+    "gemini",
+    "validation",
+    "json-schema",
+    "typescript"
+  ],
+  "packageManager": "pnpm@10.6.4",
+  "publishConfig": {
+    "access": "public",
+    "main": "lib/index.js",
+    "typings": "lib/index.d.ts"
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://typia.io",
   "dependencies": {
     "@typia/interface": "workspace:^",
-    "@typia/utils": "workspace:^"
+    "@typia/utils": "workspace:^",
+    "zod-to-json-schema": ">=3.24.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.0.0"
@@ -32,7 +33,8 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "rimraf": "catalog:utils",
-    "typescript": "catalog:typescript"
+    "typescript": "catalog:typescript",
+    "zod": "^3.25.0"
   },
   "sideEffects": false,
   "files": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,11 +25,6 @@
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.0.0"
   },
-  "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "rimraf": "catalog:utils",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,54 @@
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { IHttpLlmController, ILlmController } from "@typia/interface";
+
+import { McpControllerRegistrar } from "./internal/McpControllerRegistrar";
+
+/**
+ * Register MCP tools from controllers.
+ *
+ * Registers TypeScript class methods via `typia.llm.controller<Class>()` or
+ * OpenAPI operations via `HttpLlm.controller()` as MCP tools.
+ *
+ * Every tool call is validated by typia. If LLM provides invalid arguments,
+ * returns {@link IValidation.IFailure} formatted by
+ * {@link stringifyValidationFailure} so that LLM can correct them automatically.
+ * Below is an example of the validation error format:
+ *
+ * ```json
+ * {
+ *   "name": "John",
+ *   "age": "twenty", // ❌ [{"path":"$input.age","expected":"number & Type<\"uint32\">"}]
+ *   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+ *   "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+ * }
+ * ```
+ *
+ * If you use `McpServer.registerTool()` instead, you have to define Zod
+ * schema, function name, and description string manually for each tool.
+ * Also, without typia's validation feedback, LLM cannot auto-correct its
+ * mistakes, which significantly degrades tool calling performance.
+ *
+ * @param props Registration properties
+ */
+export function registerMcpControllers(props: {
+  /**
+   * Target MCP server to register tools.
+   *
+   * Both {@link McpServer} and raw {@link Server} are supported. If you want to
+   * combine with `McpServer.registerTool()`, call it before this function.
+   */
+  server: McpServer | Server;
+
+  /**
+   * List of controllers to register as MCP tools.
+   *
+   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, registers all
+   *   methods of the class as tools
+   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, registers all
+   *   operations from OpenAPI document as tools
+   */
+  controllers: Array<ILlmController | IHttpLlmController>;
+}): void {
+  return McpControllerRegistrar.register(props);
+}

--- a/packages/mcp/src/internal/McpControllerRegistrar.ts
+++ b/packages/mcp/src/internal/McpControllerRegistrar.ts
@@ -1,0 +1,222 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Server } from "@modelcontextprotocol/sdk/server";
+import {
+  CallToolRequestSchema,
+  CallToolResult,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  IHttpLlmController,
+  IHttpLlmFunction,
+  ILlmController,
+  ILlmFunction,
+  IValidation,
+} from "@typia/interface";
+import { HttpLlm, stringifyValidationFailure } from "@typia/utils";
+
+interface IToolEntry {
+  func: ILlmFunction | IHttpLlmFunction;
+  call: (args: unknown) => Promise<unknown>;
+}
+
+export namespace McpControllerRegistrar {
+  export const register = (props: {
+    server: McpServer | Server;
+    controllers: Array<ILlmController | IHttpLlmController>;
+  }): void => {
+    // McpServer wraps raw Server - we need raw Server for JSON Schema support
+    const server: Server =
+      "server" in props.server
+        ? (props.server as McpServer).server
+        : (props.server as Server);
+
+    // Build tool registry from controllers
+    const registry = new Map<string, IToolEntry>();
+
+    for (const controller of props.controllers) {
+      if (controller.protocol === "class") {
+        registerClassController(registry, controller);
+      } else {
+        registerHttpController(registry, controller);
+      }
+    }
+
+    // Get existing tools from McpServer if available
+    const mcpServer =
+      "server" in props.server ? (props.server as McpServer) : null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const existingTools: Record<string, any> = mcpServer
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mcpServer as any)._registeredTools ?? {}
+      : {};
+
+    // tools/list handler - includes both typia controllers and existing McpServer tools
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        // Typia controller tools with proper JSON Schema
+        ...Array.from(registry.values()).map(({ func }) => ({
+          name: func.name,
+          description: func.description,
+          inputSchema: {
+            type: "object" as const,
+            properties: func.parameters.properties,
+            required: func.parameters.required,
+          },
+        })),
+        // Existing McpServer tools (already converted to JSON Schema by MCP SDK)
+        ...Object.entries(existingTools)
+          .filter(([name, tool]) => !registry.has(name) && tool.enabled)
+          .map(([name, tool]) => ({
+            name,
+            description: tool.description,
+            inputSchema: tool.inputSchema
+              ? convertZodToJsonSchema(tool.inputSchema)
+              : { type: "object" as const, properties: {} },
+          })),
+      ],
+    }));
+
+    // tools/call handler
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+      const { name, arguments: args } = request.params;
+
+      // Check typia registry first
+      const entry = registry.get(name);
+      if (entry !== undefined) {
+        return handleToolCall(entry, args);
+      }
+
+      // Fall back to existing McpServer tools
+      const existingTool = existingTools[name];
+      if (existingTool && existingTool.enabled) {
+        return existingTool.handler(args, extra);
+      }
+
+      return {
+        isError: true,
+        content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+      };
+    });
+
+    // Mark handlers as initialized to prevent McpServer from overwriting
+    if (mcpServer) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mcpServer as any)._toolHandlersInitialized = true;
+    }
+  };
+
+  const registerClassController = (
+    registry: Map<string, IToolEntry>,
+    controller: ILlmController,
+  ): void => {
+    const execute = controller.execute;
+
+    for (const func of controller.application.functions) {
+      if (registry.has(func.name)) {
+        throw new Error(`Duplicate function name: "${func.name}"`);
+      }
+
+      const method: unknown = (execute as Record<string, unknown>)[func.name];
+      if (typeof method !== "function") {
+        throw new Error(
+          `Method "${func.name}" not found on controller "${controller.name}"`,
+        );
+      }
+
+      registry.set(func.name, {
+        func,
+        call: async (args: unknown) => method.call(execute, args),
+      });
+    }
+  };
+
+  const registerHttpController = (
+    registry: Map<string, IToolEntry>,
+    controller: IHttpLlmController,
+  ): void => {
+    const { application, connection } = controller;
+
+    for (const func of application.functions) {
+      if (registry.has(func.name)) {
+        throw new Error(`Duplicate function name: "${func.name}"`);
+      }
+      registry.set(func.name, {
+        func,
+        call: async (args: unknown) => {
+          if (controller.execute !== undefined) {
+            const response = await controller.execute({
+              connection,
+              application,
+              function: func,
+              arguments: args as object,
+            });
+            return response.body;
+          }
+          return HttpLlm.execute({
+            application,
+            function: func,
+            connection,
+            input: args as object,
+          });
+        },
+      });
+    }
+  };
+
+  const handleToolCall = async (
+    entry: IToolEntry,
+    args: unknown,
+  ): Promise<CallToolResult> => {
+    const { func, call } = entry;
+
+    const validation: IValidation<unknown> = func.validate(args);
+    if (!validation.success) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: stringifyValidationFailure(validation),
+          },
+        ],
+      };
+    }
+
+    try {
+      const result: unknown = await call(validation.data);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              result === undefined ? "Success" : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text:
+              error instanceof Error
+                ? `${error.name}: ${error.message}`
+                : String(error),
+          },
+        ],
+      };
+    }
+  };
+
+  // Convert Zod schema to JSON Schema (simplified)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const convertZodToJsonSchema = (zodSchema: any): object => {
+    // If it already looks like JSON Schema, return as-is
+    if (zodSchema.type && zodSchema.properties) {
+      return zodSchema;
+    }
+    // Fallback for Zod schemas - MCP SDK would have converted them
+    return { type: "object", properties: {} };
+  };
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../internals/config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "moduleResolution": "node16",
+    "module": "node16",
+  },
+  "include": ["src"],
+}

--- a/packages/utils/src/utils/stringifyValidationFailure.ts
+++ b/packages/utils/src/utils/stringifyValidationFailure.ts
@@ -7,17 +7,18 @@ import { dedent } from "./dedent";
  * Format validation failure for LLM auto-correction feedback.
  *
  * When LLM generates invalid function call arguments, this produces annotated
- * JSON with inline `// ❌` error comments at each invalid value. Send this
- * formatted output back to the LLM so it can understand and correct its
- * mistakes in the next conversation turn.
+ * JSON with inline `// ❌` error comments at each invalid property. The output
+ * is wrapped in a markdown code block so that LLM can understand and correct
+ * its mistakes in the next turn.
  *
- * Use this with {@link ILlmFunction.validate} results:
+ * Below is an example of the output format:
  *
- * ```typescript
- * const result = func.validate(llmArgs);
- * if (!result.success) {
- *   const feedback = stringifyValidationFailure(result);
- *   // Send feedback to LLM for auto-correction
+ * ```json
+ * {
+ *   "name": "John",
+ *   "age": "twenty", // ❌ [{"path":"$input.age","expected":"number & Type<\"uint32\">"}]
+ *   "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+ *   "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
  * }
  * ```
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,25 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
 
+  packages/mcp:
+    dependencies:
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../interface
+      '@typia/utils':
+        specifier: workspace:^
+        version: link:../utils
+    devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.26.0(zod@3.25.76)
+      rimraf:
+        specifier: catalog:utils
+        version: 6.1.3
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
   packages/transform:
     dependencies:
       '@typia/core':
@@ -959,6 +978,12 @@ packages:
     peerDependencies:
       '@sinclair/typebox': '>=0.26 <=0.32'
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -996,6 +1021,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@modelcontextprotocol/sdk@1.26.0':
+    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
@@ -1734,6 +1769,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1842,6 +1881,10 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -1980,6 +2023,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -1990,12 +2037,20 @@ packages:
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -2295,9 +2350,27 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-content-type-parse@1.1.0:
     resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
@@ -2365,6 +2438,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@8.2.2:
     resolution: {integrity: sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==}
     engines: {node: '>=14'}
@@ -2394,6 +2471,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2486,6 +2567,10 @@ packages:
   hdr-histogram-percentiles-obj@3.0.0:
     resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
 
+  hono@4.12.1:
+    resolution: {integrity: sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -2565,6 +2650,10 @@ packages:
     peerDependencies:
       fp-ts: ^2.5.0
 
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -2610,6 +2699,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -2626,6 +2718,9 @@ packages:
 
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2667,6 +2762,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2770,11 +2868,19 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2855,9 +2961,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -2926,6 +3040,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -2934,6 +3052,10 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3038,6 +3160,9 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
@@ -3073,6 +3198,10 @@ packages:
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -3151,6 +3280,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   read-pkg@3.0.0:
     resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
@@ -3232,6 +3365,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -3288,9 +3425,17 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -3533,6 +3678,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3685,6 +3834,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4463,6 +4617,10 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.31.28
 
+  '@hono/node-server@1.19.9(hono@4.12.1)':
+    dependencies:
+      hono: 4.12.1
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -4500,6 +4658,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.1
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
@@ -5428,6 +5608,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5552,6 +5737,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5683,15 +5882,24 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@1.9.0: {}
 
   cookie-signature@1.0.7: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -6042,6 +6250,17 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -6074,6 +6293,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6170,6 +6422,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@8.2.2:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6202,6 +6465,8 @@ snapshots:
   fp-ts@2.16.11: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs.realpath@1.0.0: {}
 
@@ -6302,6 +6567,8 @@ snapshots:
 
   hdr-histogram-percentiles-obj@3.0.0: {}
 
+  hono@4.12.1: {}
+
   hosted-git-info@2.8.9: {}
 
   html-encoding-sniffer@4.0.0:
@@ -6398,6 +6665,8 @@ snapshots:
     dependencies:
       fp-ts: 2.16.11
 
+  ip-address@10.0.1: {}
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -6426,6 +6695,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -6437,6 +6708,8 @@ snapshots:
   isexe@3.1.5: {}
 
   javascript-natural-sort@0.7.1: {}
+
+  jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -6486,6 +6759,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6587,10 +6862,14 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memory-pager@1.5.0:
     optional: true
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6736,9 +7015,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -6809,6 +7094,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   node-releases@2.0.27: {}
 
   normalize-package-data@2.5.0:
@@ -6819,6 +7106,8 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   nwsapi@2.2.23: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -6916,6 +7205,8 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@3.0.0:
     dependencies:
       pify: 3.0.0
@@ -6951,6 +7242,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
+
+  pkce-challenge@5.0.1: {}
 
   platform@1.3.6: {}
 
@@ -7027,6 +7320,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   read-pkg@3.0.0:
@@ -7124,6 +7424,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.8.0: {}
 
   run-async@2.4.1: {}
@@ -7180,12 +7490,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7452,6 +7787,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@5.26.5: {}
@@ -7554,5 +7895,9 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
         specifier: workspace:^
         version: link:../utils
       zod-to-json-schema:
-        specifier: ^3.24.0 || ^3.25.0
+        specifier: '>=3.24.0'
         version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@modelcontextprotocol/sdk':
@@ -422,12 +422,18 @@ importers:
 
   tests/debug:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.26.0(zod@3.25.76)
       '@typia/core':
         specifier: workspace:^
         version: link:../../packages/core
       '@typia/interface':
         specifier: workspace:^
         version: link:../../packages/interface
+      '@typia/mcp':
+        specifier: workspace:^
+        version: link:../../packages/mcp
       '@typia/transform':
         specifier: workspace:^
         version: link:../../packages/transform
@@ -512,6 +518,37 @@ importers:
         specifier: workspace:^
         version: link:../../packages/typia
     devDependencies:
+      ts-patch:
+        specifier: catalog:typescript
+        version: 3.3.0
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
+  tests/test-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.26.0(zod@3.25.76)
+      '@typia/mcp':
+        specifier: workspace:^
+        version: link:../../packages/mcp
+      typia:
+        specifier: workspace:^
+        version: link:../../packages/typia
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.2.3
+      '@types/ts-expose-internals':
+        specifier: catalog:typescript
+        version: ts-expose-internals@5.6.3
+      rimraf:
+        specifier: catalog:utils
+        version: 6.1.3
+      ts-node:
+        specifier: catalog:typescript
+        version: 10.9.2(@types/node@25.2.3)(typescript@5.9.3)
       ts-patch:
         specifier: catalog:typescript
         version: 3.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       '@typia/utils':
         specifier: workspace:^
         version: link:../utils
+      zod-to-json-schema:
+        specifier: ^3.24.0 || ^3.25.0
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
@@ -287,6 +290,9 @@ importers:
       typescript:
         specifier: catalog:typescript
         version: 5.9.3
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
 
   packages/transform:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,18 +422,12 @@ importers:
 
   tests/debug:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.12.0
-        version: 1.26.0(zod@3.25.76)
       '@typia/core':
         specifier: workspace:^
         version: link:../../packages/core
       '@typia/interface':
         specifier: workspace:^
         version: link:../../packages/interface
-      '@typia/mcp':
-        specifier: workspace:^
-        version: link:../../packages/mcp
       '@typia/transform':
         specifier: workspace:^
         version: link:../../packages/transform
@@ -518,37 +512,6 @@ importers:
         specifier: workspace:^
         version: link:../../packages/typia
     devDependencies:
-      ts-patch:
-        specifier: catalog:typescript
-        version: 3.3.0
-      typescript:
-        specifier: catalog:typescript
-        version: 5.9.3
-
-  tests/test-mcp:
-    dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.12.0
-        version: 1.26.0(zod@3.25.76)
-      '@typia/mcp':
-        specifier: workspace:^
-        version: link:../../packages/mcp
-      typia:
-        specifier: workspace:^
-        version: link:../../packages/typia
-    devDependencies:
-      '@types/node':
-        specifier: catalog:utils
-        version: 25.2.3
-      '@types/ts-expose-internals':
-        specifier: catalog:typescript
-        version: ts-expose-internals@5.6.3
-      rimraf:
-        specifier: catalog:utils
-        version: 6.1.3
-      ts-node:
-        specifier: catalog:typescript
-        version: 10.9.2(@types/node@25.2.3)(typescript@5.9.3)
       ts-patch:
         specifier: catalog:typescript
         version: 3.3.0


### PR DESCRIPTION
This pull request introduces a new MCP integration package for typia, enabling seamless registration of both TypeScript class-based and OpenAPI-based LLM function controllers as MCP tools. The changes provide robust validation feedback for LLM function calls, simplify controller creation, and ensure compatibility with MCP servers. The most important changes are grouped below.

### MCP Integration and Controller Registration

* Added new package `@typia/mcp` with configuration, dependencies, and build scripts, providing MCP integration for typia and supporting both class and HTTP controllers. (`packages/mcp/package.json`, `packages/mcp/tsconfig.json`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbR1-R66) [[2]](diffhunk://#diff-94877b9f39ff4729cab89b0d5e37fea1befc093e78316c20b6d842416d23f055R1-R9) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR272-R290)
* Implemented `registerMcpControllers` function in `packages/mcp/src/index.ts` to register controllers as MCP tools and provide validation feedback for LLM function calls. (`packages/mcp/src/index.ts`)
* Added `McpControllerRegistrar` internal module to handle tool registration, tool call routing, validation, and integration with MCP server tool handlers. (`packages/mcp/src/internal/McpControllerRegistrar.ts`)

### HTTP Controller and OpenAPI Support

* Introduced `IHttpLlmController` interface for HTTP-based LLM controllers, allowing OpenAPI operations to be registered as LLM function calling tools. (`packages/interface/src/http/IHttpLlmController.ts`, `packages/interface/src/http/index.ts`) [[1]](diffhunk://#diff-14ce260ae7c07419940da82d0cecdf4c57bafaa7f176cb6e2b7b6fec2b1cd6c8R1-R96) [[2]](diffhunk://#diff-b0eeea1af512d576c0521bf65c36001e2a163efafea55a72224ee5bdf0f65671R2)
* Added `HttpLlm.controller` function to compose HTTP LLM controllers from OpenAPI documents, simplifying MCP tool registration for API endpoints. (`packages/utils/src/http/HttpLlm.ts`) [[1]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdR4) [[2]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdR29) [[3]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdL46-R90) [[4]](diffhunk://#diff-a896d6241f1b6f31e2855b5b6e3db30da488b25950e22280643d9d175ba4cafdL68-R111)

### Documentation and Validation Feedback

* Improved documentation for `ILlmController` and `IHttpLlmController`, clarifying usage for class-based and OpenAPI-based controllers and their registration process. (`packages/interface/src/schema/ILlmController.ts`, `packages/interface/src/http/IHttpLlmController.ts`) [[1]](diffhunk://#diff-62eb0c4bd71f399b338ec57c6ad16aa0873c0ed984d442f82ba93ee19fa141fcL4-R40) [[2]](diffhunk://#diff-14ce260ae7c07419940da82d0cecdf4c57bafaa7f176cb6e2b7b6fec2b1cd6c8R1-R96)
* Enhanced `stringifyValidationFailure` output to wrap annotated JSON in a markdown code block, making validation feedback clearer for LLM auto-correction. (`packages/utils/src/utils/stringifyValidationFailure.ts`)