### PR TITLE
feat(core): rename back to `MetadataCollection` again.

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/benchmark",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Benchmark program of typia performance",
   "main": "bin/index.js",
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/config",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Shared build configuration for typia packages",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/examples",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Example codes for typia website",
   "scripts": {
     "build": "rimraf bin && cross-env NODE_OPTIONS=\"--no-experimental-strip-types -r ts-node/register\" tsc && prettier --write bin/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/station",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Typia Station",
   "scripts": {
     "build": "pnpm --filter=./packages/* -r build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/core",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/core/src/factories/JsonMetadataFactory.ts
+++ b/packages/core/src/factories/JsonMetadataFactory.ts
@@ -3,8 +3,8 @@ import ts from "typescript";
 
 import { TransformerError } from "../context/TransformerError";
 import { AtomicPredicator } from "../programmers/helpers/AtomicPredicator";
+import { MetadataCollection } from "../schemas/metadata/MetadataCollection";
 import { MetadataSchema } from "../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../schemas/metadata/MetadataStorage";
 import { MetadataFactory } from "./MetadataFactory";
 
 export namespace JsonMetadataFactory {
@@ -16,12 +16,12 @@ export namespace JsonMetadataFactory {
     validate?: MetadataFactory.Validator;
   }
   export interface IOutput {
-    collection: MetadataStorage;
+    collection: MetadataCollection;
     metadata: MetadataSchema;
   }
 
   export const analyze = (props: IProps): IOutput => {
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
       MetadataFactory.analyze({
         checker: props.checker,

--- a/packages/core/src/factories/MetadataFactory.ts
+++ b/packages/core/src/factories/MetadataFactory.ts
@@ -3,12 +3,12 @@ import ts from "typescript";
 
 import { MetadataAliasType } from "../schemas/metadata/MetadataAliasType";
 import { MetadataArrayType } from "../schemas/metadata/MetadataArrayType";
+import { MetadataCollection } from "../schemas/metadata/MetadataCollection";
 import { MetadataConstant } from "../schemas/metadata/MetadataConstant";
 import { MetadataFunction } from "../schemas/metadata/MetadataFunction";
 import { MetadataObject } from "../schemas/metadata/MetadataObject";
 import { MetadataObjectType } from "../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../schemas/metadata/MetadataStorage";
 import { MetadataTupleType } from "../schemas/metadata/MetadataTupleType";
 import { ExpressionFactory } from "./ExpressionFactory";
 import { explore_metadata } from "./internal/metadata/explore_metadata";
@@ -21,7 +21,7 @@ import { iterate_metadata_sort } from "./internal/metadata/iterate_metadata_sort
  * Analyzes TypeScript types at compile-time and extracts {@link MetadataSchema}
  * containing all type information needed for validation/serialization code
  * generation. Handles unions, intersections, generics, type aliases, and
- * collects reusable components into {@link MetadataStorage}.
+ * collects reusable components into {@link MetadataCollection}.
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
@@ -41,7 +41,7 @@ export namespace MetadataFactory {
     options: IOptions;
 
     /** Storage for collected metadata components. */
-    components: MetadataStorage;
+    components: MetadataCollection;
 
     /** Type to analyze. */
     type: ts.Type | null;

--- a/packages/core/src/factories/ProtobufFactory.ts
+++ b/packages/core/src/factories/ProtobufFactory.ts
@@ -7,10 +7,10 @@ import ts from "typescript";
 
 import { TransformerError } from "../context/TransformerError";
 import { ProtobufUtil } from "../programmers/helpers/ProtobufUtil";
+import { MetadataCollection } from "../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../schemas/metadata/MetadataObjectType";
 import { MetadataProperty } from "../schemas/metadata/MetadataProperty";
 import { MetadataSchema } from "../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../schemas/metadata/MetadataStorage";
 import { IProtobufProperty } from "../schemas/protobuf/IProtobufProperty";
 import { IProtobufPropertyType } from "../schemas/protobuf/IProtobufPropertyType";
 import { IProtobufSchema } from "../schemas/protobuf/IProtobufSchema";
@@ -21,7 +21,7 @@ export namespace ProtobufFactory {
     method: string;
     checker: ts.TypeChecker;
     transformer?: ts.TransformationContext;
-    components: MetadataStorage;
+    components: MetadataCollection;
     type: ts.Type;
   }
 

--- a/packages/core/src/factories/internal/metadata/IMetadataIteratorProps.ts
+++ b/packages/core/src/factories/internal/metadata/IMetadataIteratorProps.ts
@@ -1,13 +1,13 @@
 import ts from "typescript";
 
+import { MetadataCollection } from "../../../schemas/metadata/MetadataCollection";
 import { MetadataSchema } from "../../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../../schemas/metadata/MetadataStorage";
 import { MetadataFactory } from "../../MetadataFactory";
 
 export interface IMetadataIteratorProps<Type extends ts.Type = ts.Type> {
   options: MetadataFactory.IOptions;
   checker: ts.TypeChecker;
-  components: MetadataStorage;
+  components: MetadataCollection;
   errors: MetadataFactory.IError[];
   metadata: MetadataSchema;
   type: Type;

--- a/packages/core/src/factories/internal/metadata/iterate_metadata_collection.ts
+++ b/packages/core/src/factories/internal/metadata/iterate_metadata_collection.ts
@@ -1,14 +1,14 @@
 import { MetadataArrayType } from "../../../schemas/metadata/MetadataArrayType";
+import { MetadataCollection } from "../../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../../schemas/metadata/MetadataStorage";
 import { MetadataTupleType } from "../../../schemas/metadata/MetadataTupleType";
 import { MetadataFactory } from "../../MetadataFactory";
 import { iterate_metadata_comment_tags } from "./iterate_metadata_comment_tags";
 
 export const iterate_metadata_collection = (props: {
   errors: MetadataFactory.IError[];
-  collection: MetadataStorage;
+  collection: MetadataCollection;
 }): void => {
   for (const array of props.collection.arrays())
     if (array.recursive === null)

--- a/packages/core/src/factories/internal/metadata/iterate_metadata_intersection.ts
+++ b/packages/core/src/factories/internal/metadata/iterate_metadata_intersection.ts
@@ -1,8 +1,8 @@
 import { IMetadataTypeTag } from "@typia/interface";
 
+import { MetadataCollection } from "../../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../../schemas/metadata/MetadataStorage";
 import { MetadataFactory } from "../../MetadataFactory";
 import { MetadataTypeTagFactory } from "../../MetadataTypeTagFactory";
 import { IMetadataIteratorProps } from "./IMetadataIteratorProps";
@@ -16,7 +16,7 @@ export const iterate_metadata_intersection = (
   else if (props.type.isIntersection() === false) return false;
 
   // CONSTRUCT FAKE METADATA LIST
-  const commit: MetadataStorage = props.components.clone();
+  const commit: MetadataCollection = props.components.clone();
   props.components["options"] = undefined;
 
   const fakeErrors: MetadataFactory.IError[] = [];

--- a/packages/core/src/factories/internal/metadata/iterate_metadata_sort.ts
+++ b/packages/core/src/factories/internal/metadata/iterate_metadata_sort.ts
@@ -1,9 +1,9 @@
+import { MetadataCollection } from "../../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../../schemas/metadata/MetadataStorage";
 
 export const iterate_metadata_sort = (props: {
-  collection: MetadataStorage;
+  collection: MetadataCollection;
   metadata: MetadataSchema;
 }) => {
   const visited: Set<MetadataSchema> = new Set();
@@ -23,7 +23,7 @@ export const iterate_metadata_sort = (props: {
 
 const iterate = (props: {
   visited: Set<MetadataSchema>;
-  collection: MetadataStorage;
+  collection: MetadataCollection;
   metadata: MetadataSchema;
 }) => {
   if (props.visited.has(props.metadata)) return;

--- a/packages/core/src/programmers/IsProgrammer.ts
+++ b/packages/core/src/programmers/IsProgrammer.ts
@@ -5,9 +5,9 @@ import { ITypiaContext } from "../context/ITypiaContext";
 import { ExpressionFactory } from "../factories/ExpressionFactory";
 import { IdentifierFactory } from "../factories/IdentifierFactory";
 import { ValueFactory } from "../factories/ValueFactory";
+import { MetadataCollection } from "../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../schemas/metadata/MetadataStorage";
 import { FunctionProgrammer } from "./helpers/FunctionProgrammer";
 import { IExpressionEntry } from "./helpers/IExpressionEntry";
 import { OptionPredicator } from "./helpers/OptionPredicator";
@@ -188,7 +188,7 @@ export namespace IsProgrammer {
   export const write_function_statements = (props: {
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }) => {
     const config: CheckerProgrammer.IConfig = configure(props);
     const next = {

--- a/packages/core/src/programmers/RandomProgrammer.ts
+++ b/packages/core/src/programmers/RandomProgrammer.ts
@@ -15,11 +15,11 @@ import { TypeFactory } from "../factories/TypeFactory";
 import { MetadataArray } from "../schemas/metadata/MetadataArray";
 import { MetadataArrayType } from "../schemas/metadata/MetadataArrayType";
 import { MetadataAtomic } from "../schemas/metadata/MetadataAtomic";
+import { MetadataCollection } from "../schemas/metadata/MetadataCollection";
 import { MetadataMap } from "../schemas/metadata/MetadataMap";
 import { MetadataObjectType } from "../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../schemas/metadata/MetadataSchema";
 import { MetadataSet } from "../schemas/metadata/MetadataSet";
-import { MetadataStorage } from "../schemas/metadata/MetadataStorage";
 import { MetadataTemplate } from "../schemas/metadata/MetadataTemplate";
 import { MetadataTuple } from "../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../schemas/metadata/MetadataTupleType";
@@ -60,7 +60,7 @@ export namespace RandomProgrammer {
   export const decompose = (
     props: IDecomposeProps,
   ): FeatureProgrammer.IDecomposed => {
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,
@@ -195,7 +195,7 @@ export namespace RandomProgrammer {
   const write_object_functions = (props: {
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection.objects().map((obj, i) =>
       StatementFactory.constant({
@@ -237,7 +237,7 @@ export namespace RandomProgrammer {
   const write_array_functions = (props: {
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -293,7 +293,7 @@ export namespace RandomProgrammer {
   const write_tuple_functions = (props: {
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()

--- a/packages/core/src/programmers/http/HttpFormDataProgrammer.ts
+++ b/packages/core/src/programmers/http/HttpFormDataProgrammer.ts
@@ -10,10 +10,10 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArrayType } from "../../schemas/metadata/MetadataArrayType";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataProperty } from "../../schemas/metadata/MetadataProperty";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
 import { HttpMetadataUtil } from "../helpers/HttpMetadataUtil";
 import { FeatureProgrammer } from "../internal/FeatureProgrammer";
@@ -26,7 +26,7 @@ export namespace HttpFormDataProgrammer {
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
     // ANALYZE TYPE
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/http/HttpHeadersProgrammer.ts
+++ b/packages/core/src/programmers/http/HttpHeadersProgrammer.ts
@@ -11,10 +11,10 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArrayType } from "../../schemas/metadata/MetadataArrayType";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataProperty } from "../../schemas/metadata/MetadataProperty";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
 import { HttpMetadataUtil } from "../helpers/HttpMetadataUtil";
 import { FeatureProgrammer } from "../internal/FeatureProgrammer";
@@ -29,7 +29,7 @@ export namespace HttpHeadersProgrammer {
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
     // ANALYZE TYPE
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/http/HttpParameterProgrammer.ts
+++ b/packages/core/src/programmers/http/HttpParameterProgrammer.ts
@@ -7,8 +7,8 @@ import { IdentifierFactory } from "../../factories/IdentifierFactory";
 import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { AssertProgrammer } from "../AssertProgrammer";
 import { HttpMetadataUtil } from "../helpers/HttpMetadataUtil";
 
@@ -23,7 +23,7 @@ export namespace HttpParameterProgrammer {
         absorb: true,
         validate,
       },
-      components: new MetadataStorage(),
+      components: new MetadataCollection(),
       type: props.type,
     });
     if (result.success === false)

--- a/packages/core/src/programmers/http/HttpQueryProgrammer.ts
+++ b/packages/core/src/programmers/http/HttpQueryProgrammer.ts
@@ -10,10 +10,10 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArrayType } from "../../schemas/metadata/MetadataArrayType";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataProperty } from "../../schemas/metadata/MetadataProperty";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
 import { HttpMetadataUtil } from "../helpers/HttpMetadataUtil";
 import { FeatureProgrammer } from "../internal/FeatureProgrammer";
@@ -31,7 +31,7 @@ export namespace HttpQueryProgrammer {
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
     // ANALYZE TYPE
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/internal/CheckerProgrammer.ts
+++ b/packages/core/src/programmers/internal/CheckerProgrammer.ts
@@ -9,12 +9,12 @@ import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { ValueFactory } from "../../factories/ValueFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataConstant } from "../../schemas/metadata/MetadataConstant";
 import { MetadataMap } from "../../schemas/metadata/MetadataMap";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
 import { MetadataSet } from "../../schemas/metadata/MetadataSet";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../../schemas/metadata/MetadataTupleType";
 import { IsProgrammer } from "../IsProgrammer";
@@ -136,7 +136,7 @@ export namespace CheckerProgrammer {
     context: ITypiaContext;
     config: IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     FeatureProgrammer.write_object_functions({
       config: configure(props),
@@ -148,7 +148,7 @@ export namespace CheckerProgrammer {
     context: ITypiaContext;
     config: IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     FeatureProgrammer.write_union_functions({
       config: configure({
@@ -166,7 +166,7 @@ export namespace CheckerProgrammer {
     context: ITypiaContext;
     config: IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -206,7 +206,7 @@ export namespace CheckerProgrammer {
     context: ITypiaContext;
     config: IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()
@@ -262,7 +262,7 @@ export namespace CheckerProgrammer {
     path: props.config.path,
     prefix: props.config.prefix,
     initializer: (next) => {
-      const collection: MetadataStorage = new MetadataStorage();
+      const collection: MetadataCollection = new MetadataCollection();
       const result = MetadataFactory.analyze({
         checker: next.context.checker,
         transformer: next.context.transformer,

--- a/packages/core/src/programmers/internal/FeatureProgrammer.ts
+++ b/packages/core/src/programmers/internal/FeatureProgrammer.ts
@@ -6,9 +6,9 @@ import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { ValueFactory } from "../../factories/ValueFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { FunctionProgrammer } from "../helpers/FunctionProgrammer";
 import { IExpressionEntry } from "../helpers/IExpressionEntry";
 import { UnionExplorer } from "../helpers/UnionExplorer";
@@ -31,7 +31,7 @@ export namespace FeatureProgrammer {
     /** Whether to trace exception or not. */
     trace: boolean;
 
-    addition?: undefined | ((collection: MetadataStorage) => ts.Statement[]);
+    addition?: undefined | ((collection: MetadataCollection) => ts.Statement[]);
 
     /** Initializer of metadata. */
     initializer: (props: {
@@ -39,7 +39,7 @@ export namespace FeatureProgrammer {
       functor: FunctionProgrammer;
       type: ts.Type;
     }) => {
-      collection: MetadataStorage;
+      collection: MetadataCollection;
       metadata: MetadataSchema;
     };
 
@@ -165,12 +165,12 @@ export namespace FeatureProgrammer {
     export interface IGenerator {
       objects?:
         | undefined
-        | ((collection: MetadataStorage) => ts.VariableStatement[]);
+        | ((collection: MetadataCollection) => ts.VariableStatement[]);
       unions?:
         | undefined
-        | ((collection: MetadataStorage) => ts.VariableStatement[]);
-      arrays: (collection: MetadataStorage) => ts.VariableStatement[];
-      tuples: (collection: MetadataStorage) => ts.VariableStatement[];
+        | ((collection: MetadataCollection) => ts.VariableStatement[]);
+      arrays: (collection: MetadataCollection) => ts.VariableStatement[];
+      tuples: (collection: MetadataCollection) => ts.VariableStatement[];
     }
   }
 
@@ -377,7 +377,7 @@ export namespace FeatureProgrammer {
   export const write_object_functions = (props: {
     config: IConfig;
     context: ITypiaContext;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }) =>
     props.collection.objects().map((object) =>
       StatementFactory.constant({
@@ -408,7 +408,7 @@ export namespace FeatureProgrammer {
 
   export const write_union_functions = (props: {
     config: IConfig;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }) =>
     props.collection.unions().map((union, i) =>
       StatementFactory.constant({

--- a/packages/core/src/programmers/json/JsonStringifyProgrammer.ts
+++ b/packages/core/src/programmers/json/JsonStringifyProgrammer.ts
@@ -11,9 +11,9 @@ import { TypeFactory } from "../../factories/TypeFactory";
 import { ValueFactory } from "../../factories/ValueFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
 import { MetadataAtomic } from "../../schemas/metadata/MetadataAtomic";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../../schemas/metadata/MetadataTupleType";
 import { IsProgrammer } from "../IsProgrammer";
@@ -85,7 +85,7 @@ export namespace JsonStringifyProgrammer {
   const write_array_functions = (props: {
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -126,7 +126,7 @@ export namespace JsonStringifyProgrammer {
     context: ITypiaContext;
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()

--- a/packages/core/src/programmers/llm/LlmMetadataFactory.ts
+++ b/packages/core/src/programmers/llm/LlmMetadataFactory.ts
@@ -4,9 +4,9 @@ import ts from "typescript";
 import { ITypiaContext } from "../../context/ITypiaContext";
 import { TransformerError } from "../../context/TransformerError";
 import { MetadataFactory } from "../../factories/MetadataFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObject } from "../../schemas/metadata/MetadataObject";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 
 export namespace LlmMetadataFactory {
   export const getConfig = (props: {
@@ -23,7 +23,7 @@ export namespace LlmMetadataFactory {
     if (props.node === undefined) return undefined;
 
     const type: ts.Type = props.context.checker.getTypeFromTypeNode(props.node);
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
       MetadataFactory.analyze({
         checker: props.context.checker,

--- a/packages/core/src/programmers/misc/MiscCloneProgrammer.ts
+++ b/packages/core/src/programmers/misc/MiscCloneProgrammer.ts
@@ -9,11 +9,11 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataMap } from "../../schemas/metadata/MetadataMap";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
 import { MetadataSet } from "../../schemas/metadata/MetadataSet";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../../schemas/metadata/MetadataTupleType";
 import { IsProgrammer } from "../IsProgrammer";
@@ -78,7 +78,7 @@ export namespace MiscCloneProgrammer {
   const write_array_functions = (props: {
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -119,7 +119,7 @@ export namespace MiscCloneProgrammer {
     context: ITypiaContext;
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()
@@ -958,7 +958,7 @@ export namespace MiscCloneProgrammer {
   };
 
   const initializer: FeatureProgrammer.IConfig["initializer"] = (props) => {
-    const collection = new MetadataStorage();
+    const collection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/misc/MiscLiteralsProgrammer.ts
+++ b/packages/core/src/programmers/misc/MiscLiteralsProgrammer.ts
@@ -5,8 +5,8 @@ import { ITypiaContext } from "../../context/ITypiaContext";
 import { TransformerError } from "../../context/TransformerError";
 import { ExpressionFactory } from "../../factories/ExpressionFactory";
 import { MetadataFactory } from "../../factories/MetadataFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 
 export namespace MiscLiteralsProgrammer {
   export interface IProps {
@@ -32,7 +32,7 @@ export namespace MiscLiteralsProgrammer {
           return [];
         },
       },
-      components: new MetadataStorage(),
+      components: new MetadataCollection(),
       type: props.type,
     });
     if (result.success === false)

--- a/packages/core/src/programmers/misc/MiscPruneProgrammer.ts
+++ b/packages/core/src/programmers/misc/MiscPruneProgrammer.ts
@@ -9,9 +9,9 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../../schemas/metadata/MetadataTupleType";
 import { IsProgrammer } from "../IsProgrammer";
@@ -76,7 +76,7 @@ export namespace MiscPruneProgrammer {
   const write_array_functions = (props: {
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -117,7 +117,7 @@ export namespace MiscPruneProgrammer {
     context: ITypiaContext;
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()
@@ -671,7 +671,7 @@ export namespace MiscPruneProgrammer {
   };
 
   const initializer: FeatureProgrammer.IConfig["initializer"] = (props) => {
-    const collection = new MetadataStorage();
+    const collection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/notations/NotationGeneralProgrammer.ts
+++ b/packages/core/src/programmers/notations/NotationGeneralProgrammer.ts
@@ -10,11 +10,11 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
 import { MetadataArray } from "../../schemas/metadata/MetadataArray";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataMap } from "../../schemas/metadata/MetadataMap";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
 import { MetadataSet } from "../../schemas/metadata/MetadataSet";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { MetadataTuple } from "../../schemas/metadata/MetadataTuple";
 import { MetadataTupleType } from "../../schemas/metadata/MetadataTupleType";
 import { IsProgrammer } from "../IsProgrammer";
@@ -104,7 +104,7 @@ export namespace NotationGeneralProgrammer {
   const write_array_functions = (props: {
     config: FeatureProgrammer.IConfig;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .arrays()
@@ -145,7 +145,7 @@ export namespace NotationGeneralProgrammer {
     rename: (str: string) => string;
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
   }): ts.VariableStatement[] =>
     props.collection
       .tuples()
@@ -917,7 +917,7 @@ export namespace NotationGeneralProgrammer {
   };
 
   const initializer: FeatureProgrammer.IConfig["initializer"] = (props) => {
-    const collection = new MetadataStorage();
+    const collection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/core/src/programmers/protobuf/ProtobufDecodeProgrammer.ts
+++ b/packages/core/src/programmers/protobuf/ProtobufDecodeProgrammer.ts
@@ -8,10 +8,10 @@ import { MetadataFactory } from "../../factories/MetadataFactory";
 import { ProtobufFactory } from "../../factories/ProtobufFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataProperty } from "../../schemas/metadata/MetadataProperty";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { IProtobufProperty } from "../../schemas/protobuf/IProtobufProperty";
 import { IProtobufPropertyType } from "../../schemas/protobuf/IProtobufPropertyType";
 import { IProtobufSchema } from "../../schemas/protobuf/IProtobufSchema";
@@ -27,7 +27,7 @@ export namespace ProtobufDecodeProgrammer {
     type: ts.Type;
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const meta: MetadataSchema = ProtobufFactory.metadata({
       method: props.modulo.getText(),
       checker: props.context.checker,

--- a/packages/core/src/programmers/protobuf/ProtobufEncodeProgrammer.ts
+++ b/packages/core/src/programmers/protobuf/ProtobufEncodeProgrammer.ts
@@ -9,10 +9,10 @@ import { NumericRangeFactory } from "../../factories/NumericRangeFactory";
 import { ProtobufFactory } from "../../factories/ProtobufFactory";
 import { StatementFactory } from "../../factories/StatementFactory";
 import { TypeFactory } from "../../factories/TypeFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataMap } from "../../schemas/metadata/MetadataMap";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { IProtobufProperty } from "../../schemas/protobuf/IProtobufProperty";
 import { IProtobufPropertyType } from "../../schemas/protobuf/IProtobufPropertyType";
 import { IProtobufSchema } from "../../schemas/protobuf/IProtobufSchema";
@@ -32,7 +32,7 @@ export namespace ProtobufEncodeProgrammer {
     type: ts.Type;
     name: string | undefined;
   }): FeatureProgrammer.IDecomposed => {
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     const metadata: MetadataSchema = ProtobufFactory.metadata({
       method: props.modulo.getText(),
       checker: props.context.checker,
@@ -124,7 +124,7 @@ export namespace ProtobufEncodeProgrammer {
   const write_encoder = (props: {
     context: ITypiaContext;
     functor: FunctionProgrammer;
-    collection: MetadataStorage;
+    collection: MetadataCollection;
     metadata: MetadataSchema;
   }): ts.ArrowFunction => {
     const functors = props.collection

--- a/packages/core/src/programmers/protobuf/ProtobufMessageProgrammer.ts
+++ b/packages/core/src/programmers/protobuf/ProtobufMessageProgrammer.ts
@@ -4,9 +4,9 @@ import ts from "typescript";
 import { ITypiaContext } from "../../context/ITypiaContext";
 import { IdentifierFactory } from "../../factories/IdentifierFactory";
 import { ProtobufFactory } from "../../factories/ProtobufFactory";
+import { MetadataCollection } from "../../schemas/metadata/MetadataCollection";
 import { MetadataObjectType } from "../../schemas/metadata/MetadataObjectType";
 import { MetadataSchema } from "../../schemas/metadata/MetadataSchema";
-import { MetadataStorage } from "../../schemas/metadata/MetadataStorage";
 import { IProtobufProperty } from "../../schemas/protobuf/IProtobufProperty";
 import { IProtobufPropertyType } from "../../schemas/protobuf/IProtobufPropertyType";
 import { IProtobufSchema } from "../../schemas/protobuf/IProtobufSchema";
@@ -19,7 +19,7 @@ export namespace ProtobufMessageProgrammer {
   }
   export const write = (props: IProps) => {
     // PARSE TARGET TYPE
-    const collection: MetadataStorage = new MetadataStorage();
+    const collection: MetadataCollection = new MetadataCollection();
     ProtobufFactory.metadata({
       method: "message",
       checker: props.context.checker,

--- a/packages/core/src/schemas/metadata/MetadataCollection.ts
+++ b/packages/core/src/schemas/metadata/MetadataCollection.ts
@@ -19,7 +19,7 @@ import { MetadataTupleType } from "./MetadataTupleType";
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-export class MetadataStorage {
+export class MetadataCollection {
   private objects_: Map<ts.Type, MetadataObjectType>;
   private object_unions_: Map<string, MetadataObjectType[]>;
   private aliases_: Map<ts.Type, MetadataAliasType>;
@@ -31,7 +31,7 @@ export class MetadataStorage {
   private recursive_array_index_: number;
   private recursive_tuple_index_: number;
 
-  public constructor(private options?: Partial<MetadataStorage.IOptions>) {
+  public constructor(private options?: Partial<MetadataCollection.IOptions>) {
     this.objects_ = new Map();
     this.object_unions_ = new Map();
     this.aliases_ = new Map();
@@ -44,8 +44,8 @@ export class MetadataStorage {
     this.recursive_tuple_index_ = 0;
   }
 
-  public clone(): MetadataStorage {
-    const output: MetadataStorage = new MetadataStorage(this.options);
+  public clone(): MetadataCollection {
+    const output: MetadataCollection = new MetadataCollection(this.options);
     output.objects_ = new Map(this.objects_);
     output.object_unions_ = new Map(this.object_unions_);
     output.aliases_ = new Map(this.aliases_);
@@ -232,7 +232,7 @@ export class MetadataStorage {
     };
   }
 }
-export namespace MetadataStorage {
+export namespace MetadataCollection {
   export interface IOptions {
     replace?(str: string): string;
   }

--- a/packages/core/src/schemas/metadata/MetadataComponents.ts
+++ b/packages/core/src/schemas/metadata/MetadataComponents.ts
@@ -24,7 +24,6 @@ export class MetadataComponents {
     this.dictionary = props.dictionary;
   }
 
-  /** @internal */
   public static from(json: IMetadataComponents): MetadataComponents {
     // INITIALIZE COMPONENTS
     const dictionary: IMetadataDictionary = {

--- a/packages/core/src/schemas/metadata/index.ts
+++ b/packages/core/src/schemas/metadata/index.ts
@@ -18,7 +18,7 @@ export * from "./MetadataParameter";
 export * from "./MetadataProperty";
 export * from "./MetadataSchema";
 export * from "./MetadataSet";
-export * from "./MetadataStorage";
+export * from "./MetadataCollection";
 export * from "./MetadataTemplate";
 export * from "./MetadataTuple";
 export * from "./MetadataTupleType";

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/interface",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/langchain",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "LangChain.js integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/mcp",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "MCP (Model Context Protocol) integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/transform",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/transform/src/features/json/JsonApplicationTransformer.ts
+++ b/packages/transform/src/features/json/JsonApplicationTransformer.ts
@@ -1,9 +1,9 @@
 import {
   JsonApplicationProgrammer,
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IJsonSchemaApplication, ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -33,8 +33,8 @@ export namespace JsonApplicationTransformer {
 
     // GET TYPE
     const type: ts.Type = props.context.checker.getTypeFromTypeNode(top);
-    const collection: MetadataStorage = new MetadataStorage({
-      replace: MetadataStorage.replace,
+    const collection: MetadataCollection = new MetadataCollection({
+      replace: MetadataCollection.replace,
     });
     const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
       MetadataFactory.analyze({

--- a/packages/transform/src/features/json/JsonSchemaTransformer.ts
+++ b/packages/transform/src/features/json/JsonSchemaTransformer.ts
@@ -2,9 +2,9 @@ import {
   JsonSchemaProgrammer,
   JsonSchemasProgrammer,
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IJsonSchemaUnit, ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -63,8 +63,8 @@ export namespace JsonSchemaTransformer {
             validate:
               validate === true ? JsonSchemasProgrammer.validate : undefined,
           },
-          components: new MetadataStorage({
-            replace: MetadataStorage.replace,
+          components: new MetadataCollection({
+            replace: MetadataCollection.replace,
           }),
           type,
         });

--- a/packages/transform/src/features/json/JsonSchemasTransformer.ts
+++ b/packages/transform/src/features/json/JsonSchemasTransformer.ts
@@ -1,9 +1,9 @@
 import {
   JsonSchemasProgrammer,
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IJsonSchemaCollection, ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -66,8 +66,8 @@ export namespace JsonSchemasTransformer {
               validate:
                 validate === true ? JsonSchemasProgrammer.validate : undefined,
             },
-            components: new MetadataStorage({
-              replace: MetadataStorage.replace,
+            components: new MetadataCollection({
+              replace: MetadataCollection.replace,
             }),
             type,
           }),

--- a/packages/transform/src/features/llm/LlmApplicationTransformer.ts
+++ b/packages/transform/src/features/llm/LlmApplicationTransformer.ts
@@ -4,9 +4,9 @@ import {
   LiteralFactory,
   LlmApplicationProgrammer,
   LlmMetadataFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
   StatementFactory,
 } from "@typia/core";
 import { ILlmApplication, ILlmSchema, ValidationPipe } from "@typia/interface";
@@ -113,8 +113,8 @@ export namespace LlmApplicationTransformer {
                     })
                 : undefined,
           },
-          components: new MetadataStorage({
-            replace: MetadataStorage.replace,
+          components: new MetadataCollection({
+            replace: MetadataCollection.replace,
           }),
           type,
         });

--- a/packages/transform/src/features/llm/LlmParametersTransformer.ts
+++ b/packages/transform/src/features/llm/LlmParametersTransformer.ts
@@ -2,9 +2,9 @@ import {
   LiteralFactory,
   LlmMetadataFactory,
   LlmParametersProgrammer,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { ILlmSchema, ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -55,8 +55,8 @@ export namespace LlmParametersTransformer {
                     })
                 : undefined,
           },
-          components: new MetadataStorage({
-            replace: MetadataStorage.replace,
+          components: new MetadataCollection({
+            replace: MetadataCollection.replace,
           }),
           type,
         });

--- a/packages/transform/src/features/llm/LlmSchemaTransformer.ts
+++ b/packages/transform/src/features/llm/LlmSchemaTransformer.ts
@@ -3,9 +3,9 @@ import {
   LiteralFactory,
   LlmMetadataFactory,
   LlmSchemaProgrammer,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { ILlmSchema, ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -55,8 +55,8 @@ export namespace LlmSchemaTransformer {
                     })
                 : undefined,
           },
-          components: new MetadataStorage({
-            replace: MetadataStorage.replace,
+          components: new MetadataCollection({
+            replace: MetadataCollection.replace,
           }),
           type,
         });

--- a/packages/transform/src/features/reflect/ReflectMetadataTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectMetadataTransformer.ts
@@ -1,8 +1,8 @@
 import {
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IMetadataSchemaCollection } from "@typia/interface";
 import ts from "typescript";
@@ -37,7 +37,7 @@ export namespace ReflectMetadataTransformer {
       });
 
     // METADATA
-    const components: MetadataStorage = new MetadataStorage();
+    const components: MetadataCollection = new MetadataCollection();
     const schemas: Array<MetadataSchema> = types.map((type) => {
       const result = MetadataFactory.analyze({
         checker: props.context.checker,

--- a/packages/transform/src/features/reflect/ReflectNameTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectNameTransformer.ts
@@ -1,8 +1,8 @@
 import {
   ITypiaContext,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { ValidationPipe } from "@typia/interface";
 import ts from "typescript";
@@ -57,8 +57,8 @@ const getMetadata = (props: {
   const type: ts.Type = props.context.checker.getTypeFromTypeNode(
     props.node as ts.TypeNode,
   );
-  const collection: MetadataStorage = new MetadataStorage({
-    replace: MetadataStorage.replace,
+  const collection: MetadataCollection = new MetadataCollection({
+    replace: MetadataCollection.replace,
   });
   const result: ValidationPipe<MetadataSchema, MetadataFactory.IError> =
     MetadataFactory.analyze({

--- a/packages/transform/src/features/reflect/ReflectSchemaTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectSchemaTransformer.ts
@@ -1,8 +1,8 @@
 import {
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IMetadataSchemaUnit } from "@typia/interface";
 import ts from "typescript";
@@ -34,7 +34,7 @@ export namespace ReflectSchemaTransformer {
       });
 
     // METADATA
-    const components: MetadataStorage = new MetadataStorage();
+    const components: MetadataCollection = new MetadataCollection();
     const result = MetadataFactory.analyze({
       checker: props.context.checker,
       transformer: props.context.transformer,

--- a/packages/transform/src/features/reflect/ReflectSchemasTransformer.ts
+++ b/packages/transform/src/features/reflect/ReflectSchemasTransformer.ts
@@ -1,8 +1,8 @@
 import {
   LiteralFactory,
+  MetadataCollection,
   MetadataFactory,
   MetadataSchema,
-  MetadataStorage,
 } from "@typia/core";
 import { IMetadataSchemaCollection } from "@typia/interface";
 import ts from "typescript";
@@ -37,7 +37,7 @@ export namespace ReflectSchemasTransformer {
       });
 
     // METADATA
-    const components: MetadataStorage = new MetadataStorage();
+    const components: MetadataCollection = new MetadataCollection();
     const schemas: Array<MetadataSchema> = types.map((type) => {
       const result = MetadataFactory.analyze({
         checker: props.context.checker,

--- a/packages/typia/package.json
+++ b/packages/typia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/utils",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Superfast runtime validators with only one line",
   "main": "src/index.ts",
   "exports": {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typia/vercel",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Vercel AI SDK integration for typia",
   "main": "src/index.ts",
   "exports": {

--- a/tests/debug/package.json
+++ b/tests/debug/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/debug",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Convenient debug program for typia",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/template/package.json
+++ b/tests/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/template",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Template structures for typia testing.",
   "main": "src/index.ts",
   "repository": {

--- a/tests/test-error/package.json
+++ b/tests/test-error/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-error",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Test program of typia generated error",
   "main": "index.js",
   "scripts": {

--- a/tests/test-langchain/package.json
+++ b/tests/test-langchain/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-langchain",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Test suite for @typia/langchain package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-mcp/package.json
+++ b/tests/test-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-mcp",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Test suite for @typia/mcp package",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-automated/package.json
+++ b/tests/test-typia-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-automated",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Automated test features of typia.",
   "scripts": {
     "start": "ts-node src/index.ts"

--- a/tests/test-typia-schema/package.json
+++ b/tests/test-typia-schema/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-typia-schema",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Test features for JSON schema, LLM schema and protobuf message of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-utils-automated/package.json
+++ b/tests/test-utils-automated/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-openapiautomated",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Automated test features of openapi.",
   "scripts": {
     "start": "node -r ts-node/register src/index.ts"

--- a/tests/test-utils/package.json
+++ b/tests/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-utils",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Automated test features of typia.",
   "scripts": {
     "dev": "tsc --watch",

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@typia/test-vercel",
-  "version": "12.0.0-dev.20260228",
+  "version": "12.0.0-dev.20260303",
   "description": "Test suite for @typia/vercel package",
   "scripts": {
     "start": "ts-node src/index.ts"


### PR DESCRIPTION
This pull request refactors the codebase to replace all usages of the `MetadataStorage` class with the new `MetadataCollection` class across core factories, internal metadata utilities, and programmers. This change standardizes how metadata components are collected and managed, ensuring consistency and potentially enabling future enhancements or optimizations.

### Core Refactoring: Replace `MetadataStorage` with `MetadataCollection`

**Core factories and interfaces:**
- Updated all imports and type usages from `MetadataStorage` to `MetadataCollection` in factory files such as `JsonMetadataFactory.ts`, `MetadataFactory.ts`, and `ProtobufFactory.ts`. This includes constructor calls, interface definitions, and documentation references. [[1]](diffhunk://#diff-9a8a4467c66d9c1de4a624377fecef94b9454d50b2ae2f34871f30f4b5f9c222R6-L7) [[2]](diffhunk://#diff-9a8a4467c66d9c1de4a624377fecef94b9454d50b2ae2f34871f30f4b5f9c222L19-R24) [[3]](diffhunk://#diff-ad8887b7c6ed1ee6a5e373a631379497955b5649141993fbc3c0d5a75a76d6c3R6-L11) [[4]](diffhunk://#diff-ad8887b7c6ed1ee6a5e373a631379497955b5649141993fbc3c0d5a75a76d6c3L24-R24) [[5]](diffhunk://#diff-ad8887b7c6ed1ee6a5e373a631379497955b5649141993fbc3c0d5a75a76d6c3L44-R44) [[6]](diffhunk://#diff-f7cee14174f52c828aa1bdfd9127ac1d5ce817aaadb98bb2d14e7066f195a632R10-L13) [[7]](diffhunk://#diff-f7cee14174f52c828aa1bdfd9127ac1d5ce817aaadb98bb2d14e7066f195a632L24-R24)

**Internal metadata utilities:**
- Updated all internal metadata iterator and collection utilities to use `MetadataCollection` instead of `MetadataStorage`, including function parameters, properties, and clone operations. [[1]](diffhunk://#diff-f7391592fad4f1042b5c8e7b54c8bee3a986d6cd3d8e95a68da6c42419405a87R3-R10) [[2]](diffhunk://#diff-35c97fbb6e82b793f004a88eeb7d61b9db70b48c95900c9c8db408b417ee44a7R2-R11) [[3]](diffhunk://#diff-7db07cb6b3309b45d473c0da27e9a79bd85bdb3c591ac0d98864e339e8406aa2R3-L5) [[4]](diffhunk://#diff-7db07cb6b3309b45d473c0da27e9a79bd85bdb3c591ac0d98864e339e8406aa2L19-R19) [[5]](diffhunk://#diff-4f160ada6a9aea2a45d2c324619a1f66fdd45734f3a380b101b459a6c1ca75a7R1-R6) [[6]](diffhunk://#diff-4f160ada6a9aea2a45d2c324619a1f66fdd45734f3a380b101b459a6c1ca75a7L26-R26)

**Programmers (Is, Random, HTTP, etc.):**
- Refactored all programmer modules to use `MetadataCollection` for collecting and passing metadata, including function arguments and local variables in modules such as `IsProgrammer.ts`, `RandomProgrammer.ts`, and all HTTP-related programmers. [[1]](diffhunk://#diff-94a59ddd25e2c23dae0f77df176d469b2887b1cbbb35f56d40aa161082cbde24R8-L10) [[2]](diffhunk://#diff-94a59ddd25e2c23dae0f77df176d469b2887b1cbbb35f56d40aa161082cbde24L191-R191) [[3]](diffhunk://#diff-1eddc18e8dfbc6e5124019ad29150c4ccee21959c8713f0b36f20a8189755de4R18-L22) [[4]](diffhunk://#diff-1eddc18e8dfbc6e5124019ad29150c4ccee21959c8713f0b36f20a8189755de4L63-R63) [[5]](diffhunk://#diff-1eddc18e8dfbc6e5124019ad29150c4ccee21959c8713f0b36f20a8189755de4L198-R198) [[6]](diffhunk://#diff-1eddc18e8dfbc6e5124019ad29150c4ccee21959c8713f0b36f20a8189755de4L240-R240) [[7]](diffhunk://#diff-1eddc18e8dfbc6e5124019ad29150c4ccee21959c8713f0b36f20a8189755de4L296-R296) [[8]](diffhunk://#diff-9445aadcbbb45e0f340c3b9b42a16a3dbf478aa469f4eacb343be21a72ba9c89R13-L16) [[9]](diffhunk://#diff-9445aadcbbb45e0f340c3b9b42a16a3dbf478aa469f4eacb343be21a72ba9c89L29-R29) [[10]](diffhunk://#diff-7c835b5bf0d1bfbd70bc1c20ecd915b2b8a43f095a3f1f257a9dd5d34fe89087R14-L17) [[11]](diffhunk://#diff-7c835b5bf0d1bfbd70bc1c20ecd915b2b8a43f095a3f1f257a9dd5d34fe89087L32-R32) [[12]](diffhunk://#diff-da60310d570765d36351175d835a182c9cd723ac2fb089c0ad38527ef07f0afdR10-L11) [[13]](diffhunk://#diff-da60310d570765d36351175d835a182c9cd723ac2fb089c0ad38527ef07f0afdL26-R26) [[14]](diffhunk://#diff-f7daafe6cf9a3cf21756987ad8fe76e06b57f234faaeaff15744e6d5fd9f7e91R13-L16) [[15]](diffhunk://#diff-f7daafe6cf9a3cf21756987ad8fe76e06b57f234faaeaff15744e6d5fd9f7e91L34-R34)