### PR TITLE
feat(test): test reflect functions.

### DIFF
--- a/packages/transform/src/CallExpressionTransformer.ts
+++ b/packages/transform/src/CallExpressionTransformer.ts
@@ -116,6 +116,8 @@ import { ProtobufValidateDecodeTransformer } from "./features/protobuf/ProtobufV
 import { ProtobufValidateEncodeTransformer } from "./features/protobuf/ProtobufValidateEncodeTransformer";
 import { ReflectMetadataTransformer } from "./features/reflect/ReflectMetadataTransformer";
 import { ReflectNameTransformer } from "./features/reflect/ReflectNameTransformer";
+import { ReflectSchemaTransformer } from "./features/reflect/ReflectSchemaTransformer";
+import { ReflectSchemasTransformer } from "./features/reflect/ReflectSchemasTransformer";
 
 /**
  * Transforms `typia.*` function call expressions.
@@ -478,6 +480,8 @@ const FUNCTORS: Record<string, Record<string, () => Task>> = {
   reflect: {
     metadata: () => ReflectMetadataTransformer.transform,
     name: () => ReflectNameTransformer.transform,
+    schema: () => ReflectSchemaTransformer.transform,
+    schemas: () => ReflectSchemasTransformer.transform,
   },
   misc: {
     literals: () => MiscLiteralsTransformer.transform,

--- a/packages/transform/src/features/reflect/ReflectSchemaTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectSchemaTransformer.ts
@@ -1,0 +1,65 @@
+import {
+  LiteralFactory,
+  MetadataFactory,
+  MetadataSchema,
+  MetadataStorage,
+} from "@typia/core";
+import { IMetadataSchemaUnit } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace ReflectSchemaTransformer {
+  export const transform = (
+    props: Pick<ITransformProps, "context" | "expression">,
+  ): ts.Expression => {
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.reflect.schema",
+        message: "no generic argument.",
+      });
+
+    // VALIDATE ARGUMENT
+    const top: ts.Node | undefined = props.expression.typeArguments[0];
+    if (top === undefined || ts.isTypeNode(top) === false)
+      return props.expression;
+
+    // GET TYPE
+    const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
+    if (type.isTypeParameter())
+      throw new TransformerError({
+        code: "typia.reflect.schema",
+        message: "non-specified generic argument.",
+      });
+
+    // METADATA
+    const components: MetadataStorage = new MetadataStorage();
+    const result = MetadataFactory.analyze({
+      checker: props.context.checker,
+      transformer: props.context.transformer,
+      options: {
+        escape: true,
+        constant: true,
+        absorb: true,
+        functional: true,
+      },
+      components: components,
+      type,
+    });
+    if (result.success === false)
+      throw TransformerError.from({
+        code: "typia.reflect.schema",
+        errors: result.errors,
+      });
+
+    const schema: MetadataSchema = result.data;
+
+    // CONVERT TO PRIMITIVE TYPE
+    const unit: IMetadataSchemaUnit = {
+      schema: schema.toJSON(),
+      components: components.toJSON(),
+    };
+    return LiteralFactory.write(unit);
+  };
+}

--- a/packages/transform/src/features/reflect/ReflectSchemasTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectSchemasTransformer.ts
@@ -1,0 +1,69 @@
+import {
+  LiteralFactory,
+  MetadataFactory,
+  MetadataSchema,
+  MetadataStorage,
+} from "@typia/core";
+import { IMetadataSchemaCollection } from "@typia/interface";
+import ts from "typescript";
+
+import { ITransformProps } from "../../ITransformProps";
+import { TransformerError } from "../../TransformerError";
+
+export namespace ReflectSchemasTransformer {
+  export const transform = (
+    props: Pick<ITransformProps, "context" | "expression">,
+  ): ts.Expression => {
+    if (!props.expression.typeArguments?.length)
+      throw new TransformerError({
+        code: "typia.reflect.schemas",
+        message: "no generic argument.",
+      });
+
+    // VALIDATE TUPLE ARGUMENTS
+    const top: ts.Node = props.expression.typeArguments[0]!;
+    if (!ts.isTupleTypeNode(top)) return props.expression;
+    else if (top.elements.some((child) => !ts.isTypeNode(child)))
+      return props.expression;
+
+    // GET TYPES
+    const types: ts.Type[] = top.elements.map((child) =>
+      props.context.checker.getTypeFromTypeNode(child as ts.TypeNode),
+    );
+    if (types.some((t) => t.isTypeParameter()))
+      throw new TransformerError({
+        code: "typia.reflect.schemas",
+        message: "non-specified generic argument(s).",
+      });
+
+    // METADATA
+    const components: MetadataStorage = new MetadataStorage();
+    const schemas: Array<MetadataSchema> = types.map((type) => {
+      const result = MetadataFactory.analyze({
+        checker: props.context.checker,
+        transformer: props.context.transformer,
+        options: {
+          escape: true,
+          constant: true,
+          absorb: true,
+          functional: true,
+        },
+        components: components,
+        type,
+      });
+      if (result.success === false)
+        throw TransformerError.from({
+          code: "typia.reflect.schemas",
+          errors: result.errors,
+        });
+      return result.data;
+    });
+
+    // CONVERT TO PRIMITIVE TYPE
+    const collection: IMetadataSchemaCollection = {
+      schemas: schemas.map((s) => s.toJSON()),
+      components: components.toJSON(),
+    };
+    return LiteralFactory.write(collection);
+  };
+}

--- a/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_array.ts
+++ b/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_array.ts
@@ -1,0 +1,12 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_name_array = (): void => {
+  TestValidator.equals("string[]", typia.reflect.name<string[]>(), "string[]");
+  TestValidator.equals("number[]", typia.reflect.name<number[]>(), "number[]");
+  TestValidator.equals(
+    "boolean[][]",
+    typia.reflect.name<boolean[][]>(),
+    "boolean[][]",
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_object.ts
+++ b/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_object.ts
@@ -1,0 +1,11 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_name_object = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+  }
+
+  TestValidator.equals("named object", typia.reflect.name<IMember>(), "IMember");
+};

--- a/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_primitive.ts
+++ b/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_primitive.ts
@@ -1,0 +1,11 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_name_primitive = (): void => {
+  TestValidator.equals("string", typia.reflect.name<string>(), "string");
+  TestValidator.equals("number", typia.reflect.name<number>(), "number");
+  TestValidator.equals("boolean", typia.reflect.name<boolean>(), "boolean");
+  TestValidator.equals("bigint", typia.reflect.name<bigint>(), "bigint");
+  TestValidator.equals("null", typia.reflect.name<null>(), "null");
+  TestValidator.equals("undefined", typia.reflect.name<undefined>(), "undefined");
+};

--- a/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_tuple.ts
+++ b/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_tuple.ts
@@ -1,0 +1,15 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_name_tuple = (): void => {
+  TestValidator.equals(
+    "[string, number]",
+    typia.reflect.name<[string, number]>(),
+    "[string, number]",
+  );
+  TestValidator.equals(
+    "[boolean, string, number]",
+    typia.reflect.name<[boolean, string, number]>(),
+    "[boolean, string, number]",
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_union.ts
+++ b/tests/test-typia-schema/src/features/reflect.name/test_reflect_name_union.ts
@@ -1,0 +1,15 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_name_union = (): void => {
+  TestValidator.equals(
+    "string | number",
+    typia.reflect.name<string | number>(),
+    "string | number",
+  );
+  TestValidator.equals(
+    "string | null",
+    typia.reflect.name<string | null>(),
+    "string | null",
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_array.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_array.ts
@@ -1,0 +1,41 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_array = (): void => {
+  // string[]
+  const stringArrayUnit = typia.reflect.schema<string[]>();
+  TestValidator.equals(
+    "arrays length",
+    stringArrayUnit.schema.arrays.length,
+    1,
+  );
+  TestValidator.predicate(
+    "arrays name",
+    () => !!stringArrayUnit.schema.arrays[0]?.name.includes("string"),
+  );
+
+  // components has array definition
+  TestValidator.equals(
+    "components arrays length",
+    stringArrayUnit.components.arrays.length,
+    1,
+  );
+  TestValidator.equals(
+    "array element is string",
+    stringArrayUnit.components.arrays[0]?.value.atomics[0]?.type,
+    "string",
+  );
+
+  // number[]
+  const numberArrayUnit = typia.reflect.schema<number[]>();
+  TestValidator.equals(
+    "number arrays length",
+    numberArrayUnit.schema.arrays.length,
+    1,
+  );
+  TestValidator.equals(
+    "number array element",
+    numberArrayUnit.components.arrays[0]?.value.atomics[0]?.type,
+    "number",
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_constant.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_constant.ts
@@ -1,0 +1,22 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_constant = (): void => {
+  // string literal
+  const stringLiteral = typia.reflect.schema<"hello">();
+  TestValidator.equals("constants length", stringLiteral.schema.constants.length, 1);
+  TestValidator.equals("constant type", stringLiteral.schema.constants[0]?.type, "string");
+  TestValidator.equals("constant value", stringLiteral.schema.constants[0]?.values[0]?.value, "hello");
+
+  // number literal
+  const numberLiteral = typia.reflect.schema<42>();
+  TestValidator.equals("number constants length", numberLiteral.schema.constants.length, 1);
+  TestValidator.equals("number constant type", numberLiteral.schema.constants[0]?.type, "number");
+  TestValidator.equals("number constant value", numberLiteral.schema.constants[0]?.values[0]?.value, 42);
+
+  // boolean literal
+  const booleanLiteral = typia.reflect.schema<true>();
+  TestValidator.equals("boolean constants length", booleanLiteral.schema.constants.length, 1);
+  TestValidator.equals("boolean constant type", booleanLiteral.schema.constants[0]?.type, "boolean");
+  TestValidator.equals("boolean constant value", booleanLiteral.schema.constants[0]?.values[0]?.value, true);
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_enum.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_enum.ts
@@ -1,0 +1,23 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_enum = (): void => {
+  // string enum
+  type Color = "red" | "green" | "blue";
+  const colorUnit = typia.reflect.schema<Color>();
+  TestValidator.equals("constants length", colorUnit.schema.constants.length, 1);
+  TestValidator.equals("constant type", colorUnit.schema.constants[0]?.type, "string");
+  TestValidator.equals("values length", colorUnit.schema.constants[0]?.values.length, 3);
+
+  const values = colorUnit.schema.constants[0]?.values.map((v) => v.value) ?? [];
+  TestValidator.predicate("has red", () => values.includes("red"));
+  TestValidator.predicate("has green", () => values.includes("green"));
+  TestValidator.predicate("has blue", () => values.includes("blue"));
+
+  // number enum
+  type Status = 0 | 1 | 2;
+  const statusUnit = typia.reflect.schema<Status>();
+  TestValidator.equals("number constants length", statusUnit.schema.constants.length, 1);
+  TestValidator.equals("number constant type", statusUnit.schema.constants[0]?.type, "number");
+  TestValidator.equals("number values length", statusUnit.schema.constants[0]?.values.length, 3);
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_nullable.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_nullable.ts
@@ -1,0 +1,15 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_nullable = (): void => {
+  // nullable string
+  const nullableUnit = typia.reflect.schema<string | null>();
+  TestValidator.equals("nullable is true", nullableUnit.schema.nullable, true);
+  TestValidator.equals("atomics length", nullableUnit.schema.atomics.length, 1);
+  TestValidator.equals("atomic type is string", nullableUnit.schema.atomics[0]?.type, "string");
+
+  // string | undefined (not optional, but not required)
+  const undefinedUnit = typia.reflect.schema<string | undefined>();
+  TestValidator.equals("required is false", undefinedUnit.schema.required, false);
+  TestValidator.equals("atomics length for undefined union", undefinedUnit.schema.atomics.length, 1);
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_object.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_object.ts
@@ -1,0 +1,49 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_object = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+    email?: string;
+  }
+
+  const unit = typia.reflect.schema<IMember>();
+
+  // schema has objects reference
+  TestValidator.equals("objects length", unit.schema.objects.length, 1);
+  TestValidator.equals("object name", unit.schema.objects[0]?.name, "IMember");
+
+  // components has object definition
+  TestValidator.equals("components objects length", unit.components.objects.length, 1);
+
+  const obj = unit.components.objects[0];
+  if (obj === undefined) return;
+
+  TestValidator.equals("object name in components", obj.name, "IMember");
+  TestValidator.equals("properties count", obj.properties.length, 3);
+
+  // check property names
+  const propNames = obj.properties.map((p) => {
+    const key = p.key;
+    if (key.constants.length > 0 && key.constants[0]?.type === "string") {
+      return key.constants[0].values[0]?.value;
+    }
+    return undefined;
+  });
+
+  TestValidator.predicate("has id property", () => propNames.includes("id"));
+  TestValidator.predicate("has name property", () => propNames.includes("name"));
+  TestValidator.predicate("has email property", () => propNames.includes("email"));
+
+  // check optional property
+  const emailProp = obj.properties.find((p) => {
+    const key = p.key;
+    if (key.constants.length > 0 && key.constants[0]?.type === "string") {
+      return key.constants[0].values[0]?.value === "email";
+    }
+    return false;
+  });
+
+  TestValidator.predicate("email is optional", () => emailProp?.value.optional === true);
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_primitive.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_primitive.ts
@@ -1,0 +1,24 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_primitive = (): void => {
+  // string
+  const stringUnit = typia.reflect.schema<string>();
+  TestValidator.equals("string atomics length", stringUnit.schema.atomics.length, 1);
+  TestValidator.equals("string atomic type", stringUnit.schema.atomics[0]?.type, "string");
+
+  // number
+  const numberUnit = typia.reflect.schema<number>();
+  TestValidator.equals("number atomics length", numberUnit.schema.atomics.length, 1);
+  TestValidator.equals("number atomic type", numberUnit.schema.atomics[0]?.type, "number");
+
+  // boolean
+  const booleanUnit = typia.reflect.schema<boolean>();
+  TestValidator.equals("boolean atomics length", booleanUnit.schema.atomics.length, 1);
+  TestValidator.equals("boolean atomic type", booleanUnit.schema.atomics[0]?.type, "boolean");
+
+  // bigint
+  const bigintUnit = typia.reflect.schema<bigint>();
+  TestValidator.equals("bigint atomics length", bigintUnit.schema.atomics.length, 1);
+  TestValidator.equals("bigint atomic type", bigintUnit.schema.atomics[0]?.type, "bigint");
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_tuple.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_tuple.ts
@@ -1,0 +1,20 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_tuple = (): void => {
+  const unit = typia.reflect.schema<[string, number, boolean]>();
+
+  // schema has tuples reference
+  TestValidator.equals("tuples length", unit.schema.tuples.length, 1);
+
+  // components has tuple definition
+  TestValidator.equals("components tuples length", unit.components.tuples.length, 1);
+
+  const tuple = unit.components.tuples[0];
+  if (tuple === undefined) return;
+
+  TestValidator.equals("tuple elements count", tuple.elements.length, 3);
+  TestValidator.equals("first element is string", tuple.elements[0]?.atomics[0]?.type, "string");
+  TestValidator.equals("second element is number", tuple.elements[1]?.atomics[0]?.type, "number");
+  TestValidator.equals("third element is boolean", tuple.elements[2]?.atomics[0]?.type, "boolean");
+};

--- a/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_union.ts
+++ b/tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_union.ts
@@ -1,0 +1,29 @@
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+export const test_reflect_schema_union = (): void => {
+  // primitive union
+  const primitiveUnion = typia.reflect.schema<string | number>();
+  TestValidator.equals("atomics length", primitiveUnion.schema.atomics.length, 2);
+
+  const types = primitiveUnion.schema.atomics.map((a) => a.type);
+  TestValidator.predicate("has string", () => types.includes("string"));
+  TestValidator.predicate("has number", () => types.includes("number"));
+
+  // object union
+  interface ICat {
+    type: "cat";
+    meow: string;
+  }
+  interface IDog {
+    type: "dog";
+    bark: string;
+  }
+
+  const objectUnion = typia.reflect.schema<ICat | IDog>();
+  TestValidator.equals("objects length", objectUnion.schema.objects.length, 2);
+
+  const objectNames = objectUnion.schema.objects.map((o) => o.name);
+  TestValidator.predicate("has ICat", () => objectNames.includes("ICat"));
+  TestValidator.predicate("has IDog", () => objectNames.includes("IDog"));
+};

--- a/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas.ts
+++ b/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas.ts
@@ -1,0 +1,37 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IMetadataSchemaCollection } from "typia";
+
+export const test_reflect_schemas = (): void => {
+  interface IMember {
+    id: number;
+    name: string;
+  }
+  interface IArticle {
+    title: string;
+    body: string;
+    author: IMember;
+  }
+
+  const collection: IMetadataSchemaCollection = typia.reflect.schemas<
+    [IMember, IArticle, string, number]
+  >();
+
+  // schemas array has 4 items
+  TestValidator.equals("schemas count", collection.schemas.length, 4);
+
+  // first two are object types
+  TestValidator.equals("IMember objects length", collection.schemas[0]?.objects.length, 1);
+  TestValidator.equals("IArticle objects length", collection.schemas[1]?.objects.length, 1);
+
+  // last two are primitives
+  TestValidator.equals("string atomics length", collection.schemas[2]?.atomics.length, 1);
+  TestValidator.equals("number atomics length", collection.schemas[3]?.atomics.length, 1);
+
+  // components has both named object types
+  TestValidator.predicate("components has IMember", () =>
+    collection.components.objects.some((o) => o.name === "IMember"),
+  );
+  TestValidator.predicate("components has IArticle", () =>
+    collection.components.objects.some((o) => o.name === "IArticle"),
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_array.ts
+++ b/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_array.ts
@@ -1,0 +1,35 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IMetadataSchemaCollection } from "typia";
+
+export const test_reflect_schemas_array = (): void => {
+  const collection: IMetadataSchemaCollection = typia.reflect.schemas<
+    [string[], number[], boolean[]]
+  >();
+
+  TestValidator.equals("schemas count", collection.schemas.length, 3);
+
+  // each schema has arrays reference
+  TestValidator.equals("first schema arrays", collection.schemas[0]?.arrays.length, 1);
+  TestValidator.equals("second schema arrays", collection.schemas[1]?.arrays.length, 1);
+  TestValidator.equals("third schema arrays", collection.schemas[2]?.arrays.length, 1);
+
+  // components has array definitions
+  TestValidator.equals("components arrays count", collection.components.arrays.length, 3);
+
+  // check array element types
+  TestValidator.equals(
+    "first array element",
+    collection.components.arrays[0]?.value.atomics[0]?.type,
+    "string",
+  );
+  TestValidator.equals(
+    "second array element",
+    collection.components.arrays[1]?.value.atomics[0]?.type,
+    "number",
+  );
+  TestValidator.equals(
+    "third array element",
+    collection.components.arrays[2]?.value.atomics[0]?.type,
+    "boolean",
+  );
+};

--- a/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_components.ts
+++ b/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_components.ts
@@ -1,0 +1,42 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IMetadataSchemaCollection } from "typia";
+
+export const test_reflect_schemas_components = (): void => {
+  interface IBase {
+    id: number;
+  }
+  interface IChild extends IBase {
+    name: string;
+    parent?: IChild;
+  }
+
+  const collection: IMetadataSchemaCollection = typia.reflect.schemas<
+    [IBase, IChild]
+  >();
+
+  TestValidator.equals("schemas count", collection.schemas.length, 2);
+
+  // components has both types
+  TestValidator.predicate("has IBase", () =>
+    collection.components.objects.some((o) => o.name === "IBase"),
+  );
+  TestValidator.predicate("has IChild", () =>
+    collection.components.objects.some((o) => o.name === "IChild"),
+  );
+
+  // check recursive type
+  const child = collection.components.objects.find((o) => o.name === "IChild");
+  TestValidator.predicate("IChild is recursive", () => child?.recursive === true);
+
+  // check IChild has parent property
+  TestValidator.predicate("IChild has parent property", () => {
+    if (!child) return false;
+    return child.properties.some((p) => {
+      const key = p.key;
+      if (key.constants.length > 0 && key.constants[0]?.type === "string") {
+        return key.constants[0].values[0]?.value === "parent";
+      }
+      return false;
+    });
+  });
+};

--- a/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_primitive.ts
+++ b/tests/test-typia-schema/src/features/reflect.schemas/test_reflect_schemas_primitive.ts
@@ -1,0 +1,21 @@
+import { TestValidator } from "@nestia/e2e";
+import typia, { IMetadataSchemaCollection } from "typia";
+
+export const test_reflect_schemas_primitive = (): void => {
+  const collection: IMetadataSchemaCollection = typia.reflect.schemas<
+    [string, number, boolean, bigint]
+  >();
+
+  TestValidator.equals("schemas count", collection.schemas.length, 4);
+
+  TestValidator.equals("string type", collection.schemas[0]?.atomics[0]?.type, "string");
+  TestValidator.equals("number type", collection.schemas[1]?.atomics[0]?.type, "number");
+  TestValidator.equals("boolean type", collection.schemas[2]?.atomics[0]?.type, "boolean");
+  TestValidator.equals("bigint type", collection.schemas[3]?.atomics[0]?.type, "bigint");
+
+  // primitives don't create components
+  TestValidator.equals("objects count", collection.components.objects.length, 0);
+  TestValidator.equals("arrays count", collection.components.arrays.length, 0);
+  TestValidator.equals("tuples count", collection.components.tuples.length, 0);
+  TestValidator.equals("aliases count", collection.components.aliases.length, 0);
+};


### PR DESCRIPTION
This pull request adds support for schema reflection in the `typia.reflect` API, enabling users to obtain detailed type schema information for TypeScript types and tuples of types at compile time. It introduces two new transformers—`ReflectSchemaTransformer` and `ReflectSchemasTransformer`—and integrates them into the main transformation pipeline. Comprehensive tests are also added to validate schema reflection for various type constructs, including primitives, arrays, tuples, unions, objects, enums, constants, and nullable types.

### Core Feature Additions

* Added `ReflectSchemaTransformer` and `ReflectSchemasTransformer` to provide schema reflection for single types and tuples of types, respectively. These transformers analyze type nodes and produce metadata schema objects, handling errors for missing or unspecified generic arguments. (`packages/transform/src/features/reflect/ReflectSchemaTransformer.ts` [[1]](diffhunk://#diff-bce2b0b2e20baf1794aab971169d0f905805ca75212329553833b66925152e8aR1-R65) `packages/transform/src/features/reflect/ReflectSchemasTransformer.ts` [[2]](diffhunk://#diff-46e5152ac17837a21d036b44a7280790ab0d19b7fdee282edc447f2bd0f7d612R1-R69)
* Registered the new transformers in the main `CallExpressionTransformer`, enabling the use of `typia.reflect.schema<T>()` and `typia.reflect.schemas<[T1, T2, ...]>()` in user code. (`packages/transform/src/CallExpressionTransformer.ts` [[1]](diffhunk://#diff-8a001d0eb47041ffd9d4c1d93a9737d3e7bbb257b97f1275833bb8d4ac577f60R119-R120) [[2]](diffhunk://#diff-8a001d0eb47041ffd9d4c1d93a9737d3e7bbb257b97f1275833bb8d4ac577f60R483-R484)

### Testing and Validation

* Added extensive test coverage for the new schema reflection features, including tests for primitives, arrays, tuples, unions, objects, enums, constants, and nullable types. These tests use `TestValidator` to assert the correctness of the generated schemas and their components. (`tests/test-typia-schema/src/features/reflect.schema/test_reflect_schema_primitive.ts` [[1]](diffhunk://#diff-4f4909796a2722adc4574162bd3c475c5068b3175e35020439421058f33f0f2eR1-R24) `test_reflect_schema_array.ts` [[2]](diffhunk://#diff-4e4b5cc9681334add8224794eaa340def68e896a371e5f1aa3e2fd2466ccb92fR1-R41) `test_reflect_schema_tuple.ts` [[3]](diffhunk://#diff-b9baa1e7049f9b9a89eab066dfec15fde43f61c5e7cafd7a05bab3faaebfa6c0R1-R20) `test_reflect_schema_union.ts` [[4]](diffhunk://#diff-613357801d37a1cd6fe7f4f226475971315284f3e148408e7d0b7f836115b7deR1-R29) `test_reflect_schema_object.ts` [[5]](diffhunk://#diff-33dea2641451122333fb8076ba61ef0176c77fcc1eb22a54ce31afe6af5c9f06R1-R49) `test_reflect_schema_enum.ts` [[6]](diffhunk://#diff-c37a4165b7ae9c228e08541f8daa42795710a9cbe3cf31c4f4eeeb0e55ecff0bR1-R23) `test_reflect_schema_constant.ts` [[7]](diffhunk://#diff-19b9af71b3a8321f176d3adbbb8121c8b826867ddea7232c8c0bb502617e5186R1-R22) `test_reflect_schema_nullable.ts` [[8]](diffhunk://#diff-1192916d0637b3e2cd6c9f0fd105a36d6a0ceb7fa4730406bdc15c2615aa91caR1-R15) `test_reflect_schemas.ts` [[9]](diffhunk://#diff-430935403a25438251fce2254fb62fbb4a5f2b2a2ac555fd4a4eb9544b90b9daR1-R37) `test_reflect_schemas_array.ts` [[10]](diffhunk://#diff-e65b2cf0b976d7082a964c1bc5a45064e8c638262f94bb9fae5e3029b10ebcf0R1-R35)

### Other Reflection Improvements

* Added tests for `typia.reflect.name<T>()` covering arrays, objects, primitives, tuples, and unions, ensuring that type name reflection works as expected. (`test_reflect_name_array.ts` [[1]](diffhunk://#diff-a98b4eb28412259560f728a839af9984f813d694450c33ac519fdfa1c3c14851R1-R12) `test_reflect_name_object.ts` [[2]](diffhunk://#diff-50cdde37ba63b78ccad8b100a6bd9482fc1cfba6d62506ed5881694c29ae356dR1-R11) `test_reflect_name_primitive.ts` [[3]](diffhunk://#diff-7cd9e834ed059f711f24950a7617b785c1aa5f3b180f2a17496b781c517d66e1R1-R11) `test_reflect_name_tuple.ts` [[4]](diffhunk://#diff-c47baa51587a5ac736dce4b4e40cb25750d522795f37bd9a9e425e7e37f2b81dR1-R15) `test_reflect_name_union.ts` [[5]](diffhunk://#diff-a6118ebefbbaf008d391d92bb15fd873dcd91ed0a7b99bb4fe327bf41324e1d8R1-R15)