### PR TITLE
feat(website): introduce langchain/mcp/vercel functions.

### DIFF
--- a/website/src/content/docs/llm/_meta.ts
+++ b/website/src/content/docs/llm/_meta.ts
@@ -4,6 +4,13 @@ export default {
   application: "application() functions",
   parameters: "parameters() function",
   schema: "schema() function",
-  chat: "AI Chatbot Development",
-  strategy: "Documentation Strategy",
+  mcp: "Model Context Protocol",
+  vercel: "Vercel AI SDK",
+  langchain: "LangChain",
+  chat: {
+    display: "hidden",
+  },
+  strategy: {
+    display: "hidden",
+  },
 } satisfies MetaRecord;

--- a/website/src/content/docs/llm/langchain.mdx
+++ b/website/src/content/docs/llm/langchain.mdx
@@ -1,0 +1,245 @@
+---
+title: Guide Documents > Large Language Model > LangChain
+---
+import { Callout, Tabs } from "nextra/components";
+
+import LocalSource from "../../../components/LocalSource";
+import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
+
+## `toLangChainTools()` function
+
+<Tabs items={[
+    <code>@typia/langchain</code>,
+    <code>ILlmController</code>,
+    <code>IHttpLlmController</code>,
+    <code>HttpLlm.controller</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="@typia/langchain" showLineNumbers
+export function toLangChainTools(props: {
+  controllers: Array<ILlmController | IHttpLlmController>;
+  prefix?: boolean | undefined;
+}): DynamicStructuredTool[];
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/schema/ILlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/http/IHttpLlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/utils/src/http/HttpLlm.ts"
+      filename="@typia/utils"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+[LangChain.js](https://github.com/langchain-ai/langchainjs) integration for [`typia`](https://github.com/samchon/typia).
+
+`toLangChainTools()` converts TypeScript classes or OpenAPI documents into LangChain `DynamicStructuredTool[]` at once.
+
+Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to a `DynamicStructuredTool` with schemas from the specification.
+
+Validation feedback is embedded automatically.
+
+## Setup
+
+```bash filename="Terminal"
+npm install @typia/langchain @langchain/core
+npm install typia
+npx typia setup
+```
+
+## From TypeScript Class
+
+<Tabs items={[
+    "LangChain Agent",
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="src/main.ts" showLineNumbers {1-6, 10-15, 17-27}
+import { ChainValues, Runnable } from "@langchain/core";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { ChatOpenAI } from "@langchain/openai";
+import { toLangChainTools } from "@typia/langchain";
+import { AgentExecutor, createToolCallingAgent } from "langchain/agents";
+import typia from "typia";
+
+import { Calculator } from "./Calculator";
+
+const tools: DynamicStructuredTool[] = toLangChainTools({
+  controllers: [
+    typia.llm.controller<Calculator>("calculator", new Calculator()),
+  ],
+});
+
+const agent: Runnable = createToolCallingAgent({
+  llm: new ChatOpenAI({ model: "gpt-4o" }),
+  tools,
+  prompt: ChatPromptTemplate.fromMessages([
+    ["system", "You are a helpful assistant."],
+    ["human", "{input}"],
+    ["placeholder", "{agent_scratchpad}"],
+  ]),
+});
+const executor: AgentExecutor = new AgentExecutor({ agent, tools });
+const result: ChainValues = await executor.invoke({
+  input: "What is 10 + 5?",
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-langchain/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/BbsArticleService.ts"
+      filename="BbsArticleService.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/IBbsArticle.ts"
+      filename="IBbsArticle.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `toLangChainTools()`.
+
+  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
+  - `prefix`: When `true` (default), tool names are formatted as `{controllerName}_{methodName}`. Set to `false` to use bare method names
+
+## From OpenAPI Document
+
+```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { toLangChainTools } from "@typia/langchain";
+import { HttpLlm } from "@typia/utils";
+
+const tools: DynamicStructuredTool[] = toLangChainTools({
+  controllers: [
+    HttpLlm.controller({
+      name: "shopping",
+      document: await fetch(
+        "https://shopping-be.wrtn.ai/editor/swagger.json",
+      ).then((r) => r.json()),
+      connection: {
+        host: "https://shopping-be.wrtn.ai",
+        headers: { Authorization: "Bearer ********" },
+      },
+    }),
+  ],
+});
+```
+
+Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `toLangChainTools()`.
+
+  - `name`: Controller name used as prefix for tool names
+  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
+  - `connection`: HTTP connection info including `host` and optional `headers`
+
+## Validation Feedback
+
+<Tabs items={[
+    "Validation Test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-langchain/src/features/test_langchain_class_controller_validation.ts"
+      filename="test_langchain_class_controller_validation.ts"
+      showLineNumbers
+      highlight="29, 32-35, 40-44, 48-49" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-langchain/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+<ValidationFeedbackExampleSnippet />
+
+When LLM sends `{ x: "not a number", y: 5 }`, the validation failure message from `stringifyValidationFailure()` is returned directly as the tool result string. The LLM reads this and self-corrects. When valid arguments are provided like `{ x: 10, y: 5 }`, the result is `"15"`.
+
+In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+
+<Callout type="warning">
+**Bypassing LangChain's Built-in Validation**
+
+LangChain internally uses `@cfworker/json-schema` to validate tool arguments, which throws `ToolInputParsingException` before custom validation can run. `@typia/langchain` solves this by using a passthrough Zod schema (`z.record(z.unknown())`), allowing `typia`'s much more detailed and accurate validator to handle all argument validation instead.
+</Callout>
+
+The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+
+<ValidatorSupportMatrixSnippet />
+
+This validation feedback strategy also covers restriction properties:
+
+  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+
+## Structured Output
+
+Use `typia.llm.parameters<T>()` with LangChain's `withStructuredOutput()`:
+
+```typescript filename="src/main.ts" copy showLineNumbers {1-3, 5-11, 13-14, 16-22, 25-28}
+import { ChatOpenAI } from "@langchain/openai";
+import { dedent, stringifyValidationFailure } from "@typia/utils";
+import typia, { tags } from "typia";
+
+interface IMember {
+  email: string & tags.Format<"email">;
+  name: string;
+  age: number & tags.Minimum<0> & tags.Maximum<100>;
+  hobbies: string[];
+  joined_at: string & tags.Format<"date">;
+}
+
+const model = new ChatOpenAI({ model: "gpt-4o" })
+  .withStructuredOutput(typia.llm.parameters<IMember>());
+
+const member: IMember = await model.invoke(dedent`
+  I am a new member of the community.
+
+  My name is John Doe, and I am 25 years old.
+  I like playing basketball and reading books,
+  and joined to this community at 2022-01-01.
+`);
+
+// Validate the result
+const result = typia.validate<IMember>(member);
+if (!result.success) {
+  console.error(stringifyValidationFailure(result));
+}
+```
+
+> ```bash filename="Terminal"
+> {
+>   email: 'john.doe@example.com',
+>   name: 'John Doe',
+>   age: 25,
+>   hobbies: [ 'playing basketball', 'reading books' ],
+>   joined_at: '2022-01-01'
+> }
+> ```
+
+The `IMember` interface is the single source of truth. `typia.llm.parameters<IMember>()` generates the JSON schema, and `typia.validate<IMember>()` validates the output — all from the same type. If validation fails, feed the error back to the LLM for correction.

--- a/website/src/content/docs/llm/mcp.mdx
+++ b/website/src/content/docs/llm/mcp.mdx
@@ -1,0 +1,216 @@
+---
+title: Guide Documents > Large Language Model > MCP (Model Context Protocol)
+---
+import { Tabs } from "nextra/components";
+
+import LocalSource from "../../../components/LocalSource";
+import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
+
+## `registerMcpControllers()` function
+
+<Tabs items={[
+    <code>@typia/mcp</code>,
+    <code>ILlmController</code>,
+    <code>IHttpLlmController</code>,
+    <code>HttpLlm.controller</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="@typia/mcp" showLineNumbers
+export function registerMcpControllers(props: {
+  server: McpServer | Server;
+  controllers: Array<ILlmController | IHttpLlmController>;
+  preserve?: boolean | undefined;
+}): void;
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/schema/ILlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/http/IHttpLlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/utils/src/http/HttpLlm.ts"
+      filename="@typia/utils"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io) integration for [`typia`](https://github.com/samchon/typia).
+
+`registerMcpControllers()` converts TypeScript classes or OpenAPI documents into MCP tools at once.
+
+Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to an MCP tool with schemas from the specification.
+
+Validation feedback is embedded automatically.
+
+## Setup
+
+```bash filename="Terminal"
+npm install @typia/mcp @modelcontextprotocol/sdk
+npm install typia
+npx typia setup
+```
+
+## From TypeScript Class
+
+<Tabs items={[
+    "MCP Server",
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="src/main.ts" showLineNumbers {1-2, 9-16}
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerMcpControllers } from "@typia/mcp";
+import typia from "typia";
+
+import { BbsArticleService } from "./BbsArticleService";
+import { Calculator } from "./Calculator";
+
+const server: McpServer = new McpServer({
+  name: "my-server",
+  version: "1.0.0",
+});
+registerMcpControllers({
+  server,
+  controllers: [
+    typia.llm.controller<Calculator>("calculator", new Calculator()),
+    typia.llm.controller<BbsArticleService>(
+      "bbs",
+      new BbsArticleService(),
+    ),
+  ],
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/BbsArticleService.ts"
+      filename="BbsArticleService.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/IBbsArticle.ts"
+      filename="IBbsArticle.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `registerMcpControllers()`.
+
+  - `server`: Target MCP server instance (`McpServer` or raw `Server` from `@modelcontextprotocol/sdk`)
+  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
+  - `preserve`: When `true`, typia tools coexist with existing `McpServer.registerTool()` tools. Default is `false`
+
+## From OpenAPI Document
+
+```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerMcpControllers } from "@typia/mcp";
+import { HttpLlm } from "@typia/utils";
+
+const server: McpServer = new McpServer({
+  name: "my-server",
+  version: "1.0.0",
+});
+registerMcpControllers({
+  server,
+  controllers: [
+    HttpLlm.controller({
+      name: "shopping",
+      document: await fetch(
+        "https://shopping-be.wrtn.ai/editor/swagger.json",
+      ).then((r) => r.json()),
+      connection: {
+        host: "https://shopping-be.wrtn.ai",
+        headers: { Authorization: "Bearer ********" },
+      },
+    }),
+  ],
+});
+```
+
+Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `registerMcpControllers()`.
+
+  - `name`: Controller name used as prefix for tool names
+  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
+  - `connection`: HTTP connection info including `host` and optional `headers`
+
+## Validation Feedback
+
+<Tabs items={[
+    "Validation Test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/features/test_mcp_class_controller_validation.ts"
+      filename="test_mcp_class_controller_validation.ts"
+      showLineNumbers
+      highlight="43-56, 57-64" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+<ValidationFeedbackExampleSnippet />
+
+When LLM sends `{ x: "not a number", y: 5 }`, the validation failure is returned as text content via `stringifyValidationFailure()`, including the exact path, expected type, and actual value. The LLM reads this and self-corrects on the next turn.
+
+In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+
+The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+
+<ValidatorSupportMatrixSnippet />
+
+This validation feedback strategy also covers restriction properties:
+
+  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+
+## Preserve Mode
+
+<Tabs items={[
+    "Preserve Test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/features/test_mcp_class_controller_preserve.ts"
+      filename="test_mcp_class_controller_preserve.ts"
+      showLineNumbers
+      highlight="33-52, 55-57, 73-86" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-mcp/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+By default, `registerMcpControllers()` replaces the MCP server's tool handlers (standalone mode). Set `preserve: true` to coexist with `McpServer.registerTool()`.
+
+In the above test, the `"echo"` tool registered via `McpServer.registerTool()` and the calculator tools registered via `registerMcpControllers()` work together — 5 tools total. If duplicate names are detected, it throws at registration time.

--- a/website/src/content/docs/llm/vercel.mdx
+++ b/website/src/content/docs/llm/vercel.mdx
@@ -1,0 +1,256 @@
+---
+title: Guide Documents > Large Language Model > Vercel AI SDK
+---
+import { Tabs } from "nextra/components";
+
+import LocalSource from "../../../components/LocalSource";
+import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
+import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
+
+## `toVercelTools()` function
+
+<Tabs items={[
+    <code>@typia/vercel</code>,
+    <code>ILlmController</code>,
+    <code>IHttpLlmController</code>,
+    <code>HttpLlm.controller</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="@typia/vercel" showLineNumbers
+export function toVercelTools(props: {
+  controllers: Array<ILlmController | IHttpLlmController>;
+  prefix?: boolean | undefined;
+}): Record<string, Tool>;
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/schema/ILlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/interface/src/http/IHttpLlmController.ts"
+      filename="@typia/interface"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="packages/utils/src/http/HttpLlm.ts"
+      filename="@typia/utils"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+[Vercel AI SDK](https://github.com/vercel/ai) integration for [`typia`](https://github.com/samchon/typia).
+
+`toVercelTools()` converts TypeScript classes or OpenAPI documents into Vercel AI SDK `Record<string, Tool>` at once.
+
+Every class method becomes a tool, JSDoc comments become tool descriptions, and TypeScript types become JSON schemas — all at compile time. For OpenAPI documents, every API endpoint is converted to a Vercel tool with schemas from the specification.
+
+Validation feedback is embedded automatically.
+
+## Setup
+
+```bash filename="Terminal"
+npm install @typia/vercel ai
+npm install typia
+npx typia setup
+```
+
+## From TypeScript Class
+
+<Tabs items={[
+    "Vercel AI Tools",
+    <code>Calculator</code>,
+    <code>BbsArticleService</code>,
+    <code>IBbsArticle</code>,
+  ]}>
+  <Tabs.Tab>
+```typescript filename="src/main.ts" showLineNumbers {1-3, 7-14, 16-20}
+import { openai } from "@ai-sdk/openai";
+import { toVercelTools } from "@typia/vercel";
+import { generateText, GenerateTextResult, Tool } from "ai";
+import typia from "typia";
+
+import { Calculator } from "./Calculator";
+
+const tools: Record<string, Tool> = toVercelTools({
+  controllers: [
+    typia.llm.controller<Calculator>("calculator", new Calculator()),
+  ],
+});
+
+const result: GenerateTextResult = await generateText({
+  model: openai("gpt-4o"),
+  prompt: "What is 10 + 5?",
+  tools,
+});
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-vercel/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/BbsArticleService.ts"
+      filename="BbsArticleService.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="examples/src/llm/IBbsArticle.ts"
+      filename="IBbsArticle.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+Create controllers from TypeScript classes with `typia.llm.controller<Class>()`, and pass them to `toVercelTools()`.
+
+  - `controllers`: Array of controllers created via `typia.llm.controller<Class>()` or `HttpLlm.controller()`
+  - `prefix`: When `true` (default), tool names are formatted as `{controllerName}_{methodName}`. Set to `false` to use bare method names
+
+## From OpenAPI Document
+
+```typescript filename="src/main.ts" showLineNumbers {1-3, 5-18}
+import { toVercelTools } from "@typia/vercel";
+import { HttpLlm } from "@typia/utils";
+import { Tool } from "ai";
+
+const tools: Record<string, Tool> = toVercelTools({
+  controllers: [
+    HttpLlm.controller({
+      name: "shopping",
+      document: await fetch(
+        "https://shopping-be.wrtn.ai/editor/swagger.json",
+      ).then((r) => r.json()),
+      connection: {
+        host: "https://shopping-be.wrtn.ai",
+        headers: { Authorization: "Bearer ********" },
+      },
+    }),
+  ],
+});
+```
+
+Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass them to `toVercelTools()`.
+
+  - `name`: Controller name used as prefix for tool names
+  - `document`: Swagger/OpenAPI document (v2.0, v3.0, or v3.1)
+  - `connection`: HTTP connection info including `host` and optional `headers`
+
+## Validation Feedback
+
+<Tabs items={[
+    "Validation Test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-vercel/src/features/test_vercel_class_controller_validation.ts"
+      filename="test_vercel_class_controller_validation.ts"
+      showLineNumbers
+      highlight="22-26, 29-33, 36, 38-46" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-vercel/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+<ValidationFeedbackExampleSnippet />
+
+When LLM sends `{ x: "not a number", y: 5 }`, the result is returned as `{ error: true, message: "..." }` with detailed validation errors from `stringifyValidationFailure()`. The LLM reads this and self-corrects on the next turn.
+
+In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+
+The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+
+<ValidatorSupportMatrixSnippet />
+
+This validation feedback strategy also covers restriction properties:
+
+  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
+  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+
+## Structured Output
+
+Use `typia.llm.parameters<T>()` with Vercel's `jsonSchema()` to generate structured output with validation:
+
+```typescript filename="src/main.ts" copy showLineNumbers {1, 3-4, 6-12, 14-30}
+import { openai } from "@ai-sdk/openai";
+import { dedent, stringifyValidationFailure } from "@typia/utils";
+import { generateObject, jsonSchema } from "ai";
+import typia, { tags } from "typia";
+
+interface IMember {
+  email: string & tags.Format<"email">;
+  name: string;
+  age: number & tags.Minimum<0> & tags.Maximum<100>;
+  hobbies: string[];
+  joined_at: string & tags.Format<"date">;
+}
+
+const { object } = await generateObject({
+  model: openai("gpt-4o"),
+  schema: jsonSchema<IMember>(typia.llm.parameters<IMember>(), {
+    validate: (value) => {
+      const result = typia.validate<IMember>(value);
+      if (result.success) return { success: true, value: result.data };
+      return {
+        success: false,
+        error: new Error(stringifyValidationFailure(result)),
+      };
+    },
+  }),
+  prompt: dedent`
+    I am a new member of the community.
+
+    My name is John Doe, and I am 25 years old.
+    I like playing basketball and reading books,
+    and joined to this community at 2022-01-01.
+  `,
+});
+```
+
+> ```bash filename="Terminal"
+> {
+>   email: 'john.doe@example.com',
+>   name: 'John Doe',
+>   age: 25,
+>   hobbies: [ 'playing basketball', 'reading books' ],
+>   joined_at: '2022-01-01'
+> }
+> ```
+
+The `IMember` interface is the single source of truth. `typia.llm.parameters<IMember>()` generates the JSON schema, and `typia.validate<IMember>()` validates the output — all from the same type.
+
+## Error Handling
+
+<Tabs items={[
+    "Error Handling Test",
+    <code>Calculator</code>,
+  ]}>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-vercel/src/features/test_vercel_class_controller_error_handling.ts"
+      filename="test_vercel_class_controller_error_handling.ts"
+      showLineNumbers
+      highlight="22-26, 29-36" />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <LocalSource
+      path="tests/test-vercel/src/structures/Calculator.ts"
+      filename="Calculator.ts"
+      showLineNumbers />
+  </Tabs.Tab>
+</Tabs>
+
+When a tool execution throws a runtime error (e.g., division by zero), `@typia/vercel` catches the exception and returns `{ error: true, message: "Error: Division by zero is not allowed" }`. This is different from validation errors — validation errors indicate wrong argument types, while runtime errors indicate the function itself failed.


### PR DESCRIPTION
This pull request adds comprehensive new documentation for integrating typia-based TypeScript class and OpenAPI controllers with three major LLM tool ecosystems: Model Context Protocol (MCP), Vercel AI SDK, and LangChain. Each guide includes setup instructions, code examples, validation feedback strategies, and structured output handling. Additionally, the documentation sidebar metadata is updated to reflect these new guides, while hiding outdated entries.

**Documentation for LLM Tool Integrations:**

* Added a new guide for integrating typia with Model Context Protocol (MCP), detailing how to use `registerMcpControllers()` to convert TypeScript classes or OpenAPI documents into MCP tools, including validation feedback and preserve mode options.
* Added a new guide for integrating typia with Vercel AI SDK, introducing `toVercelTools()` for generating Vercel-compatible tools from TypeScript classes or OpenAPI specs, with examples for validation feedback, structured output, and error handling.
* Added a new guide for integrating typia with LangChain, describing the `toLangChainTools()` function for converting controllers into LangChain tools, with detailed setup, usage, and validation feedback strategies.

**Documentation Sidebar and Metadata Updates:**

* Updated the LLM documentation sidebar metadata to include the new `mcp`, `vercel`, and `langchain` guides, and set the old `chat` and `strategy` entries to hidden.