### PR TITLE
feat(station): release configuration

### DIFF
--- a/internals/benchmark/package.json
+++ b/internals/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/internals/config/package.json
+++ b/internals/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/internals/examples/package.json
+++ b/internals/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "1.0.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Example codes for typia website",
   "scripts": {
     "prepare": "ts-patch install",

--- a/next.bash
+++ b/next.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+pnpm bumpp "$1" --no-commit --no-tag --no-push --recursive --yes
+pnpm --filter=./packages/* -r publish --tag next --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",
     "test": "pnpm --filter=./tests/test-* -r start",
     "format": "prettier --write packages/**/*.ts && prettier --write internals/**/*.ts && prettier --write tests/**/*.ts",
     "package:latest": "pnpm --filter=./packages/* -r publish --tag latest --access public",
-    "package:next": "pnpm --filter=./packages/* -r publish --tag next --access public"
+    "package:next": "bash next.bash"
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "12.0.0",
+  "version": "11.0.3",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "11.0.3",
+  "version": "12.0.0-dev.20260225",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Convenient debug program for typia",
   "scripts": {
     "prepare": "ts-patch install",

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "scripts": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "prepare": "ts-patch install",

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "prepare": "ts-patch install",

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Automated test features of typia.",
   "scripts": {
     "prepare": "ts-patch install",

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Automated test features of openapi.",
   "scripts": {
     "prepare": "ts-patch install",

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "0.1.0",
+  "version": "12.0.0-dev.20260225",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "prepare": "ts-patch install",


### PR DESCRIPTION
This pull request updates the version numbers across all packages and introduces a new script for publishing "next" releases. The main goal is to transition all packages to a pre-release version (`12.0.0-dev.20260225`) and streamline the publishing workflow for "next" tags.

Version updates:

* All `package.json` files in the monorepo have their version updated to `12.0.0-dev.20260225`, including core, interface, utils, transform, langchain, mcp, vercel, typia, and all internal and test packages. [[1]](diffhunk://#diff-03702f3ebdfd885c21b361621128c28d0a830874908baa1671d12ce9aad7ea7eL4-R4) [[2]](diffhunk://#diff-982e013f8b4f27ffce2cbe311ae5b666c5163ad5ff1b18b54f2babac71f3ecacL4-R4) [[3]](diffhunk://#diff-bee3f3e558fcbd8684eb6155744a24583f8385dd3aa9776221764d502919ef3cL4-R4) [[4]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L3-R3) [[5]](diffhunk://#diff-d2327fdda1c4889df8f7c8e399de581131b8df453d232fad4e976f706607e2d0L3-R3) [[6]](diffhunk://#diff-b04b890b40f07a3710d5e81a95f8c099b5dca6077f7748f19677c6039df741d7L3-R3) [[7]](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbL3-R3) [[8]](diffhunk://#diff-c29fc5b22cdafb98d0787352d818be077dd5eabd6fec5232e80a3b71dd8ff0d8L3-R3) [[9]](diffhunk://#diff-534691e2a0052a711c4b7f6ea8248bf1fb2ddf2ede7c7336cdebf70306b6b311L3-R3) [[10]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L3-R3) [[11]](diffhunk://#diff-2f041bb019a5d2e5340dd6b3ec14de95735ebef85a1f4cc14e4614cfd4b70303L3-R3) [[12]](diffhunk://#diff-ddf4d832fcca6f6d95434e5eb9ece58e9b25b388cbf7fd89177930f039fed0c5L4-R4) [[13]](diffhunk://#diff-69fe6c0afc467eb80f5a54d3e5a060adc4f427f7ca2eaa363506b9e1f9059bc5L4-R4) [[14]](diffhunk://#diff-212867f77bdbebc6473e4ae7b4fe380c5026fada325cc1ccf98db7820258da50L4-R4) [[15]](diffhunk://#diff-1dee09836ad8ca7c146f41704203a59a198cadbfb7b059f33775252bea2f6e34L4-R4) [[16]](diffhunk://#diff-9464582f194b4b0411aae7050e294f76aa17da98205692b8dbe9439f2e2c1840L4-R4) [[17]](diffhunk://#diff-489a0506d47670fac18f10651c09e95689ee12cdf9e689e6372da8557dab830bL4-R4) [[18]](diffhunk://#diff-b0cb6cd99311d72ff21ebb6fff4ee41f696d96ab8c744044ec2de6dd29846c35L4-R4) [[19]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R11)

Publishing workflow improvements:

* Added a new `next.bash` script to automate bumping versions and publishing all packages with the "next" tag, improving the release process for pre-release versions.
* Updated the `package:next` script in the root `package.json` to use the new `next.bash` script instead of a direct `pnpm publish` command.