### PR TITLE
feat(vercel): add `@typia/vercel` package for Vercel AI SDK integration

### DIFF
--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@typia/vercel",
+  "version": "11.0.1",
+  "description": "Vercel AI SDK integration for typia",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "rimraf lib && tsc",
+    "dev": "rimraf lib && tsc --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "dependencies": {
+    "@typia/interface": "workspace:^",
+    "@typia/utils": "workspace:^"
+  },
+  "peerDependencies": {
+    "ai": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@types/json-schema": "^7.0.15",
+    "ai": "^4.3.16",
+    "rimraf": "catalog:utils",
+    "typescript": "catalog:typescript"
+  },
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "package.json",
+    "lib",
+    "src"
+  ],
+  "keywords": [
+    "vercel",
+    "ai-sdk",
+    "typia",
+    "llm",
+    "llm-function-calling",
+    "ai",
+    "tool-calling",
+    "openai",
+    "anthropic",
+    "claude",
+    "chatgpt",
+    "gemini",
+    "validation",
+    "json-schema",
+    "typescript"
+  ],
+  "packageManager": "pnpm@10.6.4",
+  "publishConfig": {
+    "access": "public",
+    "main": "lib/index.js",
+    "typings": "lib/index.d.ts"
+  }
+}

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -1,0 +1,103 @@
+import type { Tool } from "ai";
+import { IHttpLlmController, ILlmController } from "@typia/interface";
+
+import { VercelToolsRegistrar } from "./internal/VercelToolsRegistrar";
+
+/**
+ * Convert typia controllers to Vercel AI SDK tools.
+ *
+ * Transforms TypeScript class methods via `typia.llm.controller<Class>()` or
+ * OpenAPI operations via `HttpLlm.controller()` into Vercel AI SDK tools that
+ * can be used with any LLM provider (OpenAI, Anthropic, Google, etc.).
+ *
+ * Every tool call is validated by typia. If the LLM provides invalid arguments,
+ * returns a validation error formatted by {@link stringifyValidationFailure}
+ * so the LLM can auto-correct in the next turn.
+ *
+ * ## Example with OpenAI
+ *
+ * ```typescript
+ * import { generateText } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import typia from "typia";
+ * import { toVercelTools } from "@typia/vercel";
+ *
+ * class Calculator {
+ *   /&#42;&#42; Add two numbers together. &#42;/
+ *   add(props: { a: number; b: number }): number {
+ *     return props.a + props.b;
+ *   }
+ * }
+ *
+ * const controller = typia.llm.controller<Calculator>("calc", new Calculator());
+ * const tools = toVercelTools({ controllers: [controller] });
+ *
+ * const result = await generateText({
+ *   model: openai("gpt-4o"),
+ *   tools,
+ *   prompt: "What is 15 + 27?",
+ * });
+ * ```
+ *
+ * ## Example with Anthropic
+ *
+ * ```typescript
+ * import { generateText } from "ai";
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { toVercelTools } from "@typia/vercel";
+ *
+ * const result = await generateText({
+ *   model: anthropic("claude-sonnet-4-20250514"),
+ *   tools: toVercelTools({ controllers: [controller] }),
+ *   prompt: "Calculate 100 * 50",
+ * });
+ * ```
+ *
+ * ## Example with HTTP Controller (OpenAPI)
+ *
+ * ```typescript
+ * import { generateText } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import { HttpLlm } from "@typia/utils";
+ * import { toVercelTools } from "@typia/vercel";
+ *
+ * const controller = HttpLlm.controller({
+ *   name: "shopping",
+ *   document: await fetch("https://api.example.com/swagger.json").then(r => r.json()),
+ *   connection: { host: "https://api.example.com" },
+ * });
+ *
+ * const result = await generateText({
+ *   model: openai("gpt-4o"),
+ *   tools: toVercelTools({ controllers: [controller] }),
+ *   prompt: "Search for laptops under $1000",
+ * });
+ * ```
+ *
+ * @param props Conversion properties
+ * @returns Record of Vercel AI SDK Tools keyed by tool name
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export function toVercelTools(props: {
+  /**
+   * List of controllers to convert to Vercel tools.
+   *
+   * - {@link ILlmController}: from `typia.llm.controller<Class>()`, converts all
+   *   methods of the class to tools
+   * - {@link IHttpLlmController}: from `HttpLlm.controller()`, converts all
+   *   operations from OpenAPI document to tools
+   */
+  controllers: Array<ILlmController | IHttpLlmController>;
+
+  /**
+   * Whether to prefix tool names with controller name.
+   *
+   * If `true`, tool names are formatted as `{controller}_{function}`.
+   * If `false`, only the function name is used (may cause conflicts).
+   *
+   * @default true
+   */
+  prefix?: boolean | undefined;
+}): Record<string, Tool> {
+  return VercelToolsRegistrar.convert(props);
+}

--- a/packages/vercel/src/internal/VercelToolsRegistrar.ts
+++ b/packages/vercel/src/internal/VercelToolsRegistrar.ts
@@ -1,0 +1,179 @@
+import { jsonSchema, tool } from "ai";
+import type { Tool } from "ai";
+import type { JSONSchema7 } from "json-schema";
+import {
+  IHttpLlmController,
+  IHttpLlmFunction,
+  ILlmController,
+  ILlmFunction,
+  ILlmSchema,
+  IValidation,
+} from "@typia/interface";
+import { HttpLlm, stringifyValidationFailure } from "@typia/utils";
+
+export namespace VercelToolsRegistrar {
+  /**
+   * Convert typia controllers to Vercel AI SDK tools.
+   *
+   * @param props Conversion properties
+   * @returns Record of Vercel AI SDK Tools
+   */
+  export const convert = (props: {
+    controllers: Array<ILlmController | IHttpLlmController>;
+    prefix?: boolean | undefined;
+  }): Record<string, Tool> => {
+    const tools: Record<string, Tool> = {};
+    const prefix: boolean = props.prefix ?? true;
+
+    for (const controller of props.controllers) {
+      if (controller.protocol === "class") {
+        registerClassController({
+          tools,
+          controller,
+          prefix,
+        });
+      } else {
+        registerHttpController({
+          tools,
+          controller,
+          prefix,
+        });
+      }
+    }
+
+    return tools;
+  };
+
+  const registerClassController = (props: {
+    tools: Record<string, Tool>;
+    controller: ILlmController;
+    prefix: boolean;
+  }): void => {
+    const { tools, controller, prefix } = props;
+    const execute: Record<string, unknown> = controller.execute;
+
+    for (const func of controller.application.functions) {
+      const toolName: string = prefix
+        ? `${controller.name}_${func.name}`
+        : func.name;
+
+      if (tools[toolName] !== undefined) {
+        throw new Error(
+          `Duplicate tool name "${toolName}" from controller "${controller.name}"`,
+        );
+      }
+
+      const method: unknown = execute[func.name];
+      if (typeof method !== "function") {
+        throw new Error(
+          `Method "${func.name}" not found on controller "${controller.name}"`,
+        );
+      }
+
+      tools[toolName] = createTool({
+        func,
+        execute: async (args: unknown) => method.call(execute, args),
+      });
+    }
+  };
+
+  const registerHttpController = (props: {
+    tools: Record<string, Tool>;
+    controller: IHttpLlmController;
+    prefix: boolean;
+  }): void => {
+    const { tools, controller, prefix } = props;
+    const application = controller.application;
+    const connection = controller.connection;
+
+    for (const func of application.functions) {
+      const toolName: string = prefix
+        ? `${controller.name}_${func.name}`
+        : func.name;
+
+      if (tools[toolName] !== undefined) {
+        throw new Error(
+          `Duplicate tool name "${toolName}" from controller "${controller.name}"`,
+        );
+      }
+
+      tools[toolName] = createTool({
+        func,
+        execute: async (args: unknown) => {
+          if (controller.execute !== undefined) {
+            const response = await controller.execute({
+              connection,
+              application,
+              function: func,
+              arguments: args as object,
+            });
+            return response.body;
+          }
+          return HttpLlm.execute({
+            application,
+            function: func,
+            connection,
+            input: args as object,
+          });
+        },
+      });
+    }
+  };
+
+  const createTool = (props: {
+    func: ILlmFunction | IHttpLlmFunction;
+    execute: (args: unknown) => Promise<unknown>;
+  }): Tool => {
+    const { func, execute } = props;
+
+    return tool({
+      description: func.description,
+
+      // Convert ILlmSchema.IParameters to Vercel jsonSchema
+      parameters: jsonSchema<object>(
+        convertParameters(func.parameters) as JSONSchema7,
+      ),
+
+      execute: async (args: object) => {
+        // Validate using typia's built-in validator
+        const validation: IValidation<unknown> = func.validate(args);
+        if (!validation.success) {
+          // Return validation error in LLM-friendly format
+          return {
+            error: true,
+            message: stringifyValidationFailure(validation),
+          };
+        }
+
+        try {
+          const result: unknown = await execute(validation.data);
+          return result === undefined ? { success: true } : result;
+        } catch (error) {
+          return {
+            error: true,
+            message:
+              error instanceof Error
+                ? `${error.name}: ${error.message}`
+                : String(error),
+          };
+        }
+      },
+    });
+  };
+
+  const convertParameters = (params: ILlmSchema.IParameters): JSONSchema7 => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: params.properties as JSONSchema7["properties"],
+      required: params.required,
+      additionalProperties: params.additionalProperties,
+    };
+
+    // Add $defs if present
+    if (Object.keys(params.$defs).length > 0) {
+      schema.$defs = params.$defs as JSONSchema7["$defs"];
+    }
+
+    return schema;
+  };
+}

--- a/packages/vercel/tsconfig.json
+++ b/packages/vercel/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../internals/config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+  },
+  "include": ["src"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,28 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
 
+  packages/vercel:
+    dependencies:
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../interface
+      '@typia/utils':
+        specifier: workspace:^
+        version: link:../utils
+    devDependencies:
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
+      ai:
+        specifier: ^4.3.16
+        version: 4.3.19(react@19.2.4)(zod@3.25.76)
+      rimraf:
+        specifier: catalog:utils
+        version: 6.1.3
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
   tests/debug:
     dependencies:
       '@typia/core':
@@ -703,7 +725,73 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
 
+  tests/test-vercel:
+    dependencies:
+      '@nestia/e2e':
+        specifier: catalog:utils
+        version: 10.0.2
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../../packages/interface
+      '@typia/utils':
+        specifier: workspace:^
+        version: link:../../packages/utils
+      '@typia/vercel':
+        specifier: workspace:^
+        version: link:../../packages/vercel
+      ai:
+        specifier: ^4.3.16
+        version: 4.3.19(react@19.2.4)(zod@3.25.76)
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      typia:
+        specifier: workspace:^
+        version: link:../../packages/typia
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.2.3
+      '@types/ts-expose-internals':
+        specifier: catalog:typescript
+        version: ts-expose-internals@5.6.3
+      ts-node:
+        specifier: catalog:typescript
+        version: 10.9.2(@types/node@25.2.3)(typescript@5.9.3)
+      ts-patch:
+        specifier: catalog:typescript
+        version: 3.3.0
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
 packages:
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1098,6 +1186,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -1625,6 +1717,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1642,6 +1737,9 @@ packages:
 
   '@types/inquirer@8.2.12':
     resolution: {integrity: sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1839,6 +1937,16 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -2267,6 +2375,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -2815,12 +2926,20 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   kareem@2.5.1:
@@ -3334,6 +3453,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
   read-pkg@3.0.0:
     resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
     engines: {node: '>=4'}
@@ -3611,6 +3734,11 @@ packages:
   suppress-warnings@1.0.2:
     resolution: {integrity: sha512-zrKSiWJ7BNG14YfGd6BzgKN4wBPrjviMP3EYIGdQNDjDI8qbKcnxdbKL2C6ODAmonj63JTH+d7/l0MPqaqQLHg==}
 
+  swr@2.4.0:
+    resolution: {integrity: sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -3625,6 +3753,10 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -3761,6 +3893,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3893,6 +4030,34 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@19.2.4)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 19.2.4
+      swr: 2.4.0(react@19.2.4)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -4749,6 +4914,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -5392,6 +5559,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.8':
@@ -5416,6 +5585,8 @@ snapshots:
     dependencies:
       '@types/through': 0.0.33
       rxjs: 7.8.2
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -5673,6 +5844,18 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@4.3.19(react@19.2.4)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@19.2.4)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 19.2.4
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -6155,6 +6338,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff-match-patch@1.0.5: {}
 
   diff@4.0.4: {}
 
@@ -6811,9 +6996,17 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   kareem@2.5.1: {}
 
@@ -7378,6 +7571,8 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  react@19.2.4: {}
+
   read-pkg@3.0.0:
     dependencies:
       load-json-file: 4.0.0
@@ -7695,6 +7890,12 @@ snapshots:
 
   suppress-warnings@1.0.2: {}
 
+  swr@2.4.0(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
   symbol-tree@3.2.4: {}
 
   text-table@0.2.0: {}
@@ -7726,6 +7927,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  throttleit@2.1.0: {}
 
   through@2.3.8: {}
 
@@ -7865,6 +8068,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,0 +1,33 @@
+{
+  "private": true,
+  "name": "@typia/test-vercel",
+  "version": "0.1.0",
+  "description": "Test suite for @typia/vercel package",
+  "scripts": {
+    "build": "tsc",
+    "prepare": "ts-patch install",
+    "start": "ts-node src/index.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "catalog:utils",
+    "@types/ts-expose-internals": "catalog:typescript",
+    "ts-node": "catalog:typescript",
+    "ts-patch": "catalog:typescript",
+    "typescript": "catalog:typescript"
+  },
+  "dependencies": {
+    "@nestia/e2e": "catalog:utils",
+    "@typia/interface": "workspace:^",
+    "@typia/utils": "workspace:^",
+    "@typia/vercel": "workspace:^",
+    "ai": "^4.3.16",
+    "chalk": "^4.1.2",
+    "typia": "workspace:^"
+  }
+}

--- a/tests/test-vercel/src/TestGlobal.ts
+++ b/tests/test-vercel/src/TestGlobal.ts
@@ -1,0 +1,25 @@
+import { OpenApi, OpenApiV3_1 } from "@typia/interface";
+import { OpenApiConverter, Singleton } from "@typia/utils";
+
+export namespace TestGlobal {
+  export const getSwagger = (): Promise<OpenApi.IDocument> => swagger.get();
+
+  export const getArguments = (key: string): string[] => {
+    const values: string[] = [];
+    for (let i = 0; i < process.argv.length; i++) {
+      const arg = process.argv[i];
+      if (arg === `--${key}` && i + 1 < process.argv.length) {
+        values.push(process.argv[++i]!);
+      }
+    }
+    return values;
+  };
+}
+
+const swagger = new Singleton(async () => {
+  const response: Response = await fetch(
+    "https://raw.githubusercontent.com/samchon/shopping-backend/refs/heads/master/packages/api/swagger.json",
+  );
+  const document: OpenApiV3_1.IDocument = await response.json();
+  return OpenApiConverter.upgradeDocument(document);
+});

--- a/tests/test-vercel/src/features/test_vercel_class_controller_duplicate_error.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_duplicate_error.ts
@@ -1,0 +1,44 @@
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+class AnotherCalculator {
+  /** Another add function that will conflict. */
+  add(p: { a: number; b: number }): number {
+    return p.a + p.b;
+  }
+}
+
+export const test_vercel_class_controller_duplicate_error =
+  async (): Promise<void> => {
+    // 1. Create two controllers with same function names (when prefix is false)
+    const controller1: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calc1", new Calculator());
+
+    const controller2: ILlmController<AnotherCalculator> =
+      typia.llm.controller<AnotherCalculator>("calc2", new AnotherCalculator());
+
+    // 2. Should throw due to duplicate name when prefix is false
+    let threw: boolean = false;
+    let errorMessage: string = "";
+    try {
+      toVercelTools({
+        controllers: [controller1, controller2],
+        prefix: false, // This will cause "add" to conflict
+      });
+    } catch (e) {
+      threw = true;
+      errorMessage = (e as Error).message;
+    }
+
+    if (!threw) {
+      throw new Error("Expected duplicate tool name error");
+    }
+    if (!errorMessage.includes("Duplicate tool name")) {
+      throw new Error(
+        `Expected error message to include "Duplicate tool name", got: ${errorMessage}`,
+      );
+    }
+  };

--- a/tests/test-vercel/src/features/test_vercel_class_controller_error_handling.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_error_handling.ts
@@ -1,0 +1,37 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_class_controller_error_handling =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools: Record<string, Tool> = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Test divide by zero (throws an error)
+    const divideTool: Tool = tools["calculator_divide"]!;
+    const result: unknown = await divideTool.execute!(
+      { x: 10, y: 0 },
+      { toolCallId: "test-1", messages: [], abortSignal: undefined as any },
+    );
+
+    // 4. Verify the result contains error
+    TestValidator.predicate("result should be an error object", () => {
+      const res = result as { error?: boolean; message?: string };
+      return res.error === true && typeof res.message === "string";
+    });
+
+    TestValidator.predicate("error message should contain division by zero", () => {
+      const res = result as { error: boolean; message: string };
+      return res.message.includes("Division by zero");
+    });
+  };

--- a/tests/test-vercel/src/features/test_vercel_class_controller_execute.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_execute.ts
@@ -1,0 +1,52 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_class_controller_execute = async (): Promise<void> => {
+  // 1. Create class-based controller using typia.llm.controller
+  const controller: ILlmController<Calculator> = typia.llm.controller<Calculator>(
+    "calculator",
+    new Calculator(),
+  );
+
+  // 2. Convert to Vercel tools
+  const tools: Record<string, Tool> = toVercelTools({
+    controllers: [controller],
+  });
+
+  // 3. Test add function
+  const addTool: Tool = tools["calculator_add"]!;
+  const addResult: unknown = await addTool.execute!(
+    { x: 10, y: 5 },
+    { toolCallId: "test-1", messages: [], abortSignal: undefined as any },
+  );
+  TestValidator.equals("add(10, 5) should return 15", addResult, 15);
+
+  // 4. Test subtract function
+  const subtractTool: Tool = tools["calculator_subtract"]!;
+  const subtractResult: unknown = await subtractTool.execute!(
+    { x: 10, y: 3 },
+    { toolCallId: "test-2", messages: [], abortSignal: undefined as any },
+  );
+  TestValidator.equals("subtract(10, 3) should return 7", subtractResult, 7);
+
+  // 5. Test multiply function
+  const multiplyTool: Tool = tools["calculator_multiply"]!;
+  const multiplyResult: unknown = await multiplyTool.execute!(
+    { x: 4, y: 7 },
+    { toolCallId: "test-3", messages: [], abortSignal: undefined as any },
+  );
+  TestValidator.equals("multiply(4, 7) should return 28", multiplyResult, 28);
+
+  // 6. Test divide function
+  const divideTool: Tool = tools["calculator_divide"]!;
+  const divideResult: unknown = await divideTool.execute!(
+    { x: 20, y: 4 },
+    { toolCallId: "test-4", messages: [], abortSignal: undefined as any },
+  );
+  TestValidator.equals("divide(20, 4) should return 5", divideResult, 5);
+};

--- a/tests/test-vercel/src/features/test_vercel_class_controller_no_prefix.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_no_prefix.ts
@@ -1,0 +1,34 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_class_controller_no_prefix =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools without prefix
+    const tools: Record<string, Tool> = toVercelTools({
+      controllers: [controller],
+      prefix: false,
+    });
+
+    // 3. Verify all tools are registered without prefix
+    const toolNames: string[] = Object.keys(tools).sort();
+    TestValidator.equals("should have 4 tools", toolNames.length, 4);
+    TestValidator.predicate("should have add", () => toolNames.includes("add"));
+    TestValidator.predicate("should have subtract", () =>
+      toolNames.includes("subtract"),
+    );
+    TestValidator.predicate("should have multiply", () =>
+      toolNames.includes("multiply"),
+    );
+    TestValidator.predicate("should have divide", () =>
+      toolNames.includes("divide"),
+    );
+  };

--- a/tests/test-vercel/src/features/test_vercel_class_controller_register.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_register.ts
@@ -1,0 +1,51 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_class_controller_register = async (): Promise<void> => {
+  // 1. Create class-based controller using typia.llm.controller
+  const controller: ILlmController<Calculator> = typia.llm.controller<Calculator>(
+    "calculator",
+    new Calculator(),
+  );
+
+  // 2. Convert to Vercel tools
+  const tools: Record<string, Tool> = toVercelTools({
+    controllers: [controller],
+  });
+
+  // 3. Verify all tools are registered with prefix
+  const toolNames: string[] = Object.keys(tools).sort();
+  TestValidator.equals("should have 4 tools", toolNames.length, 4);
+  TestValidator.predicate("should have calculator_add", () =>
+    toolNames.includes("calculator_add"),
+  );
+  TestValidator.predicate("should have calculator_subtract", () =>
+    toolNames.includes("calculator_subtract"),
+  );
+  TestValidator.predicate("should have calculator_multiply", () =>
+    toolNames.includes("calculator_multiply"),
+  );
+  TestValidator.predicate("should have calculator_divide", () =>
+    toolNames.includes("calculator_divide"),
+  );
+
+  // 4. Verify tool structure
+  const addTool: Tool = tools["calculator_add"]!;
+  TestValidator.predicate(
+    "tool should have description",
+    () => addTool.description !== undefined,
+  );
+  TestValidator.predicate(
+    "tool should have parameters",
+    () => addTool.parameters !== undefined,
+  );
+  TestValidator.predicate(
+    "tool should have execute function",
+    () => typeof addTool.execute === "function",
+  );
+};

--- a/tests/test-vercel/src/features/test_vercel_class_controller_validation.ts
+++ b/tests/test-vercel/src/features/test_vercel_class_controller_validation.ts
@@ -1,0 +1,47 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController, IValidation } from "@typia/interface";
+import { stringifyValidationFailure } from "@typia/utils";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_class_controller_validation =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools: Record<string, Tool> = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Test validation failure: wrong type (string instead of number)
+    const addTool: Tool = tools["calculator_add"]!;
+    const result: unknown = await addTool.execute!(
+      { x: "not a number", y: 5 },
+      { toolCallId: "test-1", messages: [], abortSignal: undefined as any },
+    );
+
+    // 4. Verify the result contains validation error
+    const expected: IValidation = typia.validate<Calculator.IProps>({
+      x: "not a number",
+      y: 5,
+    });
+    if (expected.success === true)
+      throw new Error("Expected validation to fail, but it succeeded.");
+
+    const expectedMessage: string = stringifyValidationFailure(expected);
+
+    TestValidator.predicate("result should be an error object", () => {
+      const res = result as { error?: boolean; message?: string };
+      return res.error === true && typeof res.message === "string";
+    });
+
+    TestValidator.predicate("error message should contain validation info", () => {
+      const res = result as { error: boolean; message: string };
+      return res.message === expectedMessage;
+    });
+  };

--- a/tests/test-vercel/src/features/test_vercel_generate_text_multiple_tools.ts
+++ b/tests/test-vercel/src/features/test_vercel_generate_text_multiple_tools.ts
@@ -1,0 +1,84 @@
+import { generateText } from "ai";
+import { MockLanguageModelV1 } from "ai/test";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_generate_text_multiple_tools =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Create a mock model that returns multiple tool calls
+    const mockModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: "tool-calls",
+        usage: { promptTokens: 10, completionTokens: 5 },
+        toolCalls: [
+          {
+            toolCallType: "function",
+            toolCallId: "call-1",
+            toolName: "calculator_add",
+            args: JSON.stringify({ x: 10, y: 5 }),
+          },
+          {
+            toolCallType: "function",
+            toolCallId: "call-2",
+            toolName: "calculator_multiply",
+            args: JSON.stringify({ x: 3, y: 7 }),
+          },
+          {
+            toolCallType: "function",
+            toolCallId: "call-3",
+            toolName: "calculator_subtract",
+            args: JSON.stringify({ x: 100, y: 42 }),
+          },
+        ],
+      }),
+    });
+
+    // 4. Call generateText with our tools and mock model
+    const result = await generateText({
+      model: mockModel,
+      tools,
+      prompt: "Calculate multiple things",
+    });
+
+    // 5. Verify all tool calls were made
+    TestValidator.equals("should have 3 tool calls", result.toolCalls.length, 3);
+
+    // 6. Verify tool results (cast to any[] due to Record<string, Tool> type inference)
+    const toolResults = result.toolResults as Array<{
+      toolCallId: string;
+      toolName: string;
+      result: unknown;
+    }>;
+    TestValidator.equals("should have 3 tool results", toolResults.length, 3);
+
+    // Find results by toolCallId
+    const addResult = toolResults.find((r) => r.toolCallId === "call-1")!;
+    const multiplyResult = toolResults.find((r) => r.toolCallId === "call-2")!;
+    const subtractResult = toolResults.find((r) => r.toolCallId === "call-3")!;
+
+    TestValidator.equals("add(10, 5) should be 15", addResult.result, 15);
+    TestValidator.equals(
+      "multiply(3, 7) should be 21",
+      multiplyResult.result,
+      21,
+    );
+    TestValidator.equals(
+      "subtract(100, 42) should be 58",
+      subtractResult.result,
+      58,
+    );
+  };

--- a/tests/test-vercel/src/features/test_vercel_generate_text_runtime_error.ts
+++ b/tests/test-vercel/src/features/test_vercel_generate_text_runtime_error.ts
@@ -1,0 +1,62 @@
+import { generateText } from "ai";
+import { MockLanguageModelV1 } from "ai/test";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_generate_text_runtime_error =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Create a mock model that triggers division by zero
+    const mockModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: "tool-calls",
+        usage: { promptTokens: 10, completionTokens: 5 },
+        toolCalls: [
+          {
+            toolCallType: "function",
+            toolCallId: "call-1",
+            toolName: "calculator_divide",
+            args: JSON.stringify({ x: 10, y: 0 }), // Division by zero!
+          },
+        ],
+      }),
+    });
+
+    // 4. Call generateText with our tools and mock model
+    const result = await generateText({
+      model: mockModel,
+      tools,
+      prompt: "Divide 10 by 0",
+    });
+
+    // 5. Verify the tool was called
+    const toolCalls = result.toolCalls as Array<unknown>;
+    TestValidator.equals("should have 1 tool call", toolCalls.length, 1);
+
+    // 6. Verify tool result contains runtime error
+    const toolResults = result.toolResults as Array<{ result: unknown }>;
+    TestValidator.equals("should have 1 tool result", toolResults.length, 1);
+
+    const toolResult = toolResults[0]!.result as {
+      error: boolean;
+      message: string;
+    };
+    TestValidator.equals("result should be error", toolResult.error, true);
+    TestValidator.predicate(
+      "error message should contain division by zero",
+      () => toolResult.message.includes("Division by zero"),
+    );
+  };

--- a/tests/test-vercel/src/features/test_vercel_generate_text_validation_error.ts
+++ b/tests/test-vercel/src/features/test_vercel_generate_text_validation_error.ts
@@ -1,0 +1,67 @@
+import { generateText } from "ai";
+import { MockLanguageModelV1 } from "ai/test";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_generate_text_validation_error =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Create a mock model that returns invalid tool call arguments
+    const mockModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: "tool-calls",
+        usage: { promptTokens: 10, completionTokens: 5 },
+        toolCalls: [
+          {
+            toolCallType: "function",
+            toolCallId: "call-1",
+            toolName: "calculator_add",
+            // Invalid: x should be number, not string
+            args: JSON.stringify({ x: "not a number", y: 5 }),
+          },
+        ],
+      }),
+    });
+
+    // 4. Call generateText with our tools and mock model
+    const result = await generateText({
+      model: mockModel,
+      tools,
+      prompt: "What is 10 + 5?",
+    });
+
+    // 5. Verify the tool was called
+    const toolCalls = result.toolCalls as Array<unknown>;
+    TestValidator.equals("should have 1 tool call", toolCalls.length, 1);
+
+    // 6. Verify tool result contains validation error
+    const toolResults = result.toolResults as Array<{ result: unknown }>;
+    TestValidator.equals("should have 1 tool result", toolResults.length, 1);
+
+    const toolResult = toolResults[0]!.result as {
+      error: boolean;
+      message: string;
+    };
+    TestValidator.equals("result should be error", toolResult.error, true);
+    TestValidator.predicate(
+      "error message should contain validation failure",
+      () => toolResult.message.includes("```json"),
+    );
+    TestValidator.predicate(
+      "error message should indicate type error",
+      () => toolResult.message.includes("number"),
+    );
+  };

--- a/tests/test-vercel/src/features/test_vercel_generate_text_with_tool_call.ts
+++ b/tests/test-vercel/src/features/test_vercel_generate_text_with_tool_call.ts
@@ -1,0 +1,65 @@
+import { generateText } from "ai";
+import { MockLanguageModelV1 } from "ai/test";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmController } from "@typia/interface";
+import { toVercelTools } from "@typia/vercel";
+import typia from "typia";
+
+import { Calculator } from "../structures/Calculator";
+
+export const test_vercel_generate_text_with_tool_call =
+  async (): Promise<void> => {
+    // 1. Create class-based controller using typia.llm.controller
+    const controller: ILlmController<Calculator> =
+      typia.llm.controller<Calculator>("calculator", new Calculator());
+
+    // 2. Convert to Vercel tools
+    const tools = toVercelTools({
+      controllers: [controller],
+    });
+
+    // 3. Create a mock model that returns a tool call
+    const mockModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: "tool-calls",
+        usage: { promptTokens: 10, completionTokens: 5 },
+        toolCalls: [
+          {
+            toolCallType: "function",
+            toolCallId: "call-1",
+            toolName: "calculator_add",
+            args: JSON.stringify({ x: 10, y: 5 }),
+          },
+        ],
+      }),
+    });
+
+    // 4. Call generateText with our tools and mock model
+    const result = await generateText({
+      model: mockModel,
+      tools,
+      prompt: "What is 10 + 5?",
+    });
+
+    // 5. Verify the tool was called and returned correct result
+    const toolCalls = result.toolCalls as Array<{
+      toolName: string;
+      args: unknown;
+    }>;
+    TestValidator.equals("should have 1 tool call", toolCalls.length, 1);
+    TestValidator.equals(
+      "tool name should be calculator_add",
+      toolCalls[0]!.toolName,
+      "calculator_add",
+    );
+    TestValidator.equals("tool args should match", toolCalls[0]!.args, {
+      x: 10,
+      y: 5,
+    });
+
+    // 6. Verify tool result
+    const toolResults = result.toolResults as Array<{ result: unknown }>;
+    TestValidator.equals("should have 1 tool result", toolResults.length, 1);
+    TestValidator.equals("tool result should be 15", toolResults[0]!.result, 15);
+  };

--- a/tests/test-vercel/src/features/test_vercel_http_controller_register.ts
+++ b/tests/test-vercel/src/features/test_vercel_http_controller_register.ts
@@ -1,0 +1,49 @@
+import type { Tool } from "ai";
+import { TestValidator } from "@nestia/e2e";
+import { IHttpLlmController, OpenApi } from "@typia/interface";
+import { HttpLlm } from "@typia/utils";
+import { toVercelTools } from "@typia/vercel";
+
+import { TestGlobal } from "../TestGlobal";
+
+export const test_vercel_http_controller_register = async (): Promise<void> => {
+  // 1. Fetch swagger.json and create controller
+  const swagger: OpenApi.IDocument = await TestGlobal.getSwagger();
+  const controller: IHttpLlmController = HttpLlm.controller({
+    name: "shopping",
+    document: swagger,
+    connection: { host: "http://localhost:3000" },
+  });
+
+  // 2. Convert to Vercel tools
+  const tools: Record<string, Tool> = toVercelTools({
+    controllers: [controller],
+  });
+
+  // 3. Verify tools are registered
+  const toolNames: string[] = Object.keys(tools);
+  TestValidator.equals(
+    "tools count should match controller functions",
+    toolNames.length,
+    controller.application.functions.length,
+  );
+
+  // 4. Verify all tool names start with controller prefix
+  TestValidator.predicate("all tools should have shopping_ prefix", () =>
+    toolNames.every((name) => name.startsWith("shopping_")),
+  );
+
+  // 5. Verify each tool has required properties
+  for (const name of toolNames) {
+    const tool: Tool = tools[name]!;
+    TestValidator.predicate(`${name} should have description`, () =>
+      tool.description !== undefined,
+    );
+    TestValidator.predicate(`${name} should have parameters`, () =>
+      tool.parameters !== undefined,
+    );
+    TestValidator.predicate(`${name} should have execute`, () =>
+      typeof tool.execute === "function",
+    );
+  }
+};

--- a/tests/test-vercel/src/index.ts
+++ b/tests/test-vercel/src/index.ts
@@ -1,0 +1,49 @@
+import { DynamicExecutor } from "@nestia/e2e";
+import chalk from "chalk";
+
+import { TestGlobal } from "./TestGlobal";
+
+const main = async (): Promise<void> => {
+  // Parse arguments
+  const include: string[] = TestGlobal.getArguments("include");
+  const exclude: string[] = TestGlobal.getArguments("exclude");
+
+  // Execute tests
+  const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+    prefix: "test_",
+    location: __dirname + "/features",
+    extension: "ts",
+    parameters: () => [],
+    onComplete: (exec) => {
+      const trace = (str: string) =>
+        console.log(`  - ${chalk.green(exec.name)}: ${str}`);
+      if (exec.error === null) {
+        const elapsed: number =
+          new Date(exec.completed_at).getTime() -
+          new Date(exec.started_at).getTime();
+        trace(`${chalk.yellow(elapsed.toLocaleString())} ms`);
+      } else trace(chalk.red(exec.error.name));
+    },
+    filter: (name) =>
+      (include.length ? include.some((str) => name.includes(str)) : true) &&
+      (exclude.length ? exclude.every((str) => !name.includes(str)) : true),
+  });
+
+  // Report exceptions
+  const exceptions: Error[] = report.executions
+    .filter((exec) => exec.error !== null)
+    .map((exec) => exec.error!);
+
+  if (exceptions.length === 0) {
+    console.log("Success");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  } else {
+    for (const exp of exceptions) console.log(exp);
+    console.log("Failed");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  }
+
+  if (exceptions.length) process.exit(-1);
+};
+
+main().catch(console.error);

--- a/tests/test-vercel/src/structures/Calculator.ts
+++ b/tests/test-vercel/src/structures/Calculator.ts
@@ -1,0 +1,53 @@
+export class Calculator {
+  /**
+   * Add two numbers.
+   *
+   * @param p The input containing two numbers to add
+   * @returns The sum of a and b
+   */
+  add(p: Calculator.IProps): number {
+    return p.x + p.y;
+  }
+
+  /**
+   * Subtract two numbers.
+   *
+   * @param p The input containing two numbers to subtract
+   * @returns The difference of a and b
+   */
+  subtract(p: Calculator.IProps): number {
+    return p.x - p.y;
+  }
+
+  /**
+   * Multiply two numbers.
+   *
+   * @param p The input containing two numbers to multiply
+   * @returns The product of a and b
+   */
+  multiply(p: Calculator.IProps): number {
+    return p.x * p.y;
+  }
+
+  /**
+   * Divide two numbers.
+   *
+   * @param p The input containing two numbers to divide
+   * @returns The quotient of a and b
+   */
+  divide(p: Calculator.IProps): number {
+    if (p.y === 0) {
+      throw new Error("Division by zero is not allowed");
+    }
+    return p.x / p.y;
+  }
+}
+export namespace Calculator {
+  export interface IProps {
+    /** First operand */
+    x: number;
+
+    /** Second operand */
+    y: number;
+  }
+}

--- a/tests/test-vercel/tsconfig.json
+++ b/tests/test-vercel/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This pull request introduces a new package, `@typia/vercel`, which provides integration between Typia's LLM controllers and the Vercel AI SDK, allowing developers to easily convert Typia controllers and OpenAPI operations into Vercel AI SDK tools. The package includes robust validation and error handling for tool calls, and is set up with appropriate build scripts, TypeScript configuration, and dependencies. Additionally, this PR updates the monorepo's lockfile to include the new package and its dependencies.

New Vercel AI SDK integration package:

* Added `@typia/vercel` package with `package.json`, TypeScript config (`tsconfig.json`), and main implementation files. This package enables conversion of Typia LLM controllers and OpenAPI operations into Vercel AI SDK tools with validation and error handling. [[1]](diffhunk://#diff-2f041bb019a5d2e5340dd6b3ec14de95735ebef85a1f4cc14e4614cfd4b70303R1-R64) [[2]](diffhunk://#diff-b1a47f0094d17e451ea3686f3e0ee93d3faf350177a6abe711a35313f108a4bdR1-R7) [[3]](diffhunk://#diff-f9f0099646836808ed68536b1baf87e3adc7bee721500dfbbd1cbd4ac78398acR1-R103) [[4]](diffhunk://#diff-8762db14b8b1b040165b1e864442a8b490b4103cf545437274647ed8fc254fa2R1-R179)

Monorepo dependency updates:

* Updated `pnpm-lock.yaml` to register the new `@typia/vercel` package, its dependencies (`ai`, `@types/json-schema`, etc.), and related test package dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR423-R444) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR728-R795)
* Added new package snapshots and resolutions for dependencies such as `ai`, `json-schema`, `@types/json-schema`, and others required by the new package. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1190-R1193) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1720-R1722) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1741-R1743) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1941-R1950) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2379-R2381) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2929-R2931) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2940-R2944) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3456-R3459) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3737-R3741) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3757-R3760) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3896-R3900) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4034-R4061) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4917-R4918)