### PR TITLE
fix(test): propagate error from `pnpm test`.

### DIFF
--- a/tests/test-langchain/src/index.ts
+++ b/tests/test-langchain/src/index.ts
@@ -45,5 +45,7 @@ const main = async (): Promise<void> => {
 
   if (exceptions.length) process.exit(-1);
 };
-
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/tests/test-mcp/src/index.ts
+++ b/tests/test-mcp/src/index.ts
@@ -45,5 +45,7 @@ const main = async (): Promise<void> => {
 
   if (exceptions.length) process.exit(-1);
 };
-
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/tests/test-typia-schema/src/index.ts
+++ b/tests/test-typia-schema/src/index.ts
@@ -42,4 +42,7 @@ const main = async (): Promise<void> => {
   }
   if (exceptions.length) process.exit(-1);
 };
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/tests/test-utils/src/index.ts
+++ b/tests/test-utils/src/index.ts
@@ -42,4 +42,7 @@ const main = async (): Promise<void> => {
   }
   if (exceptions.length) process.exit(-1);
 };
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/tests/test-vercel/src/index.ts
+++ b/tests/test-vercel/src/index.ts
@@ -45,5 +45,7 @@ const main = async (): Promise<void> => {
 
   if (exceptions.length) process.exit(-1);
 };
-
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});


### PR DESCRIPTION
This pull request improves error handling in the test entry points by ensuring that any uncaught errors during execution will log the error and cause the process to exit with a non-zero status. This makes failures more visible and consistent across all test scripts.

Error handling improvements:

* Updated the error handling in the `main` function of `tests/test-langchain/src/index.ts`, `tests/test-mcp/src/index.ts`, and `tests/test-vercel/src/index.ts` to log the error and exit with status -1 on uncaught exceptions.
* Applied the same error handling update to `tests/test-typia-schema/src/index.ts` and `tests/test-utils/src/index.ts`.