### PR TITLE
feat(test): test typia schemas.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,52 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
 
+  tests/test-typia-schema:
+    dependencies:
+      '@nestia/e2e':
+        specifier: catalog:utils
+        version: 10.0.2
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.1.0
+      '@typia/interface':
+        specifier: workspace:^
+        version: link:../../packages/interface
+      '@typia/utils':
+        specifier: workspace:^
+        version: link:../../packages/utils
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      protobufjs:
+        specifier: 7.2.5
+        version: 7.2.5
+      tstl:
+        specifier: catalog:utils
+        version: 3.0.0
+      typia:
+        specifier: workspace:^
+        version: link:../../packages/typia
+      uuid:
+        specifier: catalog:utils
+        version: 13.0.0
+    devDependencies:
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.3.1
+      '@types/ts-expose-internals':
+        specifier: catalog:typescript
+        version: ts-expose-internals@5.6.3
+      '@types/uuid':
+        specifier: catalog:utils
+        version: 11.0.0
+      ts-node:
+        specifier: catalog:typescript
+        version: 10.9.2(@types/node@25.3.1)(typescript@5.9.3)
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
   tests/test-utils:
     dependencies:
       '@nestia/e2e':

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,0 +1,42 @@
+{
+  "private": true,
+  "name": "@typia/test-typia-schema",
+  "version": "12.0.0-dev.20260227",
+  "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
+  "scripts": {
+    "dev": "tsc --watch",
+    "start": "ts-node src/index.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/typia"
+  },
+  "keywords": [
+    "typia",
+    "test"
+  ],
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/typia/issues"
+  },
+  "homepage": "https://typia.io",
+  "devDependencies": {
+    "@types/node": "catalog:utils",
+    "@types/ts-expose-internals": "catalog:typescript",
+    "@types/uuid": "catalog:utils",
+    "ts-node": "catalog:typescript",
+    "typescript": "catalog:typescript"
+  },
+  "dependencies": {
+    "@nestia/e2e": "catalog:utils",
+    "@standard-schema/spec": "^1.0.0",
+    "@typia/interface": "workspace:^",
+    "@typia/utils": "workspace:^",
+    "chalk": "^5.6.2",
+    "protobufjs": "7.2.5",
+    "tstl": "catalog:utils",
+    "typia": "workspace:^",
+    "uuid": "catalog:utils"
+  }
+}

--- a/tests/test-typia-schema/src/TestGlobal.ts
+++ b/tests/test-typia-schema/src/TestGlobal.ts
@@ -1,0 +1,15 @@
+export class TestGlobal {
+  public static readonly ROOT: string = `${__dirname}/..`;
+
+  public static getArguments(type: string): string[] {
+    const from: number = process.argv.indexOf(`--${type}`) + 1;
+    if (from === 0) return [];
+    const to: number = process.argv
+      .slice(from)
+      .findIndex((str) => str.startsWith("--"), from);
+    return process.argv.slice(
+      from,
+      to === -1 ? process.argv.length : to + from,
+    );
+  }
+}

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_array.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_array.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_json_schema_array = (): void => {
+  const unit = typia.json.schema<string[]>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is array type", () =>
+    OpenApiTypeChecker.isArray(schema),
+  );
+
+  if (OpenApiTypeChecker.isArray(schema)) {
+    TestValidator.predicate("items is string", () =>
+      OpenApiTypeChecker.isString(schema.items),
+    );
+  }
+
+  // array with constraints
+  const constrainedUnit = typia.json.schema<
+    string[] & tags.MinItems<1> & tags.MaxItems<10>
+  >();
+  const constrained = constrainedUnit.schema;
+  if (OpenApiTypeChecker.isArray(constrained)) {
+    TestValidator.equals("minItems", constrained.minItems, 1);
+    TestValidator.equals("maxItems", constrained.maxItems, 10);
+  }
+
+  // unique items
+  const uniqueUnit = typia.json.schema<
+    (string & tags.Format<"uuid">)[] & tags.UniqueItems
+  >();
+  const unique = uniqueUnit.schema;
+  if (OpenApiTypeChecker.isArray(unique)) {
+    TestValidator.equals("uniqueItems", unique.uniqueItems, true);
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_boolean.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_boolean.ts
@@ -1,0 +1,12 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_boolean = (): void => {
+  const unit = typia.json.schema<boolean>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is boolean type", () =>
+    OpenApiTypeChecker.isBoolean(schema),
+  );
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_enum.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_enum.ts
@@ -1,0 +1,44 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_enum = (): void => {
+  type Status = "pending" | "active" | "completed";
+  const unit = typia.json.schema<Status>();
+
+  // named type may return $ref
+  const schema = unit.schema;
+  const isRef = OpenApiTypeChecker.isReference(schema);
+
+  // get actual schema from components if it's a ref
+  let actualSchema: OpenApi.IJsonSchema;
+  if (isRef) {
+    const statusSchema = unit.components.schemas?.["Status"];
+    TestValidator.predicate("Status exists in components", () =>
+      statusSchema !== undefined,
+    );
+    actualSchema = statusSchema!;
+  } else {
+    actualSchema = schema;
+  }
+
+  TestValidator.predicate("is oneOf type", () =>
+    OpenApiTypeChecker.isOneOf(actualSchema),
+  );
+
+  if (OpenApiTypeChecker.isOneOf(actualSchema)) {
+    const oneOf = actualSchema as OpenApi.IJsonSchema.IOneOf;
+    TestValidator.equals("has 3 const values", oneOf.oneOf.length, 3);
+    TestValidator.predicate("all are const", () =>
+      oneOf.oneOf.every((s) => OpenApiTypeChecker.isConstant(s)),
+    );
+    TestValidator.predicate("contains pending", () =>
+      oneOf.oneOf.some(
+        (s) =>
+          OpenApiTypeChecker.isConstant(s) &&
+          (s as OpenApi.IJsonSchema.IConstant).const === "pending",
+      ),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_nullable.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_nullable.ts
@@ -1,0 +1,23 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_nullable = (): void => {
+  const unit = typia.json.schema<string | null>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is oneOf type", () =>
+    OpenApiTypeChecker.isOneOf(schema),
+  );
+
+  if (OpenApiTypeChecker.isOneOf(schema)) {
+    const oneOf = schema as OpenApi.IJsonSchema.IOneOf;
+    TestValidator.predicate("contains string", () =>
+      oneOf.oneOf.some((s) => OpenApiTypeChecker.isString(s)),
+    );
+    TestValidator.predicate("contains null", () =>
+      oneOf.oneOf.some((s) => OpenApiTypeChecker.isNull(s)),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_number.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_number.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_json_schema_number = (): void => {
+  const unit = typia.json.schema<number>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is number type", () =>
+    OpenApiTypeChecker.isNumber(schema),
+  );
+
+  // integer type
+  const integerUnit = typia.json.schema<number & tags.Type<"int32">>();
+  const integer = integerUnit.schema;
+  TestValidator.predicate("int32 is integer", () =>
+    OpenApiTypeChecker.isInteger(integer),
+  );
+
+  // number with range
+  const rangedUnit = typia.json.schema<
+    number & tags.Minimum<0> & tags.Maximum<100>
+  >();
+  const ranged = rangedUnit.schema;
+  if (OpenApiTypeChecker.isNumber(ranged)) {
+    TestValidator.equals("minimum", ranged.minimum, 0);
+    TestValidator.equals("maximum", ranged.maximum, 100);
+  }
+
+  // exclusive range
+  const exclusiveUnit = typia.json.schema<
+    number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>
+  >();
+  const exclusive = exclusiveUnit.schema;
+  if (OpenApiTypeChecker.isNumber(exclusive)) {
+    TestValidator.equals("exclusiveMinimum", exclusive.exclusiveMinimum, 0);
+    TestValidator.equals("exclusiveMaximum", exclusive.exclusiveMaximum, 100);
+  }
+
+  // multipleOf
+  const multipleUnit = typia.json.schema<number & tags.MultipleOf<5>>();
+  const multiple = multipleUnit.schema;
+  if (OpenApiTypeChecker.isNumber(multiple)) {
+    TestValidator.equals("multipleOf", multiple.multipleOf, 5);
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_object.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_object.ts
@@ -1,0 +1,58 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_object = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+    email?: string;
+  }
+
+  const unit = typia.json.schema<IMember>();
+  const schema = unit.schema;
+
+  // named type may return $ref
+  let actualSchema: OpenApi.IJsonSchema;
+  if (OpenApiTypeChecker.isReference(schema)) {
+    const memberSchema = unit.components.schemas?.["IMember"];
+    TestValidator.predicate("IMember exists in components", () =>
+      memberSchema !== undefined,
+    );
+    actualSchema = memberSchema!;
+  } else {
+    actualSchema = schema;
+  }
+
+  TestValidator.predicate("is object type", () =>
+    OpenApiTypeChecker.isObject(actualSchema),
+  );
+
+  if (OpenApiTypeChecker.isObject(actualSchema)) {
+    const obj = actualSchema as OpenApi.IJsonSchema.IObject;
+    const props = obj.properties;
+    if (props === undefined) return;
+
+    TestValidator.predicate("has id property", () => "id" in props);
+    TestValidator.predicate("has name property", () => "name" in props);
+    TestValidator.predicate("has email property", () => "email" in props);
+
+    TestValidator.predicate("id is required", () =>
+      obj.required?.includes("id") ?? false,
+    );
+    TestValidator.predicate("name is required", () =>
+      obj.required?.includes("name") ?? false,
+    );
+    TestValidator.predicate("email is optional", () =>
+      !(obj.required?.includes("email") ?? false),
+    );
+
+    TestValidator.predicate("id is number", () =>
+      OpenApiTypeChecker.isNumber(props["id"]!),
+    );
+    TestValidator.predicate("name is string", () =>
+      OpenApiTypeChecker.isString(props["name"]!),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_oneof.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_oneof.ts
@@ -1,0 +1,72 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_oneof = (): void => {
+  // discriminated union with type property
+  interface ICat {
+    type: "cat";
+    name: string;
+    meow: boolean;
+  }
+  interface IDog {
+    type: "dog";
+    name: string;
+    bark: boolean;
+  }
+  type Animal = ICat | IDog;
+
+  const unit = typia.json.schema<Animal>();
+  const schema = unit.schema;
+
+  // named union type returns $ref
+  let actualSchema: OpenApi.IJsonSchema;
+  if (OpenApiTypeChecker.isReference(schema)) {
+    const animalSchema = unit.components.schemas?.["Animal"];
+    TestValidator.predicate("Animal exists in components", () =>
+      animalSchema !== undefined,
+    );
+    actualSchema = animalSchema!;
+  } else {
+    actualSchema = schema;
+  }
+
+  TestValidator.predicate("is oneOf type", () =>
+    OpenApiTypeChecker.isOneOf(actualSchema),
+  );
+
+  if (OpenApiTypeChecker.isOneOf(actualSchema)) {
+    const oneOf = actualSchema as OpenApi.IJsonSchema.IOneOf;
+
+    TestValidator.equals("oneOf has 2 types", oneOf.oneOf.length, 2);
+
+    // check discriminator
+    TestValidator.predicate("has discriminator", () =>
+      oneOf.discriminator !== undefined,
+    );
+    if (oneOf.discriminator) {
+      TestValidator.equals(
+        "discriminator property is type",
+        oneOf.discriminator.propertyName,
+        "type",
+      );
+    }
+
+    // each element should be reference or object
+    TestValidator.predicate("all elements are ref or object", () =>
+      oneOf.oneOf.every(
+        (s) =>
+          OpenApiTypeChecker.isReference(s) || OpenApiTypeChecker.isObject(s),
+      ),
+    );
+  }
+
+  // check ICat and IDog in components
+  TestValidator.predicate("ICat exists in components", () =>
+    unit.components.schemas !== undefined && "ICat" in unit.components.schemas,
+  );
+  TestValidator.predicate("IDog exists in components", () =>
+    unit.components.schemas !== undefined && "IDog" in unit.components.schemas,
+  );
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_recursive.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_recursive.ts
@@ -1,0 +1,52 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_recursive = (): void => {
+  interface ICategory {
+    name: string;
+    children: ICategory[];
+  }
+
+  const unit = typia.json.schema<ICategory>();
+  const schema = unit.schema;
+
+  // named type returns $ref
+  let actualSchema: OpenApi.IJsonSchema;
+  if (OpenApiTypeChecker.isReference(schema)) {
+    const categorySchema = unit.components.schemas?.["ICategory"];
+    TestValidator.predicate("ICategory exists in components", () =>
+      categorySchema !== undefined,
+    );
+    actualSchema = categorySchema!;
+  } else {
+    actualSchema = schema;
+  }
+
+  TestValidator.predicate("is object type", () =>
+    OpenApiTypeChecker.isObject(actualSchema),
+  );
+
+  if (OpenApiTypeChecker.isObject(actualSchema)) {
+    const obj = actualSchema as OpenApi.IJsonSchema.IObject;
+    const props = obj.properties;
+    if (props === undefined) return;
+
+    TestValidator.predicate("has name property", () => "name" in props);
+    TestValidator.predicate("has children property", () => "children" in props);
+
+    const children = props["children"];
+    if (children) {
+      TestValidator.predicate("children is array", () =>
+        OpenApiTypeChecker.isArray(children),
+      );
+      if (OpenApiTypeChecker.isArray(children)) {
+        // recursive type uses $ref
+        TestValidator.predicate("children items is ref", () =>
+          OpenApiTypeChecker.isReference(children.items),
+        );
+      }
+    }
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_string.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_string.ts
@@ -1,0 +1,42 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_json_schema_string = (): void => {
+  const unit = typia.json.schema<string>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is string type", () =>
+    OpenApiTypeChecker.isString(schema),
+  );
+
+  // string with format
+  const emailUnit = typia.json.schema<string & tags.Format<"email">>();
+  const email = emailUnit.schema;
+  TestValidator.predicate("email is string", () =>
+    OpenApiTypeChecker.isString(email),
+  );
+  if (OpenApiTypeChecker.isString(email)) {
+    TestValidator.equals("email format", email.format, "email");
+  }
+
+  // string with pattern
+  const patternUnit = typia.json.schema<string & tags.Pattern<"^[a-z]+$">>();
+  const pattern = patternUnit.schema;
+  TestValidator.predicate("pattern is string", () =>
+    OpenApiTypeChecker.isString(pattern),
+  );
+  if (OpenApiTypeChecker.isString(pattern)) {
+    TestValidator.equals("pattern value", pattern.pattern, "^[a-z]+$");
+  }
+
+  // string with length constraints
+  const constrainedUnit = typia.json.schema<
+    string & tags.MinLength<1> & tags.MaxLength<100>
+  >();
+  const constrained = constrainedUnit.schema;
+  if (OpenApiTypeChecker.isString(constrained)) {
+    TestValidator.equals("minLength", constrained.minLength, 1);
+    TestValidator.equals("maxLength", constrained.maxLength, 100);
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_tuple.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_tuple.ts
@@ -1,0 +1,27 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_tuple = (): void => {
+  const unit = typia.json.schema<[string, number, boolean]>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is tuple type", () =>
+    OpenApiTypeChecker.isTuple(schema),
+  );
+
+  if (OpenApiTypeChecker.isTuple(schema)) {
+    const tuple = schema as OpenApi.IJsonSchema.ITuple;
+    TestValidator.equals("prefixItems length", tuple.prefixItems.length, 3);
+    TestValidator.predicate("first is string", () =>
+      OpenApiTypeChecker.isString(tuple.prefixItems[0]!),
+    );
+    TestValidator.predicate("second is number", () =>
+      OpenApiTypeChecker.isNumber(tuple.prefixItems[1]!),
+    );
+    TestValidator.predicate("third is boolean", () =>
+      OpenApiTypeChecker.isBoolean(tuple.prefixItems[2]!),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schema/test_json_schema_union.ts
+++ b/tests/test-typia-schema/src/features/json.schema/test_json_schema_union.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@typia/interface";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_json_schema_union = (): void => {
+  const unit = typia.json.schema<string | number>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is oneOf type", () =>
+    OpenApiTypeChecker.isOneOf(schema),
+  );
+
+  if (OpenApiTypeChecker.isOneOf(schema)) {
+    const oneOf = schema as OpenApi.IJsonSchema.IOneOf;
+    TestValidator.equals("oneOf has 2 types", oneOf.oneOf.length, 2);
+    TestValidator.predicate("contains string", () =>
+      oneOf.oneOf.some((s) => OpenApiTypeChecker.isString(s)),
+    );
+    TestValidator.predicate("contains number", () =>
+      oneOf.oneOf.some((s) => OpenApiTypeChecker.isNumber(s)),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/json.schemas/test_json_schemas.ts
+++ b/tests/test-typia-schema/src/features/json.schemas/test_json_schemas.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { IJsonSchemaCollection } from "typia";
+
+export const test_json_schemas = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+  }
+  interface IArticle {
+    title: string;
+    body: string;
+    author: IMember;
+  }
+
+  const collection: IJsonSchemaCollection = typia.json.schemas<
+    [IMember, IArticle, string, number]
+  >();
+
+  // schemas array has 4 items
+  TestValidator.equals("schemas count", collection.schemas.length, 4);
+
+  // named types use $ref
+  TestValidator.predicate("IMember is ref", () =>
+    OpenApiTypeChecker.isReference(collection.schemas[0]!),
+  );
+  TestValidator.predicate("IArticle is ref", () =>
+    OpenApiTypeChecker.isReference(collection.schemas[1]!),
+  );
+
+  // primitive types are inline
+  TestValidator.predicate("string is inline", () =>
+    OpenApiTypeChecker.isString(collection.schemas[2]!),
+  );
+  TestValidator.predicate("number is inline", () =>
+    OpenApiTypeChecker.isNumber(collection.schemas[3]!),
+  );
+
+  // components has both named types
+  TestValidator.predicate("components has IMember", () =>
+    collection.components.schemas !== undefined &&
+    "IMember" in collection.components.schemas,
+  );
+  TestValidator.predicate("components has IArticle", () =>
+    collection.components.schemas !== undefined &&
+    "IArticle" in collection.components.schemas,
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.application/test_llm_application.ts
+++ b/tests/test-typia-schema/src/features/llm.application/test_llm_application.ts
@@ -1,0 +1,111 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication } from "@typia/interface";
+import typia from "typia";
+
+export const test_llm_application = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+    email: string;
+  }
+
+  interface IGetMemberInput {
+    id: number;
+  }
+  interface ICreateMemberInput {
+    name: string;
+    email: string;
+  }
+  interface IUpdateMemberInput {
+    id: number;
+    name?: string;
+    email?: string;
+  }
+  interface IDeleteMemberInput {
+    id: number;
+  }
+
+  interface IController {
+    /**
+     * Get member by ID.
+     * @param input Member ID input
+     * @returns Member information
+     */
+    getMember(input: IGetMemberInput): IMember;
+
+    /**
+     * Create a new member.
+     * @param input Member creation input
+     * @returns Created member
+     */
+    createMember(input: ICreateMemberInput): IMember;
+
+    /**
+     * Update member information.
+     * @param input Member update input
+     * @returns Updated member
+     */
+    updateMember(input: IUpdateMemberInput): IMember;
+
+    /**
+     * Delete a member.
+     * @param input Member ID input
+     */
+    deleteMember(input: IDeleteMemberInput): void;
+  }
+
+  const app: ILlmApplication = typia.llm.application<IController>();
+
+  // check functions count
+  TestValidator.equals("functions count", app.functions.length, 4);
+
+  // check function names
+  const names = app.functions.map((f) => f.name);
+  TestValidator.predicate("has getMember", () => names.includes("getMember"));
+  TestValidator.predicate("has createMember", () =>
+    names.includes("createMember"),
+  );
+  TestValidator.predicate("has updateMember", () =>
+    names.includes("updateMember"),
+  );
+  TestValidator.predicate("has deleteMember", () =>
+    names.includes("deleteMember"),
+  );
+
+  // check getMember function
+  const getMember = app.functions.find((f) => f.name === "getMember");
+  if (getMember) {
+    TestValidator.predicate("getMember has description", () =>
+      getMember.description !== undefined &&
+      getMember.description.includes("Get member"),
+    );
+    TestValidator.predicate("getMember has parameters", () =>
+      getMember.parameters !== undefined,
+    );
+  }
+
+  // check createMember function
+  const createMember = app.functions.find((f) => f.name === "createMember");
+  if (createMember && createMember.parameters) {
+    TestValidator.predicate("createMember parameters has properties", () =>
+      "properties" in createMember.parameters,
+    );
+  }
+
+  // validate actual data with typia.validate
+  const validMember: IMember = {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+  };
+  const memberValidation = typia.validate<IMember>(validMember);
+  TestValidator.equals("valid member passes", memberValidation.success, true);
+
+  const invalidMember = {
+    id: "not-a-number",
+    name: 123,
+    email: null,
+  };
+  const invalidValidation = typia.validate<IMember>(invalidMember);
+  TestValidator.equals("invalid member fails", invalidValidation.success, false);
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_anyof.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_anyof.ts
@@ -1,0 +1,67 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_anyof = (): void => {
+  interface ICat {
+    type: "cat";
+    name: string;
+    meow: boolean;
+  }
+  interface IDog {
+    type: "dog";
+    name: string;
+    bark: boolean;
+  }
+  type Animal = ICat | IDog;
+
+  interface IInput {
+    pet: Animal;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check pet - discriminated union
+  const pet = params.properties["pet"];
+  TestValidator.predicate("pet exists", () => pet !== undefined);
+
+  // pet could be reference to Animal or inline anyOf
+  if (LlmTypeChecker.isReference(pet!)) {
+    TestValidator.predicate("Animal in $defs", () => "Animal" in params.$defs);
+    const animalDef = params.$defs["Animal"];
+    if (animalDef) {
+      TestValidator.predicate("Animal is anyOf", () =>
+        LlmTypeChecker.isAnyOf(animalDef),
+      );
+      if (LlmTypeChecker.isAnyOf(animalDef)) {
+        TestValidator.equals("Animal has 2 types", animalDef.anyOf.length, 2);
+      }
+    }
+  } else if (LlmTypeChecker.isAnyOf(pet!)) {
+    TestValidator.equals("pet has 2 types", pet.anyOf.length, 2);
+  }
+
+  // ICat and IDog should be in $defs
+  TestValidator.predicate("ICat in $defs", () => "ICat" in params.$defs);
+  TestValidator.predicate("IDog in $defs", () => "IDog" in params.$defs);
+
+  // verify ICat structure
+  const catDef = params.$defs["ICat"];
+  if (catDef && LlmTypeChecker.isObject(catDef)) {
+    TestValidator.predicate("ICat has type", () => "type" in catDef.properties);
+    TestValidator.predicate("ICat has name", () => "name" in catDef.properties);
+    TestValidator.predicate("ICat has meow", () => "meow" in catDef.properties);
+  }
+
+  // verify IDog structure
+  const dogDef = params.$defs["IDog"];
+  if (dogDef && LlmTypeChecker.isObject(dogDef)) {
+    TestValidator.predicate("IDog has type", () => "type" in dogDef.properties);
+    TestValidator.predicate("IDog has name", () => "name" in dogDef.properties);
+    TestValidator.predicate("IDog has bark", () => "bark" in dogDef.properties);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_array.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_array.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_parameters_array = (): void => {
+  interface IInput {
+    tags: string[];
+    scores: number[];
+    limited: string[] & tags.MinItems<1> & tags.MaxItems<10>;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check tags
+  const tagsSchema = params.properties["tags"];
+  TestValidator.predicate("tags is array", () =>
+    LlmTypeChecker.isArray(tagsSchema!),
+  );
+  if (LlmTypeChecker.isArray(tagsSchema!)) {
+    TestValidator.predicate("tags items is string", () =>
+      LlmTypeChecker.isString(tagsSchema.items),
+    );
+  }
+
+  // check scores
+  const scores = params.properties["scores"];
+  TestValidator.predicate("scores is array", () =>
+    LlmTypeChecker.isArray(scores!),
+  );
+  if (LlmTypeChecker.isArray(scores!)) {
+    TestValidator.predicate("scores items is number", () =>
+      LlmTypeChecker.isNumber(scores.items),
+    );
+  }
+
+  // check limited array constraints
+  const limited = params.properties["limited"];
+  if (LlmTypeChecker.isArray(limited!)) {
+    TestValidator.equals("minItems", limited.minItems, 1);
+    TestValidator.equals("maxItems", limited.maxItems, 10);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_boolean.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_boolean.ts
@@ -1,0 +1,36 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_boolean = (): void => {
+  interface IInput {
+    active: boolean;
+    enabled: boolean;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check active
+  const active = params.properties["active"];
+  TestValidator.predicate("active is boolean", () =>
+    LlmTypeChecker.isBoolean(active!),
+  );
+
+  // check enabled
+  const enabled = params.properties["enabled"];
+  TestValidator.predicate("enabled is boolean", () =>
+    LlmTypeChecker.isBoolean(enabled!),
+  );
+
+  // all required
+  TestValidator.predicate("active is required", () =>
+    params.required?.includes("active") ?? false,
+  );
+  TestValidator.predicate("enabled is required", () =>
+    params.required?.includes("enabled") ?? false,
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_enum.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_enum.ts
@@ -1,0 +1,62 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_enum = (): void => {
+  type Status = "pending" | "active" | "completed";
+  type Level = 1 | 2 | 3;
+
+  interface IInput {
+    status: Status;
+    level: Level;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check status - string enum may be inline or $ref
+  const status = params.properties["status"];
+  TestValidator.predicate("status exists", () => status !== undefined);
+
+  // status could be reference to $defs or inline string with enum
+  if (LlmTypeChecker.isReference(status!)) {
+    TestValidator.predicate("Status in $defs", () => "Status" in params.$defs);
+    const statusDef = params.$defs["Status"];
+    if (statusDef && LlmTypeChecker.isString(statusDef)) {
+      TestValidator.predicate("Status has enum", () =>
+        statusDef.enum !== undefined && statusDef.enum.length === 3,
+      );
+      TestValidator.predicate("Status contains pending", () =>
+        statusDef.enum?.includes("pending") ?? false,
+      );
+    }
+  } else if (LlmTypeChecker.isString(status!)) {
+    TestValidator.predicate("status has enum", () =>
+      status.enum !== undefined && status.enum.length === 3,
+    );
+  }
+
+  // check level - number enum may be inline or $ref
+  const level = params.properties["level"];
+  TestValidator.predicate("level exists", () => level !== undefined);
+
+  if (LlmTypeChecker.isReference(level!)) {
+    TestValidator.predicate("Level in $defs", () => "Level" in params.$defs);
+    const levelDef = params.$defs["Level"];
+    if (levelDef && LlmTypeChecker.isNumber(levelDef)) {
+      TestValidator.predicate("Level has enum", () =>
+        levelDef.enum !== undefined && levelDef.enum.length === 3,
+      );
+      TestValidator.predicate("Level contains 1", () =>
+        levelDef.enum?.includes(1) ?? false,
+      );
+    }
+  } else if (LlmTypeChecker.isNumber(level!)) {
+    TestValidator.predicate("level has enum", () =>
+      level.enum !== undefined && level.enum.length === 3,
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_nullable.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_nullable.ts
@@ -1,0 +1,56 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_nullable = (): void => {
+  interface IInput {
+    required: string;
+    nullableString: string | null;
+    nullableNumber: number | null;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check required is just string
+  const required = params.properties["required"];
+  TestValidator.predicate("required is string", () =>
+    LlmTypeChecker.isString(required!),
+  );
+
+  // check nullableString - should be anyOf with string and null
+  const nullableString = params.properties["nullableString"];
+  TestValidator.predicate("nullableString exists", () =>
+    nullableString !== undefined,
+  );
+  TestValidator.predicate("nullableString is anyOf", () =>
+    LlmTypeChecker.isAnyOf(nullableString!),
+  );
+
+  if (LlmTypeChecker.isAnyOf(nullableString!)) {
+    TestValidator.predicate("nullableString has string", () =>
+      nullableString.anyOf.some((s) => LlmTypeChecker.isString(s)),
+    );
+    TestValidator.predicate("nullableString has null", () =>
+      nullableString.anyOf.some((s) => LlmTypeChecker.isNull(s)),
+    );
+  }
+
+  // check nullableNumber - should be anyOf with number and null
+  const nullableNumber = params.properties["nullableNumber"];
+  TestValidator.predicate("nullableNumber is anyOf", () =>
+    LlmTypeChecker.isAnyOf(nullableNumber!),
+  );
+
+  if (LlmTypeChecker.isAnyOf(nullableNumber!)) {
+    TestValidator.predicate("nullableNumber has number", () =>
+      nullableNumber.anyOf.some((s) => LlmTypeChecker.isNumber(s)),
+    );
+    TestValidator.predicate("nullableNumber has null", () =>
+      nullableNumber.anyOf.some((s) => LlmTypeChecker.isNull(s)),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_number.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_number.ts
@@ -1,0 +1,51 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_parameters_number = (): void => {
+  interface IInput {
+    basic: number;
+    integer: number & tags.Type<"int32">;
+    ranged: number & tags.Minimum<0> & tags.Maximum<100>;
+    exclusive: number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>;
+    multiple: number & tags.MultipleOf<5>;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check basic number
+  const basic = params.properties["basic"];
+  TestValidator.predicate("basic is number", () =>
+    LlmTypeChecker.isNumber(basic!),
+  );
+
+  // check integer
+  const integer = params.properties["integer"];
+  TestValidator.predicate("integer is integer type", () =>
+    LlmTypeChecker.isInteger(integer!),
+  );
+
+  // check ranged
+  const ranged = params.properties["ranged"];
+  if (LlmTypeChecker.isNumber(ranged!)) {
+    TestValidator.equals("minimum", ranged.minimum, 0);
+    TestValidator.equals("maximum", ranged.maximum, 100);
+  }
+
+  // check exclusive
+  const exclusive = params.properties["exclusive"];
+  if (LlmTypeChecker.isNumber(exclusive!)) {
+    TestValidator.equals("exclusiveMinimum", exclusive.exclusiveMinimum, 0);
+    TestValidator.equals("exclusiveMaximum", exclusive.exclusiveMaximum, 100);
+  }
+
+  // check multipleOf
+  const multiple = params.properties["multiple"];
+  if (LlmTypeChecker.isNumber(multiple!)) {
+    TestValidator.equals("multipleOf", multiple.multipleOf, 5);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_object.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_object.ts
@@ -1,0 +1,62 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_object = (): void => {
+  interface IAddress {
+    street: string;
+    city: string;
+  }
+  interface IInput {
+    name: string;
+    address: IAddress;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+
+  // check name
+  const name = params.properties["name"];
+  TestValidator.predicate("name is string", () =>
+    LlmTypeChecker.isString(name!),
+  );
+
+  // check address - nested object uses $ref
+  const address = params.properties["address"];
+  TestValidator.predicate("address exists", () => address !== undefined);
+
+  // address should be reference or object
+  const isRefOrObject =
+    LlmTypeChecker.isReference(address!) || LlmTypeChecker.isObject(address!);
+  TestValidator.predicate("address is ref or object", () => isRefOrObject);
+
+  // if reference, check $defs
+  if (LlmTypeChecker.isReference(address!)) {
+    TestValidator.predicate("IAddress in $defs", () =>
+      "IAddress" in params.$defs,
+    );
+
+    const addressDef = params.$defs["IAddress"];
+    if (addressDef && LlmTypeChecker.isObject(addressDef)) {
+      TestValidator.predicate("IAddress has street", () =>
+        "street" in addressDef.properties,
+      );
+      TestValidator.predicate("IAddress has city", () =>
+        "city" in addressDef.properties,
+      );
+    }
+  }
+
+  // if inline object
+  if (LlmTypeChecker.isObject(address!)) {
+    TestValidator.predicate("address has street", () =>
+      "street" in address.properties,
+    );
+    TestValidator.predicate("address has city", () =>
+      "city" in address.properties,
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_separate.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_separate.ts
@@ -1,0 +1,40 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_parameters_separate = (): void => {
+  interface IFileUpload {
+    image: string;
+    description: string;
+    tags: string[];
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IFileUpload>();
+
+  TestValidator.predicate("is object type", () => LlmTypeChecker.isObject(params));
+
+  if (LlmTypeChecker.isObject(params)) {
+    TestValidator.predicate("has image property", () =>
+      "image" in params.properties,
+    );
+    TestValidator.predicate("has description property", () =>
+      "description" in params.properties,
+    );
+    TestValidator.predicate("has tags property", () =>
+      "tags" in params.properties,
+    );
+
+    const image = params.properties["image"];
+    if (image) {
+      TestValidator.predicate("image is string", () =>
+        LlmTypeChecker.isString(image),
+      );
+    }
+
+    const tags = params.properties["tags"];
+    if (tags) {
+      TestValidator.predicate("tags is array", () => LlmTypeChecker.isArray(tags));
+    }
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_string.ts
+++ b/tests/test-typia-schema/src/features/llm.parameters/test_llm_parameters_string.ts
@@ -1,0 +1,62 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_parameters_string = (): void => {
+  interface IInput {
+    basic: string;
+    email: string & tags.Format<"email">;
+    pattern: string & tags.Pattern<"^[a-z]+$">;
+    length: string & tags.MinLength<1> & tags.MaxLength<100>;
+  }
+
+  const params: ILlmSchema.IParameters = typia.llm.parameters<IInput>();
+
+  // parameters should be object with additionalProperties: false
+  TestValidator.predicate("is object", () => LlmTypeChecker.isObject(params));
+  TestValidator.equals("additionalProperties", params.additionalProperties, false);
+  TestValidator.predicate("has $defs", () => params.$defs !== undefined);
+
+  // check properties exist
+  TestValidator.predicate("has basic", () => "basic" in params.properties);
+  TestValidator.predicate("has email", () => "email" in params.properties);
+  TestValidator.predicate("has pattern", () => "pattern" in params.properties);
+  TestValidator.predicate("has length", () => "length" in params.properties);
+
+  // all should be required
+  TestValidator.predicate("basic is required", () =>
+    params.required?.includes("basic") ?? false,
+  );
+  TestValidator.predicate("email is required", () =>
+    params.required?.includes("email") ?? false,
+  );
+
+  // check basic string
+  const basic = params.properties["basic"];
+  TestValidator.predicate("basic is string", () =>
+    LlmTypeChecker.isString(basic!),
+  );
+
+  // check email format
+  const email = params.properties["email"];
+  TestValidator.predicate("email is string", () =>
+    LlmTypeChecker.isString(email!),
+  );
+  if (LlmTypeChecker.isString(email!)) {
+    TestValidator.equals("email format", email.format, "email");
+  }
+
+  // check pattern
+  const pattern = params.properties["pattern"];
+  if (LlmTypeChecker.isString(pattern!)) {
+    TestValidator.equals("pattern value", pattern.pattern, "^[a-z]+$");
+  }
+
+  // check length constraints
+  const length = params.properties["length"];
+  if (LlmTypeChecker.isString(length!)) {
+    TestValidator.equals("minLength", length.minLength, 1);
+    TestValidator.equals("maxLength", length.maxLength, 100);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_anyof.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_anyof.ts
@@ -1,0 +1,66 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_anyof = (): void => {
+  // discriminated union with type property
+  interface ICat {
+    type: "cat";
+    name: string;
+    meow: boolean;
+  }
+  interface IDog {
+    type: "dog";
+    name: string;
+    bark: boolean;
+  }
+  type Animal = ICat | IDog;
+
+  const $defs: Record<string, ILlmSchema> = {};
+  const schema = typia.llm.schema<Animal>($defs);
+
+  // named union type returns $ref
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const animalSchema = $defs["Animal"];
+  TestValidator.predicate("Animal exists in $defs", () =>
+    animalSchema !== undefined,
+  );
+
+  if (animalSchema) {
+    // LLM schema uses anyOf for unions
+    TestValidator.predicate("is anyOf type", () =>
+      LlmTypeChecker.isAnyOf(animalSchema),
+    );
+
+    if (LlmTypeChecker.isAnyOf(animalSchema)) {
+      TestValidator.equals("anyOf has 2 types", animalSchema.anyOf.length, 2);
+
+      // each element should be reference or object
+      TestValidator.predicate("all elements are ref or object", () =>
+        animalSchema.anyOf.every(
+          (s) => LlmTypeChecker.isReference(s) || LlmTypeChecker.isObject(s),
+        ),
+      );
+    }
+  }
+
+  // check ICat and IDog in $defs
+  TestValidator.predicate("ICat exists in $defs", () => "ICat" in $defs);
+  TestValidator.predicate("IDog exists in $defs", () => "IDog" in $defs);
+
+  // verify ICat structure
+  const catSchema = $defs["ICat"];
+  if (catSchema && LlmTypeChecker.isObject(catSchema)) {
+    TestValidator.predicate("ICat has type property", () =>
+      "type" in catSchema.properties,
+    );
+    TestValidator.predicate("ICat has name property", () =>
+      "name" in catSchema.properties,
+    );
+    TestValidator.predicate("ICat has meow property", () =>
+      "meow" in catSchema.properties,
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_array.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_array.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_schema_array = (): void => {
+  const schema = typia.llm.schema<string[]>({});
+
+  TestValidator.predicate("is array type", () => LlmTypeChecker.isArray(schema));
+
+  if (LlmTypeChecker.isArray(schema)) {
+    TestValidator.predicate("items is string", () =>
+      LlmTypeChecker.isString(schema.items),
+    );
+  }
+
+  // array with constraints
+  const constrained = typia.llm.schema<
+    string[] & tags.MinItems<1> & tags.MaxItems<10>
+  >({});
+  if (LlmTypeChecker.isArray(constrained)) {
+    TestValidator.equals("minItems", constrained.minItems, 1);
+    TestValidator.equals("maxItems", constrained.maxItems, 10);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_boolean.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_boolean.ts
@@ -1,0 +1,11 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_boolean = (): void => {
+  const schema = typia.llm.schema<boolean>({});
+
+  TestValidator.predicate("is boolean type", () =>
+    LlmTypeChecker.isBoolean(schema),
+  );
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_enum.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_enum.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_enum = (): void => {
+  type Status = "pending" | "active" | "completed";
+
+  const $defs: Record<string, ILlmSchema> = {};
+  const schema = typia.llm.schema<Status>($defs);
+
+  // named type returns $ref
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const status = $defs["Status"];
+  if (status && LlmTypeChecker.isString(status)) {
+    TestValidator.predicate("has enum values", () =>
+      status.enum !== undefined && status.enum.length === 3,
+    );
+    TestValidator.predicate("contains pending", () =>
+      status.enum?.includes("pending") ?? false,
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_nullable.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_nullable.ts
@@ -1,0 +1,18 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_nullable = (): void => {
+  const schema = typia.llm.schema<string | null>({});
+
+  TestValidator.predicate("is anyOf type", () => LlmTypeChecker.isAnyOf(schema));
+
+  if (LlmTypeChecker.isAnyOf(schema)) {
+    TestValidator.predicate("contains string", () =>
+      schema.anyOf.some((s) => LlmTypeChecker.isString(s)),
+    );
+    TestValidator.predicate("contains null", () =>
+      schema.anyOf.some((s) => LlmTypeChecker.isNull(s)),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_number.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_number.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_schema_number = (): void => {
+  const schema = typia.llm.schema<number>({});
+
+  TestValidator.predicate("is number type", () => LlmTypeChecker.isNumber(schema));
+
+  // integer type
+  const integer = typia.llm.schema<number & tags.Type<"int32">>({});
+  TestValidator.predicate("int32 is integer", () =>
+    LlmTypeChecker.isInteger(integer),
+  );
+
+  // number with range
+  const ranged = typia.llm.schema<number & tags.Minimum<0> & tags.Maximum<100>>({});
+  if (LlmTypeChecker.isNumber(ranged)) {
+    TestValidator.equals("minimum", ranged.minimum, 0);
+    TestValidator.equals("maximum", ranged.maximum, 100);
+  }
+
+  // exclusive range
+  const exclusive = typia.llm.schema<
+    number & tags.ExclusiveMinimum<0> & tags.ExclusiveMaximum<100>
+  >({});
+  if (LlmTypeChecker.isNumber(exclusive)) {
+    TestValidator.equals("exclusiveMinimum", exclusive.exclusiveMinimum, 0);
+    TestValidator.equals("exclusiveMaximum", exclusive.exclusiveMaximum, 100);
+  }
+
+  // multipleOf
+  const multiple = typia.llm.schema<number & tags.MultipleOf<5>>({});
+  if (LlmTypeChecker.isNumber(multiple)) {
+    TestValidator.equals("multipleOf", multiple.multipleOf, 5);
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_object.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_object.ts
@@ -1,0 +1,39 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_object = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+    email?: string;
+  }
+
+  const $defs: Record<string, ILlmSchema> = {};
+  const schema = typia.llm.schema<IMember>($defs);
+
+  // named type returns $ref
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  // actual schema in $defs
+  TestValidator.predicate("$defs has IMember", () => "IMember" in $defs);
+
+  const member = $defs["IMember"];
+  if (member && LlmTypeChecker.isObject(member)) {
+    TestValidator.predicate("has id property", () => "id" in member.properties);
+    TestValidator.predicate("has name property", () => "name" in member.properties);
+    TestValidator.predicate("has email property", () => "email" in member.properties);
+
+    TestValidator.predicate("id is required", () =>
+      member.required?.includes("id") ?? false,
+    );
+    TestValidator.predicate("email is optional", () =>
+      !(member.required?.includes("email") ?? false),
+    );
+
+    TestValidator.predicate("id is number", () =>
+      LlmTypeChecker.isNumber(member.properties["id"]!),
+    );
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_recursive.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_recursive.ts
@@ -1,0 +1,30 @@
+import { TestValidator } from "@nestia/e2e";
+import { ILlmSchema } from "@typia/interface";
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+export const test_llm_schema_recursive = (): void => {
+  interface ICategory {
+    name: string;
+    children: ICategory[];
+  }
+
+  const $defs: Record<string, ILlmSchema> = {};
+  const schema = typia.llm.schema<ICategory>($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+  TestValidator.predicate("$defs has ICategory", () => "ICategory" in $defs);
+
+  const category = $defs["ICategory"];
+  if (category && LlmTypeChecker.isObject(category)) {
+    TestValidator.predicate("has name", () => "name" in category.properties);
+    TestValidator.predicate("has children", () => "children" in category.properties);
+
+    const children = category.properties["children"];
+    if (children && LlmTypeChecker.isArray(children)) {
+      TestValidator.predicate("children items is ref", () =>
+        LlmTypeChecker.isReference(children.items),
+      );
+    }
+  }
+};

--- a/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_string.ts
+++ b/tests/test-typia-schema/src/features/llm.schema/test_llm_schema_string.ts
@@ -1,0 +1,31 @@
+import { TestValidator } from "@nestia/e2e";
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+export const test_llm_schema_string = (): void => {
+  const schema = typia.llm.schema<string>({});
+
+  TestValidator.predicate("is string type", () => LlmTypeChecker.isString(schema));
+
+  // string with format
+  const email = typia.llm.schema<string & tags.Format<"email">>({});
+  TestValidator.predicate("email is string", () => LlmTypeChecker.isString(email));
+  if (LlmTypeChecker.isString(email)) {
+    TestValidator.equals("email format", email.format, "email");
+  }
+
+  // string with pattern
+  const pattern = typia.llm.schema<string & tags.Pattern<"^[a-z]+$">>({});
+  if (LlmTypeChecker.isString(pattern)) {
+    TestValidator.equals("pattern value", pattern.pattern, "^[a-z]+$");
+  }
+
+  // string with length constraints
+  const constrained = typia.llm.schema<
+    string & tags.MinLength<1> & tags.MaxLength<100>
+  >({});
+  if (LlmTypeChecker.isString(constrained)) {
+    TestValidator.equals("minLength", constrained.minLength, 1);
+    TestValidator.equals("maxLength", constrained.maxLength, 100);
+  }
+};

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_array.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_array.ts
@@ -1,0 +1,22 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_protobuf_message_array = (): void => {
+  interface IProduct {
+    name: string;
+    prices: (number & typia.tags.Type<"double">)[];
+    tags: string[];
+  }
+
+  const message: string = typia.protobuf.message<IProduct>();
+
+  TestValidator.predicate("contains message keyword", () =>
+    message.includes("message IProduct"),
+  );
+  TestValidator.predicate("contains repeated double prices", () =>
+    message.includes("repeated double prices"),
+  );
+  TestValidator.predicate("contains repeated string tags", () =>
+    message.includes("repeated string tags"),
+  );
+};

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_map.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_map.ts
@@ -1,0 +1,21 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_protobuf_message_map = (): void => {
+  interface ICache {
+    data: Map<string, string>;
+    counts: Map<string, number & typia.tags.Type<"int32">>;
+  }
+
+  const message: string = typia.protobuf.message<ICache>();
+
+  TestValidator.predicate("contains message keyword", () =>
+    message.includes("message ICache"),
+  );
+  TestValidator.predicate("contains map string string", () =>
+    message.includes("map<string, string> data"),
+  );
+  TestValidator.predicate("contains map string int32", () =>
+    message.includes("map<string, int32> counts"),
+  );
+};

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_object.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_object.ts
@@ -1,0 +1,29 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_protobuf_message_object = (): void => {
+  interface IMember {
+    id: number & typia.tags.Type<"int32">;
+    name: string;
+    email: string;
+    active: boolean;
+  }
+
+  const message: string = typia.protobuf.message<IMember>();
+
+  TestValidator.predicate("contains message keyword", () =>
+    message.includes("message IMember"),
+  );
+  TestValidator.predicate("contains int32 id", () =>
+    message.includes("int32 id"),
+  );
+  TestValidator.predicate("contains string name", () =>
+    message.includes("string name"),
+  );
+  TestValidator.predicate("contains string email", () =>
+    message.includes("string email"),
+  );
+  TestValidator.predicate("contains bool active", () =>
+    message.includes("bool active"),
+  );
+};

--- a/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_optional.ts
+++ b/tests/test-typia-schema/src/features/protobuf.message/test_protobuf_message_optional.ts
@@ -1,0 +1,22 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_protobuf_message_optional = (): void => {
+  interface IConfig {
+    name: string;
+    timeout?: number & typia.tags.Type<"int32">;
+    debug?: boolean;
+  }
+
+  const message: string = typia.protobuf.message<IConfig>();
+
+  TestValidator.predicate("contains message keyword", () =>
+    message.includes("message IConfig"),
+  );
+  TestValidator.predicate("contains optional timeout", () =>
+    message.includes("optional int32 timeout"),
+  );
+  TestValidator.predicate("contains optional debug", () =>
+    message.includes("optional bool debug"),
+  );
+};

--- a/tests/test-typia-schema/src/index.ts
+++ b/tests/test-typia-schema/src/index.ts
@@ -1,0 +1,45 @@
+import { DynamicExecutor } from "@nestia/e2e";
+import chalk from "chalk";
+
+import { TestGlobal } from "./TestGlobal";
+
+const main = async (): Promise<void> => {
+  // DO TEST
+  const include: string[] = TestGlobal.getArguments("include");
+  const exclude: string[] = TestGlobal.getArguments("exclude");
+  const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+    prefix: "test_",
+    location: __dirname + "/features",
+    extension: "ts",
+    parameters: () => [],
+    onComplete: (exec) => {
+      const trace = (str: string) =>
+        console.log(`  - ${chalk.green(exec.name)}: ${str}`);
+      if (exec.value === false) trace(chalk.gray("Pass"));
+      else if (exec.error === null) {
+        const elapsed: number =
+          new Date(exec.completed_at).getTime() -
+          new Date(exec.started_at).getTime();
+        trace(`${chalk.yellow(elapsed.toLocaleString())} ms`);
+      } else trace(chalk.red(exec.error.name));
+    },
+    filter: (name) =>
+      (include.length ? include.some((str) => name.includes(str)) : true) &&
+      (exclude.length ? exclude.every((str) => !name.includes(str)) : true),
+  });
+
+  // REPORT EXCEPTIONS
+  const exceptions: Error[] = report.executions
+    .filter((exec) => exec.error !== null)
+    .map((exec) => exec.error!);
+  if (exceptions.length === 0) {
+    console.log("Success");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  } else {
+    for (const exp of exceptions) console.log(exp);
+    console.log("Failed");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  }
+  if (exceptions.length) process.exit(-1);
+};
+main().catch(console.error);

--- a/tests/test-typia-schema/tsconfig.json
+++ b/tests/test-typia-schema/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../config/tsconfig.json",
+  "include": ["src"]
+}

--- a/tests/test-typia/src/features/json.schema/test_json_schema_array.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_array.ts
@@ -1,0 +1,64 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_array = (): void => {
+  interface IInput {
+    basic: string[];
+    constrained: number[] & tags.MinItems<1> & tags.MaxItems<10>;
+    unique: string[] & tags.UniqueItems;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const constrained = props["constrained"];
+  const unique = props["unique"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (constrained === undefined) return TestValidator.error("no constrained");
+  if (unique === undefined) return TestValidator.error("no unique");
+
+  TestValidator.predicate("basic is array", () =>
+    OpenApiTypeChecker.isArray(basic),
+  );
+  if (OpenApiTypeChecker.isArray(basic)) {
+    TestValidator.predicate("basic items is string", () =>
+      OpenApiTypeChecker.isString(basic.items),
+    );
+  }
+
+  TestValidator.predicate("constrained is array", () =>
+    OpenApiTypeChecker.isArray(constrained),
+  );
+  if (OpenApiTypeChecker.isArray(constrained)) {
+    TestValidator.equals("minItems", constrained.minItems, 1);
+    TestValidator.equals("maxItems", constrained.maxItems, 10);
+  }
+
+  TestValidator.predicate("unique is array", () =>
+    OpenApiTypeChecker.isArray(unique),
+  );
+  if (OpenApiTypeChecker.isArray(unique)) {
+    TestValidator.equals("uniqueItems", unique.uniqueItems, true);
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_boolean.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_boolean.ts
@@ -1,0 +1,44 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_boolean = (): void => {
+  interface IInput {
+    flag: boolean;
+    active: boolean;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const flag = props["flag"];
+  const active = props["active"];
+
+  if (flag === undefined) return TestValidator.error("no flag");
+  if (active === undefined) return TestValidator.error("no active");
+
+  TestValidator.predicate("flag is boolean", () =>
+    OpenApiTypeChecker.isBoolean(flag),
+  );
+  TestValidator.predicate("active is boolean", () =>
+    OpenApiTypeChecker.isBoolean(active),
+  );
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_enum.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_enum.ts
@@ -1,0 +1,48 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_enum = (): void => {
+  type Status = "pending" | "active" | "completed";
+  interface IInput {
+    status: Status;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const status = props["status"];
+  if (status === undefined) return TestValidator.error("no status");
+
+  // String literal unions use oneOf with const values
+  TestValidator.predicate("status is oneOf", () =>
+    OpenApiTypeChecker.isOneOf(status),
+  );
+  if (OpenApiTypeChecker.isOneOf(status)) {
+    const values = status.oneOf
+      .filter(OpenApiTypeChecker.isConstant)
+      .map((s) => s.const);
+    TestValidator.predicate("has pending", () => values.includes("pending"));
+    TestValidator.predicate("has active", () => values.includes("active"));
+    TestValidator.predicate("has completed", () => values.includes("completed"));
+    TestValidator.equals("enum count", values.length, 3);
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_nullable.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_nullable.ts
@@ -1,0 +1,52 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_nullable = (): void => {
+  interface IInput {
+    nullable: string | null;
+    required: string;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const nullable = props["nullable"];
+  const required = props["required"];
+
+  if (nullable === undefined) return TestValidator.error("no nullable");
+  if (required === undefined) return TestValidator.error("no required");
+
+  // nullable is oneOf with null
+  TestValidator.predicate("nullable is oneOf", () =>
+    OpenApiTypeChecker.isOneOf(nullable),
+  );
+  if (OpenApiTypeChecker.isOneOf(nullable)) {
+    const hasString = nullable.oneOf.some((s) => OpenApiTypeChecker.isString(s));
+    const hasNull = nullable.oneOf.some((s) => OpenApiTypeChecker.isNull(s));
+    TestValidator.predicate("has string in oneOf", () => hasString);
+    TestValidator.predicate("has null in oneOf", () => hasNull);
+  }
+
+  TestValidator.predicate("required is string", () =>
+    OpenApiTypeChecker.isString(required),
+  );
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_number.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_number.ts
@@ -1,0 +1,64 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_number = (): void => {
+  interface IInput {
+    basic: number;
+    int32: number & tags.Type<"int32">;
+    range: number & tags.Minimum<0> & tags.Maximum<100>;
+    multipleOf: number & tags.MultipleOf<5>;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const int32 = props["int32"];
+  const range = props["range"];
+  const multipleOf = props["multipleOf"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (int32 === undefined) return TestValidator.error("no int32");
+  if (range === undefined) return TestValidator.error("no range");
+  if (multipleOf === undefined) return TestValidator.error("no multipleOf");
+
+  TestValidator.predicate("basic is number", () =>
+    OpenApiTypeChecker.isNumber(basic),
+  );
+  TestValidator.predicate("int32 is integer", () =>
+    OpenApiTypeChecker.isInteger(int32),
+  );
+  TestValidator.predicate("range is number", () =>
+    OpenApiTypeChecker.isNumber(range),
+  );
+  if (OpenApiTypeChecker.isNumber(range)) {
+    TestValidator.equals("minimum", range.minimum, 0);
+    TestValidator.equals("maximum", range.maximum, 100);
+  }
+
+  TestValidator.predicate("multipleOf is number", () =>
+    OpenApiTypeChecker.isNumber(multipleOf),
+  );
+  if (OpenApiTypeChecker.isNumber(multipleOf)) {
+    TestValidator.equals("multipleOf value", multipleOf.multipleOf, 5);
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_object.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_object.ts
@@ -1,0 +1,65 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_object = (): void => {
+  interface INested {
+    value: number;
+  }
+  interface IInput {
+    name: string;
+    nested: INested;
+    optional?: string;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const name = props["name"];
+  const nested = props["nested"];
+  const optional = props["optional"];
+
+  if (name === undefined) return TestValidator.error("no name");
+  if (nested === undefined) return TestValidator.error("no nested");
+
+  TestValidator.predicate("name is string", () =>
+    OpenApiTypeChecker.isString(name),
+  );
+
+  // nested is $ref to INested
+  TestValidator.predicate("nested is reference", () =>
+    OpenApiTypeChecker.isReference(nested),
+  );
+
+  // Check required fields
+  const required = actual.required ?? [];
+  TestValidator.predicate("name is required", () => required.includes("name"));
+  TestValidator.predicate("nested is required", () =>
+    required.includes("nested"),
+  );
+
+  // optional should exist but not be required
+  if (optional !== undefined) {
+    TestValidator.predicate("optional is not required", () =>
+      !required.includes("optional"),
+    );
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_oneof.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_oneof.ts
@@ -1,0 +1,65 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_oneof = (): void => {
+  interface ICircle {
+    type: "circle";
+    radius: number;
+  }
+  interface IRectangle {
+    type: "rectangle";
+    width: number;
+    height: number;
+  }
+  type Shape = ICircle | IRectangle;
+
+  interface IInput {
+    shape: Shape;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const shape = props["shape"];
+  if (shape === undefined) return TestValidator.error("no shape");
+
+  // Discriminated union uses oneOf
+  TestValidator.predicate("shape is oneOf", () =>
+    OpenApiTypeChecker.isOneOf(shape),
+  );
+  if (OpenApiTypeChecker.isOneOf(shape)) {
+    TestValidator.equals("oneOf count", shape.oneOf.length, 2);
+
+    // Each variant should be a $ref
+    const allRefs = shape.oneOf.every((s) => OpenApiTypeChecker.isReference(s));
+    TestValidator.predicate("all variants are $ref", () => allRefs);
+
+    // Check discriminator
+    if (shape.discriminator !== undefined) {
+      TestValidator.equals(
+        "discriminator property",
+        shape.discriminator.propertyName,
+        "type",
+      );
+    }
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_recursive.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_recursive.ts
@@ -1,0 +1,57 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_recursive = (): void => {
+  interface ICategory {
+    name: string;
+    children: ICategory[];
+  }
+
+  const unit = typia.json.schema<ICategory>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const name = props["name"];
+  const children = props["children"];
+
+  if (name === undefined) return TestValidator.error("no name");
+  if (children === undefined) return TestValidator.error("no children");
+
+  TestValidator.predicate("name is string", () =>
+    OpenApiTypeChecker.isString(name),
+  );
+  TestValidator.predicate("children is array", () =>
+    OpenApiTypeChecker.isArray(children),
+  );
+
+  // Check recursive reference
+  if (OpenApiTypeChecker.isArray(children)) {
+    TestValidator.predicate("children items is reference", () =>
+      OpenApiTypeChecker.isReference(children.items),
+    );
+    // The $ref should point back to ICategory
+    if (OpenApiTypeChecker.isReference(children.items)) {
+      TestValidator.predicate("recursive reference", () =>
+        children.items.$ref.includes("ICategory"),
+      );
+    }
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_string.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_string.ts
@@ -1,0 +1,68 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_string = (): void => {
+  interface IInput {
+    basic: string;
+    email: string & tags.Format<"email">;
+    pattern: string & tags.Pattern<"^[a-z]+$">;
+    length: string & tags.MinLength<1> & tags.MaxLength<100>;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const email = props["email"];
+  const pattern = props["pattern"];
+  const length = props["length"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (email === undefined) return TestValidator.error("no email");
+  if (pattern === undefined) return TestValidator.error("no pattern");
+  if (length === undefined) return TestValidator.error("no length");
+
+  TestValidator.predicate("basic is string", () =>
+    OpenApiTypeChecker.isString(basic),
+  );
+  TestValidator.predicate("email is string", () =>
+    OpenApiTypeChecker.isString(email),
+  );
+  if (OpenApiTypeChecker.isString(email)) {
+    TestValidator.equals("email format", email.format, "email");
+  }
+
+  TestValidator.predicate("pattern is string", () =>
+    OpenApiTypeChecker.isString(pattern),
+  );
+  if (OpenApiTypeChecker.isString(pattern)) {
+    TestValidator.equals("pattern value", pattern.pattern, "^[a-z]+$");
+  }
+
+  TestValidator.predicate("length is string", () =>
+    OpenApiTypeChecker.isString(length),
+  );
+  if (OpenApiTypeChecker.isString(length)) {
+    TestValidator.equals("minLength", length.minLength, 1);
+    TestValidator.equals("maxLength", length.maxLength, 100);
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_tuple.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_tuple.ts
@@ -1,0 +1,50 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_tuple = (): void => {
+  interface IInput {
+    tuple: [string, number, boolean];
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const tuple = props["tuple"];
+  if (tuple === undefined) return TestValidator.error("no tuple");
+
+  TestValidator.predicate("tuple is tuple", () =>
+    OpenApiTypeChecker.isTuple(tuple),
+  );
+  if (OpenApiTypeChecker.isTuple(tuple)) {
+    const items = tuple.prefixItems;
+    TestValidator.equals("tuple length", items.length, 3);
+    TestValidator.predicate("first is string", () =>
+      OpenApiTypeChecker.isString(items[0]!),
+    );
+    TestValidator.predicate("second is number", () =>
+      OpenApiTypeChecker.isNumber(items[1]!),
+    );
+    TestValidator.predicate("third is boolean", () =>
+      OpenApiTypeChecker.isBoolean(items[2]!),
+    );
+  }
+};

--- a/tests/test-typia/src/features/json.schema/test_json_schema_union.ts
+++ b/tests/test-typia/src/features/json.schema/test_json_schema_union.ts
@@ -1,0 +1,44 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schema_union = (): void => {
+  interface IInput {
+    value: string | number;
+  }
+
+  const unit = typia.json.schema<IInput>();
+  const schema = unit.schema;
+
+  TestValidator.predicate("is reference", () =>
+    OpenApiTypeChecker.isReference(schema),
+  );
+
+  const components = unit.components;
+  const refName = (schema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const actual = components.schemas?.[refName];
+  if (actual === undefined) return TestValidator.error("schema not found");
+  if (!OpenApiTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const value = props["value"];
+  if (value === undefined) return TestValidator.error("no value");
+
+  // Primitive union uses oneOf
+  TestValidator.predicate("value is oneOf", () =>
+    OpenApiTypeChecker.isOneOf(value),
+  );
+  if (OpenApiTypeChecker.isOneOf(value)) {
+    const hasString = value.oneOf.some((s) => OpenApiTypeChecker.isString(s));
+    const hasNumber = value.oneOf.some((s) => OpenApiTypeChecker.isNumber(s));
+    TestValidator.predicate("has string", () => hasString);
+    TestValidator.predicate("has number", () => hasNumber);
+  }
+};

--- a/tests/test-typia/src/features/json.schemas/test_json_schemas.ts
+++ b/tests/test-typia/src/features/json.schemas/test_json_schemas.ts
@@ -1,0 +1,85 @@
+import { OpenApiTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_json_schemas = (): void => {
+  interface IUser {
+    id: number;
+    name: string;
+  }
+  interface IPost {
+    id: number;
+    title: string;
+    author: IUser;
+  }
+
+  const units = typia.json.schemas<[IUser, IPost]>();
+
+  TestValidator.equals("schemas count", units.schemas.length, 2);
+
+  const [userSchema, postSchema] = units.schemas;
+  if (userSchema === undefined) return TestValidator.error("no user schema");
+  if (postSchema === undefined) return TestValidator.error("no post schema");
+
+  // Both should be $ref because they are named types
+  TestValidator.predicate("user is reference", () =>
+    OpenApiTypeChecker.isReference(userSchema),
+  );
+  TestValidator.predicate("post is reference", () =>
+    OpenApiTypeChecker.isReference(postSchema),
+  );
+
+  // Check components has both schemas
+  const components = units.components;
+  const schemas = components.schemas;
+  if (schemas === undefined) return TestValidator.error("no components.schemas");
+
+  // Get actual schemas from $ref
+  const userRefName = (userSchema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+  const postRefName = (postSchema as { $ref: string }).$ref.replace(
+    "#/components/schemas/",
+    "",
+  );
+
+  const actualUser = schemas[userRefName];
+  const actualPost = schemas[postRefName];
+
+  if (actualUser === undefined) return TestValidator.error("user not in schemas");
+  if (actualPost === undefined) return TestValidator.error("post not in schemas");
+
+  TestValidator.predicate("user is object", () =>
+    OpenApiTypeChecker.isObject(actualUser),
+  );
+  TestValidator.predicate("post is object", () =>
+    OpenApiTypeChecker.isObject(actualPost),
+  );
+
+  // Check user properties
+  if (OpenApiTypeChecker.isObject(actualUser)) {
+    const props = actualUser.properties;
+    if (props === undefined) return TestValidator.error("no user properties");
+    TestValidator.predicate("user has id", () => props["id"] !== undefined);
+    TestValidator.predicate("user has name", () => props["name"] !== undefined);
+  }
+
+  // Check post properties
+  if (OpenApiTypeChecker.isObject(actualPost)) {
+    const props = actualPost.properties;
+    if (props === undefined) return TestValidator.error("no post properties");
+    TestValidator.predicate("post has id", () => props["id"] !== undefined);
+    TestValidator.predicate("post has title", () => props["title"] !== undefined);
+    TestValidator.predicate("post has author", () => props["author"] !== undefined);
+
+    // author should be $ref to IUser
+    const author = props["author"];
+    if (author !== undefined) {
+      TestValidator.predicate("author is reference", () =>
+        OpenApiTypeChecker.isReference(author),
+      );
+    }
+  }
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_array.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_array.ts
@@ -1,0 +1,46 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_array = (): void => {
+  interface IInput {
+    basic: string[];
+    constrained: number[] & tags.MinItems<1> & tags.MaxItems<10>;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const constrained = props["constrained"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (constrained === undefined) return TestValidator.error("no constrained");
+
+  TestValidator.predicate("basic is array", () => LlmTypeChecker.isArray(basic));
+  if (LlmTypeChecker.isArray(basic)) {
+    TestValidator.predicate("basic items is string", () =>
+      LlmTypeChecker.isString(basic.items),
+    );
+  }
+
+  TestValidator.predicate("constrained is array", () =>
+    LlmTypeChecker.isArray(constrained),
+  );
+  if (LlmTypeChecker.isArray(constrained)) {
+    TestValidator.equals("minItems", constrained.minItems, 1);
+    TestValidator.equals("maxItems", constrained.maxItems, 10);
+  }
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_boolean.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_boolean.ts
@@ -1,0 +1,34 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_boolean = (): void => {
+  interface IInput {
+    flag: boolean;
+    active: boolean;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const flag = props["flag"];
+  const active = props["active"];
+
+  if (flag === undefined) return TestValidator.error("no flag");
+  if (active === undefined) return TestValidator.error("no active");
+
+  TestValidator.predicate("flag is boolean", () => LlmTypeChecker.isBoolean(flag));
+  TestValidator.predicate("active is boolean", () => LlmTypeChecker.isBoolean(active));
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_enum.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_enum.ts
@@ -1,0 +1,42 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_enum = (): void => {
+  type Status = "pending" | "active" | "completed";
+  interface IInput {
+    status: Status;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const status = props["status"];
+  if (status === undefined) return TestValidator.error("no status");
+
+  // LLM schema uses string type with enum array
+  TestValidator.predicate("status is string", () => LlmTypeChecker.isString(status));
+  if (LlmTypeChecker.isString(status)) {
+    const enumValues = status.enum;
+    if (enumValues === undefined) return TestValidator.error("no enum values");
+
+    TestValidator.predicate("has pending", () => enumValues.includes("pending"));
+    TestValidator.predicate("has active", () => enumValues.includes("active"));
+    TestValidator.predicate("has completed", () =>
+      enumValues.includes("completed"),
+    );
+    TestValidator.equals("enum count", enumValues.length, 3);
+  }
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_nullable.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_nullable.ts
@@ -1,0 +1,46 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_nullable = (): void => {
+  interface IInput {
+    nullable: string | null;
+    required: string;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const nullable = props["nullable"];
+  const required = props["required"];
+
+  if (nullable === undefined) return TestValidator.error("no nullable");
+  if (required === undefined) return TestValidator.error("no required");
+
+  // LLM schema uses anyOf for nullable
+  TestValidator.predicate("nullable is anyOf", () =>
+    LlmTypeChecker.isAnyOf(nullable),
+  );
+  if (LlmTypeChecker.isAnyOf(nullable)) {
+    const hasString = nullable.anyOf.some((s) => LlmTypeChecker.isString(s));
+    const hasNull = nullable.anyOf.some((s) => LlmTypeChecker.isNull(s));
+    TestValidator.predicate("has string in anyOf", () => hasString);
+    TestValidator.predicate("has null in anyOf", () => hasNull);
+  }
+
+  TestValidator.predicate("required is string", () =>
+    LlmTypeChecker.isString(required),
+  );
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_number.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_number.ts
@@ -1,0 +1,53 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_number = (): void => {
+  interface IInput {
+    basic: number;
+    int32: number & tags.Type<"int32">;
+    range: number & tags.Minimum<0> & tags.Maximum<100>;
+    multipleOf: number & tags.MultipleOf<5>;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const int32 = props["int32"];
+  const range = props["range"];
+  const multipleOf = props["multipleOf"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (int32 === undefined) return TestValidator.error("no int32");
+  if (range === undefined) return TestValidator.error("no range");
+  if (multipleOf === undefined) return TestValidator.error("no multipleOf");
+
+  TestValidator.predicate("basic is number", () => LlmTypeChecker.isNumber(basic));
+  TestValidator.predicate("int32 is integer", () => LlmTypeChecker.isInteger(int32));
+
+  TestValidator.predicate("range is number", () => LlmTypeChecker.isNumber(range));
+  if (LlmTypeChecker.isNumber(range)) {
+    TestValidator.equals("minimum", range.minimum, 0);
+    TestValidator.equals("maximum", range.maximum, 100);
+  }
+
+  TestValidator.predicate("multipleOf is number", () =>
+    LlmTypeChecker.isNumber(multipleOf),
+  );
+  if (LlmTypeChecker.isNumber(multipleOf)) {
+    TestValidator.equals("multipleOf value", multipleOf.multipleOf, 5);
+  }
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_object.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_object.ts
@@ -1,0 +1,53 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_object = (): void => {
+  interface INested {
+    value: number;
+  }
+  interface IInput {
+    name: string;
+    nested: INested;
+    optional?: string;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const name = props["name"];
+  const nested = props["nested"];
+
+  if (name === undefined) return TestValidator.error("no name");
+  if (nested === undefined) return TestValidator.error("no nested");
+
+  TestValidator.predicate("name is string", () => LlmTypeChecker.isString(name));
+
+  // nested is $ref to INested
+  TestValidator.predicate("nested is reference", () =>
+    LlmTypeChecker.isReference(nested),
+  );
+
+  // Check required fields
+  const required = actual.required ?? [];
+  TestValidator.predicate("name is required", () => required.includes("name"));
+  TestValidator.predicate("nested is required", () =>
+    required.includes("nested"),
+  );
+
+  // INested should be in $defs
+  const nestedKeys = Object.keys($defs).filter((k) => k.includes("INested"));
+  TestValidator.predicate("INested in $defs", () => nestedKeys.length > 0);
+};

--- a/tests/test-typia/src/features/llm.schema/test_llm_schema_string.ts
+++ b/tests/test-typia/src/features/llm.schema/test_llm_schema_string.ts
@@ -1,0 +1,51 @@
+import { LlmTypeChecker } from "@typia/utils";
+import typia, { tags } from "typia";
+
+import { TestValidator } from "../../TestValidator";
+
+export const test_llm_schema_string = (): void => {
+  interface IInput {
+    basic: string;
+    email: string & tags.Format<"email">;
+    pattern: string & tags.Pattern<"^[a-z]+$">;
+    length: string & tags.MinLength<1> & tags.MaxLength<100>;
+  }
+
+  const $defs: Record<string, unknown> = {};
+  const schema = typia.llm.schema<IInput, "chatgpt">($defs);
+
+  TestValidator.predicate("is reference", () => LlmTypeChecker.isReference(schema));
+
+  const refName = (schema as { $ref: string }).$ref.replace("#/$defs/", "");
+  const actual = $defs[refName];
+  if (actual === undefined) return TestValidator.error("schema not in $defs");
+  if (!LlmTypeChecker.isObject(actual))
+    return TestValidator.error("not object");
+
+  const props = actual.properties;
+  if (props === undefined) return TestValidator.error("no properties");
+
+  const basic = props["basic"];
+  const email = props["email"];
+  const pattern = props["pattern"];
+  const length = props["length"];
+
+  if (basic === undefined) return TestValidator.error("no basic");
+  if (email === undefined) return TestValidator.error("no email");
+  if (pattern === undefined) return TestValidator.error("no pattern");
+  if (length === undefined) return TestValidator.error("no length");
+
+  TestValidator.predicate("basic is string", () => LlmTypeChecker.isString(basic));
+  TestValidator.predicate("email is string", () => LlmTypeChecker.isString(email));
+
+  TestValidator.predicate("pattern is string", () => LlmTypeChecker.isString(pattern));
+  if (LlmTypeChecker.isString(pattern)) {
+    TestValidator.equals("pattern value", pattern.pattern, "^[a-z]+$");
+  }
+
+  TestValidator.predicate("length is string", () => LlmTypeChecker.isString(length));
+  if (LlmTypeChecker.isString(length)) {
+    TestValidator.equals("minLength", length.minLength, 1);
+    TestValidator.equals("maxLength", length.maxLength, 100);
+  }
+};


### PR DESCRIPTION
This pull request introduces a new test suite for validating Typia's JSON schema generation features. It adds a dedicated package for these tests, including comprehensive coverage for various schema types and constraints, and utilities for argument parsing. The main changes are grouped below.

Addition of new test package:

* Added a new test package `tests/test-typia-schema` with its own `package.json` and dependency configuration in `pnpm-lock.yaml`. This package is designed to test Typia's JSON schema, LLM schema, and protobuf message features. [[1]](diffhunk://#diff-660e52a174c4ab8a4e948a59ddf1bf6f121deb42ddcf923924e9d76f4d5d61d8R1-R42) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR854-R899)

Test coverage for JSON schema features:

* Implemented test files for JSON schema generation, covering arrays, booleans, numbers, strings, objects, tuples, unions, enums, nullable types, recursive types, and discriminated unions. Each test validates schema structure and constraints using `TestValidator` and `OpenApiTypeChecker`. [[1]](diffhunk://#diff-ec6858566580daf01df3e663f10d0b331714be6a0dd74b7a87d28226b66d683cR1-R37) [[2]](diffhunk://#diff-7b8713303e0ca39f132411d0995309bd511717e1f15fc79aeaa82535adfc32b8R1-R12) [[3]](diffhunk://#diff-d945bd4056aaddf0b011a3bd21f7b2b199d26866467dec81d3ea061713a025f9R1-R46) [[4]](diffhunk://#diff-b562b49e5d857eaffe8340713c037b107917e581ae47dd2ed6ccb3288f277a95R1-R42) [[5]](diffhunk://#diff-4a0b8c36178fd461881860d8c5dc4b80afd973ffe7b5ed3c3d9187fe53fd42e5R1-R58) [[6]](diffhunk://#diff-a19e1adfe4d7acc14306ca5c2b4828e86169c7b5b674d2d578889b461da90c1eR1-R27) [[7]](diffhunk://#diff-4bb10aeeb789923ebefbf102dac70d1816ade6b421d0392749f0638226ebf6a0R1-R24) [[8]](diffhunk://#diff-38329483841653e115ffb79aaf636ea37c54041cdf7e11ac0bda43b7c34c5404R1-R44) [[9]](diffhunk://#diff-8b858e77122f40c828ea4d245c1143c2746c76cf943b2881fe60fd54dfe4c57eR1-R23) [[10]](diffhunk://#diff-9e682169d4d8c8eb8664dd540efac71d49636d061f01201486eccaead29a620cR1-R52) [[11]](diffhunk://#diff-95f0c091a3f6e96dbed4b03c8915b0aea3f8e4d61d26711a9aa02555f8d4d87eR1-R72)

Test utilities and helpers:

* Added `TestGlobal.ts` utility for parsing command-line arguments within the test suite.

Collection and components testing:

* Added tests for `typia.json.schemas` collection, verifying correct handling of multiple schemas and component references for named types.