### PR TITLE
feat(website): describe validation feedback

### DIFF
--- a/website/src/content/docs/llm/application.mdx
+++ b/website/src/content/docs/llm/application.mdx
@@ -4,8 +4,6 @@ title: Guide Documents > Large Language Model > application() function
 import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
-import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `application()` function
 
@@ -119,72 +117,52 @@ Structured output is another feature of LLM. The "structured output" means that 
 
 ## Validation Feedback
 
-<ValidationFeedbackExampleSnippet />
+`typia.llm.application<App>()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every function for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
 
-Is LLM Function Calling perfect? No, absolutely not.
+```json
+{
+  "name": "John",
+  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+}
+```
 
-LLM (Large Language Model) service vendor like OpenAI takes a lot of type level mistakes when composing the arguments of function calling or structured output. Even though target schema is super simple like `Array<string>` type, LLM often fills it just by a `string` typed value.
+The LLM reads this feedback and self-corrects on the next turn.
 
-In my experience, OpenAI `gpt-4o-mini` (`8b` parameters) is taking about 70% of type level mistakes when filling the arguments of function calling to Shopping Mall service. To overcome the imperfection of such LLM function calling, `typia.llm.application<App>()` function embeds [`typia.validate<T>()`](/docs/validators/validate) function for the validation feedback strategy.
+In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator), `qwen3-coder-next` showed only 6.75% raw function calling success rate on compiler AST types. However, with validation feedback, it reached 100%.
 
-The key concept of validation feedback strategy is, let LLM function calling to construct invalid typed arguments first, and informing detailed type errors to the LLM, so that induce LLM to emend the wrong typed arguments at the next turn. In this way, I could uprise the success rate of function calling from 30% to 99% just by one step validation feedback. Even though the LLM is still occurs type error, it always has been caught at the next turn.
+Working on compiler AST means working on any type and any use case.
 
-For reference, the embedded [`typia.validate<T>()`](/docs/validators/validate) function creates validation logic by analyzing TypeScript source codes and types in the compilation level. Therefore, it is accurate and detailed than any other validator libraries. This is exactly what is needed for function calling, and I can confidentelly say that `typia` is the best library for LLM function calling.
+  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
+  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
+  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 
-<ValidatorSupportMatrixSnippet />
-
-Additionally, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema. For example, some LLM providers do not support `format` property of JSON schema, so that cannot understand the `UUID` like type. Even though `typia.llm.application<App>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
-
-In that case, if you give validation feedback from `ILlmFunction.validate()` function to the LLM agent, the LLM agent will be able to understand the restriction information exactly and fill the arguments properly.
-
-  - Restriction properties of JSON schema
-    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
-
-## Parameters' Separation
-
-Parameter values from both LLM and Human sides.
-
-When composing parameter arguments through the LLM (Large Language Model) function calling, there can be a case that some parameters (or nested properties) must be composed not by LLM, but by Human. File uploading feature, or sensitive information like secret key (password) cases are the representative examples.
-
-In that case, you can configure the LLM function calling schemas to exclude such Human side parameters (or nested properties) by `ILlmApplication.options.separate` property. Instead, you have to merge both Human and LLM composed parameters into one by calling the `HttpLlm.mergeParameters()` before the LLM function call execution.
-
-Here is the example separating the parameter schemas.
-
-<Tabs items={[
-    "TypeScript Source Code",
-    "Compiled JavaScript",
-    <code>BbsArticleService</code>,
-    <code>IBbsArticle</code>,
-  ]}>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/llm/application-separate.ts"
-      filename="example/src/llm/application-separate.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/bin/llm/application-separate.js"
-      filename="example/bin/llm/application-separate.js"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/llm/BbsArticleService.ts"
-      filename="examples/src/llm/BbsArticleService.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource 
-      path="examples/src/llm/IBbsArticle.ts"
-      filename="examples/src/llm/IBbsArticle.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
-
-> [💻 Playground Link](/playground/?script=JYWwDg9gTgLgBAbzgSQDIBsQEExncAYwEMZgIA7AGhQxAGUCALAUxCOtoBUBPMZgYRYEA1syhwAvnABmUCCDgAiAAIBnIiCYUA9BD7kiYYIoDcAKFCRYcGL2DtENogHNVkmXIWLbRoqbMW4NDwSABCAEaqWLCE6Mx0YgBuhMzusvJKAHTaEVExBHEJUMkEzP5mBBSq8IZgAFw0mDh4hCRk5HAAvDZ2RJnomJm1+MSkFAA8udGkBfFJKQB8ABQIZnBwqsxgRFAkzA1LqkysRA1omAwsbACUXQtr63BcvAJColCZwKp0MFDA5M5DscbnAAGSgjbAvqVcgwZiwgCyzAAJvYeHw4ABCTrdACu5GRzGk-xRlDMEmu5hhqggcX6EEBtUpQA)
+```typescript filename="AutoBeTest.IExpression" showLineNumbers
+// Compiler AST may be the hardest type structure possible
+//
+// Unlimited union types + unlimited depth + recursive references
+export type IExpression =
+  | IBooleanLiteral
+  | INumericLiteral
+  | IStringLiteral
+  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
+  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | INullLiteral
+  | IUndefinedKeyword
+  | IIdentifier
+  | IPropertyAccessExpression // <- recursive
+  | IElementAccessExpression  // <- recursive
+  | ITypeOfExpression         // <- recursive
+  | IPrefixUnaryExpression    // <- recursive
+  | IPostfixUnaryExpression   // <- recursive
+  | IBinaryExpression         // <- recursive (left & right)
+  | IArrowFunction            // <- recursive (body is IExpression)
+  | ICallExpression           // <- recursive (args are IExpression[])
+  | INewExpression            // <- recursive
+  | IConditionalPredicate     // <- recursive (then & else branches)
+  | ... // 30+ expression types total
+```
 
 ## Restrictions
 

--- a/website/src/content/docs/llm/langchain.mdx
+++ b/website/src/content/docs/llm/langchain.mdx
@@ -4,8 +4,6 @@ title: Guide Documents > Large Language Model > LangChain
 import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
-import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `toLangChainTools()` function
 
@@ -156,30 +154,18 @@ Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass 
 
 ## Validation Feedback
 
-<Tabs items={[
-    "Validation Test",
-    <code>Calculator</code>,
-  ]}>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-langchain/src/features/test_langchain_class_controller_validation.ts"
-      filename="test_langchain_class_controller_validation.ts"
-      showLineNumbers
-      highlight="29, 32-35, 40-44, 48-49" />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-langchain/src/structures/Calculator.ts"
-      filename="Calculator.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+`toLangChainTools()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
 
-<ValidationFeedbackExampleSnippet />
+```json
+{
+  "name": "John",
+  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+}
+```
 
-When LLM sends `{ x: "not a number", y: 5 }`, the validation failure message from `stringifyValidationFailure()` is returned directly as the tool result string. The LLM reads this and self-corrects. When valid arguments are provided like `{ x: 10, y: 5 }`, the result is `"15"`.
-
-In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+The LLM reads this feedback and self-corrects on the next turn.
 
 <Callout type="warning">
 **Bypassing LangChain's Built-in Validation**
@@ -187,15 +173,39 @@ In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of th
 LangChain internally uses `@cfworker/json-schema` to validate tool arguments, which throws `ToolInputParsingException` before custom validation can run. `@typia/langchain` solves this by using a passthrough Zod schema (`z.record(z.unknown())`), allowing `typia`'s much more detailed and accurate validator to handle all argument validation instead.
 </Callout>
 
-The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator), `qwen3-coder-next` showed only 6.75% raw function calling success rate on compiler AST types. However, with validation feedback, it reached 100%.
 
-<ValidatorSupportMatrixSnippet />
+Working on compiler AST means working on any type and any use case.
 
-This validation feedback strategy also covers restriction properties:
+  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
+  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
+  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 
-  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+```typescript filename="AutoBeTest.IExpression" showLineNumbers
+// Compiler AST may be the hardest type structure possible
+//
+// Unlimited union types + unlimited depth + recursive references
+export type IExpression =
+  | IBooleanLiteral
+  | INumericLiteral
+  | IStringLiteral
+  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
+  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | INullLiteral
+  | IUndefinedKeyword
+  | IIdentifier
+  | IPropertyAccessExpression // <- recursive
+  | IElementAccessExpression  // <- recursive
+  | ITypeOfExpression         // <- recursive
+  | IPrefixUnaryExpression    // <- recursive
+  | IPostfixUnaryExpression   // <- recursive
+  | IBinaryExpression         // <- recursive (left & right)
+  | IArrowFunction            // <- recursive (body is IExpression)
+  | ICallExpression           // <- recursive (args are IExpression[])
+  | INewExpression            // <- recursive
+  | IConditionalPredicate     // <- recursive (then & else branches)
+  | ... // 30+ expression types total
+```
 
 ## Structured Output
 

--- a/website/src/content/docs/llm/mcp.mdx
+++ b/website/src/content/docs/llm/mcp.mdx
@@ -4,8 +4,6 @@ title: Guide Documents > Large Language Model > MCP (Model Context Protocol)
 import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
-import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `registerMcpControllers()` function
 
@@ -155,40 +153,52 @@ Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass 
 
 ## Validation Feedback
 
-<Tabs items={[
-    "Validation Test",
-    <code>Calculator</code>,
-  ]}>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-mcp/src/features/test_mcp_class_controller_validation.ts"
-      filename="test_mcp_class_controller_validation.ts"
-      showLineNumbers
-      highlight="43-56, 57-64" />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-mcp/src/structures/Calculator.ts"
-      filename="Calculator.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+`registerMcpControllers()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
 
-<ValidationFeedbackExampleSnippet />
+```json
+{
+  "name": "John",
+  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+}
+```
 
-When LLM sends `{ x: "not a number", y: 5 }`, the validation failure is returned as text content via `stringifyValidationFailure()`, including the exact path, expected type, and actual value. The LLM reads this and self-corrects on the next turn.
+The LLM reads this feedback and self-corrects on the next turn.
 
-In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator), `qwen3-coder-next` showed only 6.75% raw function calling success rate on compiler AST types. However, with validation feedback, it reached 100%.
 
-The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+Working on compiler AST means working on any type and any use case.
 
-<ValidatorSupportMatrixSnippet />
+  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
+  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
+  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 
-This validation feedback strategy also covers restriction properties:
-
-  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+```typescript filename="AutoBeTest.IExpression" showLineNumbers
+// Compiler AST may be the hardest type structure possible
+//
+// Unlimited union types + unlimited depth + recursive references
+export type IExpression =
+  | IBooleanLiteral
+  | INumericLiteral
+  | IStringLiteral
+  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
+  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | INullLiteral
+  | IUndefinedKeyword
+  | IIdentifier
+  | IPropertyAccessExpression // <- recursive
+  | IElementAccessExpression  // <- recursive
+  | ITypeOfExpression         // <- recursive
+  | IPrefixUnaryExpression    // <- recursive
+  | IPostfixUnaryExpression   // <- recursive
+  | IBinaryExpression         // <- recursive (left & right)
+  | IArrowFunction            // <- recursive (body is IExpression)
+  | ICallExpression           // <- recursive (args are IExpression[])
+  | INewExpression            // <- recursive
+  | IConditionalPredicate     // <- recursive (then & else branches)
+  | ... // 30+ expression types total
+```
 
 ## Preserve Mode
 

--- a/website/src/content/docs/llm/parameters.mdx
+++ b/website/src/content/docs/llm/parameters.mdx
@@ -4,7 +4,6 @@ title: Guide Documents > Large Language Model > parameters() function
 import { Callout, Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `parameters()` function
 
@@ -160,111 +159,52 @@ Just configure output mode as JSON schema, and deliver the `typia.llm.parameters
 
 ## Validation Feedback
 
-```typescript filename="src/examples/llm.parameters.ts" copy showLineNumbers {4-10, 13, 32-49, 55, 60}
-import OpenAI from "openai";
-import typia, { IValidation, tags } from "typia";
+Use [`typia.validate<T>()`](/docs/validators/validate) for validation feedback on structured output. When validation fails, the error can be formatted with inline `// ❌` comments at each invalid property:
 
-interface IMember {
-  email: string & tags.Format<"email">;
-  name: string;
-  age: number;
-  hobbies: string[];
-  joined_at: string & tags.Format<"date">;
+```json
+{
+  "name": "John",
+  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
 }
-
-const step = async (
-  failure?: IValidation.IFailure | undefined,
-): Promise<IValidation<IMember>> => {
-  const client: OpenAI = new OpenAI({
-    apiKey: "<YOUR_OPENAI_API_KEY>",
-  });
-  const completion: OpenAI.ChatCompletion =
-    await client.chat.completions.create({
-      model: "gpt-4o",
-      messages: [
-        {
-          role: "user",
-          content: [
-            "I am a new member of the community.",
-            "",
-            "My name is John Doe, and I am 25 years old.",
-            "I like playing basketball and reading books,",
-            "and joined to this community at 2022-01-01.",
-          ].join("\n"),
-        },
-        ...(failure
-          ? [
-              {
-                role: "system",
-                content: [
-                  "You A.I. agent had taken a mistak that",
-                  "returning wrong typed structured data.",
-                  "",
-                  "Here is the detailed list of type errors.",
-                  "Review and correct them at the next step.",
-                  "",
-                  "```json",
-                  JSON.stringify(failure.errors, null, 2),
-                  "```",
-                ].join("\n"),
-              } satisfies OpenAI.ChatCompletionSystemMessageParam,
-            ]
-          : []),
-      ],
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: "member",
-          schema: typia.llm.parameters<IMember>() as any,
-        },
-      },
-    });
-  const member: IMember = JSON.parse(completion.choices[0].message.content!);
-  return typia.validate(member);
-};
-
-const main = async (): Promise<void> => {
-  let result: IValidation<IMember> | undefined = undefined;
-  for (let i: number = 0; i < 2; ++i) {
-    if (result && result.success === true) break;
-    result = await step(result);
-  }
-  console.log(result);
-};
-
-main().catch(console.error);
 ```
 
-> ```bash filename="Terminal"
-> {
->   email: 'john.doe@example.com',
->   name: 'John Doe',
->   age: 25,
->   hobbies: [ 'playing basketball', 'reading books' ],
->   joined_at: '2022-01-01'
-> }
-> ```
+The LLM reads this feedback and self-corrects on the next turn.
 
-Is LLM Structured Output perfect? No, absolutely not.
+In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator), `qwen3-coder-next` showed only 6.75% raw function calling success rate on compiler AST types. However, with validation feedback, it reached 100%.
 
-LLM (Large Language Model) service vendor like OpenAI takes a lot of type level mistakes when composing the arguments of function calling or structured output. Even though target schema is super simple like `Array<string>` type, LLM often fills it just by a `string` typed value.
+Working on compiler AST means working on any type and any use case.
 
-In my experience, OpenAI `gpt-4o-mini` (`8b` parameters) is taking about 70% of type level mistakes when filling the arguments of structured output to Shopping Mall service. To overcome the imperfection of such structured output, you have to utilize the validation feedback strategy with [`typia.validate<T>()`](/docs/validators/validate) function.
+  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
+  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
+  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 
-The key concept of validation feedback strategy is, let LLM structured output to construct invalid typed arguments first, and informing detailed type errors to the LLM, so that induce LLM to emend the wrong typed arguments at the next turn. In this way, I could uprise the success rate of structured output from 30% to 99% just by one step validation feedback. Even though the LLM is still occurs type error, it always has been caught at the next turn.
-
-For reference, the [`typia.validate<T>()`](/docs/validators/validate) function creates validation logic by analyzing TypeScript source codes and types in the compilation level. Therefore, it is accurate and detailed than any other validator libraries. This is exactly what is needed for function calling, and I can confidentelly say that `typia` is the best library for LLM structured output.
-
-<ValidatorSupportMatrixSnippet />
-
-Additionally, this validation feedback strategy is useful for some LLM providers do not supporting restriction properties of JSON schema. For example, some LLM providers do not support `format` property of JSON schema, so that cannot understand the `UUID` like type. Even though `typia.llm.application<App>()` function is writing the restriction information to the `description` property of JSON schema, but LLM provider does not reflect it perfectly.
-
-In that case, if you give validation feedback from `ILlmFunction.validate()` function to the LLM agent, the LLM agent will be able to understand the restriction information exactly and fill the arguments properly.
-
-  - Restriction properties of JSON schema
-    - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-    - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-    - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+```typescript filename="AutoBeTest.IExpression" showLineNumbers
+// Compiler AST may be the hardest type structure possible
+//
+// Unlimited union types + unlimited depth + recursive references
+export type IExpression =
+  | IBooleanLiteral
+  | INumericLiteral
+  | IStringLiteral
+  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
+  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | INullLiteral
+  | IUndefinedKeyword
+  | IIdentifier
+  | IPropertyAccessExpression // <- recursive
+  | IElementAccessExpression  // <- recursive
+  | ITypeOfExpression         // <- recursive
+  | IPrefixUnaryExpression    // <- recursive
+  | IPostfixUnaryExpression   // <- recursive
+  | IBinaryExpression         // <- recursive (left & right)
+  | IArrowFunction            // <- recursive (body is IExpression)
+  | ICallExpression           // <- recursive (args are IExpression[])
+  | INewExpression            // <- recursive
+  | IConditionalPredicate     // <- recursive (then & else branches)
+  | ... // 30+ expression types total
+```
 
 ## Restrictions
 

--- a/website/src/content/docs/llm/vercel.mdx
+++ b/website/src/content/docs/llm/vercel.mdx
@@ -4,8 +4,6 @@ title: Guide Documents > Large Language Model > Vercel AI SDK
 import { Tabs } from "nextra/components";
 
 import LocalSource from "../../../components/LocalSource";
-import ValidationFeedbackExampleSnippet from "../../../snippets/ValidationFeedbackExampleSnippet.mdx";
-import ValidatorSupportMatrixSnippet from "../../../snippets/ValidatorSupportMatrixSnippet.mdx";
 
 ## `toVercelTools()` function
 
@@ -145,40 +143,52 @@ Create controllers from OpenAPI documents with `HttpLlm.controller()`, and pass 
 
 ## Validation Feedback
 
-<Tabs items={[
-    "Validation Test",
-    <code>Calculator</code>,
-  ]}>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-vercel/src/features/test_vercel_class_controller_validation.ts"
-      filename="test_vercel_class_controller_validation.ts"
-      showLineNumbers
-      highlight="22-26, 29-33, 36, 38-46" />
-  </Tabs.Tab>
-  <Tabs.Tab>
-    <LocalSource
-      path="tests/test-vercel/src/structures/Calculator.ts"
-      filename="Calculator.ts"
-      showLineNumbers />
-  </Tabs.Tab>
-</Tabs>
+`toVercelTools()` embeds [`typia.validate<T>()`](/docs/validators/validate) in every tool for automatic argument validation. When validation fails, the error is returned as text content with inline `// ❌` comments at each invalid property:
 
-<ValidationFeedbackExampleSnippet />
+```json
+{
+  "name": "John",
+  "age": "twenty", // ❌ [{"path":"$input.age","expected":"number"}]
+  "email": "not-an-email", // ❌ [{"path":"$input.email","expected":"string & Format<\"email\">"}]
+  "hobbies": "reading" // ❌ [{"path":"$input.hobbies","expected":"Array<string>"}]
+}
+```
 
-When LLM sends `{ x: "not a number", y: 5 }`, the result is returned as `{ error: true, message: "..." }` with detailed validation errors from `stringifyValidationFailure()`. The LLM reads this and self-corrects on the next turn.
+The LLM reads this feedback and self-corrects on the next turn.
 
-In my experience, OpenAI `gpt-4o-mini` makes type-level mistakes about 70% of the time on complex schemas (Shopping Mall service). With validation feedback, the success rate jumps from 30% to 99% on the second attempt. Third attempt has never failed.
+In the [AutoBe](https://github.com/wrtnlabs/autobe) project (AI-powered backend code generator), `qwen3-coder-next` showed only 6.75% raw function calling success rate on compiler AST types. However, with validation feedback, it reached 100%.
 
-The embedded [`typia.validate<T>()`](/docs/validators/validate) creates validation logic by analyzing TypeScript source codes and types at the compilation level — more accurate and detailed than any runtime validator.
+Working on compiler AST means working on any type and any use case.
 
-<ValidatorSupportMatrixSnippet />
+  - [AutoBeDatabase](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/database/AutoBeDatabase.ts)
+  - [AutoBeOpenApi](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/openapi/AutoBeOpenApi.ts)
+  - [AutoBeTest](https://github.com/wrtnlabs/autobe/blob/main/packages/interface/src/test/AutoBeTest.ts)
 
-This validation feedback strategy also covers restriction properties:
-
-  - `string`: `minLength`, `maxLength`, `pattern`, `format`, `contentMediaType`
-  - `number`: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
-  - `array`: `minItems`, `maxItems`, `uniqueItems`, `items`
+```typescript filename="AutoBeTest.IExpression" showLineNumbers
+// Compiler AST may be the hardest type structure possible
+//
+// Unlimited union types + unlimited depth + recursive references
+export type IExpression =
+  | IBooleanLiteral
+  | INumericLiteral
+  | IStringLiteral
+  | IArrayLiteralExpression   // <- recursive (contains IExpression[])
+  | IObjectLiteralExpression  // <- recursive (contains IExpression)
+  | INullLiteral
+  | IUndefinedKeyword
+  | IIdentifier
+  | IPropertyAccessExpression // <- recursive
+  | IElementAccessExpression  // <- recursive
+  | ITypeOfExpression         // <- recursive
+  | IPrefixUnaryExpression    // <- recursive
+  | IPostfixUnaryExpression   // <- recursive
+  | IBinaryExpression         // <- recursive (left & right)
+  | IArrowFunction            // <- recursive (body is IExpression)
+  | ICallExpression           // <- recursive (args are IExpression[])
+  | INewExpression            // <- recursive
+  | IConditionalPredicate     // <- recursive (then & else branches)
+  | ... // 30+ expression types total
+```
 
 ## Structured Output
 


### PR DESCRIPTION
This pull request updates the documentation for validation feedback in the Large Language Model (LLM) guide, streamlining and unifying the explanation of validation feedback across several sections (`application()`, `parameters()`, LangChain, and MCP). The changes remove redundant code snippets and example components, replacing them with concise, consistent JSON examples and real-world project references. The new documentation emphasizes the effectiveness of validation feedback strategies using `typia.validate<T>()`, especially for complex and recursive types, and illustrates real-world improvements in LLM output quality.

**Documentation improvements for validation feedback:**

* Replaced detailed code snippets and example components with a standardized JSON example that demonstrates inline validation errors for invalid properties, making the feedback mechanism clearer and more concise across all LLM documentation sections. [[1]](diffhunk://#diff-2e637ee7fad1dc9b51092ffdc31a7f619d5a87166f7cf7229f817fd927a73f0bL122-R165) [[2]](diffhunk://#diff-40cf51ba169404c3966e2de380b77b0f1d240936bdcf2596ee46f9e89ec5f915L159-R208) [[3]](diffhunk://#diff-f9499661d211eced28f8d971f503de32a4d15c51a01ae5447714e4d7156b6929L158-R201) [[4]](diffhunk://#diff-2a36900e1c87e7693cab0b0033bd11ef3aba9a28f93ba491976e76bf4751b0cdL163-R207)

* Unified the explanation of validation feedback strategy, highlighting how `typia.validate<T>()` is embedded in LLM tools and controllers to catch type errors and provide actionable feedback that LLMs can use to self-correct in subsequent turns. [[1]](diffhunk://#diff-2e637ee7fad1dc9b51092ffdc31a7f619d5a87166f7cf7229f817fd927a73f0bL122-R165) [[2]](diffhunk://#diff-40cf51ba169404c3966e2de380b77b0f1d240936bdcf2596ee46f9e89ec5f915L159-R208) [[3]](diffhunk://#diff-f9499661d211eced28f8d971f503de32a4d15c51a01ae5447714e4d7156b6929L158-R201) [[4]](diffhunk://#diff-2a36900e1c87e7693cab0b0033bd11ef3aba9a28f93ba491976e76bf4751b0cdL163-R207)

**Real-world validation feedback effectiveness:**

* Added references to the [AutoBe](https://github.com/wrtnlabs/autobe) project, showing that validation feedback can increase function calling success rates from under 10% to 100% for complex compiler AST types, and included a code sample for a highly recursive union type (`IExpression`). [[1]](diffhunk://#diff-2e637ee7fad1dc9b51092ffdc31a7f619d5a87166f7cf7229f817fd927a73f0bL122-R165) [[2]](diffhunk://#diff-40cf51ba169404c3966e2de380b77b0f1d240936bdcf2596ee46f9e89ec5f915L159-R208) [[3]](diffhunk://#diff-f9499661d211eced28f8d971f503de32a4d15c51a01ae5447714e4d7156b6929L158-R201) [[4]](diffhunk://#diff-2a36900e1c87e7693cab0b0033bd11ef3aba9a28f93ba491976e76bf4751b0cdL163-R207)

**Code cleanup and removal of redundant imports:**

* Removed unused snippet imports (`ValidationFeedbackExampleSnippet`, `ValidatorSupportMatrixSnippet`) from all affected documentation files for clarity and maintainability. [[1]](diffhunk://#diff-2e637ee7fad1dc9b51092ffdc31a7f619d5a87166f7cf7229f817fd927a73f0bL7-L8) [[2]](diffhunk://#diff-40cf51ba169404c3966e2de380b77b0f1d240936bdcf2596ee46f9e89ec5f915L7-L8) [[3]](diffhunk://#diff-f9499661d211eced28f8d971f503de32a4d15c51a01ae5447714e4d7156b6929L7-L8) [[4]](diffhunk://#diff-2a36900e1c87e7693cab0b0033bd11ef3aba9a28f93ba491976e76bf4751b0cdL7)

These updates make the documentation more consistent, easier to understand, and more focused on practical usage and outcomes of validation feedback in LLM applications.